### PR TITLE
docs: add Claude Code skills for automated curation and draft review

### DIFF
--- a/.claude/skills/gaia-curate/skill.md
+++ b/.claude/skills/gaia-curate/skill.md
@@ -1,0 +1,93 @@
+---
+name: gaia-curate
+description: Expand the Gaia skill registry with new popular AI agent skills, fully evidenced and validated, then push a PR. Use this skill when the user asks to "update the tree", "add new skills to Gaia", "curate the registry", "expand the skill graph", or explicitly types /gaia-curate.
+version: 1.3.0
+---
+
+# gaia-curate
+
+Expand the Gaia skill registry (`graph/gaia.json`) with new popular AI agent skills, fully evidenced and validated, then push a PR.
+
+## What this skill does
+
+1. **Read the current graph** — load `graph/gaia.json` to see every existing skill ID so nothing is duplicated.
+2. **Research** — identify the most impactful AI agent capabilities not yet in the registry. Prioritise skills with strong public evidence (arXiv papers, reproducible GitHub repos).
+3. **Design the batch** — for each candidate skill determine:
+   - Type: `atomic` (no prerequisites) / `composite` (≥2 prereqs) / `legendary` (≥3 prereqs + 3 Class A/B sources)
+   - Level: target **IV** (Proficient) minimum — requires at least 1× Class B or A evidence
+   - Rarity: `common` / `uncommon` / `rare` / `epic` / `legendary`
+   - Prerequisites and derivatives (must reference existing IDs)
+4. **Present draft for review** — before writing any code or committing, display the full proposed skills table:
+
+   | ID | Name | Type | Rarity | Prereqs | Similarity hints |
+   |---|---|---|---|---|---|
+   | … | … | … | … | … | … |
+
+   Similarity hints are lexical matches from the existing registry (≥0.45 score). For each proposed skill, ask the user to mark one of:
+   - `accept` — proceed as designed
+   - `rename <new-id>` — change the ID before generating
+   - `duplicate` — already covered by an existing skill; drop it
+   - `needs-evidence` — hold until a Class A/B source is supplied
+   - `reject` — remove from the batch entirely
+
+   **Do not proceed to step 5 until the user has reviewed and the batch contains at least one `accept`.** Incorporate all `rename` decisions before writing the script. Drop everything that is not `accept`/`rename`.
+
+5. **Write a generation script** (`scripts/add_skills.py` or equivalent) that patches `gaia.json` in place — only for the accepted skills from step 4.
+6. **Run validation** — `PYTHONIOENCODING=utf-8 python3 scripts/validate.py` must exit 0 before any commit.
+7. **Regenerate derived files** — run `python3 scripts/generateProjections.py` and `python3 scripts/exportGexf.py` so that `registry.md`, `combinations.md`, `skills/**/*.md`, `graph/gaia.gexf`, and `users/*/skill-tree.md` stay in sync. Commit these alongside `gaia.json` to pass CI drift detection.
+8. **Commit on a feature branch** — branch name `feat/add-<slug>-skills`, commit message follows `[type] Title — brief description`.
+9. **Push and open a PR** via the GitHub API using stored git credentials. The auto-triage CI classifies the PR:
+   - PRs touching `graph/` from a bot with evidence score ≥ 60 are auto-merged.
+   - PRs flagged `draft-skills` or `needs-review` are routed to the `route-review` job — a human must approve before merge.
+   - Legendary skill proposals always require maintainer approval.
+10. **Register the batch itself** as a `registryCuration` evidence entry if new demonstrations were produced.
+
+## Two-phase intake workflow (gaia push)
+
+For contributors who use the `gaia push` CLI, a separate **draft intake** path exists that does NOT directly modify `graph/gaia.json`:
+
+1. **`gaia push`** — scans the source repo for skill-shaped tokens, builds `intake/skill-batches/<batchId>.json`, and opens a draft PR with labels `draft-skills` and `needs-review`.
+2. **Reviewer classification** — maintainers review the draft PR and mark each proposed skill: `accept` / `rename` / `duplicate` / `needs-evidence` / `reject`.
+3. **Promotion PR** — accepted skills are promoted into `graph/gaia.json` in a separate follow-up PR. That PR must run `python3 scripts/validate.py` and `python3 scripts/validate_intake.py` and must link back to the intake PR.
+
+Use `/gaia-draft-curate` to triage pending intake batches before running this skill.
+
+To validate intake batch files locally:
+```bash
+python3 scripts/validate_intake.py
+```
+
+## Constraints
+
+- Only edit `graph/gaia.json` — never touch `skills/`, `registry.md`, or `combinations.md` (those are generated).
+- All evidence `source` values must be real, resolvable URLs (arXiv abs pages or GitHub repos).
+- Legendary skills at `status: validated` require ≥3 Class A/B entries; new legendaries should be `provisional` until the maintainer merges.
+- No cycles in the DAG. No orphaned composite nodes.
+- Skill IDs: `lowercase-dash` format (e.g., `chain-of-thought`, `web-search`). No camelCase, no vendor names, no abbreviations unless universally understood. Pattern: `^[a-z][a-z0-9]*(-[a-z0-9]+)*$`.
+- **Edge schema**: edges use `sourceSkillId`/`targetSkillId` keys (not `from`/`to`). Valid `edgeType` values are `prerequisite`, `corequisite`, `enhances` only — there is NO `derivative` edge type. Use `enhances` for skill→derivative edges.
+- **Encoding**: all Python `open()` calls must use `encoding='utf-8'` to avoid CP-1252 drift on Windows (em-dash `—` becomes `0x97` without it, failing CI on Linux).
+
+## Evidence standards (quick reference)
+
+| Class | Standard |
+|---|---|
+| A | Peer-reviewed paper — use `https://arxiv.org/abs/<id>` |
+| B | Reproducible open-source demo — use the GitHub repo URL |
+| C | Credible vendor/community demo (only sufficient for Level II) |
+
+## Repo location
+
+Run from the root of your local clone of this repository. If you have not cloned it yet:
+```
+git clone https://github.com/mbtiongson1/gaia-skill-tree.git
+cd gaia-skill-tree
+```
+
+## Output
+
+At the end, report:
+- PR URL
+- Skills added (count by type)
+- Validation result summary
+- Any existing skills whose `derivatives` arrays were patched
+- Review decisions applied (accepted / renamed / dropped)

