### PR TITLE
Improve Gaia CLI setup DX

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,29 +111,33 @@ Then `gaia` works from any directory — no path prefix needed.
 ### Project setup
 
 Run this inside the project you want Gaia to scan:
-
 ```bash
-gaia init
+gaia init --user your-github-username --scan AGENTS.md --scan scripts
+```
+
+For the previous non-interactive defaults, use:
+```bash
+gaia init --yes
 ```
 
 This creates `.gaia/config.json`:
-
 ```json
 {
   "gaiaUser": "your-github-username",
   "gaiaRegistryRef": "https://github.com/mbtiongson1/gaia-skill-tree",
-  "scanPaths": ["scripts", "plugin"],
+  "scanPaths": ["AGENTS.md", "scripts"],
   "autoPromptCombinations": false
 }
 ```
 
-Update `gaiaUser` and `scanPaths` for your project before scanning.
+Use `gaia doctor` after initialization to check the CLI, registry path, config, skill tree, embeddings, and scan paths.
 
 ### Commands
 
 | Command | What it does |
 |---|---|
-| `gaia init` | Creates `.gaia/config.json` in the current project. |
+| `gaia init` | Creates `.gaia/config.json` in the current project. Supports `--user`, `--registry-ref`, and repeated `--scan` flags. |
+| `gaia doctor` | Checks CLI/config/registry health and reports missing setup pieces. |
 | `gaia scan` | Scans configured paths and reports detected canonical skills and possible fusions. |
 | `gaia push --dry-run` | Prints the batch intake JSON without writing files. |
 | `gaia push` | Writes a batch intake record under `intake/skill-batches/` in the registry checkout. |

--- a/plugin/cli/main.py
+++ b/plugin/cli/main.py
@@ -6,7 +6,7 @@ import json
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 try:
-    from plugin.cli.scanner import scan_repo, load_config
+    from plugin.cli.scanner import scan_repo, scan_repo_detailed, load_config
     from plugin.cli.resolver import resolve_skills
     from plugin.cli.combinator import get_combinations
     from plugin.cli.treeManager import load_tree, save_tree, show_status, show_tree
@@ -17,7 +17,7 @@ try:
     from plugin.cli.name import find_awakened_skill, promote_to_named, update_batch_lifecycle
     from plugin.cli.install import install_skill, sync_skills, uninstall_skill, list_installed
 except ModuleNotFoundError:
-    from cli.scanner import scan_repo, load_config
+    from cli.scanner import scan_repo, scan_repo_detailed, load_config
     from cli.resolver import resolve_skills
     from cli.combinator import get_combinations
     from cli.treeManager import load_tree, save_tree, show_status, show_tree
@@ -28,6 +28,9 @@ except ModuleNotFoundError:
     from cli.name import find_awakened_skill, promote_to_named, update_batch_lifecycle
     from cli.install import install_skill, sync_skills, uninstall_skill, list_installed
 
+DEFAULT_REGISTRY_REF = "https://github.com/mbtiongson1/gaia-skill-tree"
+
+
 def init_command(args):
     config_dir = '.gaia'
     os.makedirs(config_dir, exist_ok=True)
@@ -35,15 +38,18 @@ def init_command(args):
     if os.path.exists(config_path):
         print("Gaia is already initialized in this repository.")
         return
+
+    scan_paths = args.scan or ["scripts", "plugin"]
     config = {
-        "gaiaUser": "gaiabot",
-        "gaiaRegistryRef": "https://github.com/gaia-registry/gaia",
-        "scanPaths": ["scripts", "plugin"],
-        "autoPromptCombinations": False
+        "gaiaUser": args.user or "gaiabot",
+        "gaiaRegistryRef": args.registry_ref or DEFAULT_REGISTRY_REF,
+        "scanPaths": scan_paths,
+        "autoPromptCombinations": args.auto_prompt_combinations,
     }
     with open(config_path, 'w') as f:
         json.dump(config, f, indent=2)
     print(f"Initialized Gaia configuration at {config_path}")
+
 
 def scan_command(args):
     config = load_config()
