### PR TITLE
fix: post-restructure CI compatibility

### DIFF
--- a/graph/gaia.gexf
+++ b/graph/gaia.gexf
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <gexf xmlns="http://www.gexf.net/1.2draft" version="1.2">
-  <meta lastmodifieddate="2026-04-28">
+  <meta lastmodifieddate="2026-04-29">
     <creator>Gaia</creator>
     <description>Gaia Skill Registry Graph</description>
   </meta>
@@ -14,7 +14,7 @@
     <nodes>
       <node id="api-call" label="API Call">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="II" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -22,7 +22,7 @@
       </node>
       <node id="audience-model" label="Audience Model">
         <attvalues>
-          <attvalue for="level" value="II" />
+          <attvalue for="level" value="I" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -30,7 +30,7 @@
       </node>
       <node id="automated-testing" label="Automated Testing">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="III" />
           <attvalue for="rarity" value="uncommon" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="composite" />
@@ -38,7 +38,7 @@
       </node>
       <node id="autonomous-data-scientist" label="True Oracle: Autonomous Data Scientist">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="V" />
           <attvalue for="rarity" value="legendary" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="legendary" />
@@ -54,7 +54,7 @@
       </node>
       <node id="autonomous-research-agent" label="Wisdom King: Autonomous Research Agent">
         <attvalues>
-          <attvalue for="level" value="I" />
+          <attvalue for="level" value="VI" />
           <attvalue for="rarity" value="legendary" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="legendary" />
@@ -62,7 +62,7 @@
       </node>
       <node id="browser-automation" label="Browser Automation">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="III" />
           <attvalue for="rarity" value="uncommon" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="composite" />
@@ -70,7 +70,7 @@
       </node>
       <node id="chain-of-thought" label="Chain-of-Thought Reasoning">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="II" />
           <attvalue for="rarity" value="uncommon" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -78,7 +78,7 @@
       </node>
       <node id="chunk-document" label="Chunk Document">
         <attvalues>
-          <attvalue for="level" value="II" />
+          <attvalue for="level" value="I" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -86,7 +86,7 @@
       </node>
       <node id="cite-sources" label="Cite Sources">
         <attvalues>
-          <attvalue for="level" value="II" />
+          <attvalue for="level" value="I" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -94,7 +94,7 @@
       </node>
       <node id="classify" label="Classify">
         <attvalues>
-          <attvalue for="level" value="II" />
+          <attvalue for="level" value="I" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -102,7 +102,7 @@
       </node>
       <node id="code-execution" label="Code Execution">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="II" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -110,7 +110,7 @@
       </node>
       <node id="code-generation" label="Code Generation">
         <attvalues>
-          <attvalue for="level" value="II" />
+          <attvalue for="level" value="I" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -118,7 +118,7 @@
       </node>
       <node id="code-review-pipeline" label="Code Review Pipeline">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="III" />
           <attvalue for="rarity" value="uncommon" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="composite" />
@@ -126,7 +126,7 @@
       </node>
       <node id="computer-use" label="Computer Use">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="II" />
           <attvalue for="rarity" value="rare" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -134,7 +134,7 @@
       </node>
       <node id="content-moderation" label="Content Moderation">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="III" />
           <attvalue for="rarity" value="uncommon" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="composite" />
@@ -142,7 +142,7 @@
       </node>
       <node id="conversational-agent" label="Conversational Agent">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="III" />
           <attvalue for="rarity" value="uncommon" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="composite" />
@@ -150,7 +150,7 @@
       </node>
       <node id="data-analysis" label="Data Analysis">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="III" />
           <attvalue for="rarity" value="uncommon" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="composite" />
@@ -158,7 +158,7 @@
       </node>
       <node id="data-visualize" label="Data Visualize">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="II" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -166,7 +166,7 @@
       </node>
       <node id="detect-anomaly" label="Detect Anomaly">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="II" />
           <attvalue for="rarity" value="uncommon" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -174,7 +174,7 @@
       </node>
       <node id="diff-content" label="Diff Content">
         <attvalues>