--- a/.claude/skills/gaia-draft-curate/skill.md
+++ b/.claude/skills/gaia-draft-curate/skill.md
@@ -1,0 +1,94 @@
+---
+name: gaia-draft-curate
+description: Review pending Gaia draft skill intake batches and open draft PRs. Classifies each proposed skill (accept/rename/duplicate/needs-evidence/reject) without touching graph/gaia.json. Optionally triggers a promotion PR for accepted skills. Use when the user asks to "check drafts", "review intake batches", "triage pending skills", or explicitly types /gaia-draft-curate.
+version: 1.0.0
+---
+
+# gaia-draft-curate
+
+Review pending Gaia draft skill intake batches and open draft PRs. This skill is read-only with respect to `graph/gaia.json` — it classifies proposals and, after user confirmation, may hand off to `/gaia-curate` for promotion.
+
+## What this skill does
+
+1. **Pull latest** — `git pull --ff-only` so local state matches remote.
+
+2. **Scan intake batches** — glob `intake/skill-batches/*.json` (skip `.gitkeep`). For each batch file, parse and validate against `schema/skillBatch.schema.json` using `python3 scripts/validate_intake.py`. Report any schema errors immediately.
+
+3. **Check open draft PRs** — run:
+   ```bash
+   gh pr list --label "draft-skills" --state open --json number,title,headRefName,url,createdAt
+   ```
+   Cross-reference with local batch files by `batchId` where possible. List any PRs that have no corresponding local batch (remote-only) and any local batches that have no open PR.
+
+4. **Display review table** — for each batch, show:
+
+   **Batch `<batchId>`** | Source: `<sourceRepo>` | Generated: `<generatedAt>`
+
+   | # | Proposed ID | Name | Type | Similarity hints | Decision |
+   |---|---|---|---|---|---|
+   | 1 | `skill-id` | Skill Name | atomic | `existing-skill` (0.82), `other` (0.61) | _(pending)_ |
+   | … |
+
+   Also show `knownSkills` count (already in registry — informational only, no action needed).
+
+5. **Collect decisions** — ask the user to classify each proposed skill:
+   - `accept` — ready to promote into `graph/gaia.json`
+   - `rename <new-id>` — change the ID, then accept
+   - `duplicate <existing-id>` — already covered; drop
+   - `needs-evidence` — hold; note what Class A/B source is missing
+   - `reject` — remove from consideration
+
+   Present one batch at a time. Do not proceed to the next batch until the current one is fully classified.
+
+6. **Summarise decisions** — after all batches are reviewed, print a final tally:
+   - Accepted: N skills (list IDs)
+   - Renamed: N skills (old-id → new-id)
+   - Held (needs evidence): N (list IDs + missing evidence notes)
+   - Dropped (duplicate/reject): N (list IDs)
+
+7. **Offer promotion** — if there are any accepted/renamed skills, ask the user:
+   > "Promote accepted skills to `graph/gaia.json` now? This will invoke `/gaia-curate` for the accepted batch."
+
+   - If **yes**: hand off to the `gaia-curate` workflow starting at step 4, pre-populating all decisions as `accept`. The promotion PR must link back to the originating intake PR(s).
+   - If **no**: print the manual promotion steps and exit:
+     ```
+     # For each accepted skill, add to graph/gaia.json, then:
+     python3 scripts/validate.py
+     python3 scripts/generateProjections.py
+     python3 scripts/exportGexf.py
+     git commit -am "[atomic|composite] <name> — promote from intake/<batchId>"
+     gh pr create --title "[promote] <slug>" --body "Promotes accepted skills from intake PR #<N>"
+     ```
+
+8. **Report** — output a final summary (see Output section).
+
+## When there are no pending drafts
+
+If `intake/skill-batches/` is empty and no open `draft-skills` PRs exist, report:
+
+> No pending draft intake batches found. Use `gaia push` to generate a new batch, or run `/gaia-curate` to add skills directly to the canonical graph.
+
+Then stop — do not attempt any curation.
+
+## Constraints
+
+- **Read-only by default** — this skill never writes to `graph/gaia.json` directly. That only happens via the `/gaia-curate` promotion path with explicit user confirmation.
+- Never modify batch files in `intake/skill-batches/` — they are immutable intake records.
+- `needs-evidence` decisions should note what evidence class is missing (Class A paper / Class B repo).
+- If `gh` is not authenticated, skip the PR listing step and work from local batch files only; note the limitation in output.
+
+## Repo location
+
+Run from the root of your local clone of this repository. If you have not cloned it yet:
+```
+git clone https://github.com/mbtiongson1/gaia-skill-tree.git
+cd gaia-skill-tree
+```
+
+## Output
+
+At the end, report:
+- Batches reviewed (count)
+- Open draft PRs found (count + URLs)
+- Decisions: accepted / renamed / held / dropped (counts + IDs)
+- Whether promotion was triggered (yes/no + branch name if yes)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,11 +7,12 @@ Thank you for helping map the frontier of AI agent capability. This guide covers
 ## Table of Contents
 
 1. [Contribution Types](#contribution-types)
-2. [Naming Conventions](#naming-conventions)
-3. [Evidence Requirements](#evidence-requirements)
-4. [How to Submit a PR](#how-to-submit-a-pr)
-5. [Reviewer Rubric](#reviewer-rubric)
-6. [Why a PR Gets Rejected](#why-a-pr-gets-rejected)
+2. [Automated Workflow (Claude Code)](#automated-workflow-claude-code)
+3. [Naming Conventions](#naming-conventions)
+4. [Evidence Requirements](#evidence-requirements)
+5. [How to Submit a PR](#how-to-submit-a-pr)
+6. [Reviewer Rubric](#reviewer-rubric)
+7. [Why a PR Gets Rejected](#why-a-pr-gets-rejected)
 
 ---
 
@@ -24,7 +25,41 @@ Thank you for helping map the frontier of AI agent capability. This guide covers
 | New fusion recipe | `new_fusion.md` | Adding edge records to `gaia.json` |
 | Reclassification | `reclassification.md` | Changing level or rarity of an existing skill |
 | New user tree | `new_user_tree.md` | Registering your first skill tree in `users/` |
-| Batch skill intake | `gaia push` | Submitting known and proposed skills detected from agent usage |
+| Batch skill intake | `gaia push` / `/gaia-draft-curate` | Submitting known and proposed skills detected from agent usage |
+
+---
+
+## Automated Workflow (Claude Code)
+
+If you have [Claude Code](https://claude.ai/code) installed, this repository ships two slash commands that automate the full contribution and review cycle.
+
+### `/gaia-curate` — add new skills to the registry
+
+Runs the complete curation pipeline end-to-end:
+1. Reads the current graph to avoid duplicates.
+2. Researches candidate skills with Class A/B evidence.
+3. Presents a draft review table — you classify each candidate as `accept`, `rename`, `duplicate`, `needs-evidence`, or `reject` before any file is touched.
+4. Writes and runs the generation script, validates the DAG, regenerates derived files, and opens a PR.
+
+```
+/gaia-curate
+```
+
+### `/gaia-draft-curate` — triage pending intake batches
+
+A lighter, read-only triage command for reviewing skill batches submitted via `gaia push`:
+1. Pulls latest and scans `intake/skill-batches/*.json`.
+2. Checks GitHub for open `draft-skills` PRs.
+3. Presents each proposed skill for classification: `accept`, `rename`, `duplicate`, `needs-evidence`, or `reject`.
+4. Optionally hands off to `/gaia-curate` to promote accepted skills into `graph/gaia.json`.
+
+```
+/gaia-draft-curate
+```
+
+Run `/gaia-draft-curate` first when contributors have pushed new intake batches. Use `/gaia-curate` when you are adding skills from your own research.
+
+> **Note:** These skills live in `.claude/skills/` at the root of this repo. Claude Code loads them automatically when you open the repo.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/gaia-curate/skill.md` — full canonical graph curation workflow with a human review gate before any file is written (accept / rename / duplicate / needs-evidence / reject each candidate)
- Adds `.claude/skills/gaia-draft-curate/skill.md` — lightweight triage skill for reviewing pending `intake/skill-batches/*.json` files and open `draft-skills` PRs without touching `graph/gaia.json`
- Updates `CONTRIBUTING.md` with a new **Automated Workflow (Claude Code)** section documenting both `/gaia-curate` and `/gaia-draft-curate`, and updates the Contribution Types table to reference `/gaia-draft-curate` alongside `gaia push`

## How it fits the intake flow

```
contributor runs gaia push
        ↓
draft intake PR opens (draft-skills label)
        ↓
maintainer runs /gaia-draft-curate   ← new
  → classifies each proposed skill
  → hands off to /gaia-curate        ← new
        ↓
promotion PR updates graph/gaia.json
```

## Test plan

- [x] Clone the repo and open in Claude Code — verify `/gaia-curate` and `/gaia-draft-curate` appear as available slash commands
- [x] Run `/gaia-draft-curate` with no intake batches — confirm it exits cleanly with the "no pending drafts" message
- [x] Run `/gaia-curate` — confirm the review table appears at step 4 before any script is written
- [x] Verify CONTRIBUTING.md renders correctly, ToC links resolve, and the new section appears between Contribution Types and Naming Conventions