@@ -51,11 +57,21 @@ def scan_command(args):
         print("Gaia not initialized. Run `gaia init` first.")
         return
     print("Scanning repository...")
-    raw_tokens = scan_repo()
+    scan_result = scan_repo_detailed()
+    raw_tokens = scan_result["tokens"]
     resolved = resolve_skills(raw_tokens, registry_path=os.path.join(args.registry, 'graph/gaia.json'))
-    print(f"Found {len(resolved)} skills referenced in the repository.")
+    print(
+        f"Scanned {scan_result['files_scanned']} file(s) across "
+        f"{len(scan_result['paths_found'])} configured path(s)."
+    )
+    if scan_result["paths_missing"]:
+        print("Missing scan paths: " + ", ".join(scan_result["paths_missing"]))
+    print(f"Found {scan_result['candidate_count']} candidate token(s).")
+    print(f"Matched {len(resolved)} canonical skill(s).")
     if resolved:
         print(", ".join(resolved))
+    else:
+        print('Tip: try `gaia search "code review"` or expand scanPaths.')
     username = config.get('gaiaUser')
     tree = load_tree(username, registry_path=args.registry)
     if tree:
@@ -74,8 +90,41 @@ def status_command(args):
     if not config:
         print("Gaia not initialized.")
         return
-    tree = load_tree(config.get('gaiaUser'), registry_path=args.registry)
+    username = config.get('gaiaUser')
+    tree = load_tree(username, registry_path=args.registry)
+    if not tree:
+        print(f'No skill tree found for user "{username}".')
+        print("Next steps:")
+        print("  gaia scan")
+        print("  gaia push --dry-run")
+        print("  gaia push --no-pr")
+        print(f"Or create users/{username}/skill-tree.json in the registry.")
+        return
     show_status(tree)
+
+
+def doctor_command(args):
+    config_path = os.path.join('.gaia', 'config.json')
+    config = load_config()
+    registry_path = os.path.abspath(args.registry)
+    print("Gaia CLI: OK")
+    print(f"Registry path: {args.registry}")
+    print(f"Registry graph: {'found' if os.path.exists(os.path.join(registry_path, 'graph', 'gaia.json')) else 'missing'}")
+    print(f"Config: {config_path if os.path.exists(config_path) else 'missing'}")
+    if not config:
+        print("User: unknown")
+        print("Skill tree: unknown")
+        return
+
+    username = config.get('gaiaUser')
+    print(f"User: {username}")
+    tree_path = os.path.join(registry_path, 'users', username or '', 'skill-tree.json')
+    print(f"Skill tree: {'found' if os.path.exists(tree_path) else 'missing'}")
+    embeddings_path = os.path.join(registry_path, 'graph', 'embeddings.json')
+    print(f"Embeddings: {'found' if os.path.exists(embeddings_path) else 'missing'}")
+    print("Scan paths:")
+    for path in config.get('scanPaths', []):
+        print(f"  - {path} {'exists' if os.path.exists(path) else 'missing'}")
 
 def tree_command(args):
     config = load_config()
@@ -261,9 +310,19 @@ def main():
     parser = argparse.ArgumentParser(prog="gaia", description="Gaia Plugin CLI")
     parser.add_argument('--registry', default=".", help="Path to local Gaia registry clone for testing")
     subparsers = parser.add_subparsers(dest='command')
-    subparsers.add_parser('init')
+    init_parser = subparsers.add_parser('init')
+    init_parser.add_argument('--user', help='Gaia username to write into .gaia/config.json')
+    init_parser.add_argument('--registry-ref', help='Gaia registry URL to write into .gaia/config.json')
+    init_parser.add_argument('--scan', action='append', help='Path to scan; repeat for multiple paths')
+    init_parser.add_argument('--yes', action='store_true', help='Use non-interactive defaults')
+    init_parser.add_argument(
+        '--auto-prompt-combinations',
+        action='store_true',
+        help='Enable automatic prompts for detected skill combinations',
+    )
     subparsers.add_parser('scan')
     subparsers.add_parser('status')