-          <attvalue for="level" value="II" />
+          <attvalue for="level" value="I" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -190,7 +190,7 @@
       </node>
       <node id="document-digitization" label="Document Digitization">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="III" />
           <attvalue for="rarity" value="uncommon" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="composite" />
@@ -198,7 +198,7 @@
       </node>
       <node id="embed-text" label="Embed Text">
         <attvalues>
-          <attvalue for="level" value="II" />
+          <attvalue for="level" value="I" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -206,7 +206,7 @@
       </node>
       <node id="error-interpretation" label="Error Interpretation">
         <attvalues>
-          <attvalue for="level" value="II" />
+          <attvalue for="level" value="I" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -214,7 +214,7 @@
       </node>
       <node id="evaluate-output" label="Evaluate Output">
         <attvalues>
-          <attvalue for="level" value="II" />
+          <attvalue for="level" value="I" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -222,7 +222,7 @@
       </node>
       <node id="execute-bash" label="Execute Bash">
         <attvalues>
-          <attvalue for="level" value="II" />
+          <attvalue for="level" value="I" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -230,7 +230,7 @@
       </node>
       <node id="extract-entities" label="Extract Entities">
         <attvalues>
-          <attvalue for="level" value="II" />
+          <attvalue for="level" value="I" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -238,7 +238,7 @@
       </node>
       <node id="format-output" label="Format Output">
         <attvalues>
-          <attvalue for="level" value="II" />
+          <attvalue for="level" value="I" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -246,7 +246,7 @@
       </node>
       <node id="full-stack-developer" label="True Craftsman: Full-Stack Developer">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="V" />
           <attvalue for="rarity" value="legendary" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="legendary" />
@@ -254,7 +254,7 @@
       </node>
       <node id="generate-sql" label="Generate SQL">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="II" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -262,7 +262,7 @@
       </node>
       <node id="generate-test" label="Generate Test">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="II" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -270,7 +270,7 @@
       </node>
       <node id="generate-text" label="Generate Text">
         <attvalues>
-          <attvalue for="level" value="II" />
+          <attvalue for="level" value="I" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -286,7 +286,7 @@
       </node>
       <node id="hypothesis-generate" label="Hypothesis Generation">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="II" />
           <attvalue for="rarity" value="rare" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -294,7 +294,7 @@
       </node>
       <node id="image-caption" label="Image Caption">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="II" />
           <attvalue for="rarity" value="uncommon" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -302,7 +302,7 @@
       </node>
       <node id="image-generate" label="Image Generate">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="II" />
           <attvalue for="rarity" value="uncommon" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -310,7 +310,7 @@
       </node>
       <node id="knowledge-graph-build" label="Knowledge Graph Construction">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="III" />
           <attvalue for="rarity" value="uncommon" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="composite" />
@@ -326,7 +326,7 @@
       </node>
       <node id="logical-inference" label="Logical Inference">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="II" />
           <attvalue for="rarity" value="uncommon" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -334,7 +334,7 @@
       </node>
       <node id="math-reason" label="Math Reason">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="II" />
           <attvalue for="rarity" value="uncommon" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -342,7 +342,7 @@
       </node>
       <node id="memory-manage" label="Memory Manage">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="II" />
           <attvalue for="rarity" value="uncommon" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -350,7 +350,7 @@
       </node>
       <node id="multi-agent-orchestration-v" label="Grand Conductor: Multi-Agent Orchestration">
         <attvalues>
-          <attvalue for="level" value="I" />
+          <attvalue for="level" value="V" />
           <attvalue for="rarity" value="legendary" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="legendary" />
@@ -358,7 +358,7 @@
       </node>
       <node id="multimodal-reasoning" label="Multimodal Reasoning">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="III" />
           <attvalue for="rarity" value="rare" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="composite" />
@@ -366,7 +366,7 @@
       </node>
       <node id="parse-html" label="Parse HTML">
         <attvalues>
-          <attvalue for="level" value="II" />
+          <attvalue for="level" value="I" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -374,7 +374,7 @@
       </node>
       <node id="parse-json" label="Parse JSON">
         <attvalues>