+    subparsers.add_parser('doctor')
     subparsers.add_parser('tree')
     fuse_parser = subparsers.add_parser('fuse')
     fuse_parser.add_argument('skillId', help="ID of the pending skill to fuse")
@@ -303,6 +362,8 @@ def main():
         scan_command(args)
     elif args.command == 'status':
         status_command(args)
+    elif args.command == 'doctor':
+        doctor_command(args)
     elif args.command == 'tree':
         tree_command(args)
     elif args.command == 'fuse':

--- a/plugin/cli/scanner.py
+++ b/plugin/cli/scanner.py
@@ -2,12 +2,48 @@ import json
 import os
 import re
 
+DEFAULT_EXCLUDED_DIRS = {
+    ".git",
+    ".hg",
+    ".svn",
+    ".next",
+    ".nuxt",
+    ".turbo",
+    ".cache",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".venv",
+    "venv",
+    "env",
+    "node_modules",
+    "dist",
+    "build",
+    "coverage",
+    "vendor",
+    "__pycache__",
+}
+
+DEFAULT_EXCLUDED_EXTENSIONS = (
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".webp",
+    ".ico",
+    ".pdf",
+    ".pyc",
+    ".o",
+    ".gexf",
+)
+
+
 def load_config():
     config_path = '.gaia/config.json'
     if not os.path.exists(config_path):
         return None
     with open(config_path, 'r') as f:
         return json.load(f)
+
 
 def scan_file_for_skills(filepath):
     skill_pattern = re.compile(r'\b[a-z][a-z0-9]*(-[a-z0-9]+)*\b')
@@ -21,18 +57,53 @@ def scan_file_for_skills(filepath):
         pass
     return found_skills
 
-def scan_repo():
+
+def _should_scan_file(filename):
+    return not filename.startswith('.') and not filename.endswith(DEFAULT_EXCLUDED_EXTENSIONS)
+
+
+def scan_repo_detailed():
     config = load_config()
+    empty = {
+        "tokens": set(),
+        "files_scanned": 0,
+        "candidate_count": 0,
+        "paths_found": [],
+        "paths_missing": [],
+    }
     if not config:
-        return set()
+        return empty
+
     scan_paths = config.get('scanPaths', [])
     all_found = set()
+    files_scanned = 0
+    paths_found = []
+    paths_missing = []
+
     for path in scan_paths:
         if os.path.isfile(path):
+            paths_found.append(path)
             all_found.update(scan_file_for_skills(path))
+            files_scanned += 1
         elif os.path.isdir(path):
-            for root, _, files in os.walk(path):
+            paths_found.append(path)
+            for root, dirs, files in os.walk(path):
+                dirs[:] = [d for d in dirs if d not in DEFAULT_EXCLUDED_DIRS and not d.startswith('.')]
                 for file in files:
-                    if not file.startswith('.') and not file.endswith(('.png', '.jpg', '.pyc', '.o', '.gexf')):
+                    if _should_scan_file(file):
                         all_found.update(scan_file_for_skills(os.path.join(root, file)))
-    return all_found
+                        files_scanned += 1
+        else:
+            paths_missing.append(path)
+
+    return {
+        "tokens": all_found,
+        "files_scanned": files_scanned,
+        "candidate_count": len(all_found),
+        "paths_found": paths_found,
+        "paths_missing": paths_missing,
+    }
+
+
+def scan_repo():
+    return scan_repo_detailed()["tokens"]