-          <attvalue for="level" value="II" />
+          <attvalue for="level" value="I" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -382,7 +382,7 @@
       </node>
       <node id="parse-pdf" label="Parse PDF">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="II" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -398,7 +398,7 @@
       </node>
       <node id="plan-decompose" label="Plan and Decompose">
         <attvalues>
-          <attvalue for="level" value="II" />
+          <attvalue for="level" value="I" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -406,7 +406,7 @@
       </node>
       <node id="question-answer" label="Question Answer">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="II" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -422,7 +422,7 @@
       </node>
       <node id="rank" label="Rank">
         <attvalues>
-          <attvalue for="level" value="II" />
+          <attvalue for="level" value="I" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -430,7 +430,7 @@
       </node>
       <node id="re-act-reasoning" label="ReAct Reasoning">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="III" />
           <attvalue for="rarity" value="uncommon" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="composite" />
@@ -438,7 +438,7 @@
       </node>
       <node id="real-time-voice-assistant" label="True Herald: Real-Time Voice Assistant">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="V" />
           <attvalue for="rarity" value="legendary" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="legendary" />
@@ -446,7 +446,7 @@
       </node>
       <node id="recursive-self-improvement" label="True Sage: Recursive Self-Improvement">
         <attvalues>
-          <attvalue for="level" value="I" />
+          <attvalue for="level" value="V" />
           <attvalue for="rarity" value="legendary" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="legendary" />
@@ -454,7 +454,7 @@
       </node>
       <node id="refactor-code" label="Refactor Code">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="II" />
           <attvalue for="rarity" value="uncommon" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -478,7 +478,7 @@
       </node>
       <node id="retrieve" label="Retrieve">
         <attvalues>
-          <attvalue for="level" value="II" />
+          <attvalue for="level" value="I" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -486,7 +486,7 @@
       </node>
       <node id="route-intent" label="Route Intent">
         <attvalues>
-          <attvalue for="level" value="II" />
+          <attvalue for="level" value="I" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -494,7 +494,7 @@
       </node>
       <node id="scientific-discovery" label="True Dragon: Autonomous Scientific Discovery">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="V" />
           <attvalue for="rarity" value="legendary" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="legendary" />
@@ -502,7 +502,7 @@
       </node>
       <node id="score-relevance" label="Score Relevance">
         <attvalues>
-          <attvalue for="level" value="II" />
+          <attvalue for="level" value="I" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -510,7 +510,7 @@
       </node>
       <node id="self-critique" label="Self-Critique">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="II" />
           <attvalue for="rarity" value="uncommon" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -518,7 +518,7 @@
       </node>
       <node id="sentiment-analysis" label="Sentiment Analysis">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="II" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -526,7 +526,7 @@
       </node>
       <node id="speech-to-text" label="Speech to Text">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="II" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -534,7 +534,7 @@
       </node>
       <node id="structured-output" label="Structured Output Generation">
         <attvalues>
-          <attvalue for="level" value="III" />
+          <attvalue for="level" value="II" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -542,7 +542,7 @@
       </node>
       <node id="summarize" label="Summarize">
         <attvalues>
-          <attvalue for="level" value="II" />
+          <attvalue for="level" value="I" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -550,7 +550,7 @@
       </node>
       <node id="text-to-speech" label="Text to Speech">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="II" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -558,7 +558,7 @@
       </node>
       <node id="text-to-sql-pipeline" label="Text-to-SQL Pipeline">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="III" />
           <attvalue for="rarity" value="uncommon" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="composite" />
@@ -566,7 +566,7 @@
       </node>
       <node id="tokenize" label="Tokenize">
         <attvalues>
-          <attvalue for="level" value="II" />
+          <attvalue for="level" value="I" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -574,7 +574,7 @@
       </node>
       <node id="tool-select" label="Tool Select">
         <attvalues>
-          <attvalue for="level" value="II" />
+          <attvalue for="level" value="I" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -582,7 +582,7 @@
       </node>
       <node id="tool-use" label="Tool Use">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="II" />
           <attvalue for="rarity" value="uncommon" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -590,7 +590,7 @@
       </node>
       <node id="translate" label="Translate">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="II" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -598,7 +598,7 @@
       </node>
       <node id="translation-pipeline" label="Translation Pipeline">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="III" />
           <attvalue for="rarity" value="uncommon" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="composite" />
@@ -606,7 +606,7 @@
       </node>
       <node id="voice-agent" label="Voice Agent">
         <attvalues>
-          <attvalue for="level" value="IV" />
+          <attvalue for="level" value="III" />
           <attvalue for="rarity" value="uncommon" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="composite" />
@@ -622,7 +622,7 @@
       </node>
       <node id="web-search" label="Web Search">
         <attvalues>
-          <attvalue for="level" value="II" />
+          <attvalue for="level" value="I" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
@@ -630,7 +630,7 @@
       </node>
       <node id="write-report" label="Write Report">
         <attvalues>
-          <attvalue for="level" value="II" />
+          <attvalue for="level" value="I" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -34,7 +34,7 @@ except ImportError:
 EVIDENCE_FLOOR = {
     "I": None,       # No evidence required (foundation tier)
     "II": {"C", "B", "A"},
-    "III": {"C", "B", "A"},
+    "III": {"B", "A"},
     "IV": {"B", "A"},
     "V": {"B", "A"},
     "VI": {"A"},

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -11,6 +11,8 @@ GRAPH_PATH = os.path.join(REPO_ROOT, "graph", "gaia.json")
 
 
 def run_validate_intake(intake_dir):
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "utf-8"
     result = subprocess.run(
         [
             "python3",
@@ -22,6 +24,8 @@ def run_validate_intake(intake_dir):
         ],
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        env=env,
     )
     return result.returncode, result.stdout
 

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -34,6 +34,7 @@ class TestGaiaPush(unittest.TestCase):
             env = os.environ.copy()
             env.pop("GITHUB_REPOSITORY", None)
             env["PYTHONPATH"] = REPO_ROOT
+            env["PYTHONIOENCODING"] = "utf-8"
             result = subprocess.run(
                 [
                     "python3",
@@ -47,6 +48,7 @@ class TestGaiaPush(unittest.TestCase):
                 env=env,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
             )
 
             self.assertEqual(result.returncode, 0, result.stderr)
@@ -78,6 +80,7 @@ class TestGaiaPush(unittest.TestCase):
 
             env = os.environ.copy()
             env["PYTHONPATH"] = REPO_ROOT
+            env["PYTHONIOENCODING"] = "utf-8"
             result = subprocess.run(
                 [
                     "python3",
@@ -91,6 +94,7 @@ class TestGaiaPush(unittest.TestCase):
                 env=env,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
             )
 
             self.assertEqual(result.returncode, 0, result.stderr)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -10,10 +10,14 @@ REAL_GRAPH_PATH = os.path.join(REPO_ROOT, "graph", "gaia.json")
 
 def run_validate(graph_path):
     """Helper to run validate.py and return (exit_code, stdout)."""
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "utf-8"
     result = subprocess.run(
         ["python3", VALIDATE_SCRIPT, "--graph", graph_path],
         capture_output=True,
-        text=True
+        text=True,
+        encoding="utf-8",
+        env=env
     )
     return result.returncode, result.stdout
 


### PR DESCRIPTION
## Summary
- Restore Level III evidence floor to `{"B", "A"}` (was accidentally relaxed to include `"C"`, breaking the `bad_evidence` fixture test)
- Add `encoding="utf-8"` and `PYTHONIOENCODING` env var to all subprocess calls in tests so emoji output from validate scripts works on Windows (cp1252)
- Regenerate `gaia.gexf` with updated tier levels to pass drift detection

## Test plan
- [x] `pytest tests/` — all 28 tests pass locally
- [x] `python scripts/validate.py` — clean pass
- [x] `python scripts/validate_intake.py` — clean pass
- [x] `python scripts/generateProjections.py && python scripts/exportGexf.py && git diff --exit-code` — no drift
- [ ] CI validate + generate workflows should pass on this PR