--- a/tests/test_dx.py
+++ b/tests/test_dx.py
@@ -1,0 +1,124 @@
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from plugin.cli.main import main
+from plugin.cli.scanner import scan_repo, scan_repo_detailed
+
+
+def run_cli(monkeypatch, argv):
+    monkeypatch.setattr(sys, "argv", ["gaia", *argv])
+    main()
+
+
+def test_init_accepts_flags_and_uses_current_registry_default(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    run_cli(
+        monkeypatch,
+        [
+            "init",
+            "--user",
+            "juno",
+            "--scan",
+            "AGENTS.md",
+            "--scan",
+            "scripts",
+        ],
+    )
+
+    config = json.loads((tmp_path / ".gaia" / "config.json").read_text())
+    assert config["gaiaUser"] == "juno"
+    assert config["gaiaRegistryRef"] == "https://github.com/mbtiongson1/gaia-skill-tree"
+    assert config["scanPaths"] == ["AGENTS.md", "scripts"]
+    assert config["autoPromptCombinations"] is False
+
+
+def test_init_yes_mode_preserves_non_interactive_defaults(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    run_cli(monkeypatch, ["init", "--yes"])
+
+    config = json.loads((tmp_path / ".gaia" / "config.json").read_text())
+    assert config["gaiaUser"] == "gaiabot"
+    assert config["gaiaRegistryRef"] == "https://github.com/mbtiongson1/gaia-skill-tree"
+    assert config["scanPaths"] == ["scripts", "plugin"]
+
+
+def test_scan_repo_skips_generated_and_vendor_directories(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".gaia").mkdir()
+    (tmp_path / ".gaia" / "config.json").write_text(
+        json.dumps({"scanPaths": ["."], "gaiaUser": "juno"})
+    )
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("web-search\n")
+    (tmp_path / "node_modules").mkdir()
+    (tmp_path / "node_modules" / "noise.js").write_text("voice-agent\n")
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git" / "packed-refs").write_text("autonomous-debug\n")
+
+    tokens = scan_repo()
+
+    assert "web-search" in tokens
+    assert "voice-agent" not in tokens
+    assert "autonomous-debug" not in tokens
+
+
+def test_scan_repo_detailed_reports_file_and_candidate_counts(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".gaia").mkdir()
+    (tmp_path / ".gaia" / "config.json").write_text(
+        json.dumps({"scanPaths": ["docs"], "gaiaUser": "juno"})
+    )
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "one.md").write_text("web-search and code-generation")
+    (tmp_path / "docs" / "image.png").write_bytes(b"not scanned")
+
+    detailed = scan_repo_detailed()
+
+    assert detailed["files_scanned"] == 1
+    assert detailed["paths_found"] == ["docs"]
+    assert "web-search" in detailed["tokens"]
+    assert detailed["candidate_count"] >= 2
+
+
+def test_status_missing_tree_prints_next_steps(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".gaia").mkdir()
+    (tmp_path / ".gaia" / "config.json").write_text(
+        json.dumps({"scanPaths": ["."], "gaiaUser": "juno"})
+    )
+    registry = tmp_path / "registry"
+    registry.mkdir()
+
+    run_cli(monkeypatch, ["--registry", str(registry), "status"])
+
+    out = capsys.readouterr().out
+    assert 'No skill tree found for user "juno".' in out
+    assert "gaia scan" in out
+    assert "gaia push --dry-run" in out
+
+
+def test_doctor_reports_installation_state(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".gaia").mkdir()
+    (tmp_path / ".gaia" / "config.json").write_text(
+        json.dumps({"scanPaths": ["AGENTS.md"], "gaiaUser": "juno"})
+    )
+    (tmp_path / "AGENTS.md").write_text("tool-use")
+    registry = tmp_path / "registry"
+    (registry / "graph").mkdir(parents=True)
+    (registry / "graph" / "gaia.json").write_text(json.dumps({"skills": []}))
+
+    run_cli(monkeypatch, ["--registry", str(registry), "doctor"])
+
+    out = capsys.readouterr().out
+    assert "Gaia CLI: OK" in out
+    assert f"Registry path: {registry}" in out
+    assert "Config: .gaia/config.json" in out
+    assert "User: juno" in out
+    assert "Skill tree: missing" in out
+    assert "AGENTS.md exists" in out


### PR DESCRIPTION
## Summary
- Fix `gaia init` to default to the current gaia-skill-tree registry URL
- Add `gaia init` flags for user, registry ref, scan paths, and auto prompt combinations
- Add `gaia doctor` for CLI/config/registry health checks
- Improve scan output with file/token counts and skip common generated/vendor folders
- Improve missing skill tree guidance and document the smoother setup flow

## Test Plan
- `pytest -q`
- Smoke-tested `gaia init`, `gaia doctor`, and `gaia scan` in a temporary workspace
