### PR TITLE
[intake] gaiabot skill batch - mbtiongson1/gaia-skill-tree

### DIFF
--- a/.gaia-intake-pr-body.md
+++ b/.gaia-intake-pr-body.md
@@ -1,0 +1,1738 @@
+## Gaia Draft Skill Intake
+
+This PR submits a draft intake batch for human review.
+The canonical intake artifact is the JSON file in `intake/skill-batches/`.
+Accepted skills must be promoted separately into `graph/gaia.json`.
+
+### Batch Summary
+- User: `gaiabot`
+- Source repo: `mbtiongson1/gaia-skill-tree`
+- Generated at: `2026-04-29T13:50:08Z`
+- Known skills: `51`
+- Proposed skills: `1709`
+
+### Proposed Skills
+| ID | Name | Type | Similarity hints |
+|---|---|---|---|
+| `a-z` | A-z | `atomic` | - |
+| `a-z0-9` | A-z0-9 | `atomic` | - |
+| `abductive` | Abductive | `atomic` | `retrieve` (0.471) |
+| `above` | Above | `atomic` | - |
+| `abs` | Abs | `atomic` | - |
+| `absolute` | Absolute | `atomic` | `translate` (0.588), `tool-use` (0.500) |
+| `abspath` | Abspath | `atomic` | `translate` (0.500) |
+| `accents` | Accents | `atomic` | `extract-entities` (0.522), `chunk-document` (0.476) |
+| `accept` | Accept | `atomic` | - |
+| `accepted` | Accepted | `atomic` | `parse-pdf` (0.471) |
+| `access` | Access | `atomic` | - |
+| `accidentally` | Accidentally | `atomic` | `document-analyst` (0.500), `api-call` (0.500) |
+| `accuracy` | Accuracy | `atomic` | - |
+| `accurate` | Accurate | `atomic` | `translate` (0.471), `image-generate` (0.455) |
+| `achieves` | Achieves | `atomic` | `retrieve` (0.500), `cite-sources` (0.500) |
+| `achieving` | Achieving | `atomic` | `re-act-reasoning` (0.500), `rag-pipeline` (0.476) |
+| `across` | Across | `atomic` | - |
+| `act` | Act | `atomic` | - |
+| `acting` | Acting | `atomic` | `re-act-reasoning` (0.571), `image-caption` (0.526) |
+| `action` | Action | `atomic` | `image-caption` (0.632), `code-execution` (0.500) |
+| `actions` | Actions | `atomic` | `image-caption` (0.600), `code-execution` (0.476) |
+| `actual` | Actual | `atomic` | `api-call` (0.571), `data-visualize` (0.500) |
+| `adapting` | Adapting | `atomic` | `image-caption` (0.571), `automated-testing` (0.480) |
+| `add` | Add | `atomic` | - |
+| `added` | Added | `atomic` | - |
+| `additions` | Additions | `atomic` | `document-digitization` (0.467), `image-caption` (0.455) |
+| `adjacency` | Adjacency | `atomic` | - |
+| `advancement` | Advancement | `atomic` | `audience-model` (0.560), `voice-agent` (0.545) |
+| `after` | After | `atomic` | - |
+| `against` | Against | `atomic` | `translate` (0.500), `image-caption` (0.500) |
+| `agent` | Agent | `atomic` | `voice-agent` (0.625), `image-generate` (0.526) |
+| `agent-native` | Agent-native | `atomic` | `image-caption` (0.560), `image-generate` (0.538) |
+| `agent-related` | Agent-related | `atomic` | `image-generate` (0.593), `generate-sql` (0.560) |
+| `agents` | Agents | `atomic` | `voice-agent` (0.588), `generate-sql` (0.556) |
+| `ahead` | Ahead | `atomic` | `math-reason` (0.500) |
+| `ai-agent` | Ai-agent | `atomic` | `voice-agent` (0.737), `conversational-agent` (0.571) |
+| `ai-agent-tool` | Ai-agent-tool | `atomic` | `voice-agent` (0.583), `audience-model` (0.519) |
+| `algebra` | Algebra | `atomic` | `image-generate` (0.476), `web-scrape` (0.471) |
+| `alive` | Alive | `atomic` | `rag-pipeline` (0.471), `retrieve` (0.462) |
+| `all` | All | `atomic` | `api-call` (0.545) |
+| `allocation` | Allocation | `atomic` | `image-caption` (0.609), `code-execution` (0.500) |
+| `allowed` | Allowed | `atomic` | - |
+| `also` | Also | `atomic` | - |
+| `analyses` | Analyses | `atomic` | `data-analysis` (0.667), `sentiment-analysis` (0.538) |
+| `analysis` | Analysis | `atomic` | `data-analysis` (0.762), `sentiment-analysis` (0.615) |
+| `anomaly` | Anomaly | `atomic` | `detect-anomaly` (0.667), `data-analysis` (0.500) |
+| `another` | Another | `atomic` | `translate` (0.500) |
+| `answer` | Answer | `atomic` | `question-answer` (0.571), `translate` (0.533) |
+| `answers` | Answers | `atomic` | `question-answer` (0.545), `translate` (0.500) |
+| `any` | Any | `atomic` | `rank` (0.571) |
+| `api` | Api | `atomic` | `api-call` (0.545) |
+| `api-version` | Api-version | `atomic` | `math-reason` (0.545), `rag-pipeline` (0.522) |
+| `appears` | Appears | `atomic` | `parse-pdf` (0.500), `parse-json` (0.471) |
+| `append` | Append | `atomic` | `rag-pipeline` (0.556) |
+| `application` | Application | `atomic` | `api-call` (0.526), `rag-pipeline` (0.522) |
+| `apply` | Apply | `atomic` | `rag-pipeline` (0.471), `api-call` (0.462) |
+| `approach` | Approach | `atomic` | `research` (0.500) |
+| `appropriate` | Appropriate | `atomic` | `ghostwrite` (0.476) |
+| `approval` | Approval | `atomic` | `api-call` (0.500) |
+| `archived` | Archived | `atomic` | `retrieve` (0.500), `research` (0.500) |
+| `argparse` | Argparse | `atomic` | `parse-pdf` (0.588), `parse-json` (0.556) |
+| `args` | Args | `atomic` | `parse-pdf` (0.462) |
+| `arguments` | Arguments | `atomic` | `voice-agent` (0.500), `document-analyst` (0.480) |
+| `argv` | Argv | `atomic` | - |
+| `arithmetic` | Arithmetic | `atomic` | `write-report` (0.455), `route-intent` (0.455) |
+| `array` | Array | `atomic` | - |
+| `arrays` | Arrays | `atomic` | `math-reason` (0.471) |
+| `arriving` | Arriving | `atomic` | `retrieve` (0.500) |
+| `artifact` | Artifact | `atomic` | `refactor-code` (0.476) |
+| `artifacts` | Artifacts | `atomic` | `refactor-code` (0.455) |
+| `arxiv` | Arxiv | `atomic` | `retrieve` (0.462) |
+| `asdict` | Asdict | `atomic` | - |
+| `assembles` | Assembles | `atomic` | `parse-html` (0.526) |
+| `assert` | Assert | `atomic` | `parse-html` (0.500) |
+| `assistant` | Assistant | `atomic` | `real-time-voice-assistant` (0.529), `classify` (0.471) |
+| `assistants` | Assistants | `atomic` | `real-time-voice-assistant` (0.514) |
+| `async` | Async | `atomic` | `classify` (0.462) |
+| `atomic` | Atomic | `atomic` | - |
+| `atomics` | Atomics | `atomic` | - |
+| `attrib` | Attrib | `atomic` | - |
+| `attribute` | Attribute | `atomic` | `ghostwrite` (0.526), `retrieve` (0.471) |
+| `attributes` | Attributes | `atomic` | `ghostwrite` (0.500), `math-reason` (0.476) |
+| `attvalue` | Attvalue | `atomic` | `data-visualize` (0.545), `tool-use` (0.500) |
+| `attvalues` | Attvalues | `atomic` | `data-visualize` (0.522), `tool-use` (0.471) |
+| `audience` | Audience | `atomic` | `audience-model` (0.727), `rag-pipeline` (0.500) |
+| `audience-tailored` | Audience-tailored | `atomic` | `audience-model` (0.645) |
+| `audio` | Audio | `atomic` | `audience-model` (0.526) |
+| `augmented` | Augmented | `atomic` | `image-generate` (0.522), `audience-model` (0.522) |
+| `auth` | Auth | `atomic` | - |
+| `authenticated` | Authenticated | `atomic` | `extract-entities` (0.552), `audience-model` (0.519) |
+| `author` | Author | `atomic` | `math-reason` (0.471) |
+| `authoritative` | Authoritative | `atomic` | `ghostwrite` (0.522), `retrieve` (0.476) |
+| `auto-generated` | Auto-generated | `atomic` | `image-generate` (0.714), `code-generation` (0.621) |
+| `auto-prompt-combinations` | Auto-prompt-combinations | `atomic` | `autonomous-data-scientist` (0.490), `browser-automation` (0.476) |
+| `autogen` | Autogen | `atomic` | `tokenize` (0.533) |
+| `automated` | Automated | `atomic` | `automated-testing` (0.692), `browser-automation` (0.519) |
+| `automatic` | Automatic | `atomic` | `automated-testing` (0.615), `browser-automation` (0.593) |
+| `automatically` | Automatically | `atomic` | `api-call` (0.571), `automated-testing` (0.533) |
+| `autonomous` | Autonomous | `atomic` | `autonomous-debug` (0.769), `autonomous-research-agent` (0.571) |
+| `autonomously` | Autonomously | `atomic` | `autonomous-debug` (0.714), `autonomous-research-agent` (0.541) |
+| `autoregressive` | Autoregressive | `atomic` | `retrieve` (0.545), `automated-testing` (0.516) |
+| `autoresearch` | Autoresearch | `atomic` | `research` (0.800), `autonomous-research-agent` (0.649) |
+| `availability` | Availability | `atomic` | - |
+| `available` | Available | `atomic` | `api-call` (0.471) |
+| `await` | Await | `atomic` | - |
+| `awakened` | Awakened | `atomic` | `tokenize` (0.500), `audience-model` (0.455) |
+| `awareness` | Awareness | `atomic` | `data-analysis` (0.455) |
+| `back` | Back | `atomic` | `rank` (0.500) |
+| `backends` | Backends | `atomic` | - |
+| `based` | Based | `atomic` | `parse-pdf` (0.571) |
+| `baseline` | Baseline | `atomic` | `rag-pipeline` (0.600), `translation-pipeline` (0.500) |
+| `baselines` | Baselines | `atomic` | `rag-pipeline` (0.571), `translation-pipeline` (0.483) |
+| `bash` | Bash | `atomic` | `execute-bash` (0.500) |
+| `batch` | Batch | `atomic` | `web-search` (0.533), `research` (0.462) |
+| `batched` | Batched | `atomic` | `web-search` (0.471) |
+| `batches` | Batches | `atomic` | `math-reason` (0.556), `web-search` (0.471) |
+| `becomes` | Becomes | `atomic` | `computer-use` (0.526), `plan-decompose` (0.476) |
+| `been` | Been | `atomic` | - |
+| `before` | Before | `atomic` | `refactor-code` (0.526) |
+| `begin` | Begin | `atomic` | - |
+| `behavior` | Behavior | `atomic` | - |
+| `being` | Being | `atomic` | - |
+| `beliefs` | Beliefs | `atomic` | - |
+| `bench` | Bench | `atomic` | `web-search` (0.533), `research` (0.462) |
+| `benchmark` | Benchmark | `atomic` | - |
+| `benchmarked` | Benchmarked | `atomic` | - |
+| `benchmarks` | Benchmarks | `atomic` | - |
+| `between` | Between | `atomic` | `retrieve` (0.533), `embed-text` (0.471) |
+| `bibliographic` | Bibliographic | `atomic` | - |
+| `bin` | Bin | `atomic` | - |
+| `binary` | Binary | `atomic` | - |
+| `blob` | Blob | `atomic` | - |
+| `block` | Block | `atomic` | - |
+| `body` | Body | `atomic` | - |
+| `body-file` | Body-file | `atomic` | - |
+| `bool` | Bool | `atomic` | `tool-use` (0.500) |
+| `boolean` | Boolean | `atomic` | `tool-use` (0.533), `score-relevance` (0.455) |
+| `booleans` | Booleans | `atomic` | `tool-use` (0.500) |
+| `bootstrapped` | Bootstrapped | `atomic` | `web-scrape` (0.545), `ghostwrite` (0.455) |
+| `bot` | Bot | `atomic` | - |
+| `bot-proposal` | Bot-proposal | `atomic` | - |
+| `bpush` | Bpush | `atomic` | - |
+| `branch` | Branch | `atomic` | `rank` (0.600), `research` (0.571) |
+| `break` | Break | `atomic` | `rank` (0.667), `research` (0.462) |
+| `broken` | Broken | `atomic` | `tokenize` (0.571) |
+| `browsers` | Browsers | `atomic` | `browser-automation` (0.538), `research` (0.500) |
+| `bucket` | Bucket | `atomic` | - |
+| `buckets` | Buckets | `atomic` | - |
+| `buffer` | Buffer | `atomic` | - |
+| `bugs` | Bugs | `atomic` | - |
+| `build` | Build | `atomic` | - |
+| `built` | Built | `atomic` | - |
+| `bundler` | Bundler | `atomic` | - |
+| `but` | But | `atomic` | - |
+| `bytecode` | Bytecode | `atomic` | `refactor-code` (0.476), `audience-model` (0.455) |
+| `cache` | Cache | `atomic` | `research` (0.462) |
+| `calculus` | Calculus | `atomic` | `api-call` (0.500) |
+| `call` | Call | `atomic` | `api-call` (0.667) |
+| `calling` | Calling | `atomic` | `api-call` (0.533), `re-act-reasoning` (0.455) |
+| `calls` | Calls | `atomic` | `api-call` (0.615), `classify` (0.462) |
+| `came` | Came | `atomic` | - |
+| `can` | Can | `atomic` | `rank` (0.571) |
+| `candidate` | Candidate | `atomic` | `translate` (0.556) |
+| `candidates` | Candidates | `atomic` | `translate` (0.526), `extract-entities` (0.462) |
+| `cannot` | Cannot | `atomic` | `voice-agent` (0.471), `chain-of-thought` (0.455) |
+| `canonical` | Canonical | `atomic` | `api-call` (0.588), `detect-anomaly` (0.522) |
+| `capability` | Capability | `atomic` | `rag-pipeline` (0.455) |
+| `capitalize` | Capitalize | `atomic` | `data-visualize` (0.583), `api-call` (0.556) |
+| `caps` | Caps | `atomic` | `classify` (0.500) |
+| `captures` | Captures | `atomic` | `cite-sources` (0.600), `math-reason` (0.526) |
+| `capturing` | Capturing | `atomic` | `image-caption` (0.545), `chain-of-thought` (0.457) |
+| `case` | Case | `atomic` | `classify` (0.500), `translate` (0.462) |
+| `cases` | Cases | `atomic` | `classify` (0.615), `parse-json` (0.533) |
+| `catch` | Catch | `atomic` | `research` (0.462) |
+| `catches` | Catches | `atomic` | `math-reason` (0.556), `cite-sources` (0.526) |
+| `categorical` | Categorical | `atomic` | `api-call` (0.526), `cite-sources` (0.522) |
+| `categories` | Categories | `atomic` | `cite-sources` (0.636), `extract-entities` (0.462) |
+| `categorization` | Categorization | `atomic` | `content-moderation` (0.625), `code-generation` (0.621) |
+| `category` | Category | `atomic` | `cite-sources` (0.500) |
+| `caught` | Caught | `atomic` | `chain-of-thought` (0.545), `voice-agent` (0.471) |
+| `causes` | Causes | `atomic` | `classify` (0.571), `parse-json` (0.500) |
+| `chain` | Chain | `atomic` | `chain-of-thought` (0.476), `classify` (0.462) |
+| `chain-of-thought-hub` | Chain-of-thought-hub | `atomic` | `chain-of-thought` (0.889) |
+| `chain-of-thought-only` | Chain-of-thought-only | `atomic` | `chain-of-thought` (0.865) |
+| `chains` | Chains | `atomic` | `chain-of-thought` (0.455) |
+| `change` | Change | `atomic` | `voice-agent` (0.471), `chain-of-thought` (0.455) |
+| `changed` | Changed | `atomic` | - |
+| `changes` | Changes | `atomic` | - |
+| `changing` | Changing | `atomic` | `re-act-reasoning` (0.522), `chain-of-thought` (0.500) |
+| `charts` | Charts | `atomic` | - |
+| `check` | Check | `atomic` | - |
+| `checker` | Checker | `atomic` | - |
+| `checkout` | Checkout | `atomic` | `code-execution` (0.455) |
+| `checks` | Checks | `atomic` | - |
+| `chemistry` | Chemistry | `atomic` | `registry-curation` (0.462) |
+| `chemists` | Chemists | `atomic` | - |
+| `child` | Child | `atomic` | - |
+| `children` | Children | `atomic` | `chunk-document` (0.455) |
+| `chr` | Chr | `atomic` | - |
+| `chunk` | Chunk | `atomic` | `chunk-document` (0.526) |
+| `chunking` | Chunking | `atomic` | `chunk-document` (0.545) |
+| `citation` | Citation | `atomic` | `image-caption` (0.571), `document-digitization` (0.552) |
+| `citations` | Citations | `atomic` | `image-caption` (0.545), `document-digitization` (0.533) |
+| `claims` | Claims | `atomic` | `classify` (0.571) |
+| `clarity` | Clarity | `atomic` | `classify` (0.667) |
+| `class` | Class | `atomic` | `classify` (0.769) |
+| `classification` | Classification | `atomic` | `classify` (0.636), `image-caption` (0.519) |
+| `classifier` | Classifier | `atomic` | `classify` (0.778) |
+| `cleaned` | Cleaned | `atomic` | `score-relevance` (0.545) |
+| `cli` | Cli | `atomic` | `classify` (0.545) |
+| `click` | Click | `atomic` | `classify` (0.462) |
+| `clicks` | Clicks | `atomic` | - |
+| `clone` | Clone | `atomic` | `diff-content` (0.471), `tokenize` (0.462) |
+| `cloning` | Cloning | `atomic` | `re-act-reasoning` (0.545) |
+| `closing` | Closing | `atomic` | `classify` (0.533), `re-act-reasoning` (0.455) |
+| `clustering` | Clustering | `atomic` | `route-intent` (0.455), `computer-use` (0.455) |
+| `cmd` | Cmd | `atomic` | - |
+| `co-references` | Co-references | `atomic` | `score-relevance` (0.643), `logical-inference` (0.600) |
+| `code` | Code | `atomic` | `refactor-code` (0.471) |
+| `codec` | Codec | `atomic` | `code-execution` (0.526) |
+| `codegen` | Codegen | `atomic` | `code-generation` (0.636), `code-execution` (0.571) |
+| `codes` | Codes | `atomic` | `computer-use` (0.471), `cite-sources` (0.471) |
+| `coherent` | Coherent | `atomic` | `voice-agent` (0.526), `route-intent` (0.500) |
+| `collections` | Collections | `atomic` | `code-execution` (0.640), `tool-select` (0.545) |
+| `color` | Color | `atomic` | - |
+| `com` | Com | `atomic` | - |
+| `combination` | Combination | `atomic` | `code-generation` (0.615), `content-moderation` (0.552) |
+| `combinations` | Combinations | `atomic` | `code-generation` (0.593), `content-moderation` (0.533) |
+| `combinator` | Combinator | `atomic` | `code-generation` (0.480), `computer-use` (0.455) |
+| `combine` | Combine | `atomic` | - |
+| `combining` | Combining | `atomic` | `re-act-reasoning` (0.500) |
+| `combo` | Combo | `atomic` | - |
+| `combos` | Combos | `atomic` | `plan-decompose` (0.500) |
+| `command` | Command | `atomic` | - |
+| `commands` | Commands | `atomic` | - |
+| `comment` | Comment | `atomic` | `chunk-document` (0.571), `diff-content` (0.526) |
+| `commit` | Commit | `atomic` | - |
+| `common` | Common | `atomic` | - |
+| `community` | Community | `atomic` | `computer-use` (0.476) |
+| `comparisons` | Comparisons | `atomic` | `parse-json` (0.571), `math-reason` (0.545) |
+| `compatible` | Compatible | `atomic` | `computer-use` (0.545), `conversational-agent` (0.467) |
+| `competition` | Competition | `atomic` | `document-digitization` (0.562), `code-execution` (0.560) |
+| `compile` | Compile | `atomic` | `computer-use` (0.526), `plan-decompose` (0.476) |
+| `complete` | Complete | `atomic` | `computer-use` (0.600), `plan-decompose` (0.455) |
+| `completes` | Completes | `atomic` | `computer-use` (0.667), `automated-testing` (0.462) |
+| `completing` | Completing | `atomic` | `automated-testing` (0.519), `content-moderation` (0.500) |
+| `completion` | Completion | `atomic` | `code-execution` (0.583), `content-moderation` (0.571) |
+| `complex` | Complex | `atomic` | `computer-use` (0.526), `plan-decompose` (0.476) |
+| `complexity` | Complexity | `atomic` | `computer-use` (0.455) |
+| `composite` | Composite | `atomic` | `plan-decompose` (0.609), `computer-use` (0.571) |
+| `composites` | Composites | `atomic` | `computer-use` (0.636), `plan-decompose` (0.583) |
+| `comprehension` | Comprehension | `atomic` | `code-generation` (0.571), `parse-json` (0.522) |
+| `comprehensive` | Comprehensive | `atomic` | `score-relevance` (0.500), `computer-use` (0.480) |
+| `computation` | Computation | `atomic` | `code-execution` (0.560), `content-moderation` (0.552) |
+| `compute` | Compute | `atomic` | `computer-use` (0.737), `format-output` (0.500) |
+| `computer` | Computer | `atomic` | `computer-use` (0.800), `format-output` (0.476) |
+| `computes` | Computes | `atomic` | `computer-use` (0.800), `execute-bash` (0.500) |
+| `conclusions` | Conclusions | `atomic` | `code-execution` (0.560), `question-answer` (0.462) |
+| `condition` | Condition | `atomic` | `code-execution` (0.609), `content-moderation` (0.593) |
+| `conditions` | Conditions | `atomic` | `code-execution` (0.583), `content-moderation` (0.571) |
+| `conducts` | Conducts | `atomic` | `computer-use` (0.500), `cite-sources` (0.500) |
+| `config` | Config | `atomic` | `re-act-reasoning` (0.476) |
+| `configurable` | Configurable | `atomic` | - |
+| `configuration` | Configuration | `atomic` | `code-generation` (0.643), `content-moderation` (0.581) |
+| `configured` | Configured | `atomic` | `computer-use` (0.455), `cite-sources` (0.455) |
+| `confirm` | Confirm | `atomic` | - |
+| `confirmed` | Confirmed | `atomic` | `tokenize` (0.471) |
+| `conflict` | Conflict | `atomic` | - |
+| `conform` | Conform | `atomic` | - |
+| `connector` | Connector | `atomic` | `code-execution` (0.522), `content-moderation` (0.519) |
+| `consecutive` | Consecutive | `atomic` | `code-execution` (0.560), `retrieve` (0.526) |
+| `console` | Console | `atomic` | `tool-use` (0.533), `conversational-agent` (0.519) |
+| `const` | Const | `atomic` | `diff-content` (0.471) |
+| `constrained` | Constrained | `atomic` | `ghostwrite` (0.571), `content-moderation` (0.552) |
+| `constraints` | Constraints | `atomic` | `ghostwrite` (0.571), `content-moderation` (0.552) |
+| `construction` | Construction | `atomic` | `knowledge-graph-build` (0.600), `content-moderation` (0.600) |
+| `contain` | Contain | `atomic` | `content-moderation` (0.560), `code-generation` (0.545) |
+| `containing` | Containing | `atomic` | `content-moderation` (0.500), `re-act-reasoning` (0.480) |
+| `content` | Content | `atomic` | `diff-content` (0.737), `route-intent` (0.632) |
+| `context` | Context | `atomic` | `diff-content` (0.632), `speech-to-text` (0.571) |
+| `context-grounded` | Context-grounded | `atomic` | `content-moderation` (0.588), `code-generation` (0.516) |
+| `contextually` | Contextually | `atomic` | `diff-content` (0.500), `sentiment-analysis` (0.467) |
+| `continuation` | Continuation | `atomic` | `content-moderation` (0.667), `code-generation` (0.593) |
+| `continue` | Continue | `atomic` | `code-generation` (0.522), `tokenize` (0.500) |
+| `contributor` | Contributor | `atomic` | `content-moderation` (0.483), `ghostwrite` (0.476) |
+| `control` | Control | `atomic` | `content-moderation` (0.480), `code-generation` (0.455) |
+| `controlled` | Controlled | `atomic` | `tool-select` (0.476), `conversational-agent` (0.467) |
+| `convention` | Convention | `atomic` | `content-moderation` (0.643), `code-generation` (0.640) |
+| `conversation` | Conversation | `atomic` | `conversational-agent` (0.750), `code-generation` (0.741) |
+| `conversational` | Conversational | `atomic` | `conversational-agent` (0.824), `code-generation` (0.690) |
+| `conversations` | Conversations | `atomic` | `conversational-agent` (0.727), `code-generation` (0.714) |
+| `convert` | Convert | `atomic` | `code-generation` (0.545), `diff-content` (0.526) |
+| `copilot` | Copilot | `atomic` | - |
+| `copy` | Copy | `atomic` | - |
+| `copy2` | Copy2 | `atomic` | - |
+| `core` | Core | `atomic` | `computer-use` (0.500), `cite-sources` (0.500) |
+| `corpora` | Corpora | `atomic` | `score-relevance` (0.455) |
+| `corpus` | Corpus | `atomic` | `computer-use` (0.556) |
+| `correct` | Correct | `atomic` | `score-relevance` (0.545), `code-execution` (0.476) |
+| `correctness` | Correctness | `atomic` | `score-relevance` (0.538), `cite-sources` (0.522) |
+| `cosine` | Cosine | `atomic` | `ghostwrite` (0.500), `conversational-agent` (0.462) |
+| `could` | Could | `atomic` | - |
+| `count` | Count | `atomic` | `route-intent` (0.471), `diff-content` (0.471) |
+| `coupling` | Coupling | `atomic` | `code-execution` (0.455) |
+| `coverage` | Coverage | `atomic` | `conversational-agent` (0.571), `voice-agent` (0.526) |
+| `covering` | Covering | `atomic` | `conversational-agent` (0.571), `code-generation` (0.522) |
+| `crawl` | Crawl | `atomic` | `api-call` (0.462) |
+| `crawler` | Crawler | `atomic` | `translate` (0.500), `web-scrape` (0.471) |
+| `crawlers` | Crawlers | `atomic` | `translate` (0.471) |
+| `crawling` | Crawling | `atomic` | `re-act-reasoning` (0.522), `rank` (0.500) |
+| `create` | Create | `atomic` | `retrieve` (0.571), `translate` (0.533) |
+| `created` | Created | `atomic` | `retrieve` (0.533), `translate` (0.500) |
+| `creating` | Creating | `atomic` | `re-act-reasoning` (0.609), `code-generation` (0.522) |
+| `creation` | Creation | `atomic` | `code-generation` (0.609), `image-caption` (0.571) |
+| `creator` | Creator | `atomic` | `refactor-code` (0.600), `retrieve` (0.533) |
+| `criteria` | Criteria | `atomic` | `write-report` (0.500), `cite-sources` (0.500) |
+| `cross-domain` | Cross-domain | `atomic` | `browser-automation` (0.600), `chunk-document` (0.462) |
+| `curation` | Curation | `atomic` | `registry-curation` (0.640), `code-generation` (0.609) |
+| `current` | Current | `atomic` | `chunk-document` (0.476) |
+| `cwd` | Cwd | `atomic` | - |
+| `cycle` | Cycle | `atomic` | - |
+| `cycles` | Cycles | `atomic` | - |
+| `dash` | Dash | `atomic` | - |
+| `data` | Data | `atomic` | `data-analysis` (0.471) |
+| `dataclass` | Dataclass | `atomic` | `data-analysis` (0.636), `classify` (0.588) |
+| `dataclasses` | Dataclasses | `atomic` | `data-analysis` (0.583), `classify` (0.526) |
+| `dataset` | Dataset | `atomic` | `data-visualize` (0.571), `data-analysis` (0.500) |
+| `datasets` | Datasets | `atomic` | `data-analysis` (0.571), `data-visualize` (0.545) |
+| `date` | Date | `atomic` | `translate` (0.462) |
+| `dates` | Dates | `atomic` | `math-reason` (0.500), `generate-sql` (0.471) |
+| `datetime` | Datetime | `atomic` | `tokenize` (0.500), `retrieve` (0.500) |
+| `days` | Days | `atomic` | `data-analysis` (0.471) |
+| `dead` | Dead | `atomic` | - |
+| `debugging` | Debugging | `atomic` | - |
+| `decay` | Decay | `atomic` | `detect-anomaly` (0.526), `classify` (0.462) |
+| `decide` | Decide | `atomic` | - |
+| `declaration` | Declaration | `atomic` | `code-generation` (0.615), `image-caption` (0.583) |
+| `decoding` | Decoding | `atomic` | `re-act-reasoning` (0.522), `code-execution` (0.455) |
+| `decomposed` | Decomposed | `atomic` | `plan-decompose` (0.750), `computer-use` (0.545) |
+| `decomposition` | Decomposition | `atomic` | `plan-decompose` (0.593), `image-caption` (0.538) |
+| `deductive` | Deductive | `atomic` | `retrieve` (0.588), `self-critique` (0.455) |
+| `dedup` | Dedup | `atomic` | - |
+| `deduplicate` | Deduplicate | `atomic` | - |
+| `def` | Def | `atomic` | - |
+| `default` | Default | `atomic` | - |
+| `defaultdict` | Defaultdict | `atomic` | - |
+| `defaultedgetype` | Defaultedgetype | `atomic` | `evaluate-output` (0.467) |
+| `defaults` | Defaults | `atomic` | - |
+| `defined` | Defined | `atomic` | - |
+| `definitions` | Definitions | `atomic` | `code-generation` (0.538), `document-digitization` (0.500) |
+| `delegates` | Delegates | `atomic` | `generate-sql` (0.571), `generate-test` (0.545) |
+| `deletions` | Deletions | `atomic` | `code-execution` (0.609), `code-generation` (0.583) |
+| `delimiter` | Delimiter | `atomic` | `self-critique` (0.455) |
+| `delta` | Delta | `atomic` | - |
+| `demonstrates` | Demonstrates | `atomic` | `generate-sql` (0.583), `generate-test` (0.560) |
+| `demonstrating` | Demonstrating | `atomic` | `code-generation` (0.571), `error-interpretation` (0.545) |
+| `demos` | Demos | `atomic` | `plan-decompose` (0.526) |
+| `dense` | Dense | `atomic` | `tokenize` (0.462), `research` (0.462) |
+| `dependencies` | Dependencies | `atomic` | - |
+| `depth` | Depth | `atomic` | - |
+| `deriv` | Deriv | `atomic` | `retrieve` (0.615) |
+| `derivative` | Derivative | `atomic` | `retrieve` (0.556), `self-critique` (0.522) |
+| `derivatives` | Derivatives | `atomic` | `retrieve` (0.526), `generate-sql` (0.522) |
+| `derive` | Derive | `atomic` | `retrieve` (0.714) |
+| `desc` | Desc | `atomic` | `research` (0.500) |
+| `descending` | Descending | `atomic` | `re-act-reasoning` (0.480), `code-generation` (0.480) |
+| `description` | Description | `atomic` | `image-caption` (0.583), `registry-curation` (0.571) |
+| `descriptions` | Descriptions | `atomic` | `image-caption` (0.560), `registry-curation` (0.552) |
+| `design` | Design | `atomic` | - |
+| `designs` | Designs | `atomic` | `question-answer` (0.455) |
+| `desktop` | Desktop | `atomic` | - |
+| `dest` | Dest | `atomic` | - |
+| `detail` | Detail | `atomic` | `detect-anomaly` (0.500), `data-visualize` (0.500) |
+| `detect` | Detect | `atomic` | `detect-anomaly` (0.600), `embed-text` (0.500) |
+| `detected` | Detected | `atomic` | `detect-anomaly` (0.545), `retrieve` (0.500) |
+| `detection` | Detection | `atomic` | `code-execution` (0.696), `detect-anomaly` (0.609) |
+| `detects` | Detects | `atomic` | `detect-anomaly` (0.571), `generate-test` (0.500) |
+| `dev` | Dev | `atomic` | - |
+| `development` | Development | `atomic` | `full-stack-developer` (0.516), `recursive-self-improvement` (0.486) |
+| `deviations` | Deviations | `atomic` | `code-generation` (0.560), `image-caption` (0.522) |
+| `dfs` | Dfs | `atomic` | - |
+| `diagnoses` | Diagnoses | `atomic` | - |
+| `dialogue` | Dialogue | `atomic` | `data-visualize` (0.455) |
+| `dict` | Dict | `atomic` | `diff-content` (0.500) |
+| `dicts` | Dicts | `atomic` | `diff-content` (0.471) |
+| `diff` | Diff | `atomic` | `diff-content` (0.500) |
+| `diffing` | Diffing | `atomic` | `diff-content` (0.526) |
+| `difflib` | Difflib | `atomic` | - |
+| `diffusion` | Diffusion | `atomic` | `diff-content` (0.571) |
+| `diffusion-based` | Diffusion-based | `atomic` | `question-answer` (0.600), `diff-content` (0.519) |
+| `dimensions` | Dimensions | `atomic` | `image-caption` (0.522), `sentiment-analysis` (0.500) |
+| `dir` | Dir | `atomic` | - |
+| `direct` | Direct | `atomic` | - |
+| `directed` | Directed | `atomic` | `audience-model` (0.545), `retrieve` (0.500) |
+| `directionally` | Directionally | `atomic` | `detect-anomaly` (0.593), `image-caption` (0.538) |
+| `directly` | Directly | `atomic` | `detect-anomaly` (0.545), `audience-model` (0.455) |
+| `directory` | Directory | `atomic` | `refactor-code` (0.545), `detect-anomaly` (0.522) |
+| `directs` | Directs | `atomic` | `re-act-reasoning` (0.455) |
+| `dirname` | Dirname | `atomic` | `translate` (0.500), `audience-model` (0.476) |
+| `dirs` | Dirs | `atomic` | - |
+| `discovered` | Discovered | `atomic` | `scientific-discovery` (0.533), `diff-content` (0.455) |
+| `discrete` | Discrete | `atomic` | `retrieve` (0.500), `diff-content` (0.500) |
+| `display` | Display | `atomic` | - |
+| `dist` | Dist | `atomic` | - |
+| `distance` | Distance | `atomic` | `translate` (0.471), `data-visualize` (0.455) |
+| `diverse` | Diverse | `atomic` | - |
+| `docs` | Docs | `atomic` | - |
+| `doctor` | Doctor | `atomic` | - |
+| `document` | Document | `atomic` | `chunk-document` (0.727), `document-analyst` (0.667) |
+| `documentation` | Documentation | `atomic` | `document-digitization` (0.765), `document-analyst` (0.690) |
+| `documented` | Documented | `atomic` | `chunk-document` (0.667), `document-analyst` (0.615) |
+| `documents` | Documents | `atomic` | `document-analyst` (0.720), `chunk-document` (0.696) |
+| `does` | Does | `atomic` | - |
+| `doesn` | Doesn | `atomic` | `diff-content` (0.471), `tokenize` (0.462) |
+| `dom` | Dom | `atomic` | - |
+| `don` | Don | `atomic` | - |
+| `dot` | Dot | `atomic` | - |
+| `download` | Download | `atomic` | - |
+| `downloads` | Downloads | `atomic` | - |
+| `downstream` | Downstream | `atomic` | `ghostwrite` (0.500), `diff-content` (0.455) |
+| `draft` | Draft | `atomic` | - |
+| `draft-skills` | Draft-skills | `atomic` | `data-analysis` (0.560), `generate-sql` (0.500) |
+| `dramatically` | Dramatically | `atomic` | `api-call` (0.600), `data-analysis` (0.480) |
+| `dry` | Dry | `atomic` | - |
+| `dry-run` | Dry-run | `atomic` | - |
+| `dtype` | Dtype | `atomic` | - |
+| `dual-layer` | Dual-layer | `atomic` | - |
+| `dump` | Dump | `atomic` | - |
+| `dumps` | Dumps | `atomic` | - |
+| `duplicate` | Duplicate | `atomic` | `diff-content` (0.476), `api-call` (0.471) |
+| `duplicates` | Duplicates | `atomic` | `diff-content` (0.455) |
+| `dynamic` | Dynamic | `atomic` | - |
+| `each` | Each | `atomic` | `research` (0.667), `web-search` (0.571) |
+| `echo` | Echo | `atomic` | `research` (0.500) |
+| `edge` | Edge | `atomic` | - |
+| `edge-case` | Edge-case | `atomic` | `knowledge-harvest` (0.538), `execute-bash` (0.476) |
+| `edges` | Edges | `atomic` | `knowledge-harvest` (0.455) |
+| `edit` | Edit | `atomic` | - |
+| `edits` | Edits | `atomic` | - |
+| `elem` | Elem | `atomic` | - |
+| `elements` | Elements | `atomic` | `sentiment-analysis` (0.462) |
+| `elicits` | Elicits | `atomic` | `self-critique` (0.500) |
+| `elif` | Elif | `atomic` | `classify` (0.500) |
+| `else` | Else | `atomic` | `tool-use` (0.500), `research` (0.500) |
+| `embed` | Embed | `atomic` | `embed-text` (0.667) |
+| `embedding` | Embedding | `atomic` | `embed-text` (0.526), `automated-testing` (0.462) |
+| `embeddings` | Embeddings | `atomic` | `embed-text` (0.500) |
+| `embeds` | Embeds | `atomic` | `embed-text` (0.625) |
+| `emotional` | Emotional | `atomic` | `content-moderation` (0.519), `question-answer` (0.500) |
+| `empty` | Empty | `atomic` | - |
+| `enables` | Enables | `atomic` | `generate-test` (0.500) |
+| `enabling` | Enabling | `atomic` | - |
+| `encode` | Encode | `atomic` | `audience-model` (0.600), `refactor-code` (0.526) |
+| `encoding` | Encoding | `atomic` | `content-moderation` (0.462), `code-execution` (0.455) |
+| `end` | End | `atomic` | - |
+| `end-to-end` | End-to-end | `atomic` | `text-to-speech` (0.500), `speech-to-text` (0.500) |
+| `endpoints` | Endpoints | `atomic` | - |
+| `endswith` | Endswith | `atomic` | - |
+| `engine` | Engine | `atomic` | `tokenize` (0.571) |
+| `engineering` | Engineering | `atomic` | `code-generation` (0.462), `error-interpretation` (0.452) |
+| `engines` | Engines | `atomic` | `tokenize` (0.533) |
+| `enhances` | Enhances | `atomic` | `generate-sql` (0.500), `generate-test` (0.476) |
+| `entities` | Entities | `atomic` | `extract-entities` (0.667), `generate-test` (0.571) |
+| `entity` | Entity | `atomic` | `sentiment-analysis` (0.500), `extract-entities` (0.455) |
+| `entries` | Entries | `atomic` | `retrieve` (0.667), `tokenize` (0.533) |
+| `entry` | Entry | `atomic` | `retrieve` (0.462) |
+| `enumerate` | Enumerate | `atomic` | `generate-sql` (0.667), `generate-text` (0.636) |
+| `env` | Env | `atomic` | - |
+| `environ` | Environ | `atomic` | `code-generation` (0.455) |
+| `environment` | Environment | `atomic` | `route-intent` (0.522), `diff-content` (0.522) |
+| `environments` | Environments | `atomic` | `sentiment-analysis` (0.533), `route-intent` (0.500) |
+| `epic` | Epic | `atomic` | `api-call` (0.500) |
+| `equal` | Equal | `atomic` | - |
+| `equations` | Equations | `atomic` | `question-answer` (0.583), `image-caption` (0.545) |
+| `err` | Err | `atomic` | - |
+| `error` | Error | `atomic` | `write-report` (0.471) |
+| `errors` | Errors | `atomic` | - |
+| `establishes` | Establishes | `atomic` | `question-answer` (0.462) |
+| `establishing` | Establishing | `atomic` | - |
+| `etc` | Etc | `atomic` | - |
+| `etree` | Etree | `atomic` | `retrieve` (0.769), `extract-entities` (0.476) |
+| `eval` | Eval | `atomic` | - |
+| `evaluated` | Evaluated | `atomic` | `evaluate-output` (0.667), `translate` (0.556) |
+| `evaluates` | Evaluates | `atomic` | `evaluate-output` (0.667), `translate` (0.556) |
+| `evaluating` | Evaluating | `atomic` | `evaluate-output` (0.560), `browser-automation` (0.500) |
+| `evaluation` | Evaluation | `atomic` | `evaluate-output` (0.640), `browser-automation` (0.571) |
+| `evaluator` | Evaluator | `atomic` | `evaluate-output` (0.667), `refactor-code` (0.455) |
+| `every` | Every | `atomic` | `retrieve` (0.462), `research` (0.462) |
+| `evidence` | Evidence | `atomic` | `audience-model` (0.455) |
+| `evidence-health` | Evidence-health | `atomic` | `audience-model` (0.552), `voice-agent` (0.538) |
+| `exact` | Exact | `atomic` | `extract-entities` (0.476), `research` (0.462) |
+| `exc` | Exc | `atomic` | - |
+| `exceed` | Exceed | `atomic` | `extract-entities` (0.455) |
+| `except` | Except | `atomic` | `extract-entities` (0.455) |
+| `exclude` | Exclude | `atomic` | `execute-bash` (0.526) |
+| `excludes` | Excludes | `atomic` | `execute-bash` (0.600) |
+| `executable` | Executable | `atomic` | `execute-bash` (0.636), `plan-and-execute` (0.538) |
+| `executed` | Executed | `atomic` | `execute-bash` (0.700), `plan-and-execute` (0.583) |
+| `executes` | Executes | `atomic` | `execute-bash` (0.800), `plan-and-execute` (0.583) |
+| `execution` | Execution | `atomic` | `code-execution` (0.783), `execute-bash` (0.571) |
+| `executor` | Executor | `atomic` | `code-execution` (0.636), `execute-bash` (0.600) |
+| `exhausted` | Exhausted | `atomic` | `execute-bash` (0.476) |
+| `exist` | Exist | `atomic` | - |
+| `existing` | Existing | `atomic` | `registry-curation` (0.480), `automated-testing` (0.480) |
+| `exists` | Exists | `atomic` | - |
+| `exit` | Exit | `atomic` | - |
+| `expand` | Expand | `atomic` | - |
+| `expanduser` | Expanduser | `atomic` | `plan-decompose` (0.500), `question-answer` (0.480) |
+| `expected` | Expected | `atomic` | `execute-bash` (0.600), `plan-and-execute` (0.500) |
+| `experiments` | Experiments | `atomic` | `extract-entities` (0.519), `generate-test` (0.500) |
+| `expert-level` | Expert-level | `atomic` | `retrieve` (0.500), `generate-sql` (0.500) |
+| `explanations` | Explanations | `atomic` | `code-generation` (0.519), `extract-entities` (0.500) |
+| `explicit` | Explicit | `atomic` | `self-critique` (0.476) |
+| `export` | Export | `atomic` | `write-report` (0.556) |
+| `exposes` | Exposes | `atomic` | `plan-decompose` (0.476), `parse-json` (0.471) |
+| `ext` | Ext | `atomic` | `embed-text` (0.462) |
+| `extend` | Extend | `atomic` | `extract-entities` (0.455) |
+| `extension` | Extension | `atomic` | `code-execution` (0.522), `re-act-reasoning` (0.500) |
+| `extensionquery` | Extensionquery | `atomic` | `question-answer` (0.483), `cite-sources` (0.462) |
+| `extensions` | Extensions | `atomic` | `code-execution` (0.500), `re-act-reasoning` (0.480) |
+| `extensive` | Extensive | `atomic` | `tokenize` (0.588), `retrieve` (0.588) |
+| `external` | External | `atomic` | `detect-anomaly` (0.545), `execute-bash` (0.500) |
+| `extracting` | Extracting | `atomic` | `extract-entities` (0.615), `re-act-reasoning` (0.560) |
+| `extraction` | Extraction | `atomic` | `extract-entities` (0.615), `registry-curation` (0.593) |
+| `extracts` | Extracts | `atomic` | `extract-entities` (0.667), `generate-sql` (0.500) |
+| `failure` | Failure | `atomic` | - |
+| `failures` | Failures | `atomic` | `cite-sources` (0.500) |
+| `fallback` | Fallback | `atomic` | - |
+| `falls` | Falls | `atomic` | `api-call` (0.462) |
+| `false` | False | `atomic` | `tool-use` (0.462) |
+| `feature` | Feature | `atomic` | `re-act-reasoning` (0.455) |
+| `feature-extraction` | Feature-extraction | `atomic` | `code-execution` (0.562), `code-generation` (0.545) |
+| `features` | Features | `atomic` | `re-act-reasoning` (0.522), `generate-sql` (0.500) |
+| `feedback` | Feedback | `atomic` | `research` (0.500) |
+| `few-shot` | Few-shot | `atomic` | - |
+| `field` | Field | `atomic` | - |
+| `fields` | Fields | `atomic` | - |
+| `file` | File | `atomic` | - |
+| `filename` | Filename | `atomic` | `image-generate` (0.455), `audience-model` (0.455) |
+| `filepath` | Filepath | `atomic` | - |
+| `files` | Files | `atomic` | - |
+| `fill-mask` | Fill-mask | `atomic` | - |
+| `fills` | Fills | `atomic` | `api-call` (0.462) |
+| `filter` | Filter | `atomic` | - |
+| `filtered` | Filtered | `atomic` | `write-report` (0.500), `cite-sources` (0.500) |
+| `filters` | Filters | `atomic` | `cite-sources` (0.526) |
+| `final` | Final | `atomic` | `api-call` (0.462) |
+| `finally` | Finally | `atomic` | `api-call` (0.533) |
+| `findings` | Findings | `atomic` | - |
+| `finditer` | Finditer | `atomic` | - |
+| `finite-state` | Finite-state | `atomic` | `cite-sources` (0.500), `generate-text` (0.480) |
+| `first` | First | `atomic` | - |
+| `fitness` | Fitness | `atomic` | - |
+| `fix` | Fix | `atomic` | - |
+| `fixes` | Fixes | `atomic` | - |
+| `flags` | Flags | `atomic` | `classify` (0.462) |
+| `float` | Float | `atomic` | - |
+| `floats` | Floats | `atomic` | - |
+| `floor` | Floor | `atomic` | - |
+| `flow` | Flow | `atomic` | - |
+| `flush` | Flush | `atomic` | `tool-use` (0.462) |
+| `fname` | Fname | `atomic` | - |
+| `follow-up` | Follow-up | `atomic` | `tool-use` (0.471), `format-output` (0.455) |
+| `follows` | Follows | `atomic` | - |
+| `force` | Force | `atomic` | `refactor-code` (0.556), `cite-sources` (0.471) |
+| `form` | Form | `atomic` | `format-output` (0.471) |
+| `format` | Format | `atomic` | `format-output` (0.632) |
+| `formats` | Formats | `atomic` | `format-output` (0.600) |
+| `formatted` | Formatted | `atomic` | `format-output` (0.636), `automated-testing` (0.462) |
+| `formatting` | Formatting | `atomic` | `format-output` (0.609), `automated-testing` (0.593) |
+| `forms` | Forms | `atomic` | - |
+| `forward` | Forward | `atomic` | - |
+| `forwarded` | Forwarded | `atomic` | `refactor-code` (0.455) |
+| `found` | Found | `atomic` | - |
+| `foundation` | Foundation | `atomic` | `document-digitization` (0.581), `content-moderation` (0.571) |
+| `foundational` | Foundational | `atomic` | `conversational-agent` (0.562), `document-digitization` (0.545) |
+| `fpath` | Fpath | `atomic` | - |
+| `framework` | Framework | `atomic` | `rank` (0.462) |
+| `framing` | Framing | `atomic` | `rank` (0.545), `re-act-reasoning` (0.455) |
+| `fraud` | Fraud | `atomic` | - |
+| `free-form` | Free-form | `atomic` | `research` (0.471), `refactor-code` (0.455) |
+| `fromisoformat` | Fromisoformat | `atomic` | `format-output` (0.462), `browser-automation` (0.452) |
+| `frontmatter` | Frontmatter | `atomic` | `translate` (0.500), `format-output` (0.500) |
+| `full` | Full | `atomic` | - |
+| `full-cycle` | Full-cycle | `atomic` | `full-stack-developer` (0.533) |
+| `function` | Function | `atomic` | `image-caption` (0.476), `code-execution` (0.455) |
+| `functionality` | Functionality | `atomic` | `conversational-agent` (0.485), `document-analyst` (0.483) |
+| `functionally` | Functionally | `atomic` | `document-analyst` (0.500), `sentiment-analysis` (0.467) |
+| `functions` | Functions | `atomic` | `question-answer` (0.500), `image-caption` (0.455) |
+| `fundamentally` | Fundamentally | `atomic` | `document-analyst` (0.552), `chunk-document` (0.519) |
+| `fuse` | Fuse | `atomic` | `tool-use` (0.500) |
+| `fusions` | Fusions | `atomic` | `question-answer` (0.545) |
+| `future` | Future | `atomic` | - |
+| `gaia` | Gaia | `atomic` | `api-call` (0.500) |
+| `gaia-cli` | Gaia-cli | `atomic` | `api-call` (0.625), `data-analysis` (0.476) |
+| `gaia-cli-test` | Gaia-cli-test | `atomic` | `generate-test` (0.538), `diff-content` (0.480) |
+| `gaia-intake-pr-body` | Gaia-intake-pr-body | `atomic` | - |
+| `gaia-registry` | Gaia-registry | `atomic` | `registry-curation` (0.533), `generate-test` (0.462) |
+| `gaia-skill-tree` | Gaia-skill-tree | `atomic` | - |
+| `gaiabot` | Gaiabot | `atomic` | - |
+| `gallery` | Gallery | `atomic` | - |
+| `gaps` | Gaps | `atomic` | - |
+| `gathering` | Gathering | `atomic` | `re-act-reasoning` (0.500), `math-reason` (0.500) |
+| `gen` | Gen | `atomic` | - |
+| `generate` | Generate | `atomic` | `generate-sql` (0.800), `generate-text` (0.762) |
+| `generated` | Generated | `atomic` | `generate-sql` (0.762), `generate-text` (0.727) |
+| `generates` | Generates | `atomic` | `generate-sql` (0.857), `generate-test` (0.818) |
+| `generating` | Generating | `atomic` | `code-generation` (0.720), `generate-sql` (0.636) |
+| `generation` | Generation | `atomic` | `code-generation` (0.800), `hypothesis-generate` (0.645) |
+| `generative` | Generative | `atomic` | `generate-sql` (0.727), `generate-text` (0.696) |
+| `generator` | Generator | `atomic` | `generate-sql` (0.667), `code-generation` (0.667) |
+| `get` | Get | `atomic` | - |
+| `getcode` | Getcode | `atomic` | `refactor-code` (0.600), `audience-model` (0.476) |
+| `gets` | Gets | `atomic` | `generate-sql` (0.500), `generate-test` (0.471) |
+| `gexf` | Gexf | `atomic` | - |
+| `gif` | Gif | `atomic` | - |
+| `git` | Git | `atomic` | `ghostwrite` (0.462) |
+| `github` | Github | `atomic` | - |
+| `github-action` | Github-action | `atomic` | `registry-curation` (0.600), `image-caption` (0.538) |
+| `given` | Given | `atomic` | `rag-pipeline` (0.471), `retrieve` (0.462) |
+| `glob` | Glob | `atomic` | - |
+| `global` | Global | `atomic` | - |
+| `gmtime` | Gmtime | `atomic` | `ghostwrite` (0.500) |
+| `goal-directed` | Goal-directed | `atomic` | `logical-inference` (0.600), `audience-model` (0.519) |
+| `got` | Got | `atomic` | `ghostwrite` (0.462) |
+| `gracefully` | Gracefully | `atomic` | `generate-sql` (0.455) |
+| `grammar-guided` | Grammar-guided | `atomic` | `summarize` (0.522) |
+| `grammars` | Grammars | `atomic` | `summarize` (0.471) |
+| `graph` | Graph | `atomic` | `research` (0.462) |
+| `graphrag` | Graphrag | `atomic` | - |
+| `graphs` | Graphs | `atomic` | - |
+| `ground-truth` | Ground-truth | `atomic` | `route-intent` (0.500), `format-output` (0.480) |
+| `grounding` | Grounding | `atomic` | `re-act-reasoning` (0.500), `route-intent` (0.476) |
+| `group` | Group | `atomic` | - |
+| `groups` | Groups | `atomic` | - |
+| `guaranteed` | Guaranteed | `atomic` | `translate` (0.526), `generate-text` (0.522) |
+| `guarantees` | Guarantees | `atomic` | `generate-test` (0.609), `generate-sql` (0.545) |
+| `guides` | Guides | `atomic` | - |
+| `hand-crafted` | Hand-crafted | `atomic` | `plan-and-execute` (0.500), `translate` (0.476) |
+| `handle` | Handle | `atomic` | `translate` (0.533) |
+| `handled` | Handled | `atomic` | `translate` (0.500) |
+| `handler` | Handler | `atomic` | `translate` (0.500) |
+| `handles` | Handles | `atomic` | `translate` (0.500), `plan-decompose` (0.476) |
+| `handling` | Handling | `atomic` | - |
+| `happen` | Happen | `atomic` | `rag-pipeline` (0.556) |
+| `harness` | Harness | `atomic` | - |
+| `has` | Has | `atomic` | - |
+| `hashlib` | Hashlib | `atomic` | - |
+| `have` | Have | `atomic` | - |
+| `header` | Header | `atomic` | - |
+| `headers` | Headers | `atomic` | - |
+| `headings` | Headings | `atomic` | - |
+| `health` | Health | `atomic` | - |
+| `healthy` | Healthy | `atomic` | - |
+| `help` | Help | `atomic` | - |
+| `helpful` | Helpful | `atomic` | - |
+| `hexdigest` | Hexdigest | `atomic` | - |
+| `highlighting` | Highlighting | `atomic` | `chain-of-thought` (0.474) |
+| `hints` | Hints | `atomic` | - |
+| `hit` | Hit | `atomic` | `ghostwrite` (0.462) |
+| `homepage` | Homepage | `atomic` | `voice-agent` (0.526), `memory-manage` (0.476) |
+| `hours` | Hours | `atomic` | `computer-use` (0.471), `cite-sources` (0.471) |
+| `html` | Html | `atomic` | `parse-html` (0.571) |
+| `http` | Http | `atomic` | - |
+| `https` | Https | `atomic` | - |
+| `huggingface` | Huggingface | `atomic` | - |
+| `human` | Human | `atomic` | - |
+| `human-level` | Human-level | `atomic` | `full-stack-developer` (0.452) |
+| `hypotheses` | Hypotheses | `atomic` | `hypothesis-generate` (0.621), `computer-use` (0.455) |
+| `hypothesis` | Hypothesis | `atomic` | `hypothesis-generate` (0.690) |
+| `ico` | Ico | `atomic` | - |
+| `icon` | Icon | `atomic` | `diff-content` (0.500), `image-caption` (0.471) |
+| `idea` | Idea | `atomic` | - |
+| `ideas` | Ideas | `atomic` | - |
+| `identifies` | Identifies | `atomic` | `extract-entities` (0.538), `scientific-discovery` (0.533) |
+| `identify` | Identify | `atomic` | `scientific-discovery` (0.500) |
+| `identifying` | Identifying | `atomic` | `code-generation` (0.462), `scientific-discovery` (0.452) |
+| `ids` | Ids | `atomic` | - |
+| `idx` | Idx | `atomic` | - |
+| `ignore` | Ignore | `atomic` | `image-generate` (0.500) |
+| `images` | Images | `atomic` | `image-caption` (0.526), `image-generate` (0.500) |
+| `implementation` | Implementation | `atomic` | `code-generation` (0.552), `error-interpretation` (0.529) |
+| `implements` | Implements | `atomic` | `image-generate` (0.500), `voice-agent` (0.476) |
+| `import` | Import | `atomic` | `write-report` (0.556) |
+| `importlib` | Importlib | `atomic` | `write-report` (0.476) |
+| `improve` | Improve | `atomic` | - |
+| `improvement` | Improvement | `atomic` | `recursive-self-improvement` (0.595), `route-intent` (0.522) |
+| `improves` | Improves | `atomic` | - |
+| `improving` | Improving | `atomic` | `multimodal-reasoning` (0.483), `image-caption` (0.455) |
+| `in-context` | In-context | `atomic` | `diff-content` (0.727), `generate-text` (0.522) |
+| `in-place` | In-place | `atomic` | `translate` (0.471), `plan-decompose` (0.455) |
+| `include` | Include | `atomic` | `audience-model` (0.476) |
+| `included` | Included | `atomic` | `audience-model` (0.455) |
+| `includes` | Includes | `atomic` | `audience-model` (0.455) |
+| `including` | Including | `atomic` | - |
+| `incorporating` | Incorporating | `atomic` | `error-interpretation` (0.545), `content-moderation` (0.516) |
+| `indent` | Indent | `atomic` | `route-intent` (0.556), `diff-content` (0.556) |
+| `independently` | Independently | `atomic` | - |
+| `index` | Index | `atomic` | - |
+| `indexed` | Indexed | `atomic` | - |
+| `indexes` | Indexes | `atomic` | - |
+| `inductive` | Inductive | `atomic` | - |
+| `inference` | Inference | `atomic` | `logical-inference` (0.692), `cite-sources` (0.476) |
+| `info` | Info | `atomic` | - |
+| `information` | Information | `atomic` | `image-caption` (0.583), `format-output` (0.583) |
+| `inherit` | Inherit | `atomic` | `image-generate` (0.476), `ghostwrite` (0.471) |
+| `init` | Init | `atomic` | - |
+| `initialized` | Initialized | `atomic` | `data-visualize` (0.480) |
+| `inject` | Inject | `atomic` | - |
+| `injects` | Injects | `atomic` | - |
+| `inline` | Inline | `atomic` | `rag-pipeline` (0.556), `translation-pipeline` (0.462) |
+| `inner` | Inner | `atomic` | `question-answer` (0.500) |
+| `input` | Input | `atomic` | - |
+| `inputs` | Inputs | `atomic` | - |
+| `insert` | Insert | `atomic` | `image-generate` (0.500), `question-answer` (0.476) |
+| `insight` | Insight | `atomic` | - |
+| `install` | Install | `atomic` | `api-call` (0.533) |
+| `install-manifest` | Install-manifest | `atomic` | `data-analysis` (0.483) |
+| `installation` | Installation | `atomic` | `image-caption` (0.560), `registry-curation` (0.552) |
+| `installed` | Installed | `atomic` | `api-call` (0.471) |
+| `installs` | Installs | `atomic` | `api-call` (0.500), `sentiment-analysis` (0.462) |
+| `instance` | Instance | `atomic` | `translate` (0.471) |
+| `instruction` | Instruction | `atomic` | `registry-curation` (0.643), `error-interpretation` (0.516) |
+| `instructions` | Instructions | `atomic` | `registry-curation` (0.621), `knowledge-graph-build` (0.500) |
+| `int` | Int | `atomic` | - |
+| `intake` | Intake | `atomic` | - |
+| `intake-dir` | Intake-dir | `atomic` | `scientific-discovery` (0.467), `write-report` (0.455) |
+| `integrates` | Integrates | `atomic` | `generate-sql` (0.636), `generate-test` (0.609) |
+| `integration` | Integration | `atomic` | `error-interpretation` (0.645), `content-moderation` (0.621) |
+| `integrations` | Integrations | `atomic` | `error-interpretation` (0.625), `content-moderation` (0.600) |
+| `integrity` | Integrity | `atomic` | `route-intent` (0.476), `diff-content` (0.476) |
+| `intensity` | Intensity | `atomic` | `route-intent` (0.571), `diff-content` (0.571) |
+| `intent` | Intent | `atomic` | `route-intent` (0.667), `diff-content` (0.667) |
+| `interactions` | Interactions | `atomic` | `error-interpretation` (0.625), `content-moderation` (0.600) |
+| `interface` | Interface | `atomic` | `cite-sources` (0.571), `write-report` (0.476) |
+| `intermediate` | Intermediate | `atomic` | `image-generate` (0.538), `write-report` (0.500) |
+| `interpreter` | Interpreter | `atomic` | `error-interpretation` (0.581), `write-report` (0.522) |
+| `interpreting` | Interpreting | `atomic` | `error-interpretation` (0.688), `write-report` (0.500) |
+| `interprets` | Interprets | `atomic` | `error-interpretation` (0.600), `write-report` (0.545) |
+| `intersection` | Intersection | `atomic` | `error-interpretation` (0.625), `image-caption` (0.560) |
+| `intervention` | Intervention | `atomic` | `error-interpretation` (0.625), `content-moderation` (0.533) |
+| `into` | Into | `atomic` | - |
+| `intrusion` | Intrusion | `atomic` | `registry-curation` (0.538), `math-reason` (0.500) |
+| `invalid` | Invalid | `atomic` | - |
+| `isdir` | Isdir | `atomic` | - |
+| `isfile` | Isfile | `atomic` | - |
+| `isinstance` | Isinstance | `atomic` | - |
+| `islink` | Islink | `atomic` | - |
+| `isoformat` | Isoformat | `atomic` | `format-output` (0.545) |
+| `issues` | Issues | `atomic` | `cite-sources` (0.556) |
+| `issuing` | Issuing | `atomic` | - |
+| `item` | Item | `atomic` | - |
+| `items` | Items | `atomic` | `cite-sources` (0.471) |
+| `iter` | Iter | `atomic` | `write-report` (0.500), `cite-sources` (0.500) |
+| `iterates` | Iterates | `atomic` | `generate-sql` (0.600), `cite-sources` (0.600) |
+| `iteration` | Iteration | `atomic` | `image-caption` (0.636), `error-interpretation` (0.621) |
+| `iterative` | Iterative | `atomic` | `image-generate` (0.522), `error-interpretation` (0.483) |
+| `iteratively` | Iteratively | `atomic` | `generate-sql` (0.522), `image-generate` (0.480) |
+| `its` | Its | `atomic` | - |
+| `jobs` | Jobs | `atomic` | - |
+| `join` | Join | `atomic` | - |
+| `jpeg` | Jpeg | `atomic` | - |
+| `jpg` | Jpg | `atomic` | - |
+| `json` | Json | `atomic` | `parse-json` (0.571) |
+| `jsonschema` | Jsonschema | `atomic` | - |
+| `karpathy` | Karpathy | `atomic` | - |
+| `kebab-case` | Kebab-case | `atomic` | `web-search` (0.500) |
+| `key` | Key | `atomic` | - |
+| `keyboard` | Keyboard | `atomic` | - |
+| `keys` | Keys | `atomic` | - |
+| `keyword` | Keyword | `atomic` | - |
+| `keywords` | Keywords | `atomic` | - |
+| `knowledge` | Knowledge | `atomic` | `knowledge-harvest` (0.692), `knowledge-graph-build` (0.600) |
+| `known` | Known | `atomic` | - |
+| `label` | Label | `atomic` | - |
+| `labels` | Labels | `atomic` | - |
+| `laboratory` | Laboratory | `atomic` | - |
+| `lambda` | Lambda | `atomic` | - |
+| `langchain` | Langchain | `atomic` | - |
+| `langchain-ai` | Langchain-ai | `atomic` | `multi-agent-orchestration-v` (0.462) |
+| `langchain-tool` | Langchain-tool | `atomic` | `chain-of-thought` (0.533) |
+| `language` | Language | `atomic` | `memory-manage` (0.476) |
+| `language-image` | Language-image | `atomic` | - |
+| `languages` | Languages | `atomic` | `memory-manage` (0.455) |
+| `large` | Large | `atomic` | - |
+| `large-scale` | Large-scale | `atomic` | `web-scrape` (0.571), `api-call` (0.526) |
+| `last` | Last | `atomic` | `classify` (0.500), `translate` (0.462) |
+| `last-week` | Last-week | `atomic` | - |
+| `lastmodifieddate` | Lastmodifieddate | `atomic` | - |
+| `latency` | Latency | `atomic` | `translate` (0.500) |
+| `later` | Later | `atomic` | `translate` (0.571) |
+| `layout` | Layout | `atomic` | `evaluate-output` (0.476) |
+| `leading` | Leading | `atomic` | `re-act-reasoning` (0.455) |
+| `learn` | Learn | `atomic` | `research` (0.462) |
+| `learned` | Learned | `atomic` | `parse-pdf` (0.500), `score-relevance` (0.455) |
+| `learning` | Learning | `atomic` | `re-act-reasoning` (0.609), `multimodal-reasoning` (0.500) |
+| `least` | Least | `atomic` | `classify` (0.462), `knowledge-harvest` (0.455) |
+| `left` | Left | `atomic` | - |
+| `legendaries` | Legendaries | `atomic` | `knowledge-harvest` (0.571), `generate-sql` (0.522) |
+| `legendary` | Legendary | `atomic` | `research` (0.471), `knowledge-harvest` (0.462) |
+| `legendary-specific` | Legendary-specific | `atomic` | - |
+| `len` | Len | `atomic` | - |
+| `less` | Less | `atomic` | `classify` (0.500) |
+| `let` | Let | `atomic` | - |
+| `letters` | Letters | `atomic` | - |
+| `level` | Level | `atomic` | `retrieve` (0.462) |
+| `lexically` | Lexically | `atomic` | `api-call` (0.588) |
+| `library` | Library | `atomic` | - |
+| `libs` | Libs | `atomic` | - |
+| `license` | License | `atomic` | `logical-inference` (0.500) |
+| `lid` | Lid | `atomic` | - |
+| `lida` | Lida | `atomic` | - |
+| `lifecycle` | Lifecycle | `atomic` | `classify` (0.471), `logical-inference` (0.462) |
+| `like` | Like | `atomic` | - |
+| `likes` | Likes | `atomic` | - |
+| `limit` | Limit | `atomic` | - |
+| `linalg` | Linalg | `atomic` | - |
+| `line` | Line | `atomic` | `rag-pipeline` (0.500) |
+| `lineage` | Lineage | `atomic` | `voice-agent` (0.556) |
+| `linear` | Linear | `atomic` | - |
+| `lines` | Lines | `atomic` | `rag-pipeline` (0.471) |
+| `link` | Link | `atomic` | `rank` (0.500) |
+| `links` | Links | `atomic` | - |
+| `list` | List | `atomic` | - |
+| `listdir` | Listdir | `atomic` | - |
+| `literature` | Literature | `atomic` | `cite-sources` (0.545), `image-generate` (0.500) |
+| `llevel` | Llevel | `atomic` | `full-stack-developer` (0.462) |
+| `llm` | Llm | `atomic` | - |
+| `llm-tool` | Llm-tool | `atomic` | `tool-use` (0.500) |
+| `lname` | Lname | `atomic` | - |
+| `load` | Load | `atomic` | - |
+| `loaded` | Loaded | `atomic` | - |
+| `loader` | Loader | `atomic` | - |
+| `local` | Local | `atomic` | `api-call` (0.462), `logical-inference` (0.455) |
+| `local-repo` | Local-repo | `atomic` | `logical-inference` (0.593), `multimodal-reasoning` (0.533) |
+| `locally` | Locally | `atomic` | `api-call` (0.533) |
+| `locate` | Locate | `atomic` | `translate` (0.533), `voice-agent` (0.471) |
+| `locations` | Locations | `atomic` | `image-caption` (0.545), `code-execution` (0.522) |
+| `log-scaled` | Log-scaled | `atomic` | `logical-inference` (0.519), `web-scrape` (0.500) |
+| `log10` | Log10 | `atomic` | - |
+| `log2` | Log2 | `atomic` | - |
+| `logging` | Logging | `atomic` | - |
+| `logic` | Logic | `atomic` | `logical-inference` (0.455) |
+| `logical` | Logical | `atomic` | `logical-inference` (0.583), `api-call` (0.533) |
+| `logs` | Logs | `atomic` | - |
+| `long-form` | Long-form | `atomic` | - |
+| `long-term` | Long-term | `atomic` | - |
+| `longer` | Longer | `atomic` | - |
+| `look` | Look | `atomic` | - |
+| `loop` | Loop | `atomic` | - |
+| `loops` | Loops | `atomic` | `tool-use` (0.462) |
+| `low-latency` | Low-latency | `atomic` | `voice-agent` (0.455) |
+| `lower` | Lower | `atomic` | - |
+| `lowercase-dash` | Lowercase-dash | `atomic` | `execute-bash` (0.538), `generate-sql` (0.462) |
+| `lvl` | Lvl | `atomic` | - |
+| `machine` | Machine | `atomic` | `summarize` (0.500), `image-caption` (0.500) |
+| `machine-readable` | Machine-readable | `atomic` | `math-reason` (0.519), `score-relevance` (0.452) |
+| `madaan` | Madaan | `atomic` | `math-reason` (0.471) |
+| `main` | Main | `atomic` | `rank` (0.500), `image-caption` (0.471) |
+| `maintainability` | Maintainability | `atomic` | `document-analyst` (0.516), `data-visualize` (0.483) |
+| `maintaining` | Maintaining | `atomic` | `re-act-reasoning` (0.538), `chain-of-thought` (0.486) |
+| `makedirs` | Makedirs | `atomic` | - |
+| `malformed` | Malformed | `atomic` | - |
+| `management` | Management | `atomic` | `image-generate` (0.583), `memory-manage` (0.522) |
+| `managing` | Managing | `atomic` | `memory-manage` (0.476) |
+| `manifest` | Manifest | `atomic` | `summarize` (0.471), `image-generate` (0.455) |
+| `manual` | Manual | `atomic` | `document-analyst` (0.455) |
+| `manually` | Manually | `atomic` | `document-analyst` (0.500), `api-call` (0.500) |
+| `manuscripts` | Manuscripts | `atomic` | - |
+| `map` | Map | `atomic` | - |
+| `mapping` | Mapping | `atomic` | `image-caption` (0.500) |
+| `mappings` | Mappings | `atomic` | `image-caption` (0.476) |
+| `maps` | Maps | `atomic` | - |
+| `mark` | Mark | `atomic` | `rank` (0.500), `summarize` (0.462) |
+| `markdown` | Markdown | `atomic` | `math-reason` (0.526) |
+| `marked` | Marked | `atomic` | `summarize` (0.533), `parse-pdf` (0.533) |
+| `marker` | Marker | `atomic` | `summarize` (0.533), `math-reason` (0.471) |
+| `markers` | Markers | `atomic` | `math-reason` (0.556), `summarize` (0.500) |
+| `marketplace` | Marketplace | `atomic` | `parse-html` (0.476), `math-reason` (0.455) |
+| `markup` | Markup | `atomic` | - |
+| `master` | Master | `atomic` | `translate` (0.533) |
+| `match` | Match | `atomic` | `math-reason` (0.500), `research` (0.462) |
+| `matching` | Matching | `atomic` | `math-reason` (0.526), `automated-testing` (0.480) |
+| `math` | Math | `atomic` | `math-reason` (0.533) |
+| `mathematical` | Mathematical | `atomic` | `math-reason` (0.522), `api-call` (0.500) |
+| `mathematics` | Mathematics | `atomic` | `math-reason` (0.636), `image-caption` (0.500) |
+| `max` | Max | `atomic` | - |
+| `may` | May | `atomic` | - |
+| `mbtiongson1` | Mbtiongson1 | `atomic` | `math-reason` (0.455), `multimodal-reasoning` (0.452) |
+| `mcp` | Mcp | `atomic` | - |
+| `mcp-registry` | Mcp-registry | `atomic` | `registry-curation` (0.552) |
+| `mcp-server` | Mcp-server | `atomic` | `computer-use` (0.455) |
+| `meaning` | Meaning | `atomic` | `re-act-reasoning` (0.545), `multimodal-reasoning` (0.519) |
+| `meaningful` | Meaningful | `atomic` | `re-act-reasoning` (0.480), `multimodal-reasoning` (0.467) |
+| `mechanistic` | Mechanistic | `atomic` | `image-caption` (0.500) |
+| `media` | Media | `atomic` | - |
+| `medical` | Medical | `atomic` | `api-call` (0.533) |
+| `meets` | Meets | `atomic` | `embed-text` (0.533), `generate-sql` (0.471) |
+| `memory` | Memory | `atomic` | `memory-manage` (0.632) |
+| `merged` | Merged | `atomic` | `memory-manage` (0.526) |
+| `message` | Message | `atomic` | `memory-manage` (0.500), `web-scrape` (0.471) |
+| `messages` | Messages | `atomic` | `memory-manage` (0.476) |
+| `meta` | Meta | `atomic` | - |
+| `metadata` | Metadata | `atomic` | `document-analyst` (0.500), `translate` (0.471) |
+| `metavar` | Metavar | `atomic` | - |
+| `method` | Method | `atomic` | `math-reason` (0.471) |
+| `methodology` | Methodology | `atomic` | - |
+| `methods` | Methods | `atomic` | - |
+| `microsecond` | Microsecond | `atomic` | `code-execution` (0.480), `parse-json` (0.476) |
+| `microsoft` | Microsoft | `atomic` | - |
+| `might` | Might | `atomic` | - |
+| `migration` | Migration | `atomic` | `image-caption` (0.636), `code-generation` (0.583) |
+| `min` | Min | `atomic` | - |
+| `minimum` | Minimum | `atomic` | - |
+| `missing` | Missing | `atomic` | - |
+| `mixed` | Mixed | `atomic` | - |
+| `mjs` | Mjs | `atomic` | - |
+| `mod` | Mod | `atomic` | - |
+| `modalities` | Modalities | `atomic` | `extract-entities` (0.462), `autonomous-data-scientist` (0.457) |
+| `mode` | Mode | `atomic` | - |
+| `model` | Model | `atomic` | `audience-model` (0.526) |
+| `modeling` | Modeling | `atomic` | `multimodal-reasoning` (0.500), `automated-testing` (0.480) |
+| `models` | Models | `atomic` | `audience-model` (0.500) |
+| `moderation` | Moderation | `atomic` | `code-generation` (0.720), `content-moderation` (0.714) |
+| `modern` | Modern | `atomic` | `content-moderation` (0.500), `code-generation` (0.476) |
+| `modes` | Modes | `atomic` | - |
+| `modifications` | Modifications | `atomic` | `image-caption` (0.538), `document-digitization` (0.529) |
+| `modified` | Modified | `atomic` | - |
+| `module` | Module | `atomic` | - |
+| `molecular` | Molecular | `atomic` | - |
+| `more` | More | `atomic` | `memory-manage` (0.471), `summarize` (0.462) |
+| `most` | Most | `atomic` | - |
+| `mouse` | Mouse | `atomic` | `tool-use` (0.615), `autonomous-debug` (0.476) |
+| `multi-agent` | Multi-agent | `atomic` | `voice-agent` (0.636), `multi-agent-orchestration-v` (0.579) |
+| `multi-category` | Multi-category | `atomic` | `multi-agent-orchestration-v` (0.488), `question-answer` (0.483) |
+| `multi-section` | Multi-section | `atomic` | `multi-agent-orchestration-v` (0.550), `multimodal-reasoning` (0.545) |
+| `multi-session` | Multi-session | `atomic` | `multi-agent-orchestration-v` (0.550), `multimodal-reasoning` (0.545) |
+| `multi-source` | Multi-source | `atomic` | `cite-sources` (0.667), `multi-agent-orchestration-v` (0.513) |
+| `multi-step` | Multi-step | `atomic` | `question-answer` (0.480), `multimodal-reasoning` (0.467) |
+| `multi-system` | Multi-system | `atomic` | - |
+| `multi-turn` | Multi-turn | `atomic` | `multimodal-reasoning` (0.533), `multi-agent-orchestration-v` (0.486) |
+| `multilingual` | Multilingual | `atomic` | `multimodal-reasoning` (0.562) |
+| `multimodal` | Multimodal | `atomic` | `multimodal-reasoning` (0.667), `audience-model` (0.500) |
+| `multiple` | Multiple | `atomic` | `multimodal-reasoning` (0.500) |
+| `must` | Must | `atomic` | - |
+| `name` | Name | `atomic` | `translate` (0.462) |
+| `named` | Named | `atomic` | - |
+| `named-dir` | Named-dir | `atomic` | `automated-testing` (0.462) |
+| `named-skills` | Named-skills | `atomic` | `generate-sql` (0.500), `automated-testing` (0.483) |
+| `names` | Names | `atomic` | `generate-sql` (0.471) |
+| `nargs` | Nargs | `atomic` | - |
+| `narrative` | Narrative | `atomic` | `retrieve` (0.588), `generate-sql` (0.476) |
+| `natural` | Natural | `atomic` | `data-visualize` (0.476) |
+| `natural-language` | Natural-language | `atomic` | `conversational-agent` (0.500), `memory-manage` (0.483) |
+| `natural-sounding` | Natural-sounding | `atomic` | `re-act-reasoning` (0.645), `multimodal-reasoning` (0.556) |
+| `navigating` | Navigating | `atomic` | `image-caption` (0.522), `conversational-agent` (0.467) |
+| `near-human` | Near-human | `atomic` | `memory-manage` (0.522), `parse-html` (0.500) |
+| `need` | Need | `atomic` | - |
+| `needed` | Needed | `atomic` | `embed-text` (0.500) |
+| `needs` | Needs | `atomic` | `generate-sql` (0.471) |
+| `needs-review` | Needs-review | `atomic` | `code-review-pipeline` (0.500), `embed-text` (0.455) |
+| `negative` | Negative | `atomic` | `retrieve` (0.625), `generate-sql` (0.500) |
+| `ner` | Ner | `atomic` | - |
+| `nested` | Nested | `atomic` | `translate` (0.533) |
+| `nesting` | Nesting | `atomic` | `conversational-agent` (0.519), `automated-testing` (0.500) |
+| `net` | Net | `atomic` | - |
+| `neural` | Neural | `atomic` | `generate-sql` (0.556) |
+| `neutral` | Neutral | `atomic` | `generate-sql` (0.526), `translate` (0.500) |
+| `new` | New | `atomic` | - |
+| `next` | Next | `atomic` | `generate-text` (0.471) |
+| `nline` | Nline | `atomic` | `rag-pipeline` (0.471), `tokenize` (0.462) |
+| `no-pr` | No-pr | `atomic` | - |
+| `node` | Node | `atomic` | - |
+| `node-20` | Node-20 | `atomic` | - |
+| `nodes` | Nodes | `atomic` | `knowledge-harvest` (0.455) |
+| `noise` | Noise | `atomic` | `tool-use` (0.462), `tokenize` (0.462) |
+| `non-interactive` | Non-interactive | `atomic` | `error-interpretation` (0.571), `route-intent` (0.519) |
+| `non-overlap` | Non-overlap | `atomic` | `content-moderation` (0.483), `conversational-agent` (0.452) |
+| `none` | None | `atomic` | - |
+| `nonlocal` | Nonlocal | `atomic` | - |
+| `noqa` | Noqa | `atomic` | - |
+| `norm` | Norm | `atomic` | - |
+| `normally` | Normally | `atomic` | `detect-anomaly` (0.545) |
+| `not` | Not | `atomic` | - |
+| `notebooks` | Notebooks | `atomic` | `tool-use` (0.471) |
+| `notes` | Notes | `atomic` | `generate-sql` (0.471), `computer-use` (0.471) |
+| `nothing` | Nothing | `atomic` | - |
+| `novel` | Novel | `atomic` | - |
+| `now` | Now | `atomic` | - |
+| `npm` | Npm | `atomic` | - |
+| `npmjs` | Npmjs | `atomic` | - |
+| `number` | Number | `atomic` | - |
+| `numeric` | Numeric | `atomic` | `summarize` (0.500) |
+| `numerical` | Numerical | `atomic` | `generate-sql` (0.476), `api-call` (0.471) |
+| `numpy` | Numpy | `atomic` | - |
+| `nuxt` | Nuxt | `atomic` | - |
+| `objective` | Objective | `atomic` | `retrieve` (0.588), `tokenize` (0.471) |
+| `objectives` | Objectives | `atomic` | `retrieve` (0.556), `extract-entities` (0.462) |
+| `objects` | Objects | `atomic` | - |
+| `observable` | Observable | `atomic` | `score-relevance` (0.480), `tool-select` (0.476) |
+| `observation` | Observation | `atomic` | `browser-automation` (0.621), `code-generation` (0.615) |
+| `observe` | Observe | `atomic` | `retrieve` (0.533), `web-search` (0.471) |
+| `occurrence` | Occurrence | `atomic` | `logical-inference` (0.519), `score-relevance` (0.480) |
+| `old` | Old | `atomic` | - |
+| `once` | Once | `atomic` | `tokenize` (0.500) |
+| `one` | One | `atomic` | `tokenize` (0.545) |
+| `only` | Only | `atomic` | - |
+| `open` | Open | `atomic` | `tokenize` (0.500) |
+| `open-ended` | Open-ended | `atomic` | `plan-and-execute` (0.462), `computer-use` (0.455) |
+| `open-source` | Open-source | `atomic` | `cite-sources` (0.696), `computer-use` (0.522) |
+| `openai` | Openai | `atomic` | `tokenize` (0.571), `code-generation` (0.476) |
+| `opened` | Opened | `atomic` | `tokenize` (0.571) |
+| `opening` | Opening | `atomic` | `tokenize` (0.533), `re-act-reasoning` (0.455) |
+| `opens` | Opens | `atomic` | `computer-use` (0.471), `tokenize` (0.462) |
+| `optimized` | Optimized | `atomic` | `tokenize` (0.471) |
+| `optional` | Optional | `atomic` | `conversational-agent` (0.500), `api-call` (0.500) |
+| `options` | Options | `atomic` | `image-caption` (0.500), `code-execution` (0.476) |
+| `orchestrates` | Orchestrates | `atomic` | `ghostwrite` (0.545), `hypothesis-generate` (0.516) |
+| `order` | Order | `atomic` | `retrieve` (0.462), `research` (0.462) |
+| `ordered` | Ordered | `atomic` | `score-relevance` (0.455) |
+| `org` | Org | `atomic` | - |
+| `organizations` | Organizations | `atomic` | `registry-curation` (0.533), `document-digitization` (0.529) |
+| `origin` | Origin | `atomic` | `voice-agent` (0.471) |
+| `origins` | Origins | `atomic` | - |
+| `orphaned` | Orphaned | `atomic` | `rank` (0.500), `memory-manage` (0.476) |
+| `otherwise` | Otherwise | `atomic` | `computer-use` (0.571), `hypothesis-generate` (0.500) |
+| `our` | Our | `atomic` | - |
+| `out` | Out | `atomic` | - |
+| `outliers` | Outliers | `atomic` | `computer-use` (0.600), `route-intent` (0.500) |
+| `outlines` | Outlines | `atomic` | `route-intent` (0.600), `computer-use` (0.500) |
+| `outlines-dev` | Outlines-dev | `atomic` | `route-intent` (0.500), `computer-use` (0.500) |
+| `outperforms` | Outperforms | `atomic` | `computer-use` (0.522) |
+| `output` | Output | `atomic` | `format-output` (0.632), `evaluate-output` (0.571) |
+| `outputs` | Outputs | `atomic` | `format-output` (0.600), `evaluate-output` (0.545) |
+| `outside` | Outside | `atomic` | `tool-use` (0.533), `route-intent` (0.526) |
+| `over` | Over | `atomic` | - |
+| `overhead` | Overhead | `atomic` | - |
+| `overwritten` | Overwritten | `atomic` | `ghostwrite` (0.571), `route-intent` (0.522) |
+| `own` | Own | `atomic` | - |
+| `owned` | Owned | `atomic` | `tokenize` (0.462) |
+| `owner` | Owner | `atomic` | `tokenize` (0.462) |
+| `pack` | Pack | `atomic` | `rank` (0.500) |
+| `package` | Package | `atomic` | - |
+| `packages` | Packages | `atomic` | - |
+| `packed` | Packed | `atomic` | `parse-pdf` (0.533) |
+| `pages` | Pages | `atomic` | `parse-json` (0.533) |
+| `pair` | Pair | `atomic` | `parse-pdf` (0.462) |
+| `pairs` | Pairs | `atomic` | `parse-pdf` (0.571), `parse-json` (0.533) |
+| `pairwise` | Pairwise | `atomic` | `parse-pdf` (0.588), `parse-json` (0.556) |
+| `pal` | Pal | `atomic` | `api-call` (0.545), `parse-html` (0.462) |
+| `pandas` | Pandas | `atomic` | `plan-decompose` (0.500) |
+| `pandas-ai` | Pandas-ai | `atomic` | `data-analysis` (0.455) |
+| `paper` | Paper | `atomic` | - |
+| `papers` | Papers | `atomic` | `parse-pdf` (0.533), `parse-json` (0.500) |
+| `paradigm` | Paradigm | `atomic` | `parse-pdf` (0.471) |
+| `parameters` | Parameters | `atomic` | `parse-json` (0.500), `plan-and-execute` (0.462) |
+| `params` | Params | `atomic` | `parse-pdf` (0.533), `parse-json` (0.500) |
+| `parent` | Parent | `atomic` | `parse-json` (0.625), `parse-html` (0.625) |
+| `parents` | Parents | `atomic` | `parse-json` (0.588), `parse-html` (0.588) |
+| `parse` | Parse | `atomic` | `parse-pdf` (0.714), `parse-json` (0.667) |
+| `parsed` | Parsed | `atomic` | `parse-pdf` (0.800), `parse-json` (0.625) |
+| `parser` | Parser | `atomic` | `parse-pdf` (0.667), `parse-json` (0.625) |
+| `parses` | Parses | `atomic` | `parse-json` (0.750), `parse-pdf` (0.667) |
+| `parsing` | Parsing | `atomic` | `parse-json` (0.588), `re-act-reasoning` (0.545) |
+| `partition` | Partition | `atomic` | `parse-json` (0.526), `route-intent` (0.476) |
+| `parts` | Parts | `atomic` | `parse-pdf` (0.571), `parse-json` (0.533) |
+| `pass` | Pass | `atomic` | `parse-json` (0.571), `classify` (0.500) |
+| `passages` | Passages | `atomic` | `translate` (0.471), `parse-pdf` (0.471) |
+| `passed` | Passed | `atomic` | `parse-pdf` (0.667), `parse-json` (0.500) |
+| `passing` | Passing | `atomic` | `parse-json` (0.588), `classify` (0.533) |
+| `patch` | Patch | `atomic` | `research` (0.462) |
+| `patched` | Patched | `atomic` | `parse-pdf` (0.500) |
+| `patches` | Patches | `atomic` | `math-reason` (0.556), `parse-json` (0.471) |
+| `path` | Path | `atomic` | - |
+| `paths` | Paths | `atomic` | `math-reason` (0.500) |
+| `pattern` | Pattern | `atomic` | `parse-json` (0.471) |
+| `patterns` | Patterns | `atomic` | `computer-use` (0.500), `generate-test` (0.476) |
+| `payload` | Payload | `atomic` | - |
+| `pdf` | Pdf | `atomic` | `parse-pdf` (0.500) |
+| `pending` | Pending | `atomic` | `re-act-reasoning` (0.455) |
+| `people` | People | `atomic` | - |
+| `per` | Per | `atomic` | - |
+| `percentage` | Percentage | `atomic` | `extract-entities` (0.538), `memory-manage` (0.522) |
+| `performance` | Performance | `atomic` | `memory-manage` (0.583), `refactor-code` (0.500) |
+| `persistent` | Persistent | `atomic` | `route-intent` (0.545), `hypothesis-generate` (0.516) |
+| `photorealistic` | Photorealistic | `atomic` | `hypothesis-generate` (0.457) |
+| `pid` | Pid | `atomic` | - |
+| `pip` | Pip | `atomic` | - |
+| `pipe` | Pipe | `atomic` | `rag-pipeline` (0.500) |
+| `pipeline` | Pipeline | `atomic` | `rag-pipeline` (0.800), `translation-pipeline` (0.571) |
+| `pipelines` | Pipelines | `atomic` | `rag-pipeline` (0.762), `translation-pipeline` (0.552) |
+| `pixel-space` | Pixel-space | `atomic` | `cite-sources` (0.522), `web-search` (0.476) |
+| `pkg` | Pkg | `atomic` | - |
+| `placeholder` | Placeholder | `atomic` | `audience-model` (0.480) |
+| `plain-text` | Plain-text | `atomic` | `plan-and-execute` (0.538), `generate-text` (0.522) |
+| `plan` | Plan | `atomic` | `rank` (0.500) |
+| `planned` | Planned | `atomic` | `plan-and-execute` (0.522), `parse-pdf` (0.500) |
+| `planning` | Planning | `atomic` | - |
+| `platform` | Platform | `atomic` | `plan-decompose` (0.455) |
+| `plugin` | Plugin | `atomic` | - |
+| `plus` | Plus | `atomic` | `tool-use` (0.500) |
+| `png` | Png | `atomic` | - |
+| `point` | Point | `atomic` | `voice-agent` (0.500), `route-intent` (0.471) |
+| `points` | Points | `atomic` | `voice-agent` (0.471) |
+| `policy-violating` | Policy-violating | `atomic` | - |
+| `popular` | Popular | `atomic` | - |
+| `popularity` | Popularity | `atomic` | - |
+| `positive` | Positive | `atomic` | `ghostwrite` (0.556), `self-critique` (0.476) |
+| `post` | Post | `atomic` | - |
+| `pre-computed` | Pre-computed | `atomic` | `computer-use` (0.583), `parse-pdf` (0.571) |
+| `pre-trained` | Pre-trained | `atomic` | `retrieve` (0.632), `re-act-reasoning` (0.593) |
+| `pre-training` | Pre-training | `atomic` | `re-act-reasoning` (0.714), `route-intent` (0.500) |
+| `prediction` | Prediction | `atomic` | `registry-curation` (0.593), `parse-json` (0.500) |
+| `prefix` | Prefix | `atomic` | `parse-pdf` (0.533) |
+| `premises` | Premises | `atomic` | `parse-json` (0.556), `retrieve` (0.500) |
+| `prepare` | Prepare | `atomic` | `retrieve` (0.533), `research` (0.533) |
+| `prereq` | Prereq | `atomic` | `retrieve` (0.571) |
+| `prereqs` | Prereqs | `atomic` | `retrieve` (0.533), `parse-json` (0.471) |
+| `prerequisite` | Prerequisite | `atomic` | `retrieve` (0.500) |
+| `prerequisites` | Prerequisites | `atomic` | `execute-bash` (0.480), `retrieve` (0.476) |
+| `present` | Present | `atomic` | `parse-json` (0.588), `parse-html` (0.588) |
+| `preserves` | Preserves | `atomic` | `retrieve` (0.588), `research` (0.588) |
+| `preserving` | Preserving | `atomic` | `research` (0.556), `parse-json` (0.500) |
+| `prevalence` | Prevalence | `atomic` | `score-relevance` (0.560) |
+| `preview` | Preview | `atomic` | `retrieve` (0.533) |
+| `princeton-nlp` | Princeton-nlp | `atomic` | `parse-pdf` (0.455) |
+| `print` | Print | `atomic` | `route-intent` (0.471) |
+| `prints` | Prints | `atomic` | - |
+| `problems` | Problems | `atomic` | - |
+| `process` | Process | `atomic` | - |
+| `processing` | Processing | `atomic` | `real-time-voice-assistant` (0.457), `route-intent` (0.455) |
+| `produce` | Produce | `atomic` | - |
+| `produces` | Produces | `atomic` | - |
+| `production` | Production | `atomic` | `code-execution` (0.583), `route-intent` (0.545) |
+| `production-grade` | Production-grade | `atomic` | `hypothesis-generate` (0.514), `route-intent` (0.500) |
+| `profile` | Profile | `atomic` | - |
+| `prog` | Prog | `atomic` | - |
+| `programmatic` | Programmatic | `atomic` | `browser-automation` (0.533) |
+| `programming` | Programming | `atomic` | `browser-automation` (0.483), `code-generation` (0.462) |
+| `project` | Project | `atomic` | `parse-html` (0.471) |
+| `projections` | Projections | `atomic` | `code-execution` (0.560), `registry-curation` (0.500) |
+| `promoted` | Promoted | `atomic` | `parse-pdf` (0.471), `plan-decompose` (0.455) |
+| `promotion` | Promotion | `atomic` | `content-moderation` (0.519), `browser-automation` (0.519) |
+| `prompt` | Prompt | `atomic` | - |
+| `prompting` | Prompting | `atomic` | `route-intent` (0.476), `automated-testing` (0.462) |
+| `prompts` | Prompts | `atomic` | `computer-use` (0.526), `plan-decompose` (0.476) |
+| `proper` | Proper | `atomic` | - |
+| `proposals` | Proposals | `atomic` | - |
+| `propose` | Propose | `atomic` | `plan-decompose` (0.571), `tool-use` (0.533) |
+| `proposed` | Proposed | `atomic` | `parse-pdf` (0.588), `plan-decompose` (0.545) |
+| `proposer` | Proposer | `atomic` | `plan-decompose` (0.545), `tool-use` (0.500) |
+| `proposes` | Proposes | `atomic` | `parse-json` (0.556), `plan-decompose` (0.545) |
+| `proposing` | Proposing | `atomic` | - |
+| `prosody` | Prosody | `atomic` | `parse-pdf` (0.500), `parse-json` (0.471) |
+| `provide` | Provide | `atomic` | - |
+| `provided` | Provided | `atomic` | - |
+| `provides` | Provides | `atomic` | - |
+| `providing` | Providing | `atomic` | - |
+| `provisional` | Provisional | `atomic` | `parse-json` (0.476), `conversational-agent` (0.452) |
+| `public` | Public | `atomic` | - |
+| `publicly` | Publicly | `atomic` | - |
+| `published` | Published | `atomic` | - |
+| `publisher` | Publisher | `atomic` | - |
+| `pull` | Pull | `atomic` | `api-call` (0.500) |
+| `pure` | Pure | `atomic` | `computer-use` (0.500), `summarize` (0.462) |
+| `push` | Push | `atomic` | - |
+| `pyc` | Pyc | `atomic` | - |
+| `python` | Python | `atomic` | `math-reason` (0.471) |
+| `python-shell` | Python-shell | `atomic` | `tool-select` (0.522), `tool-use` (0.500) |
+| `python-shell-5` | Python-shell-5 | `atomic` | `tool-select` (0.480) |
+| `python-version` | Python-version | `atomic` | `conversational-agent` (0.529), `hypothesis-generate` (0.514) |
+| `python3` | Python3 | `atomic` | - |
+| `quality` | Quality | `atomic` | - |
+| `quantitative` | Quantitative | `atomic` | `extract-entities` (0.500), `document-digitization` (0.485) |
+| `queries` | Queries | `atomic` | `retrieve` (0.533), `summarize` (0.500) |
+| `query` | Query | `atomic` | - |
+| `queryable` | Queryable | `atomic` | `memory-manage` (0.455) |
+| `question-answering` | Question-answering | `atomic` | `question-answer` (0.909), `sentiment-analysis` (0.500) |
+| `questions` | Questions | `atomic` | `question-answer` (0.750), `automated-testing` (0.462) |
+| `quoted` | Quoted | `atomic` | - |
+| `rag` | Rag | `atomic` | `rank` (0.571) |
+| `raise` | Raise | `atomic` | `translate` (0.571), `rag-pipeline` (0.471) |
+| `raises` | Raises | `atomic` | `translate` (0.533), `parse-json` (0.500) |
+| `range` | Range | `atomic` | `rank` (0.667), `translate` (0.571) |
+| `ranking` | Ranking | `atomic` | `rank` (0.727), `re-act-reasoning` (0.545) |
+| `ranks` | Ranks | `atomic` | `rank` (0.889), `translate` (0.571) |
+| `rare` | Rare | `atomic` | `research` (0.500), `rank` (0.500) |
+| `rarity` | Rarity | `atomic` | - |
+| `rasa` | Rasa | `atomic` | `translate` (0.615), `rank` (0.500) |
+| `rate` | Rate | `atomic` | `translate` (0.615), `retrieve` (0.500) |
+| `rated` | Rated | `atomic` | `translate` (0.571), `generate-sql` (0.471) |
+| `ratio` | Ratio | `atomic` | `code-generation` (0.500), `retrieve` (0.462) |
+| `raw` | Raw | `atomic` | `rank` (0.571) |
+| `re-derived` | Re-derived | `atomic` | `retrieve` (0.667), `score-relevance` (0.480) |
+| `re-exports` | Re-exports | `atomic` | `write-report` (0.545), `generate-text` (0.522) |
+| `reach` | Reach | `atomic` | `research` (0.769), `web-search` (0.533) |
+| `reachable` | Reachable | `atomic` | `research` (0.588), `api-call` (0.471) |
+| `reached` | Reached | `atomic` | `research` (0.667), `refactor-code` (0.500) |
+| `react-reasoning` | React-reasoning | `atomic` | `re-act-reasoning` (0.968), `math-reason` (0.692) |
+| `read` | Read | `atomic` | `research` (0.500), `rank` (0.500) |
+| `readability` | Readability | `atomic` | - |
+| `reading` | Reading | `atomic` | `re-act-reasoning` (0.545), `rank` (0.545) |
+| `ready` | Ready | `atomic` | `research` (0.462) |
+| `real` | Real | `atomic` | `research` (0.500), `rank` (0.500) |
+| `real-time` | Real-time | `atomic` | `retrieve` (0.588), `real-time-voice-assistant` (0.529) |
+| `real-world` | Real-world | `atomic` | `refactor-code` (0.522) |
+| `realistic` | Realistic | `atomic` | `research` (0.471), `registry-curation` (0.462) |
+| `reason` | Reason | `atomic` | `math-reason` (0.706), `parse-json` (0.625) |
+| `reasoning` | Reasoning | `atomic` | `re-act-reasoning` (0.750), `multimodal-reasoning` (0.621) |
+| `reasoning-machines` | Reasoning-machines | `atomic` | `re-act-reasoning` (0.545), `translation-pipeline` (0.474) |
+| `record` | Record | `atomic` | `refactor-code` (0.526) |
+| `records` | Records | `atomic` | `refactor-code` (0.500) |
+| `recursive` | Recursive | `atomic` | `retrieve` (0.706), `recursive-self-improvement` (0.514) |
+| `redirect` | Redirect | `atomic` | `route-intent` (0.500), `retrieve` (0.500) |
+| `ref` | Ref | `atomic` | `parse-pdf` (0.500) |
+| `refactor` | Refactor | `atomic` | `refactor-code` (0.762), `re-act-reasoning` (0.522) |
+| `refactors` | Refactors | `atomic` | `refactor-code` (0.727), `re-act-reasoning` (0.500) |
+| `reference` | Reference | `atomic` | `research` (0.588), `score-relevance` (0.583) |
+| `references` | References | `atomic` | `score-relevance` (0.560), `research` (0.556) |
+| `refines` | Refines | `atomic` | `retrieve` (0.533), `route-intent` (0.526) |
+| `regex` | Regex | `atomic` | `retrieve` (0.462), `research` (0.462) |
+| `register` | Register | `atomic` | `research` (0.625), `registry-curation` (0.560) |
+| `registries` | Registries | `atomic` | `retrieve` (0.667), `ghostwrite` (0.600) |
+| `registry` | Registry | `atomic` | `registry-curation` (0.640), `retrieve` (0.500) |
+| `registry-ref` | Registry-ref | `atomic` | `registry-curation` (0.690), `retrieve` (0.500) |
+| `reject` | Reject | `atomic` | `research` (0.571), `tool-select` (0.471) |
+| `rel` | Rel | `atomic` | `parse-html` (0.462) |
+| `relations` | Relations | `atomic` | `image-caption` (0.545), `registry-curation` (0.538) |
+| `relationships` | Relationships | `atomic` | `translation-pipeline` (0.545), `re-act-reasoning` (0.500) |
+| `relative` | Relative | `atomic` | `retrieve` (0.750), `translate` (0.588) |
+| `relevance` | Relevance | `atomic` | `score-relevance` (0.750), `retrieve` (0.588) |
+| `relevant` | Relevant | `atomic` | `score-relevance` (0.609), `retrieve` (0.500) |
+| `relpath` | Relpath | `atomic` | `research` (0.533), `translate` (0.500) |
+| `remote` | Remote | `atomic` | `retrieve` (0.571), `embed-text` (0.500) |
+| `remove` | Remove | `atomic` | `retrieve` (0.571) |
+| `removesuffix` | Removesuffix | `atomic` | - |
+| `rename` | Rename | `atomic` | - |
+| `repeat` | Repeat | `atomic` | `research` (0.571) |
+| `replace` | Replace | `atomic` | `score-relevance` (0.545), `research` (0.533) |
+| `repo` | Repo | `atomic` | `write-report` (0.500), `parse-pdf` (0.462) |
+| `report` | Report | `atomic` | `write-report` (0.667) |
+| `reporting` | Reporting | `atomic` | `write-report` (0.571), `re-act-reasoning` (0.500) |
+| `reports` | Reports | `atomic` | `write-report` (0.632) |
+| `repositories` | Repositories | `atomic` | `retrieve` (0.600), `extract-entities` (0.500) |
+| `repository` | Repository | `atomic` | `write-report` (0.455) |
+| `representation` | Representation | `atomic` | `error-interpretation` (0.647), `hypothesis-generate` (0.571) |
+| `representations` | Representations | `atomic` | `error-interpretation` (0.629), `hypothesis-generate` (0.556) |
+| `representing` | Representing | `atomic` | `re-act-reasoning` (0.667), `retrieve` (0.500) |
+| `reproducible` | Reproducible | `atomic` | `retrieve` (0.500), `refactor-code` (0.480) |
+| `req` | Req | `atomic` | - |
+| `request` | Request | `atomic` | `generate-test` (0.500), `question-answer` (0.455) |
+| `requests` | Requests | `atomic` | `question-answer` (0.522), `generate-test` (0.476) |
+| `required` | Required | `atomic` | `retrieve` (0.500) |
+| `requires` | Requires | `atomic` | `retrieve` (0.500) |
+| `requiring` | Requiring | `atomic` | `re-act-reasoning` (0.500), `retrieve` (0.471) |
+| `rerank` | Rerank | `atomic` | `rank` (0.800), `score-relevance` (0.476) |
+| `reranking` | Reranking | `atomic` | `re-act-reasoning` (0.667), `rank` (0.615) |
+| `res` | Res | `atomic` | `research` (0.545), `parse-json` (0.462) |
+| `research-backed` | Research-backed | `atomic` | `research` (0.696), `web-search` (0.560) |
+| `resolution` | Resolution | `atomic` | `registry-curation` (0.593), `route-intent` (0.545) |
+| `resolve` | Resolve | `atomic` | `retrieve` (0.533), `research` (0.533) |
+| `resolved` | Resolved | `atomic` | `retrieve` (0.500), `research` (0.500) |
+| `resolver` | Resolver | `atomic` | `research` (0.625), `retrieve` (0.500) |
+| `resolves` | Resolves | `atomic` | `retrieve` (0.500), `research` (0.500) |
+| `resp` | Resp | `atomic` | `research` (0.500), `parse-pdf` (0.462) |
+| `responses` | Responses | `atomic` | `parse-json` (0.526), `question-answer` (0.500) |
+| `rest` | Rest | `atomic` | `retrieve` (0.500), `research` (0.500) |
+| `result` | Result | `atomic` | - |
+| `results` | Results | `atomic` | - |
+| `retrieval` | Retrieval | `atomic` | `retrieve` (0.824), `score-relevance` (0.500) |
+| `retrieval-augmented` | Retrieval-augmented | `atomic` | `retrieve` (0.593), `conversational-agent` (0.564) |
+| `retrieves` | Retrieves | `atomic` | `retrieve` (0.941), `score-relevance` (0.500) |
+| `retry` | Retry | `atomic` | `retrieve` (0.615), `research` (0.462) |
+| `return` | Return | `atomic` | `retrieve` (0.571), `registry-curation` (0.522) |
+| `returncode` | Returncode | `atomic` | `refactor-code` (0.696), `retrieve` (0.556) |
+| `returned` | Returned | `atomic` | `retrieve` (0.625), `structured-output` (0.480) |
+| `returns` | Returns | `atomic` | `retrieve` (0.533), `registry-curation` (0.500) |
+| `reversal` | Reversal | `atomic` | `retrieve` (0.500), `research` (0.500) |
+| `reverse` | Reverse | `atomic` | `retrieve` (0.533), `research` (0.533) |
+| `review` | Review | `atomic` | `retrieve` (0.571), `code-review-pipeline` (0.462) |
+| `reviewed` | Reviewed | `atomic` | `retrieve` (0.625), `code-review-pipeline` (0.500) |
+| `reviews` | Reviews | `atomic` | `retrieve` (0.533) |
+| `rigorous` | Rigorous | `atomic` | `tool-use` (0.500) |
+| `root` | Root | `atomic` | - |
+| `roots` | Roots | `atomic` | `tool-use` (0.462) |
+| `round` | Round | `atomic` | `route-intent` (0.471) |
+| `routes` | Routes | `atomic` | `route-intent` (0.556), `computer-use` (0.556) |
+| `routing` | Routing | `atomic` | `route-intent` (0.632), `browser-automation` (0.480) |
+| `row` | Row | `atomic` | - |
+| `rule-based` | Rule-based | `atomic` | `execute-bash` (0.545), `route-intent` (0.455) |
+| `rules` | Rules | `atomic` | `research` (0.462) |
+| `run` | Run | `atomic` | `rank` (0.571) |
+| `run-gaia` | Run-gaia | `atomic` | - |
+| `runner` | Runner | `atomic` | `question-answer` (0.476) |
+| `running` | Running | `atomic` | `re-act-reasoning` (0.455) |
+| `runs` | Runs | `atomic` | `rank` (0.500), `translate` (0.462) |
+| `runs-on` | Runs-on | `atomic` | `parse-json` (0.588), `chunk-document` (0.476) |
+| `runtime` | Runtime | `atomic` | `retrieve` (0.533), `route-intent` (0.526) |
+| `s-q-l` | S-q-l | `atomic` | - |
+| `safe` | Safe | `atomic` | `translate` (0.462), `summarize` (0.462) |
+| `safely` | Safely | `atomic` | - |
+| `safety` | Safety | `atomic` | - |
+| `same` | Same | `atomic` | `translate` (0.462), `summarize` (0.462) |
+| `sandbox` | Sandbox | `atomic` | - |
+| `sandboxed` | Sandboxed | `atomic` | - |
+| `scalar` | Scalar | `atomic` | - |
+| `scalars` | Scalars | `atomic` | `classify` (0.533) |
+| `scale` | Scale | `atomic` | `web-scrape` (0.533), `api-call` (0.462) |
+| `scan` | Scan | `atomic` | `rank` (0.500) |
+| `scanned` | Scanned | `atomic` | `web-scrape` (0.471), `score-relevance` (0.455) |
+| `scanner` | Scanner | `atomic` | `web-scrape` (0.471), `score-relevance` (0.455) |
+| `schema` | Schema | `atomic` | - |
+| `schema-dir` | Schema-dir | `atomic` | `scientific-discovery` (0.467) |
+| `schema-valid` | Schema-valid | `atomic` | `sentiment-analysis` (0.467), `data-visualize` (0.462) |
+| `science` | Science | `atomic` | `score-relevance` (0.545), `cite-sources` (0.526) |
+| `scientific` | Scientific | `atomic` | `scientific-discovery` (0.667), `extract-entities` (0.462) |
+| `score` | Score | `atomic` | `web-scrape` (0.533), `score-relevance` (0.500) |
+| `scored` | Scored | `atomic` | `web-scrape` (0.500), `score-relevance` (0.476) |
+| `scores` | Scores | `atomic` | `web-scrape` (0.500), `score-relevance` (0.476) |
+| `scoring` | Scoring | `atomic` | `score-relevance` (0.455), `re-act-reasoning` (0.455) |
+| `scraper` | Scraper | `atomic` | `web-scrape` (0.706), `score-relevance` (0.455) |
+| `scraping` | Scraping | `atomic` | `web-scrape` (0.556), `rank` (0.500) |
+| `screenshot` | Screenshot | `atomic` | `speech-to-text` (0.500), `score-relevance` (0.480) |
+| `screenshot-based` | Screenshot-based | `atomic` | `speech-to-text` (0.467), `score-relevance` (0.452) |
+| `screenshots` | Screenshots | `atomic` | `speech-to-text` (0.480), `score-relevance` (0.462) |
+| `script` | Script | `atomic` | `self-critique` (0.526), `web-scrape` (0.500) |
+| `scripts` | Scripts | `atomic` | `self-critique` (0.500), `web-scrape` (0.471) |
+| `scroll` | Scroll | `atomic` | - |
+| `search` | Search | `atomic` | `research` (0.857), `web-search` (0.750) |
+| `searchable` | Searchable | `atomic` | `research` (0.667), `web-search` (0.600) |
+| `searching` | Searching | `atomic` | `research` (0.706), `web-search` (0.632) |
+| `second` | Second | `atomic` | `parse-json` (0.500) |
+| `seconds` | Seconds | `atomic` | `parse-json` (0.471) |
+| `secrets` | Secrets | `atomic` | `self-critique` (0.500), `speech-to-text` (0.476) |
+| `security` | Security | `atomic` | `self-critique` (0.571), `summarize` (0.471) |
+| `see` | See | `atomic` | - |
+| `seed` | Seed | `atomic` | `parse-pdf` (0.462) |
+| `seen` | Seen | `atomic` | - |
+| `segment` | Segment | `atomic` | `voice-agent` (0.556), `sentiment-analysis` (0.480) |
+| `segments` | Segments | `atomic` | `sentiment-analysis` (0.538), `voice-agent` (0.526) |
+| `selecting` | Selecting | `atomic` | `tool-select` (0.600), `self-critique` (0.545) |
+| `selection` | Selection | `atomic` | `code-execution` (0.609), `tool-select` (0.600) |
+| `selects` | Selects | `atomic` | `tool-select` (0.667), `execute-bash` (0.526) |
+| `self-evidence` | Self-evidence | `atomic` | `score-relevance` (0.571), `code-review-pipeline` (0.485) |
+| `self-feedback` | Self-feedback | `atomic` | `self-critique` (0.462) |
+| `self-generated` | Self-generated | `atomic` | `image-generate` (0.714), `code-generation` (0.621) |
+| `self-hosted` | Self-hosted | `atomic` | `self-critique` (0.583), `speech-to-text` (0.480) |
+| `self-refine` | Self-refine | `atomic` | `self-critique` (0.583), `score-relevance` (0.538) |
+| `self-supervised` | Self-supervised | `atomic` | `self-critique` (0.500) |
+| `semantic` | Semantic | `atomic` | `research` (0.500), `summarize` (0.471) |
+| `semantically` | Semantically | `atomic` | `api-call` (0.600), `sentiment-analysis` (0.533) |
+| `sensemaking` | Sensemaking | `atomic` | `code-generation` (0.462) |
+| `sentence-similarity` | Sentence-similarity | `atomic` | `sentiment-analysis` (0.486), `real-time-voice-assistant` (0.455) |
+| `sentence-transformers` | Sentence-transformers | `atomic` | `sentiment-analysis` (0.564), `detect-anomaly` (0.514) |
+| `sentiment` | Sentiment | `atomic` | `sentiment-analysis` (0.667), `tokenize` (0.471) |
+| `separated` | Separated | `atomic` | `parse-pdf` (0.556), `generate-sql` (0.476) |
+| `separately` | Separately | `atomic` | `generate-sql` (0.545), `parse-html` (0.500) |
+| `sequence` | Sequence | `atomic` | `score-relevance` (0.522), `self-critique` (0.476) |
+| `sequences` | Sequences | `atomic` | `score-relevance` (0.500), `cite-sources` (0.476) |
+| `server` | Server | `atomic` | `retrieve` (0.571), `score-relevance` (0.476) |
+| `servers` | Servers | `atomic` | `retrieve` (0.533), `score-relevance` (0.455) |
+| `session` | Session | `atomic` | `parse-json` (0.588), `question-answer` (0.455) |
+| `sessions` | Sessions | `atomic` | `parse-json` (0.556), `question-answer` (0.522) |
+| `set` | Set | `atomic` | `parse-html` (0.462) |
+| `setdefault` | Setdefault | `atomic` | - |
+| `sets` | Sets | `atomic` | - |
+| `setup-python` | Setup-python | `atomic` | `parse-json` (0.455) |
+| `several` | Several | `atomic` | `generate-sql` (0.526) |
+| `sha` | Sha | `atomic` | - |
+| `sha256` | Sha256 | `atomic` | - |
+| `sha512` | Sha512 | `atomic` | - |
+| `shape` | Shape | `atomic` | `web-scrape` (0.533) |
+| `shell` | Shell | `atomic` | - |
+| `shells` | Shells | `atomic` | - |
+| `short` | Short | `atomic` | `ghostwrite` (0.533) |
+| `shorter` | Shorter | `atomic` | `ghostwrite` (0.588), `speech-to-text` (0.476) |
+| `shot` | Shot | `atomic` | - |
+| `should` | Should | `atomic` | - |
+| `shouldn` | Shouldn | `atomic` | - |
+| `showing` | Showing | `atomic` | `ghostwrite` (0.471), `re-act-reasoning` (0.455) |
+| `shows` | Shows | `atomic` | - |
+| `shutil` | Shutil | `atomic` | `parse-html` (0.500) |
+| `sid` | Sid | `atomic` | - |
+| `signals` | Signals | `atomic` | `sentiment-analysis` (0.480), `question-answer` (0.455) |
+| `signatures` | Signatures | `atomic` | `generate-sql` (0.545), `generate-test` (0.522) |
+| `silent` | Silent | `atomic` | `voice-agent` (0.471), `tool-select` (0.471) |
+| `similar` | Similar | `atomic` | `summarize` (0.500) |
+| `similarity` | Similarity | `atomic` | `summarize` (0.526) |
+| `simple` | Simple | `atomic` | - |
+| `simply` | Simply | `atomic` | - |
+| `simulation` | Simulation | `atomic` | `image-caption` (0.609), `registry-curation` (0.519) |
+| `single` | Single | `atomic` | - |
+| `single-pass` | Single-pass | `atomic` | - |
+| `size` | Size | `atomic` | `summarize` (0.615), `tokenize` (0.500) |
+| `skill` | Skill | `atomic` | `api-call` (0.462) |
+| `skill-batches` | Skill-batches | `atomic` | `translate` (0.455) |
+| `skill-index` | Skill-index | `atomic` | - |
+| `skill-name` | Skill-name | `atomic` | - |
+| `skill-tree` | Skill-tree | `atomic` | - |
+| `skills` | Skills | `atomic` | - |
+| `skip` | Skip | `atomic` | - |
+| `skipped` | Skipped | `atomic` | - |
+| `skipping` | Skipping | `atomic` | - |
+| `slashes` | Slashes | `atomic` | `classify` (0.533), `translate` (0.500) |
+| `slice` | Slice | `atomic` | - |
+| `slug` | Slug | `atomic` | - |
+| `smithery` | Smithery | `atomic` | `summarize` (0.471) |
+| `software` | Software | `atomic` | `ghostwrite` (0.556), `summarize` (0.471) |
+| `some` | Some | `atomic` | `summarize` (0.462) |
+| `sort` | Sort | `atomic` | - |
+| `sorted` | Sorted | `atomic` | `ghostwrite` (0.500) |
+| `source` | Source | `atomic` | `cite-sources` (0.667), `summarize` (0.533) |
+| `sources` | Sources | `atomic` | `cite-sources` (0.737), `summarize` (0.500) |
+| `space` | Space | `atomic` | `research` (0.462) |
+| `spaces` | Spaces | `atomic` | `parse-json` (0.500) |
+| `spatial` | Spatial | `atomic` | `api-call` (0.533), `data-visualize` (0.476) |
+| `spawn` | Spawn | `atomic` | - |
+| `spec` | Spec | `atomic` | `research` (0.500) |
+| `specialized` | Specialized | `atomic` | `summarize` (0.500), `self-critique` (0.500) |
+| `specific` | Specific | `atomic` | `self-critique` (0.476) |
+| `specification` | Specification | `atomic` | `image-caption` (0.538), `scientific-discovery` (0.485) |
+| `specifications` | Specifications | `atomic` | `image-caption` (0.519), `scientific-discovery` (0.471) |
+| `specified` | Specified | `atomic` | `self-critique` (0.545) |
+| `speech` | Speech | `atomic` | `text-to-speech` (0.600), `speech-to-text` (0.600) |
+| `split` | Split | `atomic` | - |
+| `splitlines` | Splitlines | `atomic` | `rag-pipeline` (0.545), `self-critique` (0.522) |
+| `splitter` | Splitter | `atomic` | `self-critique` (0.476), `translate` (0.471) |
+| `spoken` | Spoken | `atomic` | `tokenize` (0.571) |
+| `sqrt` | Sqrt | `atomic` | - |
+| `src` | Src | `atomic` | `research` (0.545), `web-search` (0.462) |
+| `stack` | Stack | `atomic` | `research` (0.462) |
+| `standard` | Standard | `atomic` | `translate` (0.471) |
+| `stars` | Stars | `atomic` | `research` (0.462) |
+| `start` | Start | `atomic` | `ghostwrite` (0.533), `research` (0.462) |
+| `startswith` | Startswith | `atomic` | `ghostwrite` (0.500) |
+| `state` | State | `atomic` | `translate` (0.571), `ghostwrite` (0.533) |
+| `static` | Static | `atomic` | - |
+| `statistical` | Statistical | `atomic` | `api-call` (0.526), `data-visualize` (0.480) |
+| `statistics` | Statistics | `atomic` | `extract-entities` (0.538) |
+| `stats` | Stats | `atomic` | - |
+| `status` | Status | `atomic` | - |
+| `stderr` | Stderr | `atomic` | - |
+| `stdio` | Stdio | `atomic` | - |
+| `stdout` | Stdout | `atomic` | `structured-output` (0.522) |
+| `stem` | Stem | `atomic` | `translate` (0.462) |
+| `step-by-step` | Step-by-step | `atomic` | `text-to-speech` (0.462), `web-search` (0.455) |
+| `steps` | Steps | `atomic` | - |
+| `still` | Still | `atomic` | `api-call` (0.462) |
+| `store` | Store | `atomic` | `ghostwrite` (0.533), `cite-sources` (0.471) |
+| `str` | Str | `atomic` | `ghostwrite` (0.462) |
+| `strategies` | Strategies | `atomic` | `extract-entities` (0.615), `translate` (0.526) |
+| `strftime` | Strftime | `atomic` | `ghostwrite` (0.556), `retrieve` (0.500) |
+| `strict` | Strict | `atomic` | `ghostwrite` (0.625) |
+| `string` | String | `atomic` | `ghostwrite` (0.500) |
+| `stringify` | Stringify | `atomic` | `classify` (0.471) |
+| `strings` | Strings | `atomic` | `translate` (0.500), `ghostwrite` (0.471) |
+| `strip` | Strip | `atomic` | `ghostwrite` (0.533), `retrieve` (0.462) |
+| `stripped` | Stripped | `atomic` | `ghostwrite` (0.556), `retrieve` (0.500) |
+| `stripping` | Stripping | `atomic` | `rag-pipeline` (0.476) |
+| `structure` | Structure | `atomic` | `structured-output` (0.692), `ghostwrite` (0.526) |
+| `structured` | Structured | `atomic` | `structured-output` (0.741), `ghostwrite` (0.500) |
+| `structures` | Structures | `atomic` | `structured-output` (0.667), `ghostwrite` (0.500) |
+| `stub` | Stub | `atomic` | - |
+| `stubs` | Stubs | `atomic` | - |
+| `style` | Style | `atomic` | - |
+| `stylized` | Stylized | `atomic` | `tokenize` (0.500), `summarize` (0.471) |
+| `sub` | Sub | `atomic` | - |
+| `sub-agent` | Sub-agent | `atomic` | `voice-agent` (0.600), `conversational-agent` (0.483) |
+| `sub-tasks` | Sub-tasks | `atomic` | - |
+| `submits` | Submits | `atomic` | `summarize` (0.500) |
+| `subparsers` | Subparsers | `atomic` | `parse-json` (0.600), `summarize` (0.526) |
+| `subprocess` | Subprocess | `atomic` | `cite-sources` (0.545) |
+| `success` | Success | `atomic` | `cite-sources` (0.526) |
+| `such` | Such | `atomic` | `research` (0.500) |
+| `suggest` | Suggest | `atomic` | - |
+| `suggestions` | Suggestions | `atomic` | `question-answer` (0.615), `image-caption` (0.500) |
+| `suitable` | Suitable | `atomic` | `summarize` (0.471) |
+| `suite` | Suite | `atomic` | `summarize` (0.571), `ghostwrite` (0.533) |
+| `suites` | Suites | `atomic` | `summarize` (0.533), `ghostwrite` (0.500) |
+| `sum` | Sum | `atomic` | `summarize` (0.500) |
+| `summaries` | Summaries | `atomic` | `summarize` (0.889), `math-reason` (0.500) |
+| `summarization` | Summarization | `atomic` | `summarize` (0.727), `image-caption` (0.538) |
+| `summarizer` | Summarizer | `atomic` | `summarize` (0.947), `data-visualize` (0.500) |
+| `summarizes` | Summarizes | `atomic` | `summarize` (0.947), `data-visualize` (0.500) |
+| `summary` | Summary | `atomic` | `summarize` (0.750) |
+| `supervision` | Supervision | `atomic` | `parse-json` (0.476) |
+| `supporting` | Supporting | `atomic` | - |
+| `sure` | Sure | `atomic` | `summarize` (0.615), `cite-sources` (0.500) |
+| `surpasses` | Surpasses | `atomic` | `parse-json` (0.526), `cite-sources` (0.476) |
+| `survey` | Survey | `atomic` | `summarize` (0.533) |
+| `svn` | Svn | `atomic` | - |
+| `symbol` | Symbol | `atomic` | - |
+| `symbolic` | Symbolic | `atomic` | - |
+| `symlink` | Symlink | `atomic` | - |
+| `sync` | Sync | `atomic` | - |
+| `synergy` | Synergy | `atomic` | - |
+| `syntactically` | Syntactically | `atomic` | `api-call` (0.571), `sentiment-analysis` (0.452) |
+| `synthesis` | Synthesis | `atomic` | `sentiment-analysis` (0.519), `hypothesis-generate` (0.500) |
+| `synthesising` | Synthesising | `atomic` | `hypothesis-generate` (0.545), `sentiment-analysis` (0.467) |
+| `synthesizes` | Synthesizes | `atomic` | `sentiment-analysis` (0.483), `hypothesis-generate` (0.467) |
+| `sys` | Sys | `atomic` | - |
+| `system` | System | `atomic` | - |
+| `systematic` | Systematic | `atomic` | - |
+| `tables` | Tables | `atomic` | `translate` (0.533) |
+| `tags` | Tags | `atomic` | `translate` (0.462) |
+| `tail` | Tail | `atomic` | `api-call` (0.500), `translate` (0.462) |
+| `tarball` | Tarball | `atomic` | `api-call` (0.533) |
+| `target` | Target | `atomic` | `parse-html` (0.500), `voice-agent` (0.471) |
+| `task` | Task | `atomic` | `rank` (0.500), `translate` (0.462) |
+| `tasks` | Tasks | `atomic` | `classify` (0.462) |
+| `taxonomy` | Taxonomy | `atomic` | `detect-anomaly` (0.545) |
+| `teaching` | Teaching | `atomic` | `re-act-reasoning` (0.522), `research` (0.500) |
+| `template` | Template | `atomic` | `translate` (0.588) |
+| `terminal` | Terminal | `atomic` | `memory-manage` (0.476), `detect-anomaly` (0.455) |
+| `test` | Test | `atomic` | `generate-test` (0.471) |
+| `testable` | Testable | `atomic` | `detect-anomaly` (0.455) |
+| `testing` | Testing | `atomic` | `automated-testing` (0.583), `re-act-reasoning` (0.545) |
+| `tests` | Tests | `atomic` | `cite-sources` (0.471) |
+| `text` | Text | `atomic` | `embed-text` (0.571), `generate-text` (0.471) |
+| `text-based` | Text-based | `atomic` | `text-to-speech` (0.583), `execute-bash` (0.545) |
+| `text-classification` | Text-classification | `atomic` | `classify` (0.519), `image-caption` (0.500) |
+| `text-generation` | Text-generation | `atomic` | `code-generation` (0.800), `hypothesis-generate` (0.667) |
+| `text-to` | Text-to | `atomic` | `text-to-speech` (0.667), `text-to-sql-pipeline` (0.519) |
+| `text2text-generation` | Text2text-generation | `atomic` | `code-generation` (0.686), `hypothesis-generate` (0.585) |
+| `texts` | Texts | `atomic` | `embed-text` (0.533), `text-to-speech` (0.526) |
+| `tgz` | Tgz | `atomic` | - |
+| `than` | Than | `atomic` | `math-reason` (0.533), `rank` (0.500) |
+| `them` | Them | `atomic` | - |
+| `then` | Then | `atomic` | `math-reason` (0.533), `tokenize` (0.500) |
+| `these` | These | `atomic` | `math-reason` (0.500), `computer-use` (0.471) |
+| `this` | This | `atomic` | - |
+| `threshold` | Threshold | `atomic` | `math-reason` (0.600), `research` (0.471) |
+| `thresholds` | Thresholds | `atomic` | `math-reason` (0.571) |
+| `through` | Through | `atomic` | `chain-of-thought` (0.522) |
+| `throughput` | Throughput | `atomic` | `chain-of-thought` (0.538), `format-output` (0.522) |
+| `throw` | Throw | `atomic` | `math-reason` (0.500) |
+| `tier` | Tier | `atomic` | `tokenize` (0.500), `retrieve` (0.500) |
+| `time` | Time | `atomic` | `tokenize` (0.500), `retrieve` (0.500) |
+| `timed` | Timed | `atomic` | `tokenize` (0.462), `retrieve` (0.462) |
+| `timeout` | Timeout | `atomic` | `evaluate-output` (0.455) |
+| `timestamp` | Timestamp | `atomic` | - |
+| `timezone` | Timezone | `atomic` | `retrieve` (0.500), `memory-manage` (0.476) |
+| `title` | Title | `atomic` | `ghostwrite` (0.533), `route-intent` (0.471) |
+| `tmpdir` | Tmpdir | `atomic` | - |
+| `to-end` | To-end | `atomic` | `tool-use` (0.571), `tokenize` (0.571) |
+| `to-markdown` | To-markdown | `atomic` | `math-reason` (0.455) |
+| `today` | Today | `atomic` | - |
+| `token` | Token | `atomic` | `tokenize` (0.769), `tool-use` (0.462) |
+| `token-classification` | Token-classification | `atomic` | `document-digitization` (0.537), `classify` (0.500) |
+| `tokenization` | Tokenization | `atomic` | `tokenize` (0.700), `document-digitization` (0.606) |
+| `tokenizer` | Tokenizer | `atomic` | `tokenize` (0.941) |
+| `tokens` | Tokens | `atomic` | `tokenize` (0.714) |
+| `tolist` | Tolist | `atomic` | `tool-select` (0.588), `tool-use` (0.571) |
+| `tone` | Tone | `atomic` | `tokenize` (0.667), `tool-use` (0.500) |
+| `tool` | Tool | `atomic` | `tool-use` (0.667), `tool-select` (0.533) |
+| `tools` | Tools | `atomic` | `tool-use` (0.769), `tool-select` (0.625) |
+| `top` | Top | `atomic` | - |
+| `top-k` | Top-k | `atomic` | `tool-use` (0.462), `tokenize` (0.462) |
+| `top-level` | Top-level | `atomic` | `tool-select` (0.500), `score-relevance` (0.500) |
+| `topic` | Topic | `atomic` | `tokenize` (0.462), `api-call` (0.462) |
+| `total` | Total | `atomic` | `tool-use` (0.462) |
+| `traces` | Traces | `atomic` | `cite-sources` (0.556), `extract-entities` (0.545) |
+| `training` | Training | `atomic` | `re-act-reasoning` (0.609), `rank` (0.500) |
+| `transcribes` | Transcribes | `atomic` | `translate` (0.600), `extract-entities` (0.519) |
+| `transformer` | Transformer | `atomic` | `translate` (0.600), `question-answer` (0.462) |
+| `translation` | Translation | `atomic` | `translate` (0.800), `translation-pipeline` (0.710) |
+| `treat` | Treat | `atomic` | `translate` (0.571), `math-reason` (0.500) |
+| `tree` | Tree | `atomic` | `retrieve` (0.667), `tokenize` (0.500) |
+| `trees` | Trees | `atomic` | `retrieve` (0.615), `math-reason` (0.500) |
+| `trim` | Trim | `atomic` | `retrieve` (0.500) |
+| `true` | True | `atomic` | `tool-use` (0.500), `retrieve` (0.500) |
+| `try` | Try | `atomic` | - |
+| `tsc` | Tsc | `atomic` | - |
+| `tsserver` | Tsserver | `atomic` | `write-report` (0.500), `retrieve` (0.500) |
+| `tuple` | Tuple | `atomic` | `tool-use` (0.462) |
+| `tuples` | Tuples | `atomic` | - |
+| `turbo` | Turbo | `atomic` | - |
+| `turns` | Turns | `atomic` | `translate` (0.571), `cite-sources` (0.471) |
+| `two` | Two | `atomic` | - |
+| `two-pass` | Two-pass | `atomic` | `tool-use` (0.500), `data-analysis` (0.476) |
+| `type` | Type | `atomic` | - |
+| `typed` | Typed | `atomic` | - |
+| `types` | Types | `atomic` | - |
+| `typescript` | Typescript | `atomic` | `web-scrape` (0.500) |
+| `typescript-5` | Typescript-5 | `atomic` | `web-scrape` (0.455) |
+| `typing` | Typing | `atomic` | - |
+| `ubuntu-latest` | Ubuntu-latest | `atomic` | `generate-test` (0.538), `document-analyst` (0.483) |
+| `unanswerable` | Unanswerable | `atomic` | `question-answer` (0.593), `web-scrape` (0.455) |
+| `unbounded` | Unbounded | `atomic` | `autonomous-debug` (0.480) |
+| `uncommon` | Uncommon | `atomic` | `plan-decompose` (0.455), `chunk-document` (0.455) |
+| `under` | Under | `atomic` | - |
+| `undici-types` | Undici-types | `atomic` | `audience-model` (0.462) |
+| `undici-types-6` | Undici-types-6 | `atomic` | - |
+| `unified` | Unified | `atomic` | - |
+| `uninstall` | Uninstall | `atomic` | `api-call` (0.471) |
+| `union` | Union | `atomic` | - |
+| `unique` | Unique | `atomic` | - |
+| `uniqueness` | Uniqueness | `atomic` | - |
+| `unit` | Unit | `atomic` | - |
+| `unknown` | Unknown | `atomic` | - |
+| `unlikely` | Unlikely | `atomic` | - |
+| `unlock` | Unlock | `atomic` | - |
+| `unlocked` | Unlocked | `atomic` | `chunk-document` (0.455) |
+| `unlocks` | Unlocks | `atomic` | - |
+| `unstructured` | Unstructured | `atomic` | `structured-output` (0.690), `ghostwrite` (0.455) |
+| `until` | Until | `atomic` | - |
+| `update` | Update | `atomic` | - |
+| `update-tree` | Update-tree | `atomic` | `retrieve` (0.526), `route-intent` (0.522) |
+| `updated` | Updated | `atomic` | - |
+| `updates` | Updates | `atomic` | `parse-json` (0.471) |
+| `upper` | Upper | `atomic` | - |
+| `uppercase` | Uppercase | `atomic` | `computer-use` (0.476) |
+| `url` | Url | `atomic` | - |
+| `urllib` | Urllib | `atomic` | - |
+| `urlopen` | Urlopen | `atomic` | - |
+| `usable` | Usable | `atomic` | - |
+| `usage` | Usage | `atomic` | `tool-use` (0.462) |
+| `use` | Use | `atomic` | `tool-use` (0.545) |
+| `used` | Used | `atomic` | `tool-use` (0.500), `parse-pdf` (0.462) |
+| `useful` | Useful | `atomic` | - |
+| `user` | User | `atomic` | `tool-use` (0.500), `research` (0.500) |
+| `username` | Username | `atomic` | `memory-manage` (0.476), `audience-model` (0.455) |
+| `users` | Users | `atomic` | `tool-use` (0.462), `research` (0.462) |
+| `users-dir` | Users-dir | `atomic` | - |
+| `uses` | Uses | `atomic` | `tool-use` (0.500) |
+| `using` | Using | `atomic` | `automated-testing` (0.455) |
+| `usr` | Usr | `atomic` | - |
+| `usually` | Usually | `atomic` | - |
+| `utc` | Utc | `atomic` | - |
+| `utf-8` | Utf-8 | `atomic` | - |
+| `utf8` | Utf8 | `atomic` | - |
+| `util` | Util | `atomic` | - |
+| `utilities` | Utilities | `atomic` | `extract-entities` (0.480), `route-intent` (0.476) |
+| `valence` | Valence | `atomic` | `logical-inference` (0.500), `audience-model` (0.476) |
+| `valid` | Valid | `atomic` | - |
+| `validate` | Validate | `atomic` | `translate` (0.588), `evaluate-output` (0.522) |
+| `validated` | Validated | `atomic` | `translate` (0.556), `evaluate-output` (0.500) |
+| `validates` | Validates | `atomic` | `translate` (0.556), `evaluate-output` (0.500) |
+| `validation` | Validation | `atomic` | `image-caption` (0.522), `evaluate-output` (0.480) |
+| `value` | Value | `atomic` | `evaluate-output` (0.500), `tool-use` (0.462) |
+| `values` | Values | `atomic` | `evaluate-output` (0.476) |
+| `variables` | Variables | `atomic` | `api-call` (0.471) |
+| `vector` | Vector | `atomic` | `refactor-code` (0.526) |
+| `vectors` | Vectors | `atomic` | `refactor-code` (0.500) |
+| `vendor` | Vendor | `atomic` | - |
+| `venv` | Venv | `atomic` | - |
+| `verified` | Verified | `atomic` | `self-critique` (0.476) |
+| `verify` | Verify | `atomic` | - |
+| `verifying` | Verifying | `atomic` | `memory-manage` (0.455) |
+| `version` | Version | `atomic` | `conversational-agent` (0.519), `parse-json` (0.471) |
+| `versions` | Versions | `atomic` | `question-answer` (0.522), `conversational-agent` (0.500) |
+| `via` | Via | `atomic` | - |
+| `virtual` | Virtual | `atomic` | `data-visualize` (0.476) |
+| `vision` | Vision | `atomic` | - |
+| `vision-language` | Vision-language | `atomic` | `question-answer` (0.533), `conversational-agent` (0.514) |
+| `visual` | Visual | `atomic` | `data-visualize` (0.600) |
+| `visualization` | Visualization | `atomic` | `data-visualize` (0.593), `image-caption` (0.538) |
+| `visualizations` | Visualizations | `atomic` | `data-visualize` (0.571), `image-caption` (0.519) |
+| `visualstudio` | Visualstudio | `atomic` | `data-visualize` (0.538), `registry-curation` (0.483) |
+| `voice` | Voice | `atomic` | `voice-agent` (0.625), `tokenize` (0.462) |
+| `vscode` | Vscode | `atomic` | - |
+| `vscode-marketplace` | Vscode-marketplace | `atomic` | `code-review-pipeline` (0.526), `score-relevance` (0.485) |
+| `walk` | Walk | `atomic` | `rank` (0.500) |
+| `want` | Want | `atomic` | `rank` (0.500), `translate` (0.462) |
+| `warnings` | Warnings | `atomic` | `re-act-reasoning` (0.522) |
+| `weak` | Weak | `atomic` | `rank` (0.500) |
+| `web` | Web | `atomic` | `web-search` (0.462), `web-scrape` (0.462) |
+| `web-arena-x` | Web-arena-x | `atomic` | `web-search` (0.571), `web-scrape` (0.571) |
+| `webarena` | Webarena | `atomic` | `web-search` (0.556), `web-scrape` (0.556) |
+| `webp` | Webp | `atomic` | `web-scrape` (0.571) |
+| `websites` | Websites | `atomic` | `web-search` (0.556), `web-scrape` (0.556) |
+| `well-formed` | Well-formed | `atomic` | `web-scrape` (0.476) |
+| `wet-lab` | Wet-lab | `atomic` | `web-search` (0.471), `web-scrape` (0.471) |
+| `what` | What | `atomic` | - |
+| `when` | When | `atomic` | - |
+| `whenever` | Whenever | `atomic` | `retrieve` (0.500) |
+| `where` | Where | `atomic` | `web-scrape` (0.533), `write-report` (0.471) |
+| `which` | Which | `atomic` | - |
+| `while` | While | `atomic` | - |
+| `whisper` | Whisper | `atomic` | `web-scrape` (0.471) |
+| `width` | Width | `atomic` | - |
+| `will` | Will | `atomic` | `api-call` (0.500) |
+| `win32` | Win32 | `atomic` | - |
+| `window` | Window | `atomic` | - |
+| `within` | Within | `atomic` | - |
+| `without` | Without | `atomic` | `write-report` (0.526), `chain-of-thought` (0.522) |
+| `words` | Words | `atomic` | - |
+| `workflows` | Workflows | `atomic` | - |
+| `wrapper` | Wrapper | `atomic` | `web-scrape` (0.588), `rag-pipeline` (0.526) |
+| `write` | Write | `atomic` | `ghostwrite` (0.667), `write-report` (0.588) |
+| `writes` | Writes | `atomic` | `ghostwrite` (0.625), `write-report` (0.556) |
+| `writing` | Writing | `atomic` | `ghostwrite` (0.471), `re-act-reasoning` (0.455) |
+| `written` | Written | `atomic` | `ghostwrite` (0.588), `write-report` (0.526) |
+| `www` | Www | `atomic` | - |
+| `xlang-ai` | Xlang-ai | `atomic` | - |
+| `xml` | Xml | `atomic` | - |
+| `xmlns` | Xmlns | `atomic` | - |
+| `yaml` | Yaml | `atomic` | - |
+| `yes` | Yes | `atomic` | - |
+| `yet` | Yet | `atomic` | - |
+| `yml` | Yml | `atomic` | - |
+| `you` | You | `atomic` | - |
+| `your` | Your | `atomic` | - |
+| `your-github-username` | Your-github-username | `atomic` | - |
+| `ysymyth` | Ysymyth | `atomic` | - |
+| `zero-config` | Zero-config | `atomic` | `re-act-reasoning` (0.462) |
+| `zero-shot` | Zero-shot | `atomic` | `generate-test` (0.455) |
+| `zero-shot-classification` | Zero-shot-classification | `atomic` | `error-interpretation` (0.455) |
+| `zip` | Zip | `atomic` | - |
+
+### Reviewer Checklist
+- [ ] Reviewed each proposed skill for clarity and non-overlap.
+- [ ] Marked each candidate as: accept, rename, duplicate, needs evidence, or reject.
+- [ ] Verified similarity hints are directionally useful (not authoritative).
+- [ ] Noted any evidence gaps or requests for follow-up.
+
+### Maintainer Promotion Checklist
+- [ ] Convert accepted draft skills into canonical `graph/gaia.json` edits in a follow-up PR.
+- [ ] Run `python3 scripts/validate.py` and `python3 scripts/validate_intake.py` on promotion PR.
+- [ ] Close or link back this intake PR from the promotion PR.
+
+Automatically generated by `gaia push`.

--- a/.gaia-intake-pr-body.md
+++ b/.gaia-intake-pr-body.md
@@ -7,7 +7,7 @@ Accepted skills must be promoted separately into `graph/gaia.json`.
 ### Batch Summary
 - User: `gaiabot`
 - Source repo: `mbtiongson1/gaia-skill-tree`
-- Generated at: `2026-04-29T13:50:08Z`
+- Generated at: `2026-04-29T13:51:45Z`
 - Known skills: `51`
 - Proposed skills: `1709`
 

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ build/
 # Temp files
 *.tmp
 *.bak
+
+scratch/

--- a/combinations.md
+++ b/combinations.md
@@ -2,34 +2,34 @@
 
 | Skill | Class | Prerequisites | Level Floor | Conditions |
 |---|---|---|---|---|
-| ◇ Automated Testing | Extra Skill | Generate Test, Execute Bash, Error Interpretation | III · Evolved |  |
+| ◇ Automated Testing | Extra Skill | Code Execution, Error Interpretation, Execute Bash, Generate Test | III · Evolved |  |
 | ◆ True Oracle: Autonomous Data Scientist | Ultimate Skill | Data Analysis, Math Reason, Research | V · Transcendent | Requires dataset access and compute environment. Minimum 3 Class A/B evidence sources. |
-| ◇ Autonomous Debug | Extra Skill | Code Generation, Execute Bash, Error Interpretation | III · Evolved |  |
-| ◆ Wisdom King: Autonomous Research Agent | Ultimate Skill | Research, Knowledge Harvest, Ghostwrite | VI · Transcendent ★ | Requires extensive multi-system validation before level advancement. |
-| ◇ Browser Automation | Extra Skill | Web Search, Computer Use | III · Evolved |  |
-| ◇ Code Review Pipeline | Extra Skill | Code Generation, Diff Content, Evaluate Output | III · Evolved |  |
-| ◇ Content Moderation | Extra Skill | Classify, Sentiment Analysis, Extract Entities | III · Evolved |  |
-| ◇ Conversational Agent | Extra Skill | Question Answer, Memory Manage, Route Intent | III · Evolved | Requires persistent memory store across turns. |
-| ◇ Data Analysis | Extra Skill | Generate SQL, Data Visualize, Summarize | III · Evolved |  |
-| ◇ Document Analyst | Extra Skill | Parse JSON, Extract Entities, Summarize, Format Output | III · Evolved |  |
-| ◇ Document Digitization | Extra Skill | Parse PDF, Extract Entities, Format Output | III · Evolved |  |
-| ◆ True Craftsman: Full-Stack Developer | Ultimate Skill | Code Review Pipeline, Automated Testing, Refactor Code | V · Transcendent | Requires access to repository, execution environment, and test runner. Minimum 3 Class A/B evidence sources. |
-| ◇ Ghostwrite | Extra Skill | Research, Write Report, Audience Model | IV · Transcendent | Requires research output as input context. |
+| ◇ Autonomous Debug | Extra Skill | Code Execution, Code Generation, Error Interpretation, Execute Bash | III · Evolved |  |
+| ◆ Wisdom King: Autonomous Research Agent | Ultimate Skill | Browser Automation, Ghostwrite, Knowledge Graph Construction, Knowledge Harvest, ReAct Reasoning, Research | VI · Transcendent ★ | Requires extensive multi-system validation before level advancement. |
+| ◇ Browser Automation | Extra Skill | Computer Use, Web Scrape, Web Search | III · Evolved |  |
+| ◇ Code Review Pipeline | Extra Skill | Code Execution, Code Generation, Diff Content, Evaluate Output | III · Evolved |  |
+| ◇ Content Moderation | Extra Skill | Classify, Extract Entities, Sentiment Analysis | III · Evolved |  |
+| ◇ Conversational Agent | Extra Skill | Memory Manage, Question Answer, Route Intent | III · Evolved | Requires persistent memory store across turns. |
+| ◇ Data Analysis | Extra Skill | Data Visualize, Generate SQL, Summarize | III · Evolved |  |
+| ◇ Document Analyst | Extra Skill | Extract Entities, Format Output, Parse JSON, Summarize | III · Evolved |  |
+| ◇ Document Digitization | Extra Skill | Extract Entities, Format Output, Parse PDF | III · Evolved |  |
+| ◆ True Craftsman: Full-Stack Developer | Ultimate Skill | Automated Testing, Code Review Pipeline, Refactor Code | V · Transcendent | Requires access to repository, execution environment, and test runner. Minimum 3 Class A/B evidence sources. |
+| ◇ Ghostwrite | Extra Skill | Audience Model, Generate Text, Research, Write Report | IV · Transcendent | Requires research output as input context. |
 | ◇ Knowledge Graph Construction | Extra Skill | Extract Entities, Logical Inference | III · Evolved |  |
-| ◇ Knowledge Harvest | Extra Skill | Web Scrape, Extract Entities, Embed Text | IV · Transcendent |  |
+| ◇ Knowledge Harvest | Extra Skill | Embed Text, Extract Entities, Web Scrape | IV · Transcendent |  |
 | ◆ Grand Conductor: Multi-Agent Orchestration | Ultimate Skill | Plan and Execute, Route Intent, Tool Select | V · Transcendent | Requires extensive multi-system validation before level advancement. |
-| ◇ Multimodal Reasoning | Extra Skill | Image Caption, Question Answer, Logical Inference | III · Evolved | Requires vision-language model capability. |
-| ◇ Plan and Execute | Extra Skill | Route Intent, Plan and Decompose, Tool Select | III · Evolved |  |
-| ◇ RAG Pipeline | Extra Skill | Retrieve, Chunk Document, Embed Text, Score Relevance | III · Evolved |  |
-| ◇ ReAct Reasoning | Extra Skill | Plan and Decompose, Tool Use | III · Evolved |  |
-| ◆ True Herald: Real-Time Voice Assistant | Ultimate Skill | Voice Agent, Memory Manage, Plan and Execute | V · Transcendent | Requires real-time audio pipeline, <500ms end-to-end latency target, and persistent session store. Minimum 3 Class A/B evidence sources. |
-| ◆ True Sage: Recursive Self-Improvement | Ultimate Skill | Autonomous Debug, Evaluate Output, Plan and Execute | V · Transcendent | Requires extensive multi-system validation before level advancement. |
-| ◇ Registry Curation | Extra Skill | Research, Code Generation, Execute Bash | IV · Transcendent | Requires write access to the canonical graph and a passing validation suite. |
-| ◇ Research | Extra Skill | Web Search, Summarize, Cite Sources | III · Evolved |  |
-| ◆ True Dragon: Autonomous Scientific Discovery | Ultimate Skill | Hypothesis Generation, Research, Math Reason | V · Transcendent | Requires laboratory tool access or simulation environment. Minimum 3 Class A/B evidence sources. |
-| ◇ Text-to-SQL Pipeline | Extra Skill | Generate SQL, Parse JSON, Format Output | III · Evolved | Requires schema context in prompt. |
-| ◇ Translation Pipeline | Extra Skill | Translate, Sentiment Analysis, Audience Model | III · Evolved |  |
-| ◇ Voice Agent | Extra Skill | Speech to Text, Question Answer, Text to Speech | III · Evolved | Requires real-time audio I/O or audio file access. |
-| ◇ Web Scrape | Extra Skill | Web Search, Parse HTML, Extract Entities | III · Evolved | Structured output mode required. |
+| ◇ Multimodal Reasoning | Extra Skill | Image Caption, Logical Inference, Question Answer | III · Evolved | Requires vision-language model capability. |
+| ◇ Plan and Execute | Extra Skill | Plan and Decompose, ReAct Reasoning, Route Intent, Tool Select | III · Evolved |  |
+| ◇ RAG Pipeline | Extra Skill | Chunk Document, Embed Text, Knowledge Graph Construction, Rank, Retrieve, Score Relevance, Structured Output Generation, Tokenize | III · Evolved |  |
+| ◇ ReAct Reasoning | Extra Skill | Chain-of-Thought Reasoning, Plan and Decompose, Tool Select, Tool Use | III · Evolved |  |
+| ◆ True Herald: Real-Time Voice Assistant | Ultimate Skill | Memory Manage, Plan and Execute, Voice Agent | V · Transcendent | Requires real-time audio pipeline, <500ms end-to-end latency target, and persistent session store. Minimum 3 Class A/B evidence sources. |
+| ◆ True Sage: Recursive Self-Improvement | Ultimate Skill | Autonomous Debug, Evaluate Output, Plan and Execute, Self-Critique | V · Transcendent | Requires extensive multi-system validation before level advancement. |
+| ◇ Registry Curation | Extra Skill | Code Generation, Execute Bash, Research | IV · Transcendent | Requires write access to the canonical graph and a passing validation suite. |
+| ◇ Research | Extra Skill | Cite Sources, Summarize, Web Search | III · Evolved |  |
+| ◆ True Dragon: Autonomous Scientific Discovery | Ultimate Skill | Chain-of-Thought Reasoning, Hypothesis Generation, Math Reason, Research | V · Transcendent | Requires laboratory tool access or simulation environment. Minimum 3 Class A/B evidence sources. |
+| ◇ Text-to-SQL Pipeline | Extra Skill | Format Output, Generate SQL, Parse JSON, Structured Output Generation | III · Evolved | Requires schema context in prompt. |
+| ◇ Translation Pipeline | Extra Skill | Audience Model, Sentiment Analysis, Translate | III · Evolved |  |
+| ◇ Voice Agent | Extra Skill | Question Answer, Speech to Text, Text to Speech | III · Evolved | Requires real-time audio I/O or audio file access. |
+| ◇ Web Scrape | Extra Skill | Extract Entities, Parse HTML, Web Search | III · Evolved | Structured output mode required. |
 
 *Generated from gaia.json v1.0.0.*

--- a/graph/gaia.json
+++ b/graph/gaia.json
@@ -57,8 +57,8 @@
       "description": "Assigns one or more categorical labels to an input based on learned or rule-based criteria.",
       "prerequisites": [],
       "derivatives": [
-        "route-intent",
-        "content-moderation"
+        "content-moderation",
+        "route-intent"
       ],
       "conditions": "",
       "evidence": [
@@ -140,6 +140,7 @@
       "prerequisites": [],
       "derivatives": [
         "document-analyst",
+        "structured-output",
         "text-to-sql-pipeline"
       ],
       "conditions": "",
@@ -197,7 +198,8 @@
         "automated-testing",
         "autonomous-debug",
         "code-execution",
-        "registry-curation"
+        "registry-curation",
+        "tool-use"
       ],
       "conditions": "",
       "evidence": [
@@ -224,7 +226,10 @@
       "description": "Produces coherent natural language output given a prompt, instruction, or context window.",
       "prerequisites": [],
       "derivatives": [
-        "ghostwrite"
+        "chain-of-thought",
+        "ghostwrite",
+        "route-intent",
+        "self-critique"
       ],
       "conditions": "",
       "evidence": [
@@ -251,9 +256,9 @@
       "description": "Condenses longer input into a shorter representation that preserves key information and intent.",
       "prerequisites": [],
       "derivatives": [
-        "research",
+        "data-analysis",
         "document-analyst",
-        "data-analysis"
+        "research"
       ],
       "conditions": "",
       "evidence": [
@@ -333,14 +338,18 @@
     {
       "id": "route-intent",
       "name": "Route Intent",
-      "type": "atomic",
+      "type": "composite",
       "level": "I",
       "rarity": "common",
       "description": "Classifies user intent and directs execution to the appropriate handler, tool, or sub-agent.",
-      "prerequisites": [],
+      "prerequisites": [
+        "classify",
+        "generate-text"
+      ],
       "derivatives": [
-        "plan-and-execute",
-        "conversational-agent"
+        "conversational-agent",
+        "multi-agent-orchestration-v",
+        "plan-and-execute"
       ],
       "conditions": "",
       "evidence": [
@@ -368,6 +377,7 @@
       "prerequisites": [],
       "derivatives": [
         "code-review-pipeline",
+        "recursive-self-improvement",
         "self-critique"
       ],
       "conditions": "",
@@ -395,8 +405,8 @@
       "description": "Converts text into dense vector representations suitable for similarity search and clustering.",
       "prerequisites": [],
       "derivatives": [
-        "rag-pipeline",
-        "knowledge-harvest"
+        "knowledge-harvest",
+        "rag-pipeline"
       ],
       "conditions": "",
       "evidence": [
@@ -533,6 +543,7 @@
       "description": "Chooses the most appropriate tool or API from a set of available options given a task description.",
       "prerequisites": [],
       "derivatives": [
+        "multi-agent-orchestration-v",
         "plan-and-execute",
         "re-act-reasoning",
         "tool-use"
@@ -562,8 +573,8 @@
       "description": "Diagnoses error messages, stack traces, and failure modes to identify root causes and suggest fixes.",
       "prerequisites": [],
       "derivatives": [
-        "autonomous-debug",
-        "automated-testing"
+        "automated-testing",
+        "autonomous-debug"
       ],
       "conditions": "",
       "evidence": [
@@ -732,9 +743,9 @@
       "rarity": "uncommon",
       "description": "Retrieves and structures data from web pages into usable entities.",
       "prerequisites": [
-        "web-search",
+        "extract-entities",
         "parse-html",
-        "extract-entities"
+        "web-search"
       ],
       "derivatives": [
         "browser-automation",
@@ -764,12 +775,13 @@
       "rarity": "uncommon",
       "description": "Conducts multi-source information gathering, synthesis, and citation for a given topic.",
       "prerequisites": [
-        "web-search",
+        "cite-sources",
         "summarize",
-        "cite-sources"
+        "web-search"
       ],
       "derivatives": [
         "autonomous-data-scientist",
+        "autonomous-research-agent",
         "ghostwrite",
         "hypothesis-generate",
         "registry-curation",
@@ -799,11 +811,14 @@
       "rarity": "rare",
       "description": "Produces audience-tailored, research-backed long-form written content.",
       "prerequisites": [
+        "audience-model",
+        "generate-text",
         "research",
-        "write-report",
-        "audience-model"
+        "write-report"
       ],
-      "derivatives": [],
+      "derivatives": [
+        "autonomous-research-agent"
+      ],
       "conditions": "Requires research output as input context.",
       "evidence": [
         {
@@ -828,11 +843,14 @@
       "rarity": "rare",
       "description": "Independently identifies, diagnoses, and fixes software bugs through code generation and execution.",
       "prerequisites": [
+        "code-execution",
         "code-generation",
-        "execute-bash",
-        "error-interpretation"
+        "error-interpretation",
+        "execute-bash"
       ],
-      "derivatives": [],
+      "derivatives": [
+        "recursive-self-improvement"
+      ],
       "conditions": "",
       "evidence": [
         {
@@ -857,12 +875,15 @@
       "rarity": "rare",
       "description": "Decomposes complex objectives into sub-tasks, selects tools, and orchestrates execution.",
       "prerequisites": [
-        "route-intent",
         "plan-decompose",
+        "re-act-reasoning",
+        "route-intent",
         "tool-select"
       ],
       "derivatives": [
-        "real-time-voice-assistant"
+        "multi-agent-orchestration-v",
+        "real-time-voice-assistant",
+        "recursive-self-improvement"
       ],
       "conditions": "",
       "evidence": [
@@ -888,11 +909,13 @@
       "rarity": "rare",
       "description": "Extracts, structures, and embeds knowledge from web sources into a searchable corpus.",
       "prerequisites": [
-        "web-scrape",
+        "embed-text",
         "extract-entities",
-        "embed-text"
+        "web-scrape"
       ],
-      "derivatives": [],
+      "derivatives": [
+        "autonomous-research-agent"
+      ],
       "conditions": "",
       "evidence": [
         {
@@ -917,10 +940,14 @@
       "rarity": "uncommon",
       "description": "End-to-end retrieval-augmented generation combining document chunking, embedding, retrieval, and relevance scoring.",
       "prerequisites": [
-        "retrieve",
         "chunk-document",
         "embed-text",
-        "score-relevance"
+        "knowledge-graph-build",
+        "rank",
+        "retrieve",
+        "score-relevance",
+        "structured-output",
+        "tokenize"
       ],
       "derivatives": [],
       "conditions": "",
@@ -947,10 +974,10 @@
       "rarity": "uncommon",
       "description": "Parses, extracts entities from, summarizes, and formats structured documents.",
       "prerequisites": [
-        "parse-json",
         "extract-entities",
-        "summarize",
-        "format-output"
+        "format-output",
+        "parse-json",
+        "summarize"
       ],
       "derivatives": [],
       "conditions": "",
@@ -979,7 +1006,8 @@
       "prerequisites": [
         "autonomous-debug",
         "evaluate-output",
-        "plan-and-execute"
+        "plan-and-execute",
+        "self-critique"
       ],
       "derivatives": [],
       "conditions": "Requires extensive multi-system validation before level advancement.",
@@ -1035,9 +1063,12 @@
       "rarity": "legendary",
       "description": "Independently conducts end-to-end research cycles including hypothesis generation, evidence gathering, synthesis, and reporting.",
       "prerequisites": [
-        "research",
+        "browser-automation",
+        "ghostwrite",
+        "knowledge-graph-build",
         "knowledge-harvest",
-        "ghostwrite"
+        "re-act-reasoning",
+        "research"
       ],
       "derivatives": [],
       "conditions": "Requires extensive multi-system validation before level advancement.",
@@ -1201,8 +1232,8 @@
       "description": "Translates natural-language data questions into syntactically correct, executable SQL queries against a given schema.",
       "prerequisites": [],
       "derivatives": [
-        "text-to-sql-pipeline",
-        "data-analysis"
+        "data-analysis",
+        "text-to-sql-pipeline"
       ],
       "conditions": "",
       "evidence": [
@@ -1230,8 +1261,8 @@
       "prerequisites": [],
       "derivatives": [
         "conversational-agent",
-        "voice-agent",
-        "multimodal-reasoning"
+        "multimodal-reasoning",
+        "voice-agent"
       ],
       "conditions": "",
       "evidence": [
@@ -1312,6 +1343,7 @@
       "prerequisites": [],
       "derivatives": [
         "chain-of-thought",
+        "hypothesis-generate",
         "knowledge-graph-build",
         "multimodal-reasoning"
       ],
@@ -1525,8 +1557,8 @@
       "rarity": "uncommon",
       "description": "Manages coherent multi-turn dialogue by routing intent, maintaining memory across turns, and generating contextually appropriate responses.",
       "prerequisites": [
-        "question-answer",
         "memory-manage",
+        "question-answer",
         "route-intent"
       ],
       "derivatives": [],
@@ -1554,9 +1586,10 @@
       "rarity": "uncommon",
       "description": "Converts natural-language queries into validated, executable SQL against a target schema and returns formatted result sets.",
       "prerequisites": [
+        "format-output",
         "generate-sql",
         "parse-json",
-        "format-output"
+        "structured-output"
       ],
       "derivatives": [],
       "conditions": "Requires schema context in prompt.",
@@ -1583,6 +1616,7 @@
       "rarity": "uncommon",
       "description": "Performs automated code review by generating, diffing, and evaluating code changes for correctness, style, security, and maintainability.",
       "prerequisites": [
+        "code-execution",
         "code-generation",
         "diff-content",
         "evaluate-output"
@@ -1614,8 +1648,8 @@
       "rarity": "uncommon",
       "description": "Conducts end-to-end quantitative analysis: queries data via SQL, computes statistics, generates visualizations, and summarizes findings.",
       "prerequisites": [
-        "generate-sql",
         "data-visualize",
+        "generate-sql",
         "summarize"
       ],
       "derivatives": [
@@ -1645,8 +1679,8 @@
       "rarity": "uncommon",
       "description": "Handles spoken interactions end-to-end: transcribes audio input, produces language responses, and synthesizes speech output.",
       "prerequisites": [
-        "speech-to-text",
         "question-answer",
+        "speech-to-text",
         "text-to-speech"
       ],
       "derivatives": [
@@ -1676,9 +1710,10 @@
       "rarity": "uncommon",
       "description": "Generates test suites, executes them in a sandbox, interprets failures, and iterates until the target pass rate is reached.",
       "prerequisites": [
-        "generate-test",
+        "code-execution",
+        "error-interpretation",
         "execute-bash",
-        "error-interpretation"
+        "generate-test"
       ],
       "derivatives": [
         "full-stack-developer"
@@ -1708,8 +1743,8 @@
       "description": "Detects policy-violating content by combining intent classification, sentiment scoring, and entity extraction across text, images, and mixed media.",
       "prerequisites": [
         "classify",
-        "sentiment-analysis",
-        "extract-entities"
+        "extract-entities",
+        "sentiment-analysis"
       ],
       "derivatives": [],
       "conditions": "",
@@ -1737,8 +1772,8 @@
       "description": "Integrates information from images and text to answer questions requiring visual grounding and logical inference across modalities.",
       "prerequisites": [
         "image-caption",
-        "question-answer",
-        "logical-inference"
+        "logical-inference",
+        "question-answer"
       ],
       "derivatives": [],
       "conditions": "Requires vision-language model capability.",
@@ -1765,9 +1800,9 @@
       "rarity": "uncommon",
       "description": "Translates content end-to-end while preserving sentiment and adapting tone and register for the target audience.",
       "prerequisites": [
-        "translate",
+        "audience-model",
         "sentiment-analysis",
-        "audience-model"
+        "translate"
       ],
       "derivatives": [],
       "conditions": "",
@@ -1794,9 +1829,9 @@
       "rarity": "uncommon",
       "description": "Converts scanned or PDF documents into structured, machine-readable output by parsing layout, extracting entities, and formatting results.",
       "prerequisites": [
-        "parse-pdf",
         "extract-entities",
-        "format-output"
+        "format-output",
+        "parse-pdf"
       ],
       "derivatives": [],
       "conditions": "",
@@ -1823,8 +1858,8 @@
       "rarity": "legendary",
       "description": "Autonomously implements, reviews, tests, and refactors complete software features across the full development lifecycle from specification to merged PR.",
       "prerequisites": [
-        "code-review-pipeline",
         "automated-testing",
+        "code-review-pipeline",
         "refactor-code"
       ],
       "derivatives": [],
@@ -1909,9 +1944,9 @@
       "rarity": "legendary",
       "description": "Provides low-latency spoken interactions combining real-time speech I/O, persistent memory, and goal-directed task execution across multi-session conversations.",
       "prerequisites": [
-        "voice-agent",
         "memory-manage",
-        "plan-and-execute"
+        "plan-and-execute",
+        "voice-agent"
       ],
       "derivatives": [],
       "conditions": "Requires real-time audio pipeline, <500ms end-to-end latency target, and persistent session store. Minimum 3 Class A/B evidence sources.",
@@ -1952,9 +1987,9 @@
       "rarity": "rare",
       "description": "Systematically discovers, evaluates, and ingests new skill definitions into a structured skill registry: researching capabilities, sourcing reproducible evidence, scripting graph updates, validating schema and DAG integrity, and publishing via pull request.",
       "prerequisites": [
-        "research",
         "code-generation",
-        "execute-bash"
+        "execute-bash",
+        "research"
       ],
       "derivatives": [],
       "conditions": "Requires write access to the canonical graph and a passing validation suite.",
@@ -1983,11 +2018,14 @@
     {
       "id": "tool-use",
       "name": "Tool Use",
-      "type": "atomic",
+      "type": "composite",
       "level": "II",
       "rarity": "uncommon",
       "description": "Invokes external functions or APIs by generating well-formed call signatures, parsing results, and incorporating them into reasoning.",
-      "prerequisites": [],
+      "prerequisites": [
+        "execute-bash",
+        "tool-select"
+      ],
       "derivatives": [
         "re-act-reasoning"
       ],
@@ -2017,11 +2055,14 @@
     {
       "id": "chain-of-thought",
       "name": "Chain-of-Thought Reasoning",
-      "type": "atomic",
+      "type": "composite",
       "level": "II",
       "rarity": "uncommon",
       "description": "Produces explicit intermediate reasoning steps before arriving at a final answer, dramatically improving accuracy on multi-step problems.",
-      "prerequisites": [],
+      "prerequisites": [
+        "generate-text",
+        "logical-inference"
+      ],
       "derivatives": [
         "re-act-reasoning",
         "scientific-discovery"
@@ -2052,11 +2093,14 @@
     {
       "id": "self-critique",
       "name": "Self-Critique",
-      "type": "atomic",
+      "type": "composite",
       "level": "II",
       "rarity": "uncommon",
       "description": "Iteratively evaluates and refines its own outputs using self-generated feedback, improving quality without external supervision.",
-      "prerequisites": [],
+      "prerequisites": [
+        "evaluate-output",
+        "generate-text"
+      ],
       "derivatives": [
         "recursive-self-improvement"
       ],
@@ -2086,11 +2130,14 @@
     {
       "id": "structured-output",
       "name": "Structured Output Generation",
-      "type": "atomic",
+      "type": "composite",
       "level": "II",
       "rarity": "common",
       "description": "Generates output guaranteed to conform to a given schema (JSON, YAML, Pydantic model, etc.) using constrained decoding or grammar-guided generation.",
-      "prerequisites": [],
+      "prerequisites": [
+        "format-output",
+        "parse-json"
+      ],
       "derivatives": [
         "rag-pipeline",
         "text-to-sql-pipeline"
@@ -2121,15 +2168,18 @@
     {
       "id": "code-execution",
       "name": "Code Execution",
-      "type": "atomic",
+      "type": "composite",
       "level": "II",
       "rarity": "common",
       "description": "Writes and executes code in a sandboxed environment, uses the runtime output to verify correctness, and iterates until the result is correct.",
-      "prerequisites": [],
+      "prerequisites": [
+        "code-generation",
+        "execute-bash"
+      ],
       "derivatives": [
+        "automated-testing",
         "autonomous-debug",
-        "code-review-pipeline",
-        "automated-testing"
+        "code-review-pipeline"
       ],
       "conditions": "",
       "evidence": [
@@ -2191,11 +2241,14 @@
     {
       "id": "hypothesis-generate",
       "name": "Hypothesis Generation",
-      "type": "atomic",
+      "type": "composite",
       "level": "II",
       "rarity": "rare",
       "description": "Formulates novel, testable scientific hypotheses by synthesising existing literature, identifying knowledge gaps, and proposing mechanistic explanations.",
-      "prerequisites": [],
+      "prerequisites": [
+        "logical-inference",
+        "research"
+      ],
       "derivatives": [
         "scientific-discovery"
       ],
@@ -2237,12 +2290,14 @@
       "rarity": "uncommon",
       "description": "Interleaves free-form reasoning traces with discrete tool actions in a single loop, enabling agents to plan, act, observe, and update beliefs step-by-step.",
       "prerequisites": [
+        "chain-of-thought",
         "plan-decompose",
+        "tool-select",
         "tool-use"
       ],
       "derivatives": [
-        "plan-and-execute",
-        "autonomous-research-agent"
+        "autonomous-research-agent",
+        "plan-and-execute"
       ],
       "conditions": "",
       "evidence": [
@@ -2275,8 +2330,9 @@
       "rarity": "uncommon",
       "description": "Navigates web pages, fills forms, clicks elements, and extracts information by combining web search with screenshot-based GUI control to complete multi-step web tasks.",
       "prerequisites": [
-        "web-search",
-        "computer-use"
+        "computer-use",
+        "web-scrape",
+        "web-search"
       ],
       "derivatives": [
         "autonomous-research-agent"
@@ -2316,8 +2372,8 @@
         "logical-inference"
       ],
       "derivatives": [
-        "rag-pipeline",
-        "autonomous-research-agent"
+        "autonomous-research-agent",
+        "rag-pipeline"
       ],
       "conditions": "",
       "evidence": [
@@ -2350,9 +2406,10 @@
       "rarity": "legendary",
       "description": "Autonomously generates novel scientific hypotheses, designs and executes experiments, analyses results, and produces a written report \u2014 completing a full research cycle without human intervention.",
       "prerequisites": [
+        "chain-of-thought",
         "hypothesis-generate",
-        "research",
-        "math-reason"
+        "math-reason",
+        "research"
       ],
       "derivatives": [],
       "conditions": "Requires laboratory tool access or simulation environment. Minimum 3 Class A/B evidence sources.",

--- a/intake/skill-batches/20260429135008-gaiabot-gaia-skill-tree.json
+++ b/intake/skill-batches/20260429135008-gaiabot-gaia-skill-tree.json
@@ -1,0 +1,30468 @@
+{
+  "batchId": "20260429135008-gaiabot-gaia-skill-tree",
+  "userId": "gaiabot",
+  "sourceRepo": "mbtiongson1/gaia-skill-tree",
+  "generatedAt": "2026-04-29T13:50:08Z",
+  "knownSkills": [
+    {
+      "skillId": "audience-model"
+    },
+    {
+      "skillId": "autonomous-debug"
+    },
+    {
+      "skillId": "autonomous-research-agent"
+    },
+    {
+      "skillId": "browser-automation"
+    },
+    {
+      "skillId": "chain-of-thought"
+    },
+    {
+      "skillId": "chunk-document"
+    },
+    {
+      "skillId": "cite-sources"
+    },
+    {
+      "skillId": "classify"
+    },
+    {
+      "skillId": "code-execution"
+    },
+    {
+      "skillId": "code-generation"
+    },
+    {
+      "skillId": "computer-use"
+    },
+    {
+      "skillId": "diff-content"
+    },
+    {
+      "skillId": "document-analyst"
+    },
+    {
+      "skillId": "embed-text"
+    },
+    {
+      "skillId": "error-interpretation"
+    },
+    {
+      "skillId": "evaluate-output"
+    },
+    {
+      "skillId": "execute-bash"
+    },
+    {
+      "skillId": "extract-entities"
+    },
+    {
+      "skillId": "format-output"
+    },
+    {
+      "skillId": "generate-text"
+    },
+    {
+      "skillId": "ghostwrite"
+    },
+    {
+      "skillId": "hypothesis-generate"
+    },
+    {
+      "skillId": "knowledge-graph-build"
+    },
+    {
+      "skillId": "knowledge-harvest"
+    },
+    {
+      "skillId": "logical-inference"
+    },
+    {
+      "skillId": "math-reason"
+    },
+    {
+      "skillId": "multi-agent-orchestration-v"
+    },
+    {
+      "skillId": "parse-html"
+    },
+    {
+      "skillId": "parse-json"
+    },
+    {
+      "skillId": "plan-and-execute"
+    },
+    {
+      "skillId": "plan-decompose"
+    },
+    {
+      "skillId": "rag-pipeline"
+    },
+    {
+      "skillId": "rank"
+    },
+    {
+      "skillId": "recursive-self-improvement"
+    },
+    {
+      "skillId": "registry-curation"
+    },
+    {
+      "skillId": "research"
+    },
+    {
+      "skillId": "retrieve"
+    },
+    {
+      "skillId": "route-intent"
+    },
+    {
+      "skillId": "scientific-discovery"
+    },
+    {
+      "skillId": "score-relevance"
+    },
+    {
+      "skillId": "self-critique"
+    },
+    {
+      "skillId": "structured-output"
+    },
+    {
+      "skillId": "summarize"
+    },
+    {
+      "skillId": "text-to-sql-pipeline"
+    },
+    {
+      "skillId": "tokenize"
+    },
+    {
+      "skillId": "tool-select"
+    },
+    {
+      "skillId": "tool-use"
+    },
+    {
+      "skillId": "translate"
+    },
+    {
+      "skillId": "web-scrape"
+    },
+    {
+      "skillId": "web-search"
+    },
+    {
+      "skillId": "write-report"
+    }
+  ],
+  "proposedSkills": [
+    {
+      "id": "a-z",
+      "name": "A-z",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: A-z.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "a-z0-9",
+      "name": "A-z0-9",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: A-z0-9.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "abductive",
+      "name": "Abductive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Abductive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "above",
+      "name": "Above",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Above.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "abs",
+      "name": "Abs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Abs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "absolute",
+      "name": "Absolute",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Absolute.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "abspath",
+      "name": "Abspath",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Abspath.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "accents",
+      "name": "Accents",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Accents.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "accept",
+      "name": "Accept",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Accept.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "accepted",
+      "name": "Accepted",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Accepted.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "access",
+      "name": "Access",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Access.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "accidentally",
+      "name": "Accidentally",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Accidentally.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "accuracy",
+      "name": "Accuracy",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Accuracy.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "accurate",
+      "name": "Accurate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Accurate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "achieves",
+      "name": "Achieves",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Achieves.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "achieving",
+      "name": "Achieving",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Achieving.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "across",
+      "name": "Across",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Across.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "act",
+      "name": "Act",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Act.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "acting",
+      "name": "Acting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Acting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "action",
+      "name": "Action",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Action.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "actions",
+      "name": "Actions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Actions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "actual",
+      "name": "Actual",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Actual.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "adapting",
+      "name": "Adapting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Adapting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "add",
+      "name": "Add",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Add.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "added",
+      "name": "Added",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Added.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "additions",
+      "name": "Additions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Additions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "adjacency",
+      "name": "Adjacency",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Adjacency.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "advancement",
+      "name": "Advancement",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Advancement.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "after",
+      "name": "After",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: After.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "against",
+      "name": "Against",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Against.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "agent",
+      "name": "Agent",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Agent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "agent-native",
+      "name": "Agent-native",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Agent-native.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "agent-related",
+      "name": "Agent-related",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Agent-related.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "agents",
+      "name": "Agents",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Agents.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ahead",
+      "name": "Ahead",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ahead.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ai-agent",
+      "name": "Ai-agent",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ai-agent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ai-agent-tool",
+      "name": "Ai-agent-tool",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ai-agent-tool.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "algebra",
+      "name": "Algebra",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Algebra.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "alive",
+      "name": "Alive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Alive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "all",
+      "name": "All",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: All.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "allocation",
+      "name": "Allocation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Allocation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "allowed",
+      "name": "Allowed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Allowed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "also",
+      "name": "Also",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Also.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "analyses",
+      "name": "Analyses",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Analyses.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "analysis",
+      "name": "Analysis",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Analysis.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "anomaly",
+      "name": "Anomaly",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Anomaly.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "another",
+      "name": "Another",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Another.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "answer",
+      "name": "Answer",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Answer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "answers",
+      "name": "Answers",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Answers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "any",
+      "name": "Any",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Any.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "api",
+      "name": "Api",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Api.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "api-version",
+      "name": "Api-version",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Api-version.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "appears",
+      "name": "Appears",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Appears.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "append",
+      "name": "Append",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Append.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "application",
+      "name": "Application",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Application.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "apply",
+      "name": "Apply",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Apply.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "approach",
+      "name": "Approach",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Approach.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "appropriate",
+      "name": "Appropriate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Appropriate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "approval",
+      "name": "Approval",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Approval.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "archived",
+      "name": "Archived",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Archived.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "argparse",
+      "name": "Argparse",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Argparse.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.483
+        }
+      ]
+    },
+    {
+      "id": "args",
+      "name": "Args",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Args.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "arguments",
+      "name": "Arguments",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Arguments.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "argv",
+      "name": "Argv",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Argv.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "arithmetic",
+      "name": "Arithmetic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Arithmetic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "array",
+      "name": "Array",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Array.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "arrays",
+      "name": "Arrays",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Arrays.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "arriving",
+      "name": "Arriving",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Arriving.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "artifact",
+      "name": "Artifact",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Artifact.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "artifacts",
+      "name": "Artifacts",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Artifacts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "arxiv",
+      "name": "Arxiv",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Arxiv.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "asdict",
+      "name": "Asdict",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Asdict.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "assembles",
+      "name": "Assembles",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Assembles.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "assert",
+      "name": "Assert",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Assert.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "assistant",
+      "name": "Assistant",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Assistant.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "assistants",
+      "name": "Assistants",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Assistants.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "async",
+      "name": "Async",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Async.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "atomic",
+      "name": "Atomic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Atomic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "atomics",
+      "name": "Atomics",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Atomics.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "attrib",
+      "name": "Attrib",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Attrib.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "attribute",
+      "name": "Attribute",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Attribute.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "attributes",
+      "name": "Attributes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Attributes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "attvalue",
+      "name": "Attvalue",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Attvalue.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "attvalues",
+      "name": "Attvalues",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Attvalues.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "audience",
+      "name": "Audience",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Audience.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "audience-tailored",
+      "name": "Audience-tailored",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Audience-tailored.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "audio",
+      "name": "Audio",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Audio.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "augmented",
+      "name": "Augmented",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Augmented.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "auth",
+      "name": "Auth",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Auth.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "authenticated",
+      "name": "Authenticated",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Authenticated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "author",
+      "name": "Author",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Author.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.556
+        }
+      ]
+    },
+    {
+      "id": "authoritative",
+      "name": "Authoritative",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Authoritative.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.48
+        }
+      ]
+    },
+    {
+      "id": "auto-generated",
+      "name": "Auto-generated",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Auto-generated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.538
+        }
+      ]
+    },
+    {
+      "id": "auto-prompt-combinations",
+      "name": "Auto-prompt-combinations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Auto-prompt-combinations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "autogen",
+      "name": "Autogen",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Autogen.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.526
+        },
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "automated",
+      "name": "Automated",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Automated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.522
+        },
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "automatic",
+      "name": "Automatic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Automatic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.571
+        }
+      ]
+    },
+    {
+      "id": "automatically",
+      "name": "Automatically",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Automatically.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.48
+        }
+      ]
+    },
+    {
+      "id": "autonomous",
+      "name": "Autonomous",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Autonomous.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.833
+        },
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "autonomously",
+      "name": "Autonomously",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Autonomously.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.769
+        }
+      ]
+    },
+    {
+      "id": "autoregressive",
+      "name": "Autoregressive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Autoregressive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.538
+        }
+      ]
+    },
+    {
+      "id": "autoresearch",
+      "name": "Autoresearch",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Autoresearch.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 1.0
+        }
+      ]
+    },
+    {
+      "id": "availability",
+      "name": "Availability",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Availability.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "available",
+      "name": "Available",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Available.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "await",
+      "name": "Await",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Await.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "awakened",
+      "name": "Awakened",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Awakened.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "awareness",
+      "name": "Awareness",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Awareness.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "back",
+      "name": "Back",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Back.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "backends",
+      "name": "Backends",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Backends.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "based",
+      "name": "Based",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Based.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "baseline",
+      "name": "Baseline",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Baseline.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "baselines",
+      "name": "Baselines",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Baselines.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bash",
+      "name": "Bash",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bash.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "batch",
+      "name": "Batch",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Batch.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "batched",
+      "name": "Batched",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Batched.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "batches",
+      "name": "Batches",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Batches.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "becomes",
+      "name": "Becomes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Becomes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "been",
+      "name": "Been",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Been.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "before",
+      "name": "Before",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Before.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "begin",
+      "name": "Begin",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Begin.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "behavior",
+      "name": "Behavior",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Behavior.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "being",
+      "name": "Being",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Being.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "beliefs",
+      "name": "Beliefs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Beliefs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bench",
+      "name": "Bench",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bench.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "benchmark",
+      "name": "Benchmark",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Benchmark.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "benchmarked",
+      "name": "Benchmarked",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Benchmarked.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "benchmarks",
+      "name": "Benchmarks",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Benchmarks.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "between",
+      "name": "Between",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Between.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bibliographic",
+      "name": "Bibliographic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bibliographic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bin",
+      "name": "Bin",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bin.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "binary",
+      "name": "Binary",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Binary.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "blob",
+      "name": "Blob",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Blob.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "block",
+      "name": "Block",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Block.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "body",
+      "name": "Body",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Body.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "body-file",
+      "name": "Body-file",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Body-file.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bool",
+      "name": "Bool",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bool.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "boolean",
+      "name": "Boolean",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Boolean.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "booleans",
+      "name": "Booleans",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Booleans.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bootstrapped",
+      "name": "Bootstrapped",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bootstrapped.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bot",
+      "name": "Bot",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bot.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bot-proposal",
+      "name": "Bot-proposal",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bot-proposal.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bpush",
+      "name": "Bpush",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bpush.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "branch",
+      "name": "Branch",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Branch.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "break",
+      "name": "Break",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Break.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "broken",
+      "name": "Broken",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Broken.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "browsers",
+      "name": "Browsers",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Browsers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bucket",
+      "name": "Bucket",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bucket.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "buckets",
+      "name": "Buckets",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Buckets.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "buffer",
+      "name": "Buffer",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Buffer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bugs",
+      "name": "Bugs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bugs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "build",
+      "name": "Build",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Build.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "built",
+      "name": "Built",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Built.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bundler",
+      "name": "Bundler",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bundler.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "but",
+      "name": "But",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: But.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bytecode",
+      "name": "Bytecode",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bytecode.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cache",
+      "name": "Cache",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cache.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "calculus",
+      "name": "Calculus",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Calculus.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "call",
+      "name": "Call",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Call.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "calling",
+      "name": "Calling",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Calling.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "calls",
+      "name": "Calls",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Calls.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "came",
+      "name": "Came",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Came.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "can",
+      "name": "Can",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Can.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "candidate",
+      "name": "Candidate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Candidate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "candidates",
+      "name": "Candidates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Candidates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cannot",
+      "name": "Cannot",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cannot.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "canonical",
+      "name": "Canonical",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Canonical.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "capability",
+      "name": "Capability",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Capability.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "capitalize",
+      "name": "Capitalize",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Capitalize.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "caps",
+      "name": "Caps",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Caps.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "captures",
+      "name": "Captures",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Captures.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "capturing",
+      "name": "Capturing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Capturing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "case",
+      "name": "Case",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Case.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cases",
+      "name": "Cases",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cases.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "catch",
+      "name": "Catch",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Catch.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "catches",
+      "name": "Catches",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Catches.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "categorical",
+      "name": "Categorical",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Categorical.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "categories",
+      "name": "Categories",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Categories.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.545
+        }
+      ]
+    },
+    {
+      "id": "categorization",
+      "name": "Categorization",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Categorization.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "category",
+      "name": "Category",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Category.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "caught",
+      "name": "Caught",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Caught.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "causes",
+      "name": "Causes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Causes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "chain",
+      "name": "Chain",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Chain.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "chain-of-thought-hub",
+      "name": "Chain-of-thought-hub",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Chain-of-thought-hub.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "chain-of-thought-only",
+      "name": "Chain-of-thought-only",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Chain-of-thought-only.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "chains",
+      "name": "Chains",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Chains.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "change",
+      "name": "Change",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Change.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "changed",
+      "name": "Changed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Changed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "changes",
+      "name": "Changes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Changes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "changing",
+      "name": "Changing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Changing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "charts",
+      "name": "Charts",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Charts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "check",
+      "name": "Check",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Check.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "checker",
+      "name": "Checker",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Checker.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "checkout",
+      "name": "Checkout",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Checkout.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "checks",
+      "name": "Checks",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Checks.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "chemistry",
+      "name": "Chemistry",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Chemistry.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "chemists",
+      "name": "Chemists",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Chemists.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "child",
+      "name": "Child",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Child.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "children",
+      "name": "Children",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Children.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "chr",
+      "name": "Chr",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Chr.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "chunk",
+      "name": "Chunk",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Chunk.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "chunking",
+      "name": "Chunking",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Chunking.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "citation",
+      "name": "Citation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Citation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "citations",
+      "name": "Citations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Citations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "claims",
+      "name": "Claims",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Claims.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "clarity",
+      "name": "Clarity",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Clarity.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "class",
+      "name": "Class",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Class.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "classification",
+      "name": "Classification",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Classification.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "classifier",
+      "name": "Classifier",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Classifier.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cleaned",
+      "name": "Cleaned",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cleaned.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cli",
+      "name": "Cli",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cli.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "click",
+      "name": "Click",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Click.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "clicks",
+      "name": "Clicks",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Clicks.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "clone",
+      "name": "Clone",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Clone.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cloning",
+      "name": "Cloning",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cloning.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "closing",
+      "name": "Closing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Closing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "clustering",
+      "name": "Clustering",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Clustering.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cmd",
+      "name": "Cmd",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cmd.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "co-references",
+      "name": "Co-references",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Co-references.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.48
+        }
+      ]
+    },
+    {
+      "id": "code",
+      "name": "Code",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Code.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "codec",
+      "name": "Codec",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Codec.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "codegen",
+      "name": "Codegen",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Codegen.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "codes",
+      "name": "Codes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Codes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "coherent",
+      "name": "Coherent",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Coherent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "collections",
+      "name": "Collections",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Collections.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "color",
+      "name": "Color",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Color.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "com",
+      "name": "Com",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Com.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "combination",
+      "name": "Combination",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Combination.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "combinations",
+      "name": "Combinations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Combinations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "combinator",
+      "name": "Combinator",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Combinator.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "combine",
+      "name": "Combine",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Combine.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "combining",
+      "name": "Combining",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Combining.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "combo",
+      "name": "Combo",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Combo.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "combos",
+      "name": "Combos",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Combos.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "command",
+      "name": "Command",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Command.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "commands",
+      "name": "Commands",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Commands.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "comment",
+      "name": "Comment",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Comment.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "commit",
+      "name": "Commit",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Commit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "common",
+      "name": "Common",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Common.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "community",
+      "name": "Community",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Community.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "comparisons",
+      "name": "Comparisons",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Comparisons.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "compatible",
+      "name": "Compatible",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Compatible.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "competition",
+      "name": "Competition",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Competition.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "compile",
+      "name": "Compile",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Compile.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "complete",
+      "name": "Complete",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Complete.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "completes",
+      "name": "Completes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Completes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "completing",
+      "name": "Completing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Completing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "completion",
+      "name": "Completion",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Completion.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "complex",
+      "name": "Complex",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Complex.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "complexity",
+      "name": "Complexity",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Complexity.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "composite",
+      "name": "Composite",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Composite.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "composites",
+      "name": "Composites",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Composites.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "comprehension",
+      "name": "Comprehension",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Comprehension.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "comprehensive",
+      "name": "Comprehensive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Comprehensive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "computation",
+      "name": "Computation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Computation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "compute",
+      "name": "Compute",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Compute.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "computer",
+      "name": "Computer",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Computer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "computes",
+      "name": "Computes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Computes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "conclusions",
+      "name": "Conclusions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Conclusions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "condition",
+      "name": "Condition",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Condition.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "conditions",
+      "name": "Conditions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Conditions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "conducts",
+      "name": "Conducts",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Conducts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "config",
+      "name": "Config",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Config.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "configurable",
+      "name": "Configurable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Configurable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "configuration",
+      "name": "Configuration",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Configuration.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "configured",
+      "name": "Configured",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Configured.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "confirm",
+      "name": "Confirm",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Confirm.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "confirmed",
+      "name": "Confirmed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Confirmed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "conflict",
+      "name": "Conflict",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Conflict.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "conform",
+      "name": "Conform",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Conform.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "connector",
+      "name": "Connector",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Connector.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "consecutive",
+      "name": "Consecutive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Consecutive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "console",
+      "name": "Console",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Console.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "const",
+      "name": "Const",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Const.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "constrained",
+      "name": "Constrained",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Constrained.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "constraints",
+      "name": "Constraints",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Constraints.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "construction",
+      "name": "Construction",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Construction.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "contain",
+      "name": "Contain",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Contain.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "containing",
+      "name": "Containing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Containing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "content",
+      "name": "Content",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Content.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "context",
+      "name": "Context",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Context.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "context-grounded",
+      "name": "Context-grounded",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Context-grounded.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "contextually",
+      "name": "Contextually",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Contextually.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "continuation",
+      "name": "Continuation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Continuation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "continue",
+      "name": "Continue",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Continue.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "contributor",
+      "name": "Contributor",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Contributor.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "control",
+      "name": "Control",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Control.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "controlled",
+      "name": "Controlled",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Controlled.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "convention",
+      "name": "Convention",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Convention.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "conversation",
+      "name": "Conversation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Conversation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "conversational",
+      "name": "Conversational",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Conversational.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "conversations",
+      "name": "Conversations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Conversations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "convert",
+      "name": "Convert",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Convert.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "copilot",
+      "name": "Copilot",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Copilot.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "copy",
+      "name": "Copy",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Copy.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "copy2",
+      "name": "Copy2",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Copy2.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "core",
+      "name": "Core",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Core.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "corpora",
+      "name": "Corpora",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Corpora.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "corpus",
+      "name": "Corpus",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Corpus.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "correct",
+      "name": "Correct",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Correct.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "correctness",
+      "name": "Correctness",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Correctness.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cosine",
+      "name": "Cosine",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cosine.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "could",
+      "name": "Could",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Could.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "count",
+      "name": "Count",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Count.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "coupling",
+      "name": "Coupling",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Coupling.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "coverage",
+      "name": "Coverage",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Coverage.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "covering",
+      "name": "Covering",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Covering.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "crawl",
+      "name": "Crawl",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Crawl.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "crawler",
+      "name": "Crawler",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Crawler.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "crawlers",
+      "name": "Crawlers",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Crawlers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "crawling",
+      "name": "Crawling",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Crawling.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "create",
+      "name": "Create",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Create.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "created",
+      "name": "Created",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Created.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "creating",
+      "name": "Creating",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Creating.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "creation",
+      "name": "Creation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Creation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "creator",
+      "name": "Creator",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Creator.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "criteria",
+      "name": "Criteria",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Criteria.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cross-domain",
+      "name": "Cross-domain",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cross-domain.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "curation",
+      "name": "Curation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Curation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "current",
+      "name": "Current",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Current.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cwd",
+      "name": "Cwd",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cwd.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cycle",
+      "name": "Cycle",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cycle.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cycles",
+      "name": "Cycles",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cycles.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dash",
+      "name": "Dash",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dash.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "data",
+      "name": "Data",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Data.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dataclass",
+      "name": "Dataclass",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dataclass.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dataclasses",
+      "name": "Dataclasses",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dataclasses.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dataset",
+      "name": "Dataset",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dataset.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "datasets",
+      "name": "Datasets",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Datasets.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "date",
+      "name": "Date",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Date.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dates",
+      "name": "Dates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "datetime",
+      "name": "Datetime",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Datetime.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "days",
+      "name": "Days",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Days.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dead",
+      "name": "Dead",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dead.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "debugging",
+      "name": "Debugging",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Debugging.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "decay",
+      "name": "Decay",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Decay.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "decide",
+      "name": "Decide",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Decide.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "declaration",
+      "name": "Declaration",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Declaration.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "decoding",
+      "name": "Decoding",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Decoding.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "decomposed",
+      "name": "Decomposed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Decomposed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "decomposition",
+      "name": "Decomposition",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Decomposition.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "deductive",
+      "name": "Deductive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Deductive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dedup",
+      "name": "Dedup",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dedup.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "deduplicate",
+      "name": "Deduplicate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Deduplicate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "def",
+      "name": "Def",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Def.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "default",
+      "name": "Default",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Default.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "defaultdict",
+      "name": "Defaultdict",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Defaultdict.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "defaultedgetype",
+      "name": "Defaultedgetype",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Defaultedgetype.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "defaults",
+      "name": "Defaults",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Defaults.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "defined",
+      "name": "Defined",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Defined.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "definitions",
+      "name": "Definitions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Definitions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.529
+        }
+      ]
+    },
+    {
+      "id": "delegates",
+      "name": "Delegates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Delegates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "deletions",
+      "name": "Deletions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Deletions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "delimiter",
+      "name": "Delimiter",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Delimiter.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "delta",
+      "name": "Delta",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Delta.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "demonstrates",
+      "name": "Demonstrates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Demonstrates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "demonstrating",
+      "name": "Demonstrating",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Demonstrating.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "demos",
+      "name": "Demos",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Demos.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dense",
+      "name": "Dense",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dense.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dependencies",
+      "name": "Dependencies",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dependencies.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "depth",
+      "name": "Depth",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Depth.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "deriv",
+      "name": "Deriv",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Deriv.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "derivative",
+      "name": "Derivative",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Derivative.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "derivatives",
+      "name": "Derivatives",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Derivatives.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "derive",
+      "name": "Derive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Derive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "desc",
+      "name": "Desc",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Desc.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "descending",
+      "name": "Descending",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Descending.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "description",
+      "name": "Description",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Description.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "descriptions",
+      "name": "Descriptions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Descriptions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "design",
+      "name": "Design",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Design.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "designs",
+      "name": "Designs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Designs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "desktop",
+      "name": "Desktop",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Desktop.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dest",
+      "name": "Dest",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dest.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "detail",
+      "name": "Detail",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Detail.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "detect",
+      "name": "Detect",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Detect.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "detected",
+      "name": "Detected",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Detected.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "detection",
+      "name": "Detection",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Detection.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "detects",
+      "name": "Detects",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Detects.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dev",
+      "name": "Dev",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dev.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "development",
+      "name": "Development",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Development.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "deviations",
+      "name": "Deviations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Deviations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.545
+        }
+      ]
+    },
+    {
+      "id": "dfs",
+      "name": "Dfs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dfs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "diagnoses",
+      "name": "Diagnoses",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Diagnoses.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dialogue",
+      "name": "Dialogue",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dialogue.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dict",
+      "name": "Dict",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dict.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dicts",
+      "name": "Dicts",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dicts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "diff",
+      "name": "Diff",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Diff.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "diffing",
+      "name": "Diffing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Diffing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "difflib",
+      "name": "Difflib",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Difflib.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "diffusion",
+      "name": "Diffusion",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Diffusion.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "diffusion-based",
+      "name": "Diffusion-based",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Diffusion-based.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dimensions",
+      "name": "Dimensions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dimensions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dir",
+      "name": "Dir",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dir.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "direct",
+      "name": "Direct",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Direct.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "directed",
+      "name": "Directed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Directed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "directionally",
+      "name": "Directionally",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Directionally.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "directly",
+      "name": "Directly",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Directly.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "directory",
+      "name": "Directory",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Directory.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "directs",
+      "name": "Directs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Directs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dirname",
+      "name": "Dirname",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dirname.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dirs",
+      "name": "Dirs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dirs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "discovered",
+      "name": "Discovered",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Discovered.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "discrete",
+      "name": "Discrete",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Discrete.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "display",
+      "name": "Display",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Display.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dist",
+      "name": "Dist",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dist.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "distance",
+      "name": "Distance",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Distance.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "diverse",
+      "name": "Diverse",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Diverse.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "docs",
+      "name": "Docs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Docs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "doctor",
+      "name": "Doctor",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Doctor.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "document",
+      "name": "Document",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Document.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "documentation",
+      "name": "Documentation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Documentation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "documented",
+      "name": "Documented",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Documented.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "documents",
+      "name": "Documents",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Documents.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "does",
+      "name": "Does",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Does.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "doesn",
+      "name": "Doesn",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Doesn.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dom",
+      "name": "Dom",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dom.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "don",
+      "name": "Don",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Don.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dot",
+      "name": "Dot",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dot.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "download",
+      "name": "Download",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Download.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "downloads",
+      "name": "Downloads",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Downloads.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "downstream",
+      "name": "Downstream",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Downstream.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "draft",
+      "name": "Draft",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Draft.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "draft-skills",
+      "name": "Draft-skills",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Draft-skills.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dramatically",
+      "name": "Dramatically",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dramatically.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dry",
+      "name": "Dry",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dry.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dry-run",
+      "name": "Dry-run",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dry-run.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dtype",
+      "name": "Dtype",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dtype.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dual-layer",
+      "name": "Dual-layer",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dual-layer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dump",
+      "name": "Dump",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dump.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dumps",
+      "name": "Dumps",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dumps.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "duplicate",
+      "name": "Duplicate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Duplicate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "duplicates",
+      "name": "Duplicates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Duplicates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dynamic",
+      "name": "Dynamic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dynamic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "each",
+      "name": "Each",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Each.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "echo",
+      "name": "Echo",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Echo.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "edge",
+      "name": "Edge",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Edge.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "edge-case",
+      "name": "Edge-case",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Edge-case.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "edges",
+      "name": "Edges",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Edges.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "edit",
+      "name": "Edit",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Edit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "edits",
+      "name": "Edits",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Edits.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "elem",
+      "name": "Elem",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Elem.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "elements",
+      "name": "Elements",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Elements.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "elicits",
+      "name": "Elicits",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Elicits.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "elif",
+      "name": "Elif",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Elif.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "else",
+      "name": "Else",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Else.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "embed",
+      "name": "Embed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Embed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "embedding",
+      "name": "Embedding",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Embedding.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "embeddings",
+      "name": "Embeddings",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Embeddings.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "embeds",
+      "name": "Embeds",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Embeds.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "emotional",
+      "name": "Emotional",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Emotional.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "empty",
+      "name": "Empty",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Empty.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "enables",
+      "name": "Enables",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Enables.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "enabling",
+      "name": "Enabling",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Enabling.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "encode",
+      "name": "Encode",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Encode.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "encoding",
+      "name": "Encoding",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Encoding.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "end",
+      "name": "End",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: End.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "end-to-end",
+      "name": "End-to-end",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: End-to-end.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "endpoints",
+      "name": "Endpoints",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Endpoints.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "endswith",
+      "name": "Endswith",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Endswith.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "engine",
+      "name": "Engine",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Engine.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "engineering",
+      "name": "Engineering",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Engineering.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "engines",
+      "name": "Engines",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Engines.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "enhances",
+      "name": "Enhances",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Enhances.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "entities",
+      "name": "Entities",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Entities.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "entity",
+      "name": "Entity",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Entity.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "entries",
+      "name": "Entries",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Entries.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "entry",
+      "name": "Entry",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Entry.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "enumerate",
+      "name": "Enumerate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Enumerate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "env",
+      "name": "Env",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Env.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "environ",
+      "name": "Environ",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Environ.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "environment",
+      "name": "Environment",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Environment.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "environments",
+      "name": "Environments",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Environments.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "epic",
+      "name": "Epic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Epic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "equal",
+      "name": "Equal",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Equal.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "equations",
+      "name": "Equations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Equations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "err",
+      "name": "Err",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Err.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "error",
+      "name": "Error",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Error.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "errors",
+      "name": "Errors",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Errors.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "establishes",
+      "name": "Establishes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Establishes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "establishing",
+      "name": "Establishing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Establishing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "etc",
+      "name": "Etc",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Etc.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "etree",
+      "name": "Etree",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Etree.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "eval",
+      "name": "Eval",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Eval.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "evaluated",
+      "name": "Evaluated",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Evaluated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "evaluates",
+      "name": "Evaluates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Evaluates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "evaluating",
+      "name": "Evaluating",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Evaluating.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "evaluation",
+      "name": "Evaluation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Evaluation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "evaluator",
+      "name": "Evaluator",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Evaluator.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "every",
+      "name": "Every",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Every.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "evidence",
+      "name": "Evidence",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Evidence.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "evidence-health",
+      "name": "Evidence-health",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Evidence-health.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "exact",
+      "name": "Exact",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exact.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "exc",
+      "name": "Exc",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exc.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "exceed",
+      "name": "Exceed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exceed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "except",
+      "name": "Except",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Except.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "exclude",
+      "name": "Exclude",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exclude.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "excludes",
+      "name": "Excludes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Excludes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "executable",
+      "name": "Executable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Executable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "executed",
+      "name": "Executed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Executed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "executes",
+      "name": "Executes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Executes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "execution",
+      "name": "Execution",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Execution.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "executor",
+      "name": "Executor",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Executor.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "exhausted",
+      "name": "Exhausted",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exhausted.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "exist",
+      "name": "Exist",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exist.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "existing",
+      "name": "Existing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Existing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "exists",
+      "name": "Exists",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exists.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "exit",
+      "name": "Exit",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "expand",
+      "name": "Expand",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Expand.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "expanduser",
+      "name": "Expanduser",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Expanduser.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "expected",
+      "name": "Expected",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Expected.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "experiments",
+      "name": "Experiments",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Experiments.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "expert-level",
+      "name": "Expert-level",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Expert-level.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "explanations",
+      "name": "Explanations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Explanations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "explicit",
+      "name": "Explicit",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Explicit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "export",
+      "name": "Export",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Export.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "exposes",
+      "name": "Exposes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exposes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ext",
+      "name": "Ext",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ext.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "extend",
+      "name": "Extend",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Extend.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "extension",
+      "name": "Extension",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Extension.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "extensionquery",
+      "name": "Extensionquery",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Extensionquery.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "extensions",
+      "name": "Extensions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Extensions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "extensive",
+      "name": "Extensive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Extensive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "external",
+      "name": "External",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: External.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "extracting",
+      "name": "Extracting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Extracting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "extraction",
+      "name": "Extraction",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Extraction.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "extracts",
+      "name": "Extracts",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Extracts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "failure",
+      "name": "Failure",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Failure.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "failures",
+      "name": "Failures",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Failures.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "fallback",
+      "name": "Fallback",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fallback.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "falls",
+      "name": "Falls",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Falls.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "false",
+      "name": "False",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: False.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "feature",
+      "name": "Feature",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Feature.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "feature-extraction",
+      "name": "Feature-extraction",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Feature-extraction.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "features",
+      "name": "Features",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Features.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "feedback",
+      "name": "Feedback",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Feedback.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "few-shot",
+      "name": "Few-shot",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Few-shot.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "field",
+      "name": "Field",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Field.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fields",
+      "name": "Fields",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fields.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "file",
+      "name": "File",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: File.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "filename",
+      "name": "Filename",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Filename.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "filepath",
+      "name": "Filepath",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Filepath.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "files",
+      "name": "Files",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Files.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fill-mask",
+      "name": "Fill-mask",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fill-mask.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fills",
+      "name": "Fills",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fills.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "filter",
+      "name": "Filter",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Filter.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "filtered",
+      "name": "Filtered",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Filtered.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "filters",
+      "name": "Filters",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Filters.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "final",
+      "name": "Final",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Final.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "finally",
+      "name": "Finally",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Finally.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "findings",
+      "name": "Findings",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Findings.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "finditer",
+      "name": "Finditer",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Finditer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "finite-state",
+      "name": "Finite-state",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Finite-state.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "first",
+      "name": "First",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: First.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fitness",
+      "name": "Fitness",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fitness.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fix",
+      "name": "Fix",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fix.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fixes",
+      "name": "Fixes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fixes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "flags",
+      "name": "Flags",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Flags.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "float",
+      "name": "Float",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Float.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "floats",
+      "name": "Floats",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Floats.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "floor",
+      "name": "Floor",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Floor.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "flow",
+      "name": "Flow",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Flow.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "flush",
+      "name": "Flush",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Flush.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fname",
+      "name": "Fname",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fname.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "follow-up",
+      "name": "Follow-up",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Follow-up.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "follows",
+      "name": "Follows",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Follows.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "force",
+      "name": "Force",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Force.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "form",
+      "name": "Form",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Form.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "format",
+      "name": "Format",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Format.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "formats",
+      "name": "Formats",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Formats.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "formatted",
+      "name": "Formatted",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Formatted.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "formatting",
+      "name": "Formatting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Formatting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "forms",
+      "name": "Forms",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Forms.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "forward",
+      "name": "Forward",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Forward.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "forwarded",
+      "name": "Forwarded",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Forwarded.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "found",
+      "name": "Found",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Found.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "foundation",
+      "name": "Foundation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Foundation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "foundational",
+      "name": "Foundational",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Foundational.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fpath",
+      "name": "Fpath",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fpath.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "framework",
+      "name": "Framework",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Framework.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "framing",
+      "name": "Framing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Framing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fraud",
+      "name": "Fraud",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fraud.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "free-form",
+      "name": "Free-form",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Free-form.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fromisoformat",
+      "name": "Fromisoformat",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fromisoformat.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "frontmatter",
+      "name": "Frontmatter",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Frontmatter.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "full",
+      "name": "Full",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Full.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "full-cycle",
+      "name": "Full-cycle",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Full-cycle.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "function",
+      "name": "Function",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Function.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "functionality",
+      "name": "Functionality",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Functionality.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "functionally",
+      "name": "Functionally",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Functionally.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "functions",
+      "name": "Functions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Functions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fundamentally",
+      "name": "Fundamentally",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fundamentally.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fuse",
+      "name": "Fuse",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fuse.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fusions",
+      "name": "Fusions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fusions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "future",
+      "name": "Future",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Future.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gaia",
+      "name": "Gaia",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaia.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gaia-cli",
+      "name": "Gaia-cli",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaia-cli.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gaia-cli-test",
+      "name": "Gaia-cli-test",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaia-cli-test.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gaia-intake-pr-body",
+      "name": "Gaia-intake-pr-body",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaia-intake-pr-body.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gaia-registry",
+      "name": "Gaia-registry",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaia-registry.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gaia-skill-tree",
+      "name": "Gaia-skill-tree",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaia-skill-tree.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gaiabot",
+      "name": "Gaiabot",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaiabot.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gallery",
+      "name": "Gallery",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gallery.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gaps",
+      "name": "Gaps",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaps.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gathering",
+      "name": "Gathering",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gathering.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gen",
+      "name": "Gen",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gen.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "generate",
+      "name": "Generate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Generate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "generated",
+      "name": "Generated",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Generated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "generates",
+      "name": "Generates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Generates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "generating",
+      "name": "Generating",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Generating.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "generation",
+      "name": "Generation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Generation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "generative",
+      "name": "Generative",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Generative.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "generator",
+      "name": "Generator",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Generator.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "get",
+      "name": "Get",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Get.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "getcode",
+      "name": "Getcode",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Getcode.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gets",
+      "name": "Gets",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gets.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gexf",
+      "name": "Gexf",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gexf.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gif",
+      "name": "Gif",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gif.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "git",
+      "name": "Git",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Git.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "github",
+      "name": "Github",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Github.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "github-action",
+      "name": "Github-action",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Github-action.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "given",
+      "name": "Given",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Given.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "glob",
+      "name": "Glob",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Glob.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "global",
+      "name": "Global",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Global.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gmtime",
+      "name": "Gmtime",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gmtime.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "goal-directed",
+      "name": "Goal-directed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Goal-directed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "got",
+      "name": "Got",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Got.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gracefully",
+      "name": "Gracefully",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gracefully.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "grammar-guided",
+      "name": "Grammar-guided",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Grammar-guided.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "grammars",
+      "name": "Grammars",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Grammars.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "graph",
+      "name": "Graph",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Graph.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "graphrag",
+      "name": "Graphrag",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Graphrag.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "graphs",
+      "name": "Graphs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Graphs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ground-truth",
+      "name": "Ground-truth",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ground-truth.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "grounding",
+      "name": "Grounding",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Grounding.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "group",
+      "name": "Group",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Group.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "groups",
+      "name": "Groups",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Groups.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "guaranteed",
+      "name": "Guaranteed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Guaranteed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "guarantees",
+      "name": "Guarantees",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Guarantees.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "guides",
+      "name": "Guides",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Guides.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "hand-crafted",
+      "name": "Hand-crafted",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hand-crafted.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "handle",
+      "name": "Handle",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Handle.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "handled",
+      "name": "Handled",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Handled.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "handler",
+      "name": "Handler",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Handler.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "handles",
+      "name": "Handles",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Handles.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "handling",
+      "name": "Handling",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Handling.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "happen",
+      "name": "Happen",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Happen.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "harness",
+      "name": "Harness",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Harness.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "has",
+      "name": "Has",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Has.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "hashlib",
+      "name": "Hashlib",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hashlib.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "have",
+      "name": "Have",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Have.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "header",
+      "name": "Header",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Header.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "headers",
+      "name": "Headers",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Headers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "headings",
+      "name": "Headings",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Headings.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "health",
+      "name": "Health",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Health.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "healthy",
+      "name": "Healthy",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Healthy.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "help",
+      "name": "Help",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Help.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "helpful",
+      "name": "Helpful",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Helpful.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "hexdigest",
+      "name": "Hexdigest",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hexdigest.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "highlighting",
+      "name": "Highlighting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Highlighting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "hints",
+      "name": "Hints",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hints.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "hit",
+      "name": "Hit",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "homepage",
+      "name": "Homepage",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Homepage.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "hours",
+      "name": "Hours",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hours.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "html",
+      "name": "Html",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Html.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "http",
+      "name": "Http",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Http.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "https",
+      "name": "Https",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Https.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "huggingface",
+      "name": "Huggingface",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Huggingface.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "human",
+      "name": "Human",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Human.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "human-level",
+      "name": "Human-level",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Human-level.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "hypotheses",
+      "name": "Hypotheses",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hypotheses.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "hypothesis",
+      "name": "Hypothesis",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hypothesis.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ico",
+      "name": "Ico",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ico.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "icon",
+      "name": "Icon",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Icon.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "idea",
+      "name": "Idea",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Idea.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ideas",
+      "name": "Ideas",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ideas.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "identifies",
+      "name": "Identifies",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Identifies.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "identify",
+      "name": "Identify",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Identify.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "identifying",
+      "name": "Identifying",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Identifying.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ids",
+      "name": "Ids",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ids.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "idx",
+      "name": "Idx",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Idx.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ignore",
+      "name": "Ignore",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ignore.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "images",
+      "name": "Images",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Images.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "implementation",
+      "name": "Implementation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Implementation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "implements",
+      "name": "Implements",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Implements.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "import",
+      "name": "Import",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Import.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "importlib",
+      "name": "Importlib",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Importlib.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "improve",
+      "name": "Improve",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Improve.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "improvement",
+      "name": "Improvement",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Improvement.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "improves",
+      "name": "Improves",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Improves.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "improving",
+      "name": "Improving",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Improving.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "in-context",
+      "name": "In-context",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: In-context.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "in-place",
+      "name": "In-place",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: In-place.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "include",
+      "name": "Include",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Include.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "included",
+      "name": "Included",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Included.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "includes",
+      "name": "Includes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Includes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "including",
+      "name": "Including",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Including.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "incorporating",
+      "name": "Incorporating",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Incorporating.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "indent",
+      "name": "Indent",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Indent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "independently",
+      "name": "Independently",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Independently.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "index",
+      "name": "Index",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Index.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "indexed",
+      "name": "Indexed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Indexed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "indexes",
+      "name": "Indexes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Indexes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "inductive",
+      "name": "Inductive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Inductive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "inference",
+      "name": "Inference",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Inference.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "info",
+      "name": "Info",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Info.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "information",
+      "name": "Information",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Information.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "inherit",
+      "name": "Inherit",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Inherit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "init",
+      "name": "Init",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Init.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "initialized",
+      "name": "Initialized",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Initialized.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "inject",
+      "name": "Inject",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Inject.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "injects",
+      "name": "Injects",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Injects.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "inline",
+      "name": "Inline",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Inline.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "inner",
+      "name": "Inner",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Inner.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "input",
+      "name": "Input",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Input.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "inputs",
+      "name": "Inputs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Inputs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "insert",
+      "name": "Insert",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Insert.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "insight",
+      "name": "Insight",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Insight.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "install",
+      "name": "Install",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Install.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "install-manifest",
+      "name": "Install-manifest",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Install-manifest.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "installation",
+      "name": "Installation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Installation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "installed",
+      "name": "Installed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Installed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "installs",
+      "name": "Installs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Installs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "instance",
+      "name": "Instance",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Instance.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "instruction",
+      "name": "Instruction",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Instruction.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "instructions",
+      "name": "Instructions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Instructions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "int",
+      "name": "Int",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Int.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "intake",
+      "name": "Intake",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Intake.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "intake-dir",
+      "name": "Intake-dir",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Intake-dir.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "integrates",
+      "name": "Integrates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Integrates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "integration",
+      "name": "Integration",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Integration.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "integrations",
+      "name": "Integrations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Integrations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "integrity",
+      "name": "Integrity",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Integrity.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "intensity",
+      "name": "Intensity",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Intensity.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "intent",
+      "name": "Intent",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Intent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "interactions",
+      "name": "Interactions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Interactions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "interface",
+      "name": "Interface",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Interface.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "intermediate",
+      "name": "Intermediate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Intermediate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "interpreter",
+      "name": "Interpreter",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Interpreter.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "interpreting",
+      "name": "Interpreting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Interpreting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "interprets",
+      "name": "Interprets",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Interprets.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "intersection",
+      "name": "Intersection",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Intersection.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "intervention",
+      "name": "Intervention",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Intervention.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "into",
+      "name": "Into",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Into.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "intrusion",
+      "name": "Intrusion",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Intrusion.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "invalid",
+      "name": "Invalid",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Invalid.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "isdir",
+      "name": "Isdir",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Isdir.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "isfile",
+      "name": "Isfile",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Isfile.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "isinstance",
+      "name": "Isinstance",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Isinstance.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "islink",
+      "name": "Islink",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Islink.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "isoformat",
+      "name": "Isoformat",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Isoformat.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "issues",
+      "name": "Issues",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Issues.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "issuing",
+      "name": "Issuing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Issuing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "item",
+      "name": "Item",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Item.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "items",
+      "name": "Items",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Items.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "iter",
+      "name": "Iter",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Iter.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "iterates",
+      "name": "Iterates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Iterates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "iteration",
+      "name": "Iteration",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Iteration.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "iterative",
+      "name": "Iterative",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Iterative.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "iteratively",
+      "name": "Iteratively",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Iteratively.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "its",
+      "name": "Its",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Its.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "jobs",
+      "name": "Jobs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Jobs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "join",
+      "name": "Join",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Join.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "jpeg",
+      "name": "Jpeg",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Jpeg.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "jpg",
+      "name": "Jpg",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Jpg.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "json",
+      "name": "Json",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Json.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "jsonschema",
+      "name": "Jsonschema",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Jsonschema.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "karpathy",
+      "name": "Karpathy",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Karpathy.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.552
+        }
+      ]
+    },
+    {
+      "id": "kebab-case",
+      "name": "Kebab-case",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Kebab-case.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "key",
+      "name": "Key",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Key.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "keyboard",
+      "name": "Keyboard",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Keyboard.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "keys",
+      "name": "Keys",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Keys.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "keyword",
+      "name": "Keyword",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Keyword.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "keywords",
+      "name": "Keywords",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Keywords.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "knowledge",
+      "name": "Knowledge",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Knowledge.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "known",
+      "name": "Known",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Known.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "label",
+      "name": "Label",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Label.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "labels",
+      "name": "Labels",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Labels.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "laboratory",
+      "name": "Laboratory",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Laboratory.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lambda",
+      "name": "Lambda",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lambda.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "langchain",
+      "name": "Langchain",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Langchain.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "langchain-ai",
+      "name": "Langchain-ai",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Langchain-ai.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "langchain-tool",
+      "name": "Langchain-tool",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Langchain-tool.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "language",
+      "name": "Language",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Language.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "language-image",
+      "name": "Language-image",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Language-image.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "languages",
+      "name": "Languages",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Languages.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "large",
+      "name": "Large",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Large.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "large-scale",
+      "name": "Large-scale",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Large-scale.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "last",
+      "name": "Last",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Last.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "last-week",
+      "name": "Last-week",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Last-week.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lastmodifieddate",
+      "name": "Lastmodifieddate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lastmodifieddate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "latency",
+      "name": "Latency",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Latency.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "later",
+      "name": "Later",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Later.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "layout",
+      "name": "Layout",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Layout.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "leading",
+      "name": "Leading",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Leading.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "learn",
+      "name": "Learn",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Learn.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "learned",
+      "name": "Learned",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Learned.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "learning",
+      "name": "Learning",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Learning.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "least",
+      "name": "Least",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Least.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "left",
+      "name": "Left",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Left.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "legendaries",
+      "name": "Legendaries",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Legendaries.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "legendary",
+      "name": "Legendary",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Legendary.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "legendary-specific",
+      "name": "Legendary-specific",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Legendary-specific.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "len",
+      "name": "Len",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Len.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "less",
+      "name": "Less",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Less.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "let",
+      "name": "Let",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Let.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "letters",
+      "name": "Letters",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Letters.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "level",
+      "name": "Level",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Level.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lexically",
+      "name": "Lexically",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lexically.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "library",
+      "name": "Library",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Library.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "libs",
+      "name": "Libs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Libs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "license",
+      "name": "License",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: License.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lid",
+      "name": "Lid",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lid.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lida",
+      "name": "Lida",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lida.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lifecycle",
+      "name": "Lifecycle",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lifecycle.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "like",
+      "name": "Like",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Like.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "likes",
+      "name": "Likes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Likes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "limit",
+      "name": "Limit",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Limit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "linalg",
+      "name": "Linalg",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Linalg.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "line",
+      "name": "Line",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Line.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lineage",
+      "name": "Lineage",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lineage.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "linear",
+      "name": "Linear",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Linear.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lines",
+      "name": "Lines",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lines.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "link",
+      "name": "Link",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Link.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "links",
+      "name": "Links",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Links.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "list",
+      "name": "List",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: List.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "listdir",
+      "name": "Listdir",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Listdir.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "literature",
+      "name": "Literature",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Literature.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "llevel",
+      "name": "Llevel",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Llevel.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "llm",
+      "name": "Llm",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Llm.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "llm-tool",
+      "name": "Llm-tool",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Llm-tool.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lname",
+      "name": "Lname",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lname.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "load",
+      "name": "Load",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Load.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "loaded",
+      "name": "Loaded",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Loaded.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "loader",
+      "name": "Loader",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Loader.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "local",
+      "name": "Local",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Local.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "local-repo",
+      "name": "Local-repo",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Local-repo.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "locally",
+      "name": "Locally",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Locally.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "locate",
+      "name": "Locate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Locate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "locations",
+      "name": "Locations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Locations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "log-scaled",
+      "name": "Log-scaled",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Log-scaled.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "log10",
+      "name": "Log10",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Log10.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "log2",
+      "name": "Log2",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Log2.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "logging",
+      "name": "Logging",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Logging.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "logic",
+      "name": "Logic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Logic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "logical",
+      "name": "Logical",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Logical.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "logs",
+      "name": "Logs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Logs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "long-form",
+      "name": "Long-form",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Long-form.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "long-term",
+      "name": "Long-term",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Long-term.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "longer",
+      "name": "Longer",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Longer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "look",
+      "name": "Look",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Look.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "loop",
+      "name": "Loop",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Loop.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "loops",
+      "name": "Loops",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Loops.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "low-latency",
+      "name": "Low-latency",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Low-latency.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lower",
+      "name": "Lower",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lower.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lowercase-dash",
+      "name": "Lowercase-dash",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lowercase-dash.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lvl",
+      "name": "Lvl",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lvl.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "machine",
+      "name": "Machine",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Machine.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "machine-readable",
+      "name": "Machine-readable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Machine-readable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "madaan",
+      "name": "Madaan",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Madaan.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "main",
+      "name": "Main",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Main.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "maintainability",
+      "name": "Maintainability",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Maintainability.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "maintaining",
+      "name": "Maintaining",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Maintaining.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "makedirs",
+      "name": "Makedirs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Makedirs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "malformed",
+      "name": "Malformed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Malformed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "management",
+      "name": "Management",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Management.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "managing",
+      "name": "Managing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Managing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "manifest",
+      "name": "Manifest",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Manifest.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "manual",
+      "name": "Manual",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Manual.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "manually",
+      "name": "Manually",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Manually.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "manuscripts",
+      "name": "Manuscripts",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Manuscripts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "map",
+      "name": "Map",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Map.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mapping",
+      "name": "Mapping",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mapping.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mappings",
+      "name": "Mappings",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mappings.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "maps",
+      "name": "Maps",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Maps.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mark",
+      "name": "Mark",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mark.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "markdown",
+      "name": "Markdown",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Markdown.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "marked",
+      "name": "Marked",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Marked.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "marker",
+      "name": "Marker",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Marker.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "markers",
+      "name": "Markers",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Markers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "marketplace",
+      "name": "Marketplace",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Marketplace.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "markup",
+      "name": "Markup",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Markup.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "master",
+      "name": "Master",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Master.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "match",
+      "name": "Match",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Match.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "matching",
+      "name": "Matching",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Matching.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "math",
+      "name": "Math",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Math.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mathematical",
+      "name": "Mathematical",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mathematical.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mathematics",
+      "name": "Mathematics",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mathematics.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "max",
+      "name": "Max",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Max.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "may",
+      "name": "May",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: May.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mbtiongson1",
+      "name": "Mbtiongson1",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mbtiongson1.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mcp",
+      "name": "Mcp",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mcp.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mcp-registry",
+      "name": "Mcp-registry",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mcp-registry.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mcp-server",
+      "name": "Mcp-server",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mcp-server.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "meaning",
+      "name": "Meaning",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Meaning.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "meaningful",
+      "name": "Meaningful",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Meaningful.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mechanistic",
+      "name": "Mechanistic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mechanistic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "media",
+      "name": "Media",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Media.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "medical",
+      "name": "Medical",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Medical.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "meets",
+      "name": "Meets",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Meets.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "memory",
+      "name": "Memory",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Memory.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "merged",
+      "name": "Merged",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Merged.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "message",
+      "name": "Message",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Message.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "messages",
+      "name": "Messages",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Messages.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "meta",
+      "name": "Meta",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Meta.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "metadata",
+      "name": "Metadata",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Metadata.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "metavar",
+      "name": "Metavar",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Metavar.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "method",
+      "name": "Method",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Method.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "methodology",
+      "name": "Methodology",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Methodology.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "methods",
+      "name": "Methods",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Methods.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "microsecond",
+      "name": "Microsecond",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Microsecond.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "microsoft",
+      "name": "Microsoft",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Microsoft.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "might",
+      "name": "Might",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Might.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "migration",
+      "name": "Migration",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Migration.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "min",
+      "name": "Min",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Min.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "minimum",
+      "name": "Minimum",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Minimum.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "missing",
+      "name": "Missing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Missing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mixed",
+      "name": "Mixed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mixed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mjs",
+      "name": "Mjs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mjs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mod",
+      "name": "Mod",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mod.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "modalities",
+      "name": "Modalities",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Modalities.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mode",
+      "name": "Mode",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mode.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "model",
+      "name": "Model",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Model.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "modeling",
+      "name": "Modeling",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Modeling.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "models",
+      "name": "Models",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Models.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "moderation",
+      "name": "Moderation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Moderation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "modern",
+      "name": "Modern",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Modern.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "modes",
+      "name": "Modes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Modes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "modifications",
+      "name": "Modifications",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Modifications.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "modified",
+      "name": "Modified",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Modified.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "module",
+      "name": "Module",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Module.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "molecular",
+      "name": "Molecular",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Molecular.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "more",
+      "name": "More",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: More.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "most",
+      "name": "Most",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Most.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mouse",
+      "name": "Mouse",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mouse.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.526
+        }
+      ]
+    },
+    {
+      "id": "multi-agent",
+      "name": "Multi-agent",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multi-agent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "multi-category",
+      "name": "Multi-category",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multi-category.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "multi-section",
+      "name": "Multi-section",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multi-section.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "multi-session",
+      "name": "Multi-session",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multi-session.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "multi-source",
+      "name": "Multi-source",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multi-source.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "multi-step",
+      "name": "Multi-step",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multi-step.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "multi-system",
+      "name": "Multi-system",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multi-system.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "multi-turn",
+      "name": "Multi-turn",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multi-turn.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "multilingual",
+      "name": "Multilingual",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multilingual.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "multimodal",
+      "name": "Multimodal",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multimodal.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "multiple",
+      "name": "Multiple",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multiple.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "must",
+      "name": "Must",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Must.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "name",
+      "name": "Name",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Name.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "named",
+      "name": "Named",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Named.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "named-dir",
+      "name": "Named-dir",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Named-dir.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "named-skills",
+      "name": "Named-skills",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Named-skills.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "names",
+      "name": "Names",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Names.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "nargs",
+      "name": "Nargs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Nargs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "narrative",
+      "name": "Narrative",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Narrative.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "natural",
+      "name": "Natural",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Natural.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "natural-language",
+      "name": "Natural-language",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Natural-language.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "natural-sounding",
+      "name": "Natural-sounding",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Natural-sounding.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "navigating",
+      "name": "Navigating",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Navigating.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "near-human",
+      "name": "Near-human",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Near-human.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "need",
+      "name": "Need",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Need.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "needed",
+      "name": "Needed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Needed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "needs",
+      "name": "Needs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Needs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "needs-review",
+      "name": "Needs-review",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Needs-review.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "negative",
+      "name": "Negative",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Negative.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ner",
+      "name": "Ner",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ner.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "nested",
+      "name": "Nested",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Nested.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "nesting",
+      "name": "Nesting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Nesting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "net",
+      "name": "Net",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Net.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "neural",
+      "name": "Neural",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Neural.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "neutral",
+      "name": "Neutral",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Neutral.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "new",
+      "name": "New",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: New.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "next",
+      "name": "Next",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Next.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "nline",
+      "name": "Nline",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Nline.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "no-pr",
+      "name": "No-pr",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: No-pr.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "node",
+      "name": "Node",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Node.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "node-20",
+      "name": "Node-20",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Node-20.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "nodes",
+      "name": "Nodes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Nodes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "noise",
+      "name": "Noise",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Noise.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "non-interactive",
+      "name": "Non-interactive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Non-interactive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "non-overlap",
+      "name": "Non-overlap",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Non-overlap.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "none",
+      "name": "None",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: None.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "nonlocal",
+      "name": "Nonlocal",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Nonlocal.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "noqa",
+      "name": "Noqa",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Noqa.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "norm",
+      "name": "Norm",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Norm.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "normally",
+      "name": "Normally",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Normally.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "not",
+      "name": "Not",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Not.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "notebooks",
+      "name": "Notebooks",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Notebooks.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "notes",
+      "name": "Notes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Notes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "nothing",
+      "name": "Nothing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Nothing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "novel",
+      "name": "Novel",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Novel.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "now",
+      "name": "Now",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Now.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "npm",
+      "name": "Npm",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Npm.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "npmjs",
+      "name": "Npmjs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Npmjs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "number",
+      "name": "Number",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Number.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "numeric",
+      "name": "Numeric",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Numeric.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "numerical",
+      "name": "Numerical",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Numerical.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "numpy",
+      "name": "Numpy",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Numpy.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "nuxt",
+      "name": "Nuxt",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Nuxt.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "objective",
+      "name": "Objective",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Objective.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "objectives",
+      "name": "Objectives",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Objectives.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "objects",
+      "name": "Objects",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Objects.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "observable",
+      "name": "Observable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Observable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "observation",
+      "name": "Observation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Observation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "observe",
+      "name": "Observe",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Observe.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "occurrence",
+      "name": "Occurrence",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Occurrence.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "old",
+      "name": "Old",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Old.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "once",
+      "name": "Once",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Once.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "one",
+      "name": "One",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: One.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "only",
+      "name": "Only",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Only.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "open",
+      "name": "Open",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Open.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "open-ended",
+      "name": "Open-ended",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Open-ended.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "open-source",
+      "name": "Open-source",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Open-source.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "openai",
+      "name": "Openai",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Openai.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "opened",
+      "name": "Opened",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Opened.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "opening",
+      "name": "Opening",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Opening.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "opens",
+      "name": "Opens",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Opens.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "optimized",
+      "name": "Optimized",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Optimized.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "optional",
+      "name": "Optional",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Optional.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "options",
+      "name": "Options",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Options.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "orchestrates",
+      "name": "Orchestrates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Orchestrates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "order",
+      "name": "Order",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Order.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "ordered",
+      "name": "Ordered",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ordered.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "org",
+      "name": "Org",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Org.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "organizations",
+      "name": "Organizations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Organizations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "origin",
+      "name": "Origin",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Origin.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "origins",
+      "name": "Origins",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Origins.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "orphaned",
+      "name": "Orphaned",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Orphaned.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "otherwise",
+      "name": "Otherwise",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Otherwise.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "our",
+      "name": "Our",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Our.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "out",
+      "name": "Out",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Out.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "outliers",
+      "name": "Outliers",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Outliers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "outlines",
+      "name": "Outlines",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Outlines.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "outlines-dev",
+      "name": "Outlines-dev",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Outlines-dev.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "outperforms",
+      "name": "Outperforms",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Outperforms.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "output",
+      "name": "Output",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Output.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "outputs",
+      "name": "Outputs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Outputs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "outside",
+      "name": "Outside",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Outside.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "over",
+      "name": "Over",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Over.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "overhead",
+      "name": "Overhead",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Overhead.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "overwritten",
+      "name": "Overwritten",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Overwritten.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "own",
+      "name": "Own",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Own.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "owned",
+      "name": "Owned",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Owned.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "owner",
+      "name": "Owner",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Owner.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pack",
+      "name": "Pack",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pack.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "package",
+      "name": "Package",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Package.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "packages",
+      "name": "Packages",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Packages.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "packed",
+      "name": "Packed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Packed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pages",
+      "name": "Pages",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pages.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pair",
+      "name": "Pair",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pair.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pairs",
+      "name": "Pairs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pairs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pairwise",
+      "name": "Pairwise",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pairwise.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pal",
+      "name": "Pal",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pal.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pandas",
+      "name": "Pandas",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pandas.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pandas-ai",
+      "name": "Pandas-ai",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pandas-ai.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "paper",
+      "name": "Paper",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Paper.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "papers",
+      "name": "Papers",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Papers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "paradigm",
+      "name": "Paradigm",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Paradigm.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "parameters",
+      "name": "Parameters",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Parameters.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "params",
+      "name": "Params",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Params.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "parent",
+      "name": "Parent",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Parent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "parents",
+      "name": "Parents",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Parents.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "parse",
+      "name": "Parse",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Parse.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "parsed",
+      "name": "Parsed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Parsed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "parser",
+      "name": "Parser",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Parser.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "parses",
+      "name": "Parses",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Parses.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "parsing",
+      "name": "Parsing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Parsing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "partition",
+      "name": "Partition",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Partition.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "parts",
+      "name": "Parts",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Parts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pass",
+      "name": "Pass",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pass.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "passages",
+      "name": "Passages",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Passages.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "passed",
+      "name": "Passed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Passed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "passing",
+      "name": "Passing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Passing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "patch",
+      "name": "Patch",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Patch.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "patched",
+      "name": "Patched",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Patched.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "patches",
+      "name": "Patches",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Patches.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "path",
+      "name": "Path",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Path.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "paths",
+      "name": "Paths",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Paths.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pattern",
+      "name": "Pattern",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pattern.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "patterns",
+      "name": "Patterns",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Patterns.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "payload",
+      "name": "Payload",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Payload.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pdf",
+      "name": "Pdf",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pdf.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pending",
+      "name": "Pending",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pending.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "people",
+      "name": "People",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: People.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "per",
+      "name": "Per",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Per.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "percentage",
+      "name": "Percentage",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Percentage.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "performance",
+      "name": "Performance",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Performance.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "persistent",
+      "name": "Persistent",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Persistent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "photorealistic",
+      "name": "Photorealistic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Photorealistic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "pid",
+      "name": "Pid",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pid.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pip",
+      "name": "Pip",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pip.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pipe",
+      "name": "Pipe",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pipe.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pipeline",
+      "name": "Pipeline",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pipeline.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pipelines",
+      "name": "Pipelines",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pipelines.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pixel-space",
+      "name": "Pixel-space",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pixel-space.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pkg",
+      "name": "Pkg",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pkg.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "placeholder",
+      "name": "Placeholder",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Placeholder.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "plain-text",
+      "name": "Plain-text",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Plain-text.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "plan",
+      "name": "Plan",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Plan.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "planned",
+      "name": "Planned",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Planned.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "planning",
+      "name": "Planning",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Planning.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "platform",
+      "name": "Platform",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Platform.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "plugin",
+      "name": "Plugin",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Plugin.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "plus",
+      "name": "Plus",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Plus.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "png",
+      "name": "Png",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Png.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "point",
+      "name": "Point",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Point.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "points",
+      "name": "Points",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Points.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "policy-violating",
+      "name": "Policy-violating",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Policy-violating.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "popular",
+      "name": "Popular",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Popular.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "popularity",
+      "name": "Popularity",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Popularity.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "positive",
+      "name": "Positive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Positive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "post",
+      "name": "Post",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Post.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pre-computed",
+      "name": "Pre-computed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pre-computed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pre-trained",
+      "name": "Pre-trained",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pre-trained.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pre-training",
+      "name": "Pre-training",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pre-training.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prediction",
+      "name": "Prediction",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prediction.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prefix",
+      "name": "Prefix",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prefix.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "premises",
+      "name": "Premises",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Premises.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prepare",
+      "name": "Prepare",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prepare.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prereq",
+      "name": "Prereq",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prereq.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prereqs",
+      "name": "Prereqs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prereqs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prerequisite",
+      "name": "Prerequisite",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prerequisite.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prerequisites",
+      "name": "Prerequisites",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prerequisites.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "present",
+      "name": "Present",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Present.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "preserves",
+      "name": "Preserves",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Preserves.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "preserving",
+      "name": "Preserving",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Preserving.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "prevalence",
+      "name": "Prevalence",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prevalence.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "preview",
+      "name": "Preview",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Preview.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "princeton-nlp",
+      "name": "Princeton-nlp",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Princeton-nlp.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "print",
+      "name": "Print",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Print.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prints",
+      "name": "Prints",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prints.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "problems",
+      "name": "Problems",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Problems.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "process",
+      "name": "Process",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Process.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "processing",
+      "name": "Processing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Processing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "produce",
+      "name": "Produce",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Produce.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "produces",
+      "name": "Produces",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Produces.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "production",
+      "name": "Production",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Production.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "production-grade",
+      "name": "Production-grade",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Production-grade.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "profile",
+      "name": "Profile",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Profile.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prog",
+      "name": "Prog",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prog.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "programmatic",
+      "name": "Programmatic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Programmatic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "programming",
+      "name": "Programming",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Programming.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "project",
+      "name": "Project",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Project.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "projections",
+      "name": "Projections",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Projections.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "promoted",
+      "name": "Promoted",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Promoted.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "promotion",
+      "name": "Promotion",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Promotion.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prompt",
+      "name": "Prompt",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prompt.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prompting",
+      "name": "Prompting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prompting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prompts",
+      "name": "Prompts",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prompts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "proper",
+      "name": "Proper",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Proper.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "proposals",
+      "name": "Proposals",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Proposals.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "propose",
+      "name": "Propose",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Propose.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "proposed",
+      "name": "Proposed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Proposed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "proposer",
+      "name": "Proposer",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Proposer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "proposes",
+      "name": "Proposes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Proposes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "proposing",
+      "name": "Proposing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Proposing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prosody",
+      "name": "Prosody",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prosody.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "provide",
+      "name": "Provide",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Provide.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "provided",
+      "name": "Provided",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Provided.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "provides",
+      "name": "Provides",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Provides.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "providing",
+      "name": "Providing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Providing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "provisional",
+      "name": "Provisional",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Provisional.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "public",
+      "name": "Public",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Public.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "publicly",
+      "name": "Publicly",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Publicly.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "published",
+      "name": "Published",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Published.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "publisher",
+      "name": "Publisher",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Publisher.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pull",
+      "name": "Pull",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pull.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pure",
+      "name": "Pure",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pure.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "push",
+      "name": "Push",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Push.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pyc",
+      "name": "Pyc",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pyc.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "python",
+      "name": "Python",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Python.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "python-shell",
+      "name": "Python-shell",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Python-shell.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "python-shell-5",
+      "name": "Python-shell-5",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Python-shell-5.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "python-version",
+      "name": "Python-version",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Python-version.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "python3",
+      "name": "Python3",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Python3.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "quality",
+      "name": "Quality",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Quality.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "quantitative",
+      "name": "Quantitative",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Quantitative.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "queries",
+      "name": "Queries",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Queries.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "query",
+      "name": "Query",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Query.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "queryable",
+      "name": "Queryable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Queryable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "question-answering",
+      "name": "Question-answering",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Question-answering.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "questions",
+      "name": "Questions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Questions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "quoted",
+      "name": "Quoted",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Quoted.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rag",
+      "name": "Rag",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rag.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "raise",
+      "name": "Raise",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Raise.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "raises",
+      "name": "Raises",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Raises.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "range",
+      "name": "Range",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Range.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ranking",
+      "name": "Ranking",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ranking.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ranks",
+      "name": "Ranks",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ranks.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rare",
+      "name": "Rare",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rare.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rarity",
+      "name": "Rarity",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rarity.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rasa",
+      "name": "Rasa",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rasa.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rate",
+      "name": "Rate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rated",
+      "name": "Rated",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ratio",
+      "name": "Ratio",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ratio.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "raw",
+      "name": "Raw",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Raw.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "re-derived",
+      "name": "Re-derived",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Re-derived.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "re-exports",
+      "name": "Re-exports",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Re-exports.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reach",
+      "name": "Reach",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reach.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.588
+        }
+      ]
+    },
+    {
+      "id": "reachable",
+      "name": "Reachable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reachable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "reached",
+      "name": "Reached",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reached.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.526
+        }
+      ]
+    },
+    {
+      "id": "react-reasoning",
+      "name": "React-reasoning",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: React-reasoning.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "read",
+      "name": "Read",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Read.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "readability",
+      "name": "Readability",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Readability.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reading",
+      "name": "Reading",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reading.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ready",
+      "name": "Ready",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ready.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "real",
+      "name": "Real",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Real.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "real-time",
+      "name": "Real-time",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Real-time.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "real-world",
+      "name": "Real-world",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Real-world.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "realistic",
+      "name": "Realistic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Realistic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reason",
+      "name": "Reason",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reason.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reasoning",
+      "name": "Reasoning",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reasoning.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reasoning-machines",
+      "name": "Reasoning-machines",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reasoning-machines.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "record",
+      "name": "Record",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Record.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "records",
+      "name": "Records",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Records.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "recursive",
+      "name": "Recursive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Recursive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "redirect",
+      "name": "Redirect",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Redirect.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ref",
+      "name": "Ref",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ref.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "refactor",
+      "name": "Refactor",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Refactor.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "refactors",
+      "name": "Refactors",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Refactors.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "reference",
+      "name": "Reference",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reference.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "references",
+      "name": "References",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: References.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "refines",
+      "name": "Refines",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Refines.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "regex",
+      "name": "Regex",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Regex.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "register",
+      "name": "Register",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Register.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "registries",
+      "name": "Registries",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Registries.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "registry",
+      "name": "Registry",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Registry.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "registry-ref",
+      "name": "Registry-ref",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Registry-ref.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reject",
+      "name": "Reject",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reject.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rel",
+      "name": "Rel",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rel.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "relations",
+      "name": "Relations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Relations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "relationships",
+      "name": "Relationships",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Relationships.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "relative",
+      "name": "Relative",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Relative.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "relevance",
+      "name": "Relevance",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Relevance.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "relevant",
+      "name": "Relevant",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Relevant.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "relpath",
+      "name": "Relpath",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Relpath.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "remote",
+      "name": "Remote",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Remote.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "remove",
+      "name": "Remove",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Remove.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "removesuffix",
+      "name": "Removesuffix",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Removesuffix.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rename",
+      "name": "Rename",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rename.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "repeat",
+      "name": "Repeat",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Repeat.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "replace",
+      "name": "Replace",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Replace.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "repo",
+      "name": "Repo",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Repo.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "report",
+      "name": "Report",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Report.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reporting",
+      "name": "Reporting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reporting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reports",
+      "name": "Reports",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reports.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "repositories",
+      "name": "Repositories",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Repositories.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "repository",
+      "name": "Repository",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Repository.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "representation",
+      "name": "Representation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Representation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "representations",
+      "name": "Representations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Representations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "representing",
+      "name": "Representing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Representing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reproducible",
+      "name": "Reproducible",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reproducible.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "req",
+      "name": "Req",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Req.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "request",
+      "name": "Request",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Request.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "requests",
+      "name": "Requests",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Requests.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "required",
+      "name": "Required",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Required.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "requires",
+      "name": "Requires",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Requires.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "requiring",
+      "name": "Requiring",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Requiring.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rerank",
+      "name": "Rerank",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rerank.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reranking",
+      "name": "Reranking",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reranking.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "res",
+      "name": "Res",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Res.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "research-backed",
+      "name": "Research-backed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Research-backed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.593
+        }
+      ]
+    },
+    {
+      "id": "resolution",
+      "name": "Resolution",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Resolution.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "resolve",
+      "name": "Resolve",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Resolve.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "resolved",
+      "name": "Resolved",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Resolved.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "resolver",
+      "name": "Resolver",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Resolver.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "resolves",
+      "name": "Resolves",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Resolves.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "resp",
+      "name": "Resp",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Resp.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "responses",
+      "name": "Responses",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Responses.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rest",
+      "name": "Rest",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rest.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "result",
+      "name": "Result",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Result.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "results",
+      "name": "Results",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Results.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "retrieval",
+      "name": "Retrieval",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Retrieval.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "retrieval-augmented",
+      "name": "Retrieval-augmented",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Retrieval-augmented.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "retrieves",
+      "name": "Retrieves",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Retrieves.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "retry",
+      "name": "Retry",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Retry.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "return",
+      "name": "Return",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Return.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "returncode",
+      "name": "Returncode",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Returncode.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "returned",
+      "name": "Returned",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Returned.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "returns",
+      "name": "Returns",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Returns.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reversal",
+      "name": "Reversal",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reversal.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reverse",
+      "name": "Reverse",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reverse.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "review",
+      "name": "Review",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Review.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reviewed",
+      "name": "Reviewed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reviewed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reviews",
+      "name": "Reviews",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reviews.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rigorous",
+      "name": "Rigorous",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rigorous.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "root",
+      "name": "Root",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Root.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "roots",
+      "name": "Roots",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Roots.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "round",
+      "name": "Round",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Round.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "routes",
+      "name": "Routes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Routes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "routing",
+      "name": "Routing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Routing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "row",
+      "name": "Row",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Row.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rule-based",
+      "name": "Rule-based",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rule-based.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rules",
+      "name": "Rules",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rules.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "run",
+      "name": "Run",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Run.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "run-gaia",
+      "name": "Run-gaia",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Run-gaia.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "runner",
+      "name": "Runner",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Runner.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "running",
+      "name": "Running",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Running.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "runs",
+      "name": "Runs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Runs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "runs-on",
+      "name": "Runs-on",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Runs-on.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "runtime",
+      "name": "Runtime",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Runtime.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "s-q-l",
+      "name": "S-q-l",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: S-q-l.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "safe",
+      "name": "Safe",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Safe.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "safely",
+      "name": "Safely",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Safely.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "safety",
+      "name": "Safety",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Safety.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "same",
+      "name": "Same",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Same.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sandbox",
+      "name": "Sandbox",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sandbox.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sandboxed",
+      "name": "Sandboxed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sandboxed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scalar",
+      "name": "Scalar",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scalar.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scalars",
+      "name": "Scalars",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scalars.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scale",
+      "name": "Scale",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scale.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scan",
+      "name": "Scan",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scan.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scanned",
+      "name": "Scanned",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scanned.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scanner",
+      "name": "Scanner",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scanner.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "schema",
+      "name": "Schema",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Schema.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "schema-dir",
+      "name": "Schema-dir",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Schema-dir.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "schema-valid",
+      "name": "Schema-valid",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Schema-valid.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "science",
+      "name": "Science",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Science.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scientific",
+      "name": "Scientific",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scientific.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "score",
+      "name": "Score",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Score.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scored",
+      "name": "Scored",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scored.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scores",
+      "name": "Scores",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scores.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scoring",
+      "name": "Scoring",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scoring.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scraper",
+      "name": "Scraper",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scraper.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scraping",
+      "name": "Scraping",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scraping.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "screenshot",
+      "name": "Screenshot",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Screenshot.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "screenshot-based",
+      "name": "Screenshot-based",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Screenshot-based.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "screenshots",
+      "name": "Screenshots",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Screenshots.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "script",
+      "name": "Script",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Script.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scripts",
+      "name": "Scripts",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scripts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scroll",
+      "name": "Scroll",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scroll.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "search",
+      "name": "Search",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Search.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.667
+        }
+      ]
+    },
+    {
+      "id": "searchable",
+      "name": "Searchable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Searchable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.545
+        }
+      ]
+    },
+    {
+      "id": "searching",
+      "name": "Searching",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Searching.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.571
+        }
+      ]
+    },
+    {
+      "id": "second",
+      "name": "Second",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Second.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "seconds",
+      "name": "Seconds",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Seconds.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "secrets",
+      "name": "Secrets",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Secrets.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "security",
+      "name": "Security",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Security.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "see",
+      "name": "See",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: See.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "seed",
+      "name": "Seed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Seed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "seen",
+      "name": "Seen",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Seen.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "segment",
+      "name": "Segment",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Segment.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "segments",
+      "name": "Segments",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Segments.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "selecting",
+      "name": "Selecting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Selecting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "selection",
+      "name": "Selection",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Selection.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "selects",
+      "name": "Selects",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Selects.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "self-evidence",
+      "name": "Self-evidence",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Self-evidence.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "self-feedback",
+      "name": "Self-feedback",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Self-feedback.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "self-generated",
+      "name": "Self-generated",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Self-generated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "self-hosted",
+      "name": "Self-hosted",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Self-hosted.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "self-refine",
+      "name": "Self-refine",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Self-refine.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "self-supervised",
+      "name": "Self-supervised",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Self-supervised.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "semantic",
+      "name": "Semantic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Semantic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "semantically",
+      "name": "Semantically",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Semantically.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sensemaking",
+      "name": "Sensemaking",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sensemaking.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sentence-similarity",
+      "name": "Sentence-similarity",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sentence-similarity.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sentence-transformers",
+      "name": "Sentence-transformers",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sentence-transformers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sentiment",
+      "name": "Sentiment",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sentiment.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "separated",
+      "name": "Separated",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Separated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "separately",
+      "name": "Separately",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Separately.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sequence",
+      "name": "Sequence",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sequence.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sequences",
+      "name": "Sequences",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sequences.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "server",
+      "name": "Server",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Server.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "servers",
+      "name": "Servers",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Servers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "session",
+      "name": "Session",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Session.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sessions",
+      "name": "Sessions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sessions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "set",
+      "name": "Set",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Set.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "setdefault",
+      "name": "Setdefault",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Setdefault.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sets",
+      "name": "Sets",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sets.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "setup-python",
+      "name": "Setup-python",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Setup-python.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "several",
+      "name": "Several",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Several.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sha",
+      "name": "Sha",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sha.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sha256",
+      "name": "Sha256",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sha256.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sha512",
+      "name": "Sha512",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sha512.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "shape",
+      "name": "Shape",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Shape.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "shell",
+      "name": "Shell",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Shell.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "shells",
+      "name": "Shells",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Shells.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "short",
+      "name": "Short",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Short.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "shorter",
+      "name": "Shorter",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Shorter.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "shot",
+      "name": "Shot",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Shot.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "should",
+      "name": "Should",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Should.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "shouldn",
+      "name": "Shouldn",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Shouldn.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "showing",
+      "name": "Showing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Showing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "shows",
+      "name": "Shows",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Shows.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "shutil",
+      "name": "Shutil",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Shutil.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sid",
+      "name": "Sid",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sid.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "signals",
+      "name": "Signals",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Signals.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "signatures",
+      "name": "Signatures",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Signatures.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "silent",
+      "name": "Silent",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Silent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "similar",
+      "name": "Similar",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Similar.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "similarity",
+      "name": "Similarity",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Similarity.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "simple",
+      "name": "Simple",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Simple.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "simply",
+      "name": "Simply",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Simply.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "simulation",
+      "name": "Simulation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Simulation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "single",
+      "name": "Single",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Single.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "single-pass",
+      "name": "Single-pass",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Single-pass.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "size",
+      "name": "Size",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Size.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "skill",
+      "name": "Skill",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skill.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "skill-batches",
+      "name": "Skill-batches",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skill-batches.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "skill-index",
+      "name": "Skill-index",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skill-index.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "skill-name",
+      "name": "Skill-name",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skill-name.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "skill-tree",
+      "name": "Skill-tree",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skill-tree.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "skills",
+      "name": "Skills",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skills.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "skip",
+      "name": "Skip",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skip.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "skipped",
+      "name": "Skipped",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skipped.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "skipping",
+      "name": "Skipping",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skipping.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "slashes",
+      "name": "Slashes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Slashes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "slice",
+      "name": "Slice",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Slice.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "slug",
+      "name": "Slug",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Slug.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "smithery",
+      "name": "Smithery",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Smithery.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "software",
+      "name": "Software",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Software.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "some",
+      "name": "Some",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Some.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sort",
+      "name": "Sort",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sort.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sorted",
+      "name": "Sorted",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sorted.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "source",
+      "name": "Source",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Source.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sources",
+      "name": "Sources",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sources.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "space",
+      "name": "Space",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Space.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "spaces",
+      "name": "Spaces",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Spaces.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "spatial",
+      "name": "Spatial",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Spatial.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "spawn",
+      "name": "Spawn",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Spawn.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "spec",
+      "name": "Spec",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Spec.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "specialized",
+      "name": "Specialized",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Specialized.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "specific",
+      "name": "Specific",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Specific.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "specification",
+      "name": "Specification",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Specification.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "specifications",
+      "name": "Specifications",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Specifications.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "specified",
+      "name": "Specified",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Specified.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "speech",
+      "name": "Speech",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Speech.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "split",
+      "name": "Split",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Split.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "splitlines",
+      "name": "Splitlines",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Splitlines.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "splitter",
+      "name": "Splitter",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Splitter.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "spoken",
+      "name": "Spoken",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Spoken.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sqrt",
+      "name": "Sqrt",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sqrt.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "src",
+      "name": "Src",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Src.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stack",
+      "name": "Stack",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stack.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "standard",
+      "name": "Standard",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Standard.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stars",
+      "name": "Stars",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stars.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "start",
+      "name": "Start",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Start.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "startswith",
+      "name": "Startswith",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Startswith.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "state",
+      "name": "State",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: State.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "static",
+      "name": "Static",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Static.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "statistical",
+      "name": "Statistical",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Statistical.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "statistics",
+      "name": "Statistics",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Statistics.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stats",
+      "name": "Stats",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stats.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "status",
+      "name": "Status",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Status.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stderr",
+      "name": "Stderr",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stderr.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stdio",
+      "name": "Stdio",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stdio.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stdout",
+      "name": "Stdout",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stdout.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stem",
+      "name": "Stem",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stem.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "step-by-step",
+      "name": "Step-by-step",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Step-by-step.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "steps",
+      "name": "Steps",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Steps.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "still",
+      "name": "Still",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Still.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "store",
+      "name": "Store",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Store.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "str",
+      "name": "Str",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Str.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "strategies",
+      "name": "Strategies",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Strategies.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "strftime",
+      "name": "Strftime",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Strftime.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "strict",
+      "name": "Strict",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Strict.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "string",
+      "name": "String",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: String.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stringify",
+      "name": "Stringify",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stringify.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "strings",
+      "name": "Strings",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Strings.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "strip",
+      "name": "Strip",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Strip.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stripped",
+      "name": "Stripped",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stripped.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stripping",
+      "name": "Stripping",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stripping.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "structure",
+      "name": "Structure",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Structure.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "structured",
+      "name": "Structured",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Structured.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "structures",
+      "name": "Structures",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Structures.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stub",
+      "name": "Stub",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stub.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stubs",
+      "name": "Stubs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stubs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "style",
+      "name": "Style",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Style.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stylized",
+      "name": "Stylized",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stylized.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sub",
+      "name": "Sub",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sub.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sub-agent",
+      "name": "Sub-agent",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sub-agent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sub-tasks",
+      "name": "Sub-tasks",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sub-tasks.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "submits",
+      "name": "Submits",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Submits.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "subparsers",
+      "name": "Subparsers",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Subparsers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "subprocess",
+      "name": "Subprocess",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Subprocess.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "success",
+      "name": "Success",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Success.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "such",
+      "name": "Such",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Such.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "suggest",
+      "name": "Suggest",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Suggest.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "suggestions",
+      "name": "Suggestions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Suggestions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "suitable",
+      "name": "Suitable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Suitable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "suite",
+      "name": "Suite",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Suite.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "suites",
+      "name": "Suites",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Suites.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sum",
+      "name": "Sum",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sum.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "summaries",
+      "name": "Summaries",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Summaries.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "summarization",
+      "name": "Summarization",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Summarization.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "summarizer",
+      "name": "Summarizer",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Summarizer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "summarizes",
+      "name": "Summarizes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Summarizes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "summary",
+      "name": "Summary",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Summary.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "supervision",
+      "name": "Supervision",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Supervision.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "supporting",
+      "name": "Supporting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Supporting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sure",
+      "name": "Sure",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sure.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "surpasses",
+      "name": "Surpasses",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Surpasses.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "survey",
+      "name": "Survey",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Survey.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "svn",
+      "name": "Svn",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Svn.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "symbol",
+      "name": "Symbol",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Symbol.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "symbolic",
+      "name": "Symbolic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Symbolic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "symlink",
+      "name": "Symlink",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Symlink.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sync",
+      "name": "Sync",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sync.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "synergy",
+      "name": "Synergy",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Synergy.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "syntactically",
+      "name": "Syntactically",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Syntactically.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "synthesis",
+      "name": "Synthesis",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Synthesis.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "synthesising",
+      "name": "Synthesising",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Synthesising.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "synthesizes",
+      "name": "Synthesizes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Synthesizes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sys",
+      "name": "Sys",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sys.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "system",
+      "name": "System",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: System.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "systematic",
+      "name": "Systematic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Systematic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tables",
+      "name": "Tables",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tables.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tags",
+      "name": "Tags",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tags.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tail",
+      "name": "Tail",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tail.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tarball",
+      "name": "Tarball",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tarball.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "target",
+      "name": "Target",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Target.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "task",
+      "name": "Task",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Task.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tasks",
+      "name": "Tasks",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tasks.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "taxonomy",
+      "name": "Taxonomy",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Taxonomy.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "teaching",
+      "name": "Teaching",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Teaching.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "template",
+      "name": "Template",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Template.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "terminal",
+      "name": "Terminal",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Terminal.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "test",
+      "name": "Test",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Test.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "testable",
+      "name": "Testable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Testable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "testing",
+      "name": "Testing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Testing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tests",
+      "name": "Tests",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tests.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "text",
+      "name": "Text",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Text.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "text-based",
+      "name": "Text-based",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Text-based.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "text-classification",
+      "name": "Text-classification",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Text-classification.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "text-generation",
+      "name": "Text-generation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Text-generation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "text-to",
+      "name": "Text-to",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Text-to.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "text2text-generation",
+      "name": "Text2text-generation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Text2text-generation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "texts",
+      "name": "Texts",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Texts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tgz",
+      "name": "Tgz",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tgz.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "than",
+      "name": "Than",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Than.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "them",
+      "name": "Them",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Them.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "then",
+      "name": "Then",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Then.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "these",
+      "name": "These",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: These.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "this",
+      "name": "This",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: This.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "threshold",
+      "name": "Threshold",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Threshold.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "thresholds",
+      "name": "Thresholds",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Thresholds.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "through",
+      "name": "Through",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Through.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "throughput",
+      "name": "Throughput",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Throughput.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "throw",
+      "name": "Throw",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Throw.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tier",
+      "name": "Tier",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tier.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "time",
+      "name": "Time",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Time.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "timed",
+      "name": "Timed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Timed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "timeout",
+      "name": "Timeout",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Timeout.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "timestamp",
+      "name": "Timestamp",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Timestamp.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "timezone",
+      "name": "Timezone",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Timezone.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "title",
+      "name": "Title",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Title.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tmpdir",
+      "name": "Tmpdir",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tmpdir.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "to-end",
+      "name": "To-end",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: To-end.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "to-markdown",
+      "name": "To-markdown",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: To-markdown.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "today",
+      "name": "Today",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Today.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "token",
+      "name": "Token",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Token.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "token-classification",
+      "name": "Token-classification",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Token-classification.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tokenization",
+      "name": "Tokenization",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tokenization.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tokenizer",
+      "name": "Tokenizer",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tokenizer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "tokens",
+      "name": "Tokens",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tokens.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tolist",
+      "name": "Tolist",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tolist.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tone",
+      "name": "Tone",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tone.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tool",
+      "name": "Tool",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tool.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tools",
+      "name": "Tools",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tools.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "top",
+      "name": "Top",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Top.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "top-k",
+      "name": "Top-k",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Top-k.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "top-level",
+      "name": "Top-level",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Top-level.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "topic",
+      "name": "Topic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Topic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "total",
+      "name": "Total",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Total.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "traces",
+      "name": "Traces",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Traces.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "training",
+      "name": "Training",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Training.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "transcribes",
+      "name": "Transcribes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Transcribes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "transformer",
+      "name": "Transformer",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Transformer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "translation",
+      "name": "Translation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Translation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "treat",
+      "name": "Treat",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Treat.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "tree",
+      "name": "Tree",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tree.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "trees",
+      "name": "Trees",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Trees.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "trim",
+      "name": "Trim",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Trim.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "true",
+      "name": "True",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: True.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "try",
+      "name": "Try",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Try.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tsc",
+      "name": "Tsc",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tsc.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tsserver",
+      "name": "Tsserver",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tsserver.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tuple",
+      "name": "Tuple",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tuple.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tuples",
+      "name": "Tuples",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tuples.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "turbo",
+      "name": "Turbo",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Turbo.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "turns",
+      "name": "Turns",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Turns.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "two",
+      "name": "Two",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Two.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "two-pass",
+      "name": "Two-pass",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Two-pass.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "type",
+      "name": "Type",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Type.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "typed",
+      "name": "Typed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Typed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "types",
+      "name": "Types",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Types.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "typescript",
+      "name": "Typescript",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Typescript.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "typescript-5",
+      "name": "Typescript-5",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Typescript-5.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "typing",
+      "name": "Typing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Typing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ubuntu-latest",
+      "name": "Ubuntu-latest",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ubuntu-latest.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unanswerable",
+      "name": "Unanswerable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unanswerable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unbounded",
+      "name": "Unbounded",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unbounded.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "uncommon",
+      "name": "Uncommon",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Uncommon.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "under",
+      "name": "Under",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Under.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "undici-types",
+      "name": "Undici-types",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Undici-types.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "undici-types-6",
+      "name": "Undici-types-6",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Undici-types-6.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unified",
+      "name": "Unified",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unified.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "uninstall",
+      "name": "Uninstall",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Uninstall.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "union",
+      "name": "Union",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Union.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unique",
+      "name": "Unique",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unique.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "uniqueness",
+      "name": "Uniqueness",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Uniqueness.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unit",
+      "name": "Unit",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unknown",
+      "name": "Unknown",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unknown.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unlikely",
+      "name": "Unlikely",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unlikely.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unlock",
+      "name": "Unlock",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unlock.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unlocked",
+      "name": "Unlocked",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unlocked.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unlocks",
+      "name": "Unlocks",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unlocks.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unstructured",
+      "name": "Unstructured",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unstructured.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "until",
+      "name": "Until",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Until.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "update",
+      "name": "Update",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Update.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "update-tree",
+      "name": "Update-tree",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Update-tree.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "updated",
+      "name": "Updated",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Updated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "updates",
+      "name": "Updates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Updates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "upper",
+      "name": "Upper",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Upper.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "uppercase",
+      "name": "Uppercase",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Uppercase.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "url",
+      "name": "Url",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Url.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "urllib",
+      "name": "Urllib",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Urllib.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "urlopen",
+      "name": "Urlopen",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Urlopen.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "usable",
+      "name": "Usable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Usable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "usage",
+      "name": "Usage",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Usage.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "use",
+      "name": "Use",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Use.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "used",
+      "name": "Used",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Used.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "useful",
+      "name": "Useful",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Useful.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "user",
+      "name": "User",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: User.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "username",
+      "name": "Username",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Username.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "users",
+      "name": "Users",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Users.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "users-dir",
+      "name": "Users-dir",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Users-dir.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "uses",
+      "name": "Uses",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Uses.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "using",
+      "name": "Using",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Using.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "usr",
+      "name": "Usr",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Usr.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "usually",
+      "name": "Usually",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Usually.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "utc",
+      "name": "Utc",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Utc.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "utf-8",
+      "name": "Utf-8",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Utf-8.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "utf8",
+      "name": "Utf8",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Utf8.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "util",
+      "name": "Util",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Util.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "utilities",
+      "name": "Utilities",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Utilities.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "valence",
+      "name": "Valence",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Valence.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "valid",
+      "name": "Valid",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Valid.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "validate",
+      "name": "Validate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Validate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "validated",
+      "name": "Validated",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Validated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "validates",
+      "name": "Validates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Validates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "validation",
+      "name": "Validation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Validation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "value",
+      "name": "Value",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Value.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "values",
+      "name": "Values",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Values.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "variables",
+      "name": "Variables",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Variables.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "vector",
+      "name": "Vector",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Vector.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "vectors",
+      "name": "Vectors",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Vectors.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "vendor",
+      "name": "Vendor",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Vendor.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "venv",
+      "name": "Venv",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Venv.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "verified",
+      "name": "Verified",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Verified.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "verify",
+      "name": "Verify",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Verify.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "verifying",
+      "name": "Verifying",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Verifying.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "version",
+      "name": "Version",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Version.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "versions",
+      "name": "Versions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Versions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "via",
+      "name": "Via",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Via.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "virtual",
+      "name": "Virtual",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Virtual.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "vision",
+      "name": "Vision",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Vision.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "vision-language",
+      "name": "Vision-language",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Vision-language.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "visual",
+      "name": "Visual",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Visual.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "visualization",
+      "name": "Visualization",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Visualization.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "visualizations",
+      "name": "Visualizations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Visualizations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "visualstudio",
+      "name": "Visualstudio",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Visualstudio.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "voice",
+      "name": "Voice",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Voice.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "vscode",
+      "name": "Vscode",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Vscode.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "vscode-marketplace",
+      "name": "Vscode-marketplace",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Vscode-marketplace.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "walk",
+      "name": "Walk",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Walk.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "want",
+      "name": "Want",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Want.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "warnings",
+      "name": "Warnings",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Warnings.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "weak",
+      "name": "Weak",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Weak.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "web",
+      "name": "Web",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Web.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "web-arena-x",
+      "name": "Web-arena-x",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Web-arena-x.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "webarena",
+      "name": "Webarena",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Webarena.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "webp",
+      "name": "Webp",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Webp.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "websites",
+      "name": "Websites",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Websites.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "well-formed",
+      "name": "Well-formed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Well-formed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "wet-lab",
+      "name": "Wet-lab",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Wet-lab.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "what",
+      "name": "What",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: What.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "when",
+      "name": "When",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: When.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "whenever",
+      "name": "Whenever",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Whenever.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "where",
+      "name": "Where",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Where.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "which",
+      "name": "Which",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Which.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "while",
+      "name": "While",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: While.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "whisper",
+      "name": "Whisper",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Whisper.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "width",
+      "name": "Width",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Width.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "will",
+      "name": "Will",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Will.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "win32",
+      "name": "Win32",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Win32.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "window",
+      "name": "Window",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Window.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "within",
+      "name": "Within",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Within.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "without",
+      "name": "Without",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Without.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "words",
+      "name": "Words",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Words.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "workflows",
+      "name": "Workflows",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Workflows.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "wrapper",
+      "name": "Wrapper",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Wrapper.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "write",
+      "name": "Write",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Write.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "writes",
+      "name": "Writes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Writes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "writing",
+      "name": "Writing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Writing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "written",
+      "name": "Written",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Written.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "www",
+      "name": "Www",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Www.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "xlang-ai",
+      "name": "Xlang-ai",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Xlang-ai.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "xml",
+      "name": "Xml",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Xml.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "xmlns",
+      "name": "Xmlns",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Xmlns.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "yaml",
+      "name": "Yaml",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Yaml.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "yes",
+      "name": "Yes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Yes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "yet",
+      "name": "Yet",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Yet.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "yml",
+      "name": "Yml",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Yml.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "you",
+      "name": "You",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: You.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "your",
+      "name": "Your",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Your.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "your-github-username",
+      "name": "Your-github-username",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Your-github-username.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ysymyth",
+      "name": "Ysymyth",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ysymyth.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "zero-config",
+      "name": "Zero-config",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Zero-config.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "zero-shot",
+      "name": "Zero-shot",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Zero-shot.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "zero-shot-classification",
+      "name": "Zero-shot-classification",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Zero-shot-classification.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "zip",
+      "name": "Zip",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Zip.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    }
+  ],
+  "similarity": [
+    {
+      "sourceSkillId": "abductive",
+      "targetSkillId": "retrieve",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "absolute",
+      "targetSkillId": "translate",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "absolute",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "abspath",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accents",
+      "targetSkillId": "extract-entities",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accents",
+      "targetSkillId": "chunk-document",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accepted",
+      "targetSkillId": "parse-pdf",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accidentally",
+      "targetSkillId": "document-analyst",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accidentally",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accidentally",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accurate",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accurate",
+      "targetSkillId": "image-generate",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "achieves",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "achieves",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "achieving",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "achieving",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "acting",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "acting",
+      "targetSkillId": "image-caption",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "action",
+      "targetSkillId": "image-caption",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "action",
+      "targetSkillId": "code-execution",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "action",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "actions",
+      "targetSkillId": "image-caption",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "actions",
+      "targetSkillId": "code-execution",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "actions",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "actual",
+      "targetSkillId": "api-call",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "actual",
+      "targetSkillId": "data-visualize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "adapting",
+      "targetSkillId": "image-caption",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "adapting",
+      "targetSkillId": "automated-testing",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "additions",
+      "targetSkillId": "document-digitization",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "additions",
+      "targetSkillId": "image-caption",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "advancement",
+      "targetSkillId": "audience-model",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "advancement",
+      "targetSkillId": "voice-agent",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "advancement",
+      "targetSkillId": "chunk-document",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "against",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "against",
+      "targetSkillId": "image-caption",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agent",
+      "targetSkillId": "voice-agent",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agent",
+      "targetSkillId": "image-generate",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agent",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agent-native",
+      "targetSkillId": "image-caption",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agent-native",
+      "targetSkillId": "image-generate",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agent-native",
+      "targetSkillId": "multi-agent-orchestration-v",
+      "score": 0.513,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agent-related",
+      "targetSkillId": "image-generate",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agent-related",
+      "targetSkillId": "generate-sql",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agent-related",
+      "targetSkillId": "translate",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agents",
+      "targetSkillId": "voice-agent",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agents",
+      "targetSkillId": "generate-sql",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agents",
+      "targetSkillId": "generate-test",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ahead",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ai-agent",
+      "targetSkillId": "voice-agent",
+      "score": 0.737,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ai-agent",
+      "targetSkillId": "conversational-agent",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ai-agent",
+      "targetSkillId": "image-generate",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ai-agent-tool",
+      "targetSkillId": "voice-agent",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ai-agent-tool",
+      "targetSkillId": "audience-model",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ai-agent-tool",
+      "targetSkillId": "multi-agent-orchestration-v",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "algebra",
+      "targetSkillId": "image-generate",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "algebra",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "alive",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "alive",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "all",
+      "targetSkillId": "api-call",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "allocation",
+      "targetSkillId": "image-caption",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "allocation",
+      "targetSkillId": "code-execution",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "allocation",
+      "targetSkillId": "browser-automation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "analyses",
+      "targetSkillId": "data-analysis",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "analyses",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "analyses",
+      "targetSkillId": "document-analyst",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "analysis",
+      "targetSkillId": "data-analysis",
+      "score": 0.762,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "analysis",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "analysis",
+      "targetSkillId": "document-analyst",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "anomaly",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "anomaly",
+      "targetSkillId": "data-analysis",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "another",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "answer",
+      "targetSkillId": "question-answer",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "answer",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "answers",
+      "targetSkillId": "question-answer",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "answers",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "any",
+      "targetSkillId": "rank",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "api",
+      "targetSkillId": "api-call",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "api-version",
+      "targetSkillId": "math-reason",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "api-version",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "api-version",
+      "targetSkillId": "parse-json",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "appears",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "appears",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "appears",
+      "targetSkillId": "parse-html",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "append",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "application",
+      "targetSkillId": "api-call",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "application",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "application",
+      "targetSkillId": "registry-curation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "apply",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "apply",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "approach",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "appropriate",
+      "targetSkillId": "ghostwrite",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "approval",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "archived",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "archived",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "archived",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "argparse",
+      "targetSkillId": "parse-pdf",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "argparse",
+      "targetSkillId": "parse-json",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "argparse",
+      "targetSkillId": "parse-html",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "args",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "arguments",
+      "targetSkillId": "voice-agent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "arguments",
+      "targetSkillId": "document-analyst",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "arguments",
+      "targetSkillId": "route-intent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "arithmetic",
+      "targetSkillId": "write-report",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "arithmetic",
+      "targetSkillId": "route-intent",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "arrays",
+      "targetSkillId": "math-reason",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "arriving",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "artifact",
+      "targetSkillId": "refactor-code",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "artifacts",
+      "targetSkillId": "refactor-code",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "arxiv",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "assembles",
+      "targetSkillId": "parse-html",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "assert",
+      "targetSkillId": "parse-html",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "assistant",
+      "targetSkillId": "real-time-voice-assistant",
+      "score": 0.529,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "assistant",
+      "targetSkillId": "classify",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "assistants",
+      "targetSkillId": "real-time-voice-assistant",
+      "score": 0.514,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "async",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attribute",
+      "targetSkillId": "ghostwrite",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attribute",
+      "targetSkillId": "retrieve",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attributes",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attributes",
+      "targetSkillId": "math-reason",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attributes",
+      "targetSkillId": "extract-entities",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attvalue",
+      "targetSkillId": "data-visualize",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attvalue",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attvalues",
+      "targetSkillId": "data-visualize",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attvalues",
+      "targetSkillId": "tool-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attvalues",
+      "targetSkillId": "generate-test",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "audience",
+      "targetSkillId": "audience-model",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "audience",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "audience",
+      "targetSkillId": "logical-inference",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "audience-tailored",
+      "targetSkillId": "audience-model",
+      "score": 0.645,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "audio",
+      "targetSkillId": "audience-model",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "augmented",
+      "targetSkillId": "image-generate",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "augmented",
+      "targetSkillId": "audience-model",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "augmented",
+      "targetSkillId": "voice-agent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "authenticated",
+      "targetSkillId": "extract-entities",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "authenticated",
+      "targetSkillId": "audience-model",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "authenticated",
+      "targetSkillId": "tokenize",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "author",
+      "targetSkillId": "math-reason",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "authoritative",
+      "targetSkillId": "ghostwrite",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "authoritative",
+      "targetSkillId": "retrieve",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "authoritative",
+      "targetSkillId": "automated-testing",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "auto-generated",
+      "targetSkillId": "image-generate",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "auto-generated",
+      "targetSkillId": "code-generation",
+      "score": 0.621,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "auto-generated",
+      "targetSkillId": "generate-sql",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "auto-prompt-combinations",
+      "targetSkillId": "autonomous-data-scientist",
+      "score": 0.49,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "auto-prompt-combinations",
+      "targetSkillId": "browser-automation",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autogen",
+      "targetSkillId": "tokenize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "automated",
+      "targetSkillId": "automated-testing",
+      "score": 0.692,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "automated",
+      "targetSkillId": "browser-automation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "automated",
+      "targetSkillId": "autonomous-debug",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "automatic",
+      "targetSkillId": "automated-testing",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "automatic",
+      "targetSkillId": "browser-automation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "automatic",
+      "targetSkillId": "autonomous-data-scientist",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "automatically",
+      "targetSkillId": "api-call",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "automatically",
+      "targetSkillId": "automated-testing",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "automatically",
+      "targetSkillId": "browser-automation",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autonomous",
+      "targetSkillId": "autonomous-debug",
+      "score": 0.769,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autonomous",
+      "targetSkillId": "autonomous-research-agent",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autonomous",
+      "targetSkillId": "autonomous-data-scientist",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autonomously",
+      "targetSkillId": "autonomous-debug",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autonomously",
+      "targetSkillId": "autonomous-research-agent",
+      "score": 0.541,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autonomously",
+      "targetSkillId": "autonomous-data-scientist",
+      "score": 0.541,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autoregressive",
+      "targetSkillId": "retrieve",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autoregressive",
+      "targetSkillId": "automated-testing",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autoregressive",
+      "targetSkillId": "score-relevance",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autoresearch",
+      "targetSkillId": "research",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autoresearch",
+      "targetSkillId": "autonomous-research-agent",
+      "score": 0.649,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autoresearch",
+      "targetSkillId": "web-search",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "available",
+      "targetSkillId": "api-call",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "awakened",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "awakened",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "awareness",
+      "targetSkillId": "data-analysis",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "back",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "based",
+      "targetSkillId": "parse-pdf",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "baseline",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "baseline",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "baseline",
+      "targetSkillId": "self-critique",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "baselines",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "baselines",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "baselines",
+      "targetSkillId": "self-critique",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "bash",
+      "targetSkillId": "execute-bash",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "batch",
+      "targetSkillId": "web-search",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "batch",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "batched",
+      "targetSkillId": "web-search",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "batches",
+      "targetSkillId": "math-reason",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "batches",
+      "targetSkillId": "web-search",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "becomes",
+      "targetSkillId": "computer-use",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "becomes",
+      "targetSkillId": "plan-decompose",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "before",
+      "targetSkillId": "refactor-code",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "bench",
+      "targetSkillId": "web-search",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "bench",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "between",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "between",
+      "targetSkillId": "embed-text",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "bool",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "boolean",
+      "targetSkillId": "tool-use",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "boolean",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "booleans",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "bootstrapped",
+      "targetSkillId": "web-scrape",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "bootstrapped",
+      "targetSkillId": "ghostwrite",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "branch",
+      "targetSkillId": "rank",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "branch",
+      "targetSkillId": "research",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "branch",
+      "targetSkillId": "web-search",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "break",
+      "targetSkillId": "rank",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "break",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "broken",
+      "targetSkillId": "tokenize",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "browsers",
+      "targetSkillId": "browser-automation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "browsers",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "bytecode",
+      "targetSkillId": "refactor-code",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "bytecode",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cache",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "calculus",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "call",
+      "targetSkillId": "api-call",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "calling",
+      "targetSkillId": "api-call",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "calling",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "calls",
+      "targetSkillId": "api-call",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "calls",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "can",
+      "targetSkillId": "rank",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "candidate",
+      "targetSkillId": "translate",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "candidates",
+      "targetSkillId": "translate",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "candidates",
+      "targetSkillId": "extract-entities",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "candidates",
+      "targetSkillId": "generate-sql",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cannot",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cannot",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "canonical",
+      "targetSkillId": "api-call",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "canonical",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "capability",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "capitalize",
+      "targetSkillId": "data-visualize",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "capitalize",
+      "targetSkillId": "api-call",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "capitalize",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "caps",
+      "targetSkillId": "classify",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "captures",
+      "targetSkillId": "cite-sources",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "captures",
+      "targetSkillId": "math-reason",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "captures",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "capturing",
+      "targetSkillId": "image-caption",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "capturing",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.457,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "case",
+      "targetSkillId": "classify",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "case",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "case",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cases",
+      "targetSkillId": "classify",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cases",
+      "targetSkillId": "parse-json",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cases",
+      "targetSkillId": "cite-sources",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "catch",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "catches",
+      "targetSkillId": "math-reason",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "catches",
+      "targetSkillId": "cite-sources",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "categorical",
+      "targetSkillId": "api-call",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "categorical",
+      "targetSkillId": "cite-sources",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "categories",
+      "targetSkillId": "cite-sources",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "categories",
+      "targetSkillId": "extract-entities",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "categories",
+      "targetSkillId": "computer-use",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "categorization",
+      "targetSkillId": "content-moderation",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "categorization",
+      "targetSkillId": "code-generation",
+      "score": 0.621,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "categorization",
+      "targetSkillId": "document-digitization",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "category",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "caught",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "caught",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "causes",
+      "targetSkillId": "classify",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "causes",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "chain",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "chain",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "chain-of-thought-hub",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.889,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "chain-of-thought-only",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.865,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "chains",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "change",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "change",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "changing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "changing",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "checkout",
+      "targetSkillId": "code-execution",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "chemistry",
+      "targetSkillId": "registry-curation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "children",
+      "targetSkillId": "chunk-document",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "chunk",
+      "targetSkillId": "chunk-document",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "chunking",
+      "targetSkillId": "chunk-document",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "citation",
+      "targetSkillId": "image-caption",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "citation",
+      "targetSkillId": "document-digitization",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "citation",
+      "targetSkillId": "content-moderation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "citations",
+      "targetSkillId": "image-caption",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "citations",
+      "targetSkillId": "document-digitization",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "citations",
+      "targetSkillId": "content-moderation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "claims",
+      "targetSkillId": "classify",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "clarity",
+      "targetSkillId": "classify",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "class",
+      "targetSkillId": "classify",
+      "score": 0.769,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "classification",
+      "targetSkillId": "classify",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "classification",
+      "targetSkillId": "image-caption",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "classification",
+      "targetSkillId": "document-digitization",
+      "score": 0.457,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "classifier",
+      "targetSkillId": "classify",
+      "score": 0.778,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cleaned",
+      "targetSkillId": "score-relevance",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cli",
+      "targetSkillId": "classify",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "click",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "clone",
+      "targetSkillId": "diff-content",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "clone",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cloning",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "closing",
+      "targetSkillId": "classify",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "closing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "clustering",
+      "targetSkillId": "route-intent",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "clustering",
+      "targetSkillId": "computer-use",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "co-references",
+      "targetSkillId": "score-relevance",
+      "score": 0.643,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "co-references",
+      "targetSkillId": "logical-inference",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "co-references",
+      "targetSkillId": "code-review-pipeline",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "code",
+      "targetSkillId": "refactor-code",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "codec",
+      "targetSkillId": "code-execution",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "codegen",
+      "targetSkillId": "code-generation",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "codegen",
+      "targetSkillId": "code-execution",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "codegen",
+      "targetSkillId": "voice-agent",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "codes",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "codes",
+      "targetSkillId": "cite-sources",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "coherent",
+      "targetSkillId": "voice-agent",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "coherent",
+      "targetSkillId": "route-intent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "coherent",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "collections",
+      "targetSkillId": "code-execution",
+      "score": 0.64,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "collections",
+      "targetSkillId": "tool-select",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "collections",
+      "targetSkillId": "code-generation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combination",
+      "targetSkillId": "code-generation",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combination",
+      "targetSkillId": "content-moderation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combination",
+      "targetSkillId": "error-interpretation",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combinations",
+      "targetSkillId": "code-generation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combinations",
+      "targetSkillId": "content-moderation",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combinations",
+      "targetSkillId": "error-interpretation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combinator",
+      "targetSkillId": "code-generation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combinator",
+      "targetSkillId": "computer-use",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combining",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combos",
+      "targetSkillId": "plan-decompose",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comment",
+      "targetSkillId": "chunk-document",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comment",
+      "targetSkillId": "diff-content",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comment",
+      "targetSkillId": "code-generation",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "community",
+      "targetSkillId": "computer-use",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comparisons",
+      "targetSkillId": "parse-json",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comparisons",
+      "targetSkillId": "math-reason",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comparisons",
+      "targetSkillId": "computer-use",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "compatible",
+      "targetSkillId": "computer-use",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "compatible",
+      "targetSkillId": "conversational-agent",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "competition",
+      "targetSkillId": "document-digitization",
+      "score": 0.562,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "competition",
+      "targetSkillId": "code-execution",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "competition",
+      "targetSkillId": "content-moderation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "compile",
+      "targetSkillId": "computer-use",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "compile",
+      "targetSkillId": "plan-decompose",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "complete",
+      "targetSkillId": "computer-use",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "complete",
+      "targetSkillId": "plan-decompose",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "complete",
+      "targetSkillId": "chunk-document",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "completes",
+      "targetSkillId": "computer-use",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "completes",
+      "targetSkillId": "automated-testing",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "completing",
+      "targetSkillId": "automated-testing",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "completing",
+      "targetSkillId": "content-moderation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "completing",
+      "targetSkillId": "code-execution",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "completion",
+      "targetSkillId": "code-execution",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "completion",
+      "targetSkillId": "content-moderation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "completion",
+      "targetSkillId": "code-generation",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "complex",
+      "targetSkillId": "computer-use",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "complex",
+      "targetSkillId": "plan-decompose",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "complexity",
+      "targetSkillId": "computer-use",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "composite",
+      "targetSkillId": "plan-decompose",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "composite",
+      "targetSkillId": "computer-use",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "composite",
+      "targetSkillId": "ghostwrite",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "composites",
+      "targetSkillId": "computer-use",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "composites",
+      "targetSkillId": "plan-decompose",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "composites",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comprehension",
+      "targetSkillId": "code-generation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comprehension",
+      "targetSkillId": "parse-json",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comprehension",
+      "targetSkillId": "code-execution",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comprehensive",
+      "targetSkillId": "score-relevance",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comprehensive",
+      "targetSkillId": "computer-use",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comprehensive",
+      "targetSkillId": "tokenize",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "computation",
+      "targetSkillId": "code-execution",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "computation",
+      "targetSkillId": "content-moderation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "computation",
+      "targetSkillId": "code-generation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "compute",
+      "targetSkillId": "computer-use",
+      "score": 0.737,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "compute",
+      "targetSkillId": "format-output",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "compute",
+      "targetSkillId": "plan-decompose",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "computer",
+      "targetSkillId": "computer-use",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "computer",
+      "targetSkillId": "format-output",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "computer",
+      "targetSkillId": "plan-decompose",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "computes",
+      "targetSkillId": "computer-use",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "computes",
+      "targetSkillId": "execute-bash",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "computes",
+      "targetSkillId": "format-output",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conclusions",
+      "targetSkillId": "code-execution",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conclusions",
+      "targetSkillId": "question-answer",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conclusions",
+      "targetSkillId": "code-generation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "condition",
+      "targetSkillId": "code-execution",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "condition",
+      "targetSkillId": "content-moderation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "condition",
+      "targetSkillId": "code-generation",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conditions",
+      "targetSkillId": "code-execution",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conditions",
+      "targetSkillId": "content-moderation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conditions",
+      "targetSkillId": "code-generation",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conducts",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conducts",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "config",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "configuration",
+      "targetSkillId": "code-generation",
+      "score": 0.643,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "configuration",
+      "targetSkillId": "content-moderation",
+      "score": 0.581,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "configuration",
+      "targetSkillId": "conversational-agent",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "configured",
+      "targetSkillId": "computer-use",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "configured",
+      "targetSkillId": "cite-sources",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "confirmed",
+      "targetSkillId": "tokenize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "connector",
+      "targetSkillId": "code-execution",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "connector",
+      "targetSkillId": "content-moderation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "connector",
+      "targetSkillId": "code-generation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "consecutive",
+      "targetSkillId": "code-execution",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "consecutive",
+      "targetSkillId": "retrieve",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "consecutive",
+      "targetSkillId": "self-critique",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "console",
+      "targetSkillId": "tool-use",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "console",
+      "targetSkillId": "conversational-agent",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "console",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "const",
+      "targetSkillId": "diff-content",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "constrained",
+      "targetSkillId": "ghostwrite",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "constrained",
+      "targetSkillId": "content-moderation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "constrained",
+      "targetSkillId": "code-generation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "constraints",
+      "targetSkillId": "ghostwrite",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "constraints",
+      "targetSkillId": "content-moderation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "constraints",
+      "targetSkillId": "code-generation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "construction",
+      "targetSkillId": "knowledge-graph-build",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "construction",
+      "targetSkillId": "content-moderation",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "construction",
+      "targetSkillId": "code-generation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contain",
+      "targetSkillId": "content-moderation",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contain",
+      "targetSkillId": "code-generation",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contain",
+      "targetSkillId": "diff-content",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "containing",
+      "targetSkillId": "content-moderation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "containing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "containing",
+      "targetSkillId": "code-generation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "content",
+      "targetSkillId": "diff-content",
+      "score": 0.737,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "content",
+      "targetSkillId": "route-intent",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "content",
+      "targetSkillId": "content-moderation",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "context",
+      "targetSkillId": "diff-content",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "context",
+      "targetSkillId": "speech-to-text",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "context",
+      "targetSkillId": "route-intent",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "context-grounded",
+      "targetSkillId": "content-moderation",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "context-grounded",
+      "targetSkillId": "code-generation",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "context-grounded",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contextually",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contextually",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contextually",
+      "targetSkillId": "content-moderation",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "continuation",
+      "targetSkillId": "content-moderation",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "continuation",
+      "targetSkillId": "code-generation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "continuation",
+      "targetSkillId": "document-digitization",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "continue",
+      "targetSkillId": "code-generation",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "continue",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "continue",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contributor",
+      "targetSkillId": "content-moderation",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contributor",
+      "targetSkillId": "ghostwrite",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contributor",
+      "targetSkillId": "code-generation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "control",
+      "targetSkillId": "content-moderation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "control",
+      "targetSkillId": "code-generation",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "controlled",
+      "targetSkillId": "tool-select",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "controlled",
+      "targetSkillId": "conversational-agent",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "controlled",
+      "targetSkillId": "diff-content",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "convention",
+      "targetSkillId": "content-moderation",
+      "score": 0.643,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "convention",
+      "targetSkillId": "code-generation",
+      "score": 0.64,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "convention",
+      "targetSkillId": "conversational-agent",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conversation",
+      "targetSkillId": "conversational-agent",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conversation",
+      "targetSkillId": "code-generation",
+      "score": 0.741,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conversation",
+      "targetSkillId": "content-moderation",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conversational",
+      "targetSkillId": "conversational-agent",
+      "score": 0.824,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conversational",
+      "targetSkillId": "code-generation",
+      "score": 0.69,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conversational",
+      "targetSkillId": "content-moderation",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conversations",
+      "targetSkillId": "conversational-agent",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conversations",
+      "targetSkillId": "code-generation",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conversations",
+      "targetSkillId": "content-moderation",
+      "score": 0.645,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "convert",
+      "targetSkillId": "code-generation",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "convert",
+      "targetSkillId": "diff-content",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "convert",
+      "targetSkillId": "conversational-agent",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "core",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "core",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "corpora",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "corpus",
+      "targetSkillId": "computer-use",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "correct",
+      "targetSkillId": "score-relevance",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "correct",
+      "targetSkillId": "code-execution",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "correctness",
+      "targetSkillId": "score-relevance",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "correctness",
+      "targetSkillId": "cite-sources",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "correctness",
+      "targetSkillId": "code-execution",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cosine",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cosine",
+      "targetSkillId": "conversational-agent",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "count",
+      "targetSkillId": "route-intent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "count",
+      "targetSkillId": "diff-content",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "count",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "coupling",
+      "targetSkillId": "code-execution",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "coverage",
+      "targetSkillId": "conversational-agent",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "coverage",
+      "targetSkillId": "voice-agent",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "coverage",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "covering",
+      "targetSkillId": "conversational-agent",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "covering",
+      "targetSkillId": "code-generation",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "covering",
+      "targetSkillId": "content-moderation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "crawl",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "crawler",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "crawler",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "crawlers",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "crawling",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "crawling",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "crawling",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "create",
+      "targetSkillId": "retrieve",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "create",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "create",
+      "targetSkillId": "refactor-code",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "created",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "created",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "created",
+      "targetSkillId": "refactor-code",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "creating",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "creating",
+      "targetSkillId": "code-generation",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "creating",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "creation",
+      "targetSkillId": "code-generation",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "creation",
+      "targetSkillId": "image-caption",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "creation",
+      "targetSkillId": "registry-curation",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "creator",
+      "targetSkillId": "refactor-code",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "creator",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "creator",
+      "targetSkillId": "research",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "criteria",
+      "targetSkillId": "write-report",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "criteria",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "criteria",
+      "targetSkillId": "self-critique",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cross-domain",
+      "targetSkillId": "browser-automation",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cross-domain",
+      "targetSkillId": "chunk-document",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "curation",
+      "targetSkillId": "registry-curation",
+      "score": 0.64,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "curation",
+      "targetSkillId": "code-generation",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "curation",
+      "targetSkillId": "image-caption",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "current",
+      "targetSkillId": "chunk-document",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "data",
+      "targetSkillId": "data-analysis",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dataclass",
+      "targetSkillId": "data-analysis",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dataclass",
+      "targetSkillId": "classify",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dataclasses",
+      "targetSkillId": "data-analysis",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dataclasses",
+      "targetSkillId": "classify",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dataclasses",
+      "targetSkillId": "data-visualize",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dataset",
+      "targetSkillId": "data-visualize",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dataset",
+      "targetSkillId": "data-analysis",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dataset",
+      "targetSkillId": "parse-html",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "datasets",
+      "targetSkillId": "data-analysis",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "datasets",
+      "targetSkillId": "data-visualize",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "datasets",
+      "targetSkillId": "autonomous-data-scientist",
+      "score": 0.485,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "date",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dates",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dates",
+      "targetSkillId": "generate-sql",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "datetime",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "datetime",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "datetime",
+      "targetSkillId": "extract-entities",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "days",
+      "targetSkillId": "data-analysis",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decay",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decay",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "declaration",
+      "targetSkillId": "code-generation",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "declaration",
+      "targetSkillId": "image-caption",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "declaration",
+      "targetSkillId": "registry-curation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decoding",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decoding",
+      "targetSkillId": "code-execution",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decomposed",
+      "targetSkillId": "plan-decompose",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decomposed",
+      "targetSkillId": "computer-use",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decomposition",
+      "targetSkillId": "plan-decompose",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decomposition",
+      "targetSkillId": "image-caption",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decomposition",
+      "targetSkillId": "code-execution",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deductive",
+      "targetSkillId": "retrieve",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deductive",
+      "targetSkillId": "self-critique",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "defaultedgetype",
+      "targetSkillId": "evaluate-output",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "definitions",
+      "targetSkillId": "code-generation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "definitions",
+      "targetSkillId": "document-digitization",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "definitions",
+      "targetSkillId": "code-execution",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "delegates",
+      "targetSkillId": "generate-sql",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "delegates",
+      "targetSkillId": "generate-test",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "delegates",
+      "targetSkillId": "execute-bash",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deletions",
+      "targetSkillId": "code-execution",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deletions",
+      "targetSkillId": "code-generation",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deletions",
+      "targetSkillId": "question-answer",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "delimiter",
+      "targetSkillId": "self-critique",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "demonstrates",
+      "targetSkillId": "generate-sql",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "demonstrates",
+      "targetSkillId": "generate-test",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "demonstrates",
+      "targetSkillId": "ghostwrite",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "demonstrating",
+      "targetSkillId": "code-generation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "demonstrating",
+      "targetSkillId": "error-interpretation",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "demonstrating",
+      "targetSkillId": "registry-curation",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "demos",
+      "targetSkillId": "plan-decompose",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dense",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dense",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deriv",
+      "targetSkillId": "retrieve",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "derivative",
+      "targetSkillId": "retrieve",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "derivative",
+      "targetSkillId": "self-critique",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "derivative",
+      "targetSkillId": "code-generation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "derivatives",
+      "targetSkillId": "retrieve",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "derivatives",
+      "targetSkillId": "generate-sql",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "derivatives",
+      "targetSkillId": "extract-entities",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "derive",
+      "targetSkillId": "retrieve",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "desc",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "descending",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "descending",
+      "targetSkillId": "code-generation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "descending",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "description",
+      "targetSkillId": "image-caption",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "description",
+      "targetSkillId": "registry-curation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "description",
+      "targetSkillId": "code-execution",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "descriptions",
+      "targetSkillId": "image-caption",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "descriptions",
+      "targetSkillId": "registry-curation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "descriptions",
+      "targetSkillId": "code-execution",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "designs",
+      "targetSkillId": "question-answer",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detail",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detail",
+      "targetSkillId": "data-visualize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detail",
+      "targetSkillId": "document-analyst",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detect",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detect",
+      "targetSkillId": "embed-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detect",
+      "targetSkillId": "code-execution",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detected",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detected",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detected",
+      "targetSkillId": "generate-text",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detection",
+      "targetSkillId": "code-execution",
+      "score": 0.696,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detection",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detection",
+      "targetSkillId": "code-generation",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detects",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detects",
+      "targetSkillId": "generate-test",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detects",
+      "targetSkillId": "code-execution",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "development",
+      "targetSkillId": "full-stack-developer",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "development",
+      "targetSkillId": "recursive-self-improvement",
+      "score": 0.486,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "development",
+      "targetSkillId": "chunk-document",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deviations",
+      "targetSkillId": "code-generation",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deviations",
+      "targetSkillId": "image-caption",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deviations",
+      "targetSkillId": "registry-curation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dialogue",
+      "targetSkillId": "data-visualize",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dict",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dicts",
+      "targetSkillId": "diff-content",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "diff",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "diffing",
+      "targetSkillId": "diff-content",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "diffusion",
+      "targetSkillId": "diff-content",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "diffusion-based",
+      "targetSkillId": "question-answer",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "diffusion-based",
+      "targetSkillId": "diff-content",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dimensions",
+      "targetSkillId": "image-caption",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dimensions",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dimensions",
+      "targetSkillId": "question-answer",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directed",
+      "targetSkillId": "audience-model",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directed",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directed",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directionally",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directionally",
+      "targetSkillId": "image-caption",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directionally",
+      "targetSkillId": "code-execution",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directly",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directly",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directory",
+      "targetSkillId": "refactor-code",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directory",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directory",
+      "targetSkillId": "write-report",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directs",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dirname",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dirname",
+      "targetSkillId": "audience-model",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "discovered",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "discovered",
+      "targetSkillId": "diff-content",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "discovered",
+      "targetSkillId": "computer-use",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "discrete",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "discrete",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "discrete",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "distance",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "distance",
+      "targetSkillId": "data-visualize",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "distance",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "document",
+      "targetSkillId": "chunk-document",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "document",
+      "targetSkillId": "document-analyst",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "document",
+      "targetSkillId": "document-digitization",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documentation",
+      "targetSkillId": "document-digitization",
+      "score": 0.765,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documentation",
+      "targetSkillId": "document-analyst",
+      "score": 0.69,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documentation",
+      "targetSkillId": "chunk-document",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documented",
+      "targetSkillId": "chunk-document",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documented",
+      "targetSkillId": "document-analyst",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documented",
+      "targetSkillId": "document-digitization",
+      "score": 0.581,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documents",
+      "targetSkillId": "document-analyst",
+      "score": 0.72,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documents",
+      "targetSkillId": "chunk-document",
+      "score": 0.696,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documents",
+      "targetSkillId": "document-digitization",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "doesn",
+      "targetSkillId": "diff-content",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "doesn",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "downstream",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "downstream",
+      "targetSkillId": "diff-content",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "draft-skills",
+      "targetSkillId": "data-analysis",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "draft-skills",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "draft-skills",
+      "targetSkillId": "data-visualize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dramatically",
+      "targetSkillId": "api-call",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dramatically",
+      "targetSkillId": "data-analysis",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dramatically",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "duplicate",
+      "targetSkillId": "diff-content",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "duplicate",
+      "targetSkillId": "api-call",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "duplicates",
+      "targetSkillId": "diff-content",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "each",
+      "targetSkillId": "research",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "each",
+      "targetSkillId": "web-search",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "echo",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "edge-case",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "edge-case",
+      "targetSkillId": "execute-bash",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "edge-case",
+      "targetSkillId": "image-caption",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "edges",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "elements",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "elicits",
+      "targetSkillId": "self-critique",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "elif",
+      "targetSkillId": "classify",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "else",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "else",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "embed",
+      "targetSkillId": "embed-text",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "embedding",
+      "targetSkillId": "embed-text",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "embedding",
+      "targetSkillId": "automated-testing",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "embeddings",
+      "targetSkillId": "embed-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "embeds",
+      "targetSkillId": "embed-text",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "emotional",
+      "targetSkillId": "content-moderation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "emotional",
+      "targetSkillId": "question-answer",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "emotional",
+      "targetSkillId": "conversational-agent",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enables",
+      "targetSkillId": "generate-test",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "encode",
+      "targetSkillId": "audience-model",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "encode",
+      "targetSkillId": "refactor-code",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "encoding",
+      "targetSkillId": "content-moderation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "encoding",
+      "targetSkillId": "code-execution",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "encoding",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "end-to-end",
+      "targetSkillId": "text-to-speech",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "end-to-end",
+      "targetSkillId": "speech-to-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "end-to-end",
+      "targetSkillId": "embed-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "engine",
+      "targetSkillId": "tokenize",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "engineering",
+      "targetSkillId": "code-generation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "engineering",
+      "targetSkillId": "error-interpretation",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "engines",
+      "targetSkillId": "tokenize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enhances",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enhances",
+      "targetSkillId": "generate-test",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entities",
+      "targetSkillId": "extract-entities",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entities",
+      "targetSkillId": "generate-test",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entities",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entity",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entity",
+      "targetSkillId": "extract-entities",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entries",
+      "targetSkillId": "retrieve",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entries",
+      "targetSkillId": "tokenize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entries",
+      "targetSkillId": "generate-sql",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entry",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enumerate",
+      "targetSkillId": "generate-sql",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enumerate",
+      "targetSkillId": "generate-text",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enumerate",
+      "targetSkillId": "generate-test",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "environ",
+      "targetSkillId": "code-generation",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "environment",
+      "targetSkillId": "route-intent",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "environment",
+      "targetSkillId": "diff-content",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "environment",
+      "targetSkillId": "conversational-agent",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "environments",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "environments",
+      "targetSkillId": "route-intent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "environments",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "epic",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "equations",
+      "targetSkillId": "question-answer",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "equations",
+      "targetSkillId": "image-caption",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "equations",
+      "targetSkillId": "registry-curation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "error",
+      "targetSkillId": "write-report",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "establishes",
+      "targetSkillId": "question-answer",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "etree",
+      "targetSkillId": "retrieve",
+      "score": 0.769,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "etree",
+      "targetSkillId": "extract-entities",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "etree",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluated",
+      "targetSkillId": "evaluate-output",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluated",
+      "targetSkillId": "translate",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluated",
+      "targetSkillId": "automated-testing",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluates",
+      "targetSkillId": "evaluate-output",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluates",
+      "targetSkillId": "translate",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluates",
+      "targetSkillId": "generate-sql",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluating",
+      "targetSkillId": "evaluate-output",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluating",
+      "targetSkillId": "browser-automation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluating",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluation",
+      "targetSkillId": "evaluate-output",
+      "score": 0.64,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluation",
+      "targetSkillId": "browser-automation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluation",
+      "targetSkillId": "image-caption",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluator",
+      "targetSkillId": "evaluate-output",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluator",
+      "targetSkillId": "refactor-code",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "every",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "every",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evidence",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evidence-health",
+      "targetSkillId": "audience-model",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evidence-health",
+      "targetSkillId": "voice-agent",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evidence-health",
+      "targetSkillId": "document-analyst",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "exact",
+      "targetSkillId": "extract-entities",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "exact",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "exceed",
+      "targetSkillId": "extract-entities",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "except",
+      "targetSkillId": "extract-entities",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "exclude",
+      "targetSkillId": "execute-bash",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "excludes",
+      "targetSkillId": "execute-bash",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executable",
+      "targetSkillId": "execute-bash",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executable",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executable",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executed",
+      "targetSkillId": "execute-bash",
+      "score": 0.7,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executed",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executed",
+      "targetSkillId": "code-execution",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executes",
+      "targetSkillId": "execute-bash",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executes",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executes",
+      "targetSkillId": "code-execution",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "execution",
+      "targetSkillId": "code-execution",
+      "score": 0.783,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "execution",
+      "targetSkillId": "execute-bash",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "execution",
+      "targetSkillId": "image-caption",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executor",
+      "targetSkillId": "code-execution",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executor",
+      "targetSkillId": "execute-bash",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executor",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "exhausted",
+      "targetSkillId": "execute-bash",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "existing",
+      "targetSkillId": "registry-curation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "existing",
+      "targetSkillId": "automated-testing",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "existing",
+      "targetSkillId": "code-execution",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "expanduser",
+      "targetSkillId": "plan-decompose",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "expanduser",
+      "targetSkillId": "question-answer",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "expanduser",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "expected",
+      "targetSkillId": "execute-bash",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "expected",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "expected",
+      "targetSkillId": "text-to-speech",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "experiments",
+      "targetSkillId": "extract-entities",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "experiments",
+      "targetSkillId": "generate-test",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "experiments",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "expert-level",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "expert-level",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "expert-level",
+      "targetSkillId": "extract-entities",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "explanations",
+      "targetSkillId": "code-generation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "explanations",
+      "targetSkillId": "extract-entities",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "explanations",
+      "targetSkillId": "image-caption",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "explicit",
+      "targetSkillId": "self-critique",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "export",
+      "targetSkillId": "write-report",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "exposes",
+      "targetSkillId": "plan-decompose",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "exposes",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ext",
+      "targetSkillId": "embed-text",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extend",
+      "targetSkillId": "extract-entities",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extension",
+      "targetSkillId": "code-execution",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extension",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extension",
+      "targetSkillId": "code-generation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extensionquery",
+      "targetSkillId": "question-answer",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extensionquery",
+      "targetSkillId": "cite-sources",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extensionquery",
+      "targetSkillId": "tokenize",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extensions",
+      "targetSkillId": "code-execution",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extensions",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extensions",
+      "targetSkillId": "question-answer",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extensive",
+      "targetSkillId": "tokenize",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extensive",
+      "targetSkillId": "retrieve",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extensive",
+      "targetSkillId": "extract-entities",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "external",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "external",
+      "targetSkillId": "execute-bash",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "external",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extracting",
+      "targetSkillId": "extract-entities",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extracting",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extracting",
+      "targetSkillId": "registry-curation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extraction",
+      "targetSkillId": "extract-entities",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extraction",
+      "targetSkillId": "registry-curation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extraction",
+      "targetSkillId": "code-execution",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extracts",
+      "targetSkillId": "extract-entities",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extracts",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extracts",
+      "targetSkillId": "execute-bash",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "failures",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "falls",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "false",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "feature",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "feature-extraction",
+      "targetSkillId": "code-execution",
+      "score": 0.562,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "feature-extraction",
+      "targetSkillId": "code-generation",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "feature-extraction",
+      "targetSkillId": "error-interpretation",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "features",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "features",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "features",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "feedback",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "filename",
+      "targetSkillId": "image-generate",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "filename",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "fills",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "filtered",
+      "targetSkillId": "write-report",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "filtered",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "filters",
+      "targetSkillId": "cite-sources",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "final",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "finally",
+      "targetSkillId": "api-call",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "finite-state",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "finite-state",
+      "targetSkillId": "generate-text",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "finite-state",
+      "targetSkillId": "generate-test",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "flags",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "flush",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "follow-up",
+      "targetSkillId": "tool-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "follow-up",
+      "targetSkillId": "format-output",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "force",
+      "targetSkillId": "refactor-code",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "force",
+      "targetSkillId": "cite-sources",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "form",
+      "targetSkillId": "format-output",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "format",
+      "targetSkillId": "format-output",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "formats",
+      "targetSkillId": "format-output",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "formatted",
+      "targetSkillId": "format-output",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "formatted",
+      "targetSkillId": "automated-testing",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "formatted",
+      "targetSkillId": "memory-manage",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "formatting",
+      "targetSkillId": "format-output",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "formatting",
+      "targetSkillId": "automated-testing",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "formatting",
+      "targetSkillId": "memory-manage",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "forwarded",
+      "targetSkillId": "refactor-code",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "foundation",
+      "targetSkillId": "document-digitization",
+      "score": 0.581,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "foundation",
+      "targetSkillId": "content-moderation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "foundation",
+      "targetSkillId": "code-generation",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "foundational",
+      "targetSkillId": "conversational-agent",
+      "score": 0.562,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "foundational",
+      "targetSkillId": "document-digitization",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "foundational",
+      "targetSkillId": "content-moderation",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "framework",
+      "targetSkillId": "rank",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "framing",
+      "targetSkillId": "rank",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "framing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "free-form",
+      "targetSkillId": "research",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "free-form",
+      "targetSkillId": "refactor-code",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "fromisoformat",
+      "targetSkillId": "format-output",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "fromisoformat",
+      "targetSkillId": "browser-automation",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "frontmatter",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "frontmatter",
+      "targetSkillId": "format-output",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "full-cycle",
+      "targetSkillId": "full-stack-developer",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "function",
+      "targetSkillId": "image-caption",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "function",
+      "targetSkillId": "code-execution",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "functionality",
+      "targetSkillId": "conversational-agent",
+      "score": 0.485,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "functionality",
+      "targetSkillId": "document-analyst",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "functionality",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "functionally",
+      "targetSkillId": "document-analyst",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "functionally",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "functionally",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "functions",
+      "targetSkillId": "question-answer",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "functions",
+      "targetSkillId": "image-caption",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "fundamentally",
+      "targetSkillId": "document-analyst",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "fundamentally",
+      "targetSkillId": "chunk-document",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "fundamentally",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "fuse",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "fusions",
+      "targetSkillId": "question-answer",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-cli",
+      "targetSkillId": "api-call",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-cli",
+      "targetSkillId": "data-analysis",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-cli",
+      "targetSkillId": "data-visualize",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-cli-test",
+      "targetSkillId": "generate-test",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-cli-test",
+      "targetSkillId": "diff-content",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-cli-test",
+      "targetSkillId": "api-call",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-registry",
+      "targetSkillId": "registry-curation",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-registry",
+      "targetSkillId": "generate-test",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gathering",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gathering",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gathering",
+      "targetSkillId": "automated-testing",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generate",
+      "targetSkillId": "generate-sql",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generate",
+      "targetSkillId": "generate-text",
+      "score": 0.762,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generate",
+      "targetSkillId": "generate-test",
+      "score": 0.762,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generated",
+      "targetSkillId": "generate-sql",
+      "score": 0.762,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generated",
+      "targetSkillId": "generate-text",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generated",
+      "targetSkillId": "generate-test",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generates",
+      "targetSkillId": "generate-sql",
+      "score": 0.857,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generates",
+      "targetSkillId": "generate-test",
+      "score": 0.818,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generates",
+      "targetSkillId": "generate-text",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generating",
+      "targetSkillId": "code-generation",
+      "score": 0.72,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generating",
+      "targetSkillId": "generate-sql",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generating",
+      "targetSkillId": "generate-text",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generation",
+      "targetSkillId": "code-generation",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generation",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.645,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generation",
+      "targetSkillId": "content-moderation",
+      "score": 0.643,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generative",
+      "targetSkillId": "generate-sql",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generative",
+      "targetSkillId": "generate-text",
+      "score": 0.696,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generative",
+      "targetSkillId": "generate-test",
+      "score": 0.696,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generator",
+      "targetSkillId": "generate-sql",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generator",
+      "targetSkillId": "code-generation",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generator",
+      "targetSkillId": "generate-text",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "getcode",
+      "targetSkillId": "refactor-code",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "getcode",
+      "targetSkillId": "audience-model",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gets",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gets",
+      "targetSkillId": "generate-test",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "git",
+      "targetSkillId": "ghostwrite",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "github-action",
+      "targetSkillId": "registry-curation",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "github-action",
+      "targetSkillId": "image-caption",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "github-action",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "given",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "given",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gmtime",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "goal-directed",
+      "targetSkillId": "logical-inference",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "goal-directed",
+      "targetSkillId": "audience-model",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "goal-directed",
+      "targetSkillId": "tool-select",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "got",
+      "targetSkillId": "ghostwrite",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gracefully",
+      "targetSkillId": "generate-sql",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "grammar-guided",
+      "targetSkillId": "summarize",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "grammars",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "graph",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ground-truth",
+      "targetSkillId": "route-intent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ground-truth",
+      "targetSkillId": "format-output",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "grounding",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "grounding",
+      "targetSkillId": "route-intent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "guaranteed",
+      "targetSkillId": "translate",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "guaranteed",
+      "targetSkillId": "generate-text",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "guaranteed",
+      "targetSkillId": "generate-test",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "guarantees",
+      "targetSkillId": "generate-test",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "guarantees",
+      "targetSkillId": "generate-sql",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "guarantees",
+      "targetSkillId": "translate",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hand-crafted",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hand-crafted",
+      "targetSkillId": "translate",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hand-crafted",
+      "targetSkillId": "image-generate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "handle",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "handled",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "handler",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "handles",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "handles",
+      "targetSkillId": "plan-decompose",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "happen",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "highlighting",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.474,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hit",
+      "targetSkillId": "ghostwrite",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "homepage",
+      "targetSkillId": "voice-agent",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "homepage",
+      "targetSkillId": "memory-manage",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hours",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hours",
+      "targetSkillId": "cite-sources",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hours",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "html",
+      "targetSkillId": "parse-html",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "human-level",
+      "targetSkillId": "full-stack-developer",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hypotheses",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.621,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hypotheses",
+      "targetSkillId": "computer-use",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hypothesis",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.69,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "icon",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "icon",
+      "targetSkillId": "image-caption",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "identifies",
+      "targetSkillId": "extract-entities",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "identifies",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "identifies",
+      "targetSkillId": "generate-sql",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "identify",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "identifying",
+      "targetSkillId": "code-generation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "identifying",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ignore",
+      "targetSkillId": "image-generate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "images",
+      "targetSkillId": "image-caption",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "images",
+      "targetSkillId": "image-generate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "images",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "implementation",
+      "targetSkillId": "code-generation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "implementation",
+      "targetSkillId": "error-interpretation",
+      "score": 0.529,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "implementation",
+      "targetSkillId": "image-caption",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "implements",
+      "targetSkillId": "image-generate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "implements",
+      "targetSkillId": "voice-agent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "import",
+      "targetSkillId": "write-report",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "importlib",
+      "targetSkillId": "write-report",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "improvement",
+      "targetSkillId": "recursive-self-improvement",
+      "score": 0.595,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "improvement",
+      "targetSkillId": "route-intent",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "improvement",
+      "targetSkillId": "image-generate",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "improving",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "improving",
+      "targetSkillId": "image-caption",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "in-context",
+      "targetSkillId": "diff-content",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "in-context",
+      "targetSkillId": "generate-text",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "in-context",
+      "targetSkillId": "speech-to-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "in-place",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "in-place",
+      "targetSkillId": "plan-decompose",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "include",
+      "targetSkillId": "audience-model",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "included",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "includes",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "incorporating",
+      "targetSkillId": "error-interpretation",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "incorporating",
+      "targetSkillId": "content-moderation",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "incorporating",
+      "targetSkillId": "code-generation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "indent",
+      "targetSkillId": "route-intent",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "indent",
+      "targetSkillId": "diff-content",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "indent",
+      "targetSkillId": "chunk-document",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "inference",
+      "targetSkillId": "logical-inference",
+      "score": 0.692,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "inference",
+      "targetSkillId": "cite-sources",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "inference",
+      "targetSkillId": "generate-text",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "information",
+      "targetSkillId": "image-caption",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "information",
+      "targetSkillId": "format-output",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "information",
+      "targetSkillId": "content-moderation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "inherit",
+      "targetSkillId": "image-generate",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "inherit",
+      "targetSkillId": "ghostwrite",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "initialized",
+      "targetSkillId": "data-visualize",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "inline",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "inline",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "inner",
+      "targetSkillId": "question-answer",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "insert",
+      "targetSkillId": "image-generate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "insert",
+      "targetSkillId": "question-answer",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "install",
+      "targetSkillId": "api-call",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "install-manifest",
+      "targetSkillId": "data-analysis",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "installation",
+      "targetSkillId": "image-caption",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "installation",
+      "targetSkillId": "registry-curation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "installation",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "installed",
+      "targetSkillId": "api-call",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "installs",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "installs",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "instance",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "instruction",
+      "targetSkillId": "registry-curation",
+      "score": 0.643,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "instruction",
+      "targetSkillId": "error-interpretation",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "instruction",
+      "targetSkillId": "knowledge-graph-build",
+      "score": 0.513,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "instructions",
+      "targetSkillId": "registry-curation",
+      "score": 0.621,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "instructions",
+      "targetSkillId": "knowledge-graph-build",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "instructions",
+      "targetSkillId": "error-interpretation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intake-dir",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intake-dir",
+      "targetSkillId": "write-report",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intake-dir",
+      "targetSkillId": "cite-sources",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integrates",
+      "targetSkillId": "generate-sql",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integrates",
+      "targetSkillId": "generate-test",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integrates",
+      "targetSkillId": "image-generate",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integration",
+      "targetSkillId": "error-interpretation",
+      "score": 0.645,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integration",
+      "targetSkillId": "content-moderation",
+      "score": 0.621,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integration",
+      "targetSkillId": "code-generation",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integrations",
+      "targetSkillId": "error-interpretation",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integrations",
+      "targetSkillId": "content-moderation",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integrations",
+      "targetSkillId": "code-generation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integrity",
+      "targetSkillId": "route-intent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integrity",
+      "targetSkillId": "diff-content",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intensity",
+      "targetSkillId": "route-intent",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intensity",
+      "targetSkillId": "diff-content",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intensity",
+      "targetSkillId": "tokenize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intent",
+      "targetSkillId": "route-intent",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intent",
+      "targetSkillId": "diff-content",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intent",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interactions",
+      "targetSkillId": "error-interpretation",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interactions",
+      "targetSkillId": "content-moderation",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interactions",
+      "targetSkillId": "code-generation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interface",
+      "targetSkillId": "cite-sources",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interface",
+      "targetSkillId": "write-report",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interface",
+      "targetSkillId": "logical-inference",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intermediate",
+      "targetSkillId": "image-generate",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intermediate",
+      "targetSkillId": "write-report",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intermediate",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interpreter",
+      "targetSkillId": "error-interpretation",
+      "score": 0.581,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interpreter",
+      "targetSkillId": "write-report",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interpreting",
+      "targetSkillId": "error-interpretation",
+      "score": 0.688,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interpreting",
+      "targetSkillId": "write-report",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interpreting",
+      "targetSkillId": "automated-testing",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interprets",
+      "targetSkillId": "error-interpretation",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interprets",
+      "targetSkillId": "write-report",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interprets",
+      "targetSkillId": "cite-sources",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intersection",
+      "targetSkillId": "error-interpretation",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intersection",
+      "targetSkillId": "image-caption",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intersection",
+      "targetSkillId": "registry-curation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intervention",
+      "targetSkillId": "error-interpretation",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intervention",
+      "targetSkillId": "content-moderation",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intervention",
+      "targetSkillId": "code-generation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intrusion",
+      "targetSkillId": "registry-curation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intrusion",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intrusion",
+      "targetSkillId": "error-interpretation",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "isoformat",
+      "targetSkillId": "format-output",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "issues",
+      "targetSkillId": "cite-sources",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "items",
+      "targetSkillId": "cite-sources",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iter",
+      "targetSkillId": "write-report",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iter",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iterates",
+      "targetSkillId": "generate-sql",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iterates",
+      "targetSkillId": "cite-sources",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iterates",
+      "targetSkillId": "translate",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iteration",
+      "targetSkillId": "image-caption",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iteration",
+      "targetSkillId": "error-interpretation",
+      "score": 0.621,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iteration",
+      "targetSkillId": "registry-curation",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iterative",
+      "targetSkillId": "image-generate",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iterative",
+      "targetSkillId": "error-interpretation",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iterative",
+      "targetSkillId": "write-report",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iteratively",
+      "targetSkillId": "generate-sql",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iteratively",
+      "targetSkillId": "image-generate",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iteratively",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "json",
+      "targetSkillId": "parse-json",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "kebab-case",
+      "targetSkillId": "web-search",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "knowledge",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.692,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "knowledge",
+      "targetSkillId": "knowledge-graph-build",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "langchain-ai",
+      "targetSkillId": "multi-agent-orchestration-v",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "langchain-tool",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "language",
+      "targetSkillId": "memory-manage",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "languages",
+      "targetSkillId": "memory-manage",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "large-scale",
+      "targetSkillId": "web-scrape",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "large-scale",
+      "targetSkillId": "api-call",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "large-scale",
+      "targetSkillId": "image-caption",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "last",
+      "targetSkillId": "classify",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "last",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "latency",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "later",
+      "targetSkillId": "translate",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "layout",
+      "targetSkillId": "evaluate-output",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "leading",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "learn",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "learned",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "learned",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "learning",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "learning",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "least",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "least",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "legendaries",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "legendaries",
+      "targetSkillId": "generate-sql",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "legendaries",
+      "targetSkillId": "generate-test",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "legendary",
+      "targetSkillId": "research",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "legendary",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "less",
+      "targetSkillId": "classify",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "level",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lexically",
+      "targetSkillId": "api-call",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "license",
+      "targetSkillId": "logical-inference",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lifecycle",
+      "targetSkillId": "classify",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lifecycle",
+      "targetSkillId": "logical-inference",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "line",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lineage",
+      "targetSkillId": "voice-agent",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lines",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "link",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "literature",
+      "targetSkillId": "cite-sources",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "literature",
+      "targetSkillId": "image-generate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "literature",
+      "targetSkillId": "write-report",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "llevel",
+      "targetSkillId": "full-stack-developer",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "llm-tool",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "local",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "local",
+      "targetSkillId": "logical-inference",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "local-repo",
+      "targetSkillId": "logical-inference",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "local-repo",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "local-repo",
+      "targetSkillId": "math-reason",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "locally",
+      "targetSkillId": "api-call",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "locate",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "locate",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "locations",
+      "targetSkillId": "image-caption",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "locations",
+      "targetSkillId": "code-execution",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "locations",
+      "targetSkillId": "code-generation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "log-scaled",
+      "targetSkillId": "logical-inference",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "log-scaled",
+      "targetSkillId": "web-scrape",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "log-scaled",
+      "targetSkillId": "tool-select",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "logic",
+      "targetSkillId": "logical-inference",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "logical",
+      "targetSkillId": "logical-inference",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "logical",
+      "targetSkillId": "api-call",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "loops",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "low-latency",
+      "targetSkillId": "voice-agent",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lowercase-dash",
+      "targetSkillId": "execute-bash",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lowercase-dash",
+      "targetSkillId": "generate-sql",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lowercase-dash",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "machine",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "machine",
+      "targetSkillId": "image-caption",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "machine-readable",
+      "targetSkillId": "math-reason",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "machine-readable",
+      "targetSkillId": "score-relevance",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "madaan",
+      "targetSkillId": "math-reason",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "main",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "main",
+      "targetSkillId": "image-caption",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "main",
+      "targetSkillId": "summarize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "maintainability",
+      "targetSkillId": "document-analyst",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "maintainability",
+      "targetSkillId": "data-visualize",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "maintaining",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "maintaining",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.486,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "maintaining",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "management",
+      "targetSkillId": "image-generate",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "management",
+      "targetSkillId": "memory-manage",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "management",
+      "targetSkillId": "voice-agent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "managing",
+      "targetSkillId": "memory-manage",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "manifest",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "manifest",
+      "targetSkillId": "image-generate",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "manual",
+      "targetSkillId": "document-analyst",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "manually",
+      "targetSkillId": "document-analyst",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "manually",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "manually",
+      "targetSkillId": "data-analysis",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mapping",
+      "targetSkillId": "image-caption",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mappings",
+      "targetSkillId": "image-caption",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mark",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mark",
+      "targetSkillId": "summarize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "markdown",
+      "targetSkillId": "math-reason",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marked",
+      "targetSkillId": "summarize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marked",
+      "targetSkillId": "parse-pdf",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marked",
+      "targetSkillId": "math-reason",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marker",
+      "targetSkillId": "summarize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marker",
+      "targetSkillId": "math-reason",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "markers",
+      "targetSkillId": "math-reason",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "markers",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "markers",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marketplace",
+      "targetSkillId": "parse-html",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marketplace",
+      "targetSkillId": "math-reason",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "master",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "match",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "match",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "matching",
+      "targetSkillId": "math-reason",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "matching",
+      "targetSkillId": "automated-testing",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "matching",
+      "targetSkillId": "image-caption",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "math",
+      "targetSkillId": "math-reason",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mathematical",
+      "targetSkillId": "math-reason",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mathematical",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mathematical",
+      "targetSkillId": "image-caption",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mathematics",
+      "targetSkillId": "math-reason",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mathematics",
+      "targetSkillId": "image-caption",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mbtiongson1",
+      "targetSkillId": "math-reason",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mbtiongson1",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mcp-registry",
+      "targetSkillId": "registry-curation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mcp-server",
+      "targetSkillId": "computer-use",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "meaning",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "meaning",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "meaning",
+      "targetSkillId": "memory-manage",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "meaningful",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "meaningful",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mechanistic",
+      "targetSkillId": "image-caption",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "medical",
+      "targetSkillId": "api-call",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "meets",
+      "targetSkillId": "embed-text",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "meets",
+      "targetSkillId": "generate-sql",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "meets",
+      "targetSkillId": "execute-bash",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "memory",
+      "targetSkillId": "memory-manage",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "merged",
+      "targetSkillId": "memory-manage",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "message",
+      "targetSkillId": "memory-manage",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "message",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "messages",
+      "targetSkillId": "memory-manage",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "metadata",
+      "targetSkillId": "document-analyst",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "metadata",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "method",
+      "targetSkillId": "math-reason",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "microsecond",
+      "targetSkillId": "code-execution",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "microsecond",
+      "targetSkillId": "parse-json",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "microsecond",
+      "targetSkillId": "math-reason",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "migration",
+      "targetSkillId": "image-caption",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "migration",
+      "targetSkillId": "code-generation",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "migration",
+      "targetSkillId": "registry-curation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "modalities",
+      "targetSkillId": "extract-entities",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "modalities",
+      "targetSkillId": "autonomous-data-scientist",
+      "score": 0.457,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "model",
+      "targetSkillId": "audience-model",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "modeling",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "modeling",
+      "targetSkillId": "automated-testing",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "modeling",
+      "targetSkillId": "content-moderation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "models",
+      "targetSkillId": "audience-model",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "moderation",
+      "targetSkillId": "code-generation",
+      "score": 0.72,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "moderation",
+      "targetSkillId": "content-moderation",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "moderation",
+      "targetSkillId": "image-caption",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "modern",
+      "targetSkillId": "content-moderation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "modern",
+      "targetSkillId": "code-generation",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "modifications",
+      "targetSkillId": "image-caption",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "modifications",
+      "targetSkillId": "document-digitization",
+      "score": 0.529,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "modifications",
+      "targetSkillId": "code-execution",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "more",
+      "targetSkillId": "memory-manage",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "more",
+      "targetSkillId": "summarize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mouse",
+      "targetSkillId": "tool-use",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mouse",
+      "targetSkillId": "autonomous-debug",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mouse",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-agent",
+      "targetSkillId": "voice-agent",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-agent",
+      "targetSkillId": "multi-agent-orchestration-v",
+      "score": 0.579,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-agent",
+      "targetSkillId": "route-intent",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-category",
+      "targetSkillId": "multi-agent-orchestration-v",
+      "score": 0.488,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-category",
+      "targetSkillId": "question-answer",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-category",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-section",
+      "targetSkillId": "multi-agent-orchestration-v",
+      "score": 0.55,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-section",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-section",
+      "targetSkillId": "image-caption",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-session",
+      "targetSkillId": "multi-agent-orchestration-v",
+      "score": 0.55,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-session",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-session",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-source",
+      "targetSkillId": "cite-sources",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-source",
+      "targetSkillId": "multi-agent-orchestration-v",
+      "score": 0.513,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-source",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-step",
+      "targetSkillId": "question-answer",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-step",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-step",
+      "targetSkillId": "full-stack-developer",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-turn",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-turn",
+      "targetSkillId": "multi-agent-orchestration-v",
+      "score": 0.486,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-turn",
+      "targetSkillId": "math-reason",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multilingual",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.562,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multimodal",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multimodal",
+      "targetSkillId": "audience-model",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multiple",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "name",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "named-dir",
+      "targetSkillId": "automated-testing",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "named-skills",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "named-skills",
+      "targetSkillId": "automated-testing",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "names",
+      "targetSkillId": "generate-sql",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "narrative",
+      "targetSkillId": "retrieve",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "narrative",
+      "targetSkillId": "generate-sql",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "narrative",
+      "targetSkillId": "generate-text",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "natural",
+      "targetSkillId": "data-visualize",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "natural-language",
+      "targetSkillId": "conversational-agent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "natural-language",
+      "targetSkillId": "memory-manage",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "natural-sounding",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.645,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "natural-sounding",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "natural-sounding",
+      "targetSkillId": "math-reason",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "navigating",
+      "targetSkillId": "image-caption",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "navigating",
+      "targetSkillId": "conversational-agent",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "navigating",
+      "targetSkillId": "document-digitization",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "near-human",
+      "targetSkillId": "memory-manage",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "near-human",
+      "targetSkillId": "parse-html",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "near-human",
+      "targetSkillId": "browser-automation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "needed",
+      "targetSkillId": "embed-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "needs",
+      "targetSkillId": "generate-sql",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "needs-review",
+      "targetSkillId": "code-review-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "needs-review",
+      "targetSkillId": "embed-text",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "negative",
+      "targetSkillId": "retrieve",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "negative",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "negative",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "nested",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "nesting",
+      "targetSkillId": "conversational-agent",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "nesting",
+      "targetSkillId": "automated-testing",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "nesting",
+      "targetSkillId": "question-answer",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "neural",
+      "targetSkillId": "generate-sql",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "neutral",
+      "targetSkillId": "generate-sql",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "neutral",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "next",
+      "targetSkillId": "generate-text",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "nline",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "nline",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "nodes",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "noise",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "noise",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "non-interactive",
+      "targetSkillId": "error-interpretation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "non-interactive",
+      "targetSkillId": "route-intent",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "non-interactive",
+      "targetSkillId": "logical-inference",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "non-overlap",
+      "targetSkillId": "content-moderation",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "non-overlap",
+      "targetSkillId": "conversational-agent",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "normally",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "notebooks",
+      "targetSkillId": "tool-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "notes",
+      "targetSkillId": "generate-sql",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "notes",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "numeric",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "numerical",
+      "targetSkillId": "generate-sql",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "numerical",
+      "targetSkillId": "api-call",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "objective",
+      "targetSkillId": "retrieve",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "objective",
+      "targetSkillId": "tokenize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "objective",
+      "targetSkillId": "self-critique",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "objectives",
+      "targetSkillId": "retrieve",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "objectives",
+      "targetSkillId": "extract-entities",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "objectives",
+      "targetSkillId": "execute-bash",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "observable",
+      "targetSkillId": "score-relevance",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "observable",
+      "targetSkillId": "tool-select",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "observation",
+      "targetSkillId": "browser-automation",
+      "score": 0.621,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "observation",
+      "targetSkillId": "code-generation",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "observation",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.562,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "observe",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "observe",
+      "targetSkillId": "web-search",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "observe",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "occurrence",
+      "targetSkillId": "logical-inference",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "occurrence",
+      "targetSkillId": "score-relevance",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "occurrence",
+      "targetSkillId": "cite-sources",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "once",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "one",
+      "targetSkillId": "tokenize",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "open",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "open-ended",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "open-ended",
+      "targetSkillId": "computer-use",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "open-source",
+      "targetSkillId": "cite-sources",
+      "score": 0.696,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "open-source",
+      "targetSkillId": "computer-use",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "open-source",
+      "targetSkillId": "web-search",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "openai",
+      "targetSkillId": "tokenize",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "openai",
+      "targetSkillId": "code-generation",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "opened",
+      "targetSkillId": "tokenize",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "opening",
+      "targetSkillId": "tokenize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "opening",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "opening",
+      "targetSkillId": "code-generation",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "opens",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "opens",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "optimized",
+      "targetSkillId": "tokenize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "optional",
+      "targetSkillId": "conversational-agent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "optional",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "optional",
+      "targetSkillId": "image-caption",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "options",
+      "targetSkillId": "image-caption",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "options",
+      "targetSkillId": "code-execution",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "options",
+      "targetSkillId": "question-answer",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "orchestrates",
+      "targetSkillId": "ghostwrite",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "orchestrates",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "orchestrates",
+      "targetSkillId": "multi-agent-orchestration-v",
+      "score": 0.513,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "order",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "order",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ordered",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "organizations",
+      "targetSkillId": "registry-curation",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "organizations",
+      "targetSkillId": "document-digitization",
+      "score": 0.529,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "organizations",
+      "targetSkillId": "browser-automation",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "origin",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "orphaned",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "orphaned",
+      "targetSkillId": "memory-manage",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "orphaned",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "otherwise",
+      "targetSkillId": "computer-use",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "otherwise",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "otherwise",
+      "targetSkillId": "route-intent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outliers",
+      "targetSkillId": "computer-use",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outliers",
+      "targetSkillId": "route-intent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outlines",
+      "targetSkillId": "route-intent",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outlines",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outlines",
+      "targetSkillId": "code-execution",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outlines-dev",
+      "targetSkillId": "route-intent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outlines-dev",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outperforms",
+      "targetSkillId": "computer-use",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "output",
+      "targetSkillId": "format-output",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "output",
+      "targetSkillId": "evaluate-output",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "output",
+      "targetSkillId": "structured-output",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outputs",
+      "targetSkillId": "format-output",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outputs",
+      "targetSkillId": "evaluate-output",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outputs",
+      "targetSkillId": "computer-use",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outside",
+      "targetSkillId": "tool-use",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outside",
+      "targetSkillId": "route-intent",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outside",
+      "targetSkillId": "computer-use",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "overwritten",
+      "targetSkillId": "ghostwrite",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "overwritten",
+      "targetSkillId": "route-intent",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "overwritten",
+      "targetSkillId": "error-interpretation",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "owned",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "owner",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pack",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "packed",
+      "targetSkillId": "parse-pdf",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pages",
+      "targetSkillId": "parse-json",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pair",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pairs",
+      "targetSkillId": "parse-pdf",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pairs",
+      "targetSkillId": "parse-json",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pairs",
+      "targetSkillId": "parse-html",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pairwise",
+      "targetSkillId": "parse-pdf",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pairwise",
+      "targetSkillId": "parse-json",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pairwise",
+      "targetSkillId": "parse-html",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pal",
+      "targetSkillId": "api-call",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pal",
+      "targetSkillId": "parse-html",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pandas",
+      "targetSkillId": "plan-decompose",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pandas-ai",
+      "targetSkillId": "data-analysis",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "papers",
+      "targetSkillId": "parse-pdf",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "papers",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "papers",
+      "targetSkillId": "parse-html",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "paradigm",
+      "targetSkillId": "parse-pdf",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parameters",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parameters",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parameters",
+      "targetSkillId": "extract-entities",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "params",
+      "targetSkillId": "parse-pdf",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "params",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "params",
+      "targetSkillId": "parse-html",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parent",
+      "targetSkillId": "parse-json",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parent",
+      "targetSkillId": "parse-html",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parent",
+      "targetSkillId": "parse-pdf",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parents",
+      "targetSkillId": "parse-json",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parents",
+      "targetSkillId": "parse-html",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parents",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parse",
+      "targetSkillId": "parse-pdf",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parse",
+      "targetSkillId": "parse-json",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parse",
+      "targetSkillId": "parse-html",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parsed",
+      "targetSkillId": "parse-pdf",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parsed",
+      "targetSkillId": "parse-json",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parsed",
+      "targetSkillId": "parse-html",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parser",
+      "targetSkillId": "parse-pdf",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parser",
+      "targetSkillId": "parse-json",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parser",
+      "targetSkillId": "parse-html",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parses",
+      "targetSkillId": "parse-json",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parses",
+      "targetSkillId": "parse-pdf",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parses",
+      "targetSkillId": "parse-html",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parsing",
+      "targetSkillId": "parse-json",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parsing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parsing",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "partition",
+      "targetSkillId": "parse-json",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "partition",
+      "targetSkillId": "route-intent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "partition",
+      "targetSkillId": "image-caption",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parts",
+      "targetSkillId": "parse-pdf",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parts",
+      "targetSkillId": "parse-json",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parts",
+      "targetSkillId": "parse-html",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pass",
+      "targetSkillId": "parse-json",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pass",
+      "targetSkillId": "classify",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pass",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "passages",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "passages",
+      "targetSkillId": "parse-pdf",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "passed",
+      "targetSkillId": "parse-pdf",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "passed",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "passed",
+      "targetSkillId": "parse-html",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "passing",
+      "targetSkillId": "parse-json",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "passing",
+      "targetSkillId": "classify",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "passing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "patch",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "patched",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "patches",
+      "targetSkillId": "math-reason",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "patches",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "paths",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pattern",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "patterns",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "patterns",
+      "targetSkillId": "generate-test",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pdf",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pending",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "percentage",
+      "targetSkillId": "extract-entities",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "percentage",
+      "targetSkillId": "memory-manage",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "performance",
+      "targetSkillId": "memory-manage",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "performance",
+      "targetSkillId": "refactor-code",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "performance",
+      "targetSkillId": "score-relevance",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "persistent",
+      "targetSkillId": "route-intent",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "persistent",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "persistent",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "photorealistic",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.457,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pipe",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pipeline",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pipeline",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pipeline",
+      "targetSkillId": "text-to-sql-pipeline",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pipelines",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.762,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pipelines",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pipelines",
+      "targetSkillId": "text-to-sql-pipeline",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pixel-space",
+      "targetSkillId": "cite-sources",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pixel-space",
+      "targetSkillId": "web-search",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pixel-space",
+      "targetSkillId": "web-scrape",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "placeholder",
+      "targetSkillId": "audience-model",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "plain-text",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "plain-text",
+      "targetSkillId": "generate-text",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "plain-text",
+      "targetSkillId": "speech-to-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "plan",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "planned",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "planned",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "planned",
+      "targetSkillId": "plan-decompose",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "platform",
+      "targetSkillId": "plan-decompose",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "plus",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "point",
+      "targetSkillId": "voice-agent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "point",
+      "targetSkillId": "route-intent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "points",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "positive",
+      "targetSkillId": "ghostwrite",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "positive",
+      "targetSkillId": "self-critique",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pre-computed",
+      "targetSkillId": "computer-use",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pre-computed",
+      "targetSkillId": "parse-pdf",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pre-computed",
+      "targetSkillId": "plan-decompose",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pre-trained",
+      "targetSkillId": "retrieve",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pre-trained",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pre-trained",
+      "targetSkillId": "score-relevance",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pre-training",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pre-training",
+      "targetSkillId": "route-intent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pre-training",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prediction",
+      "targetSkillId": "registry-curation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prediction",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prediction",
+      "targetSkillId": "code-execution",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prefix",
+      "targetSkillId": "parse-pdf",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "premises",
+      "targetSkillId": "parse-json",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "premises",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "premises",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prepare",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prepare",
+      "targetSkillId": "research",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prepare",
+      "targetSkillId": "refactor-code",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prereq",
+      "targetSkillId": "retrieve",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prereqs",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prereqs",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prereqs",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prerequisite",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prerequisites",
+      "targetSkillId": "execute-bash",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prerequisites",
+      "targetSkillId": "retrieve",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prerequisites",
+      "targetSkillId": "generate-test",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "present",
+      "targetSkillId": "parse-json",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "present",
+      "targetSkillId": "parse-html",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "present",
+      "targetSkillId": "research",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "preserves",
+      "targetSkillId": "retrieve",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "preserves",
+      "targetSkillId": "research",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "preserves",
+      "targetSkillId": "parse-json",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "preserving",
+      "targetSkillId": "research",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "preserving",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "preserving",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prevalence",
+      "targetSkillId": "score-relevance",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "preview",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "princeton-nlp",
+      "targetSkillId": "parse-pdf",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "print",
+      "targetSkillId": "route-intent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "processing",
+      "targetSkillId": "real-time-voice-assistant",
+      "score": 0.457,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "processing",
+      "targetSkillId": "route-intent",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "processing",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "production",
+      "targetSkillId": "code-execution",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "production",
+      "targetSkillId": "route-intent",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "production",
+      "targetSkillId": "browser-automation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "production-grade",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.514,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "production-grade",
+      "targetSkillId": "route-intent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "production-grade",
+      "targetSkillId": "code-execution",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "programmatic",
+      "targetSkillId": "browser-automation",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "programming",
+      "targetSkillId": "browser-automation",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "programming",
+      "targetSkillId": "code-generation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "project",
+      "targetSkillId": "parse-html",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "projections",
+      "targetSkillId": "code-execution",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "projections",
+      "targetSkillId": "registry-curation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "projections",
+      "targetSkillId": "browser-automation",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "promoted",
+      "targetSkillId": "parse-pdf",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "promoted",
+      "targetSkillId": "plan-decompose",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "promotion",
+      "targetSkillId": "content-moderation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "promotion",
+      "targetSkillId": "browser-automation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "promotion",
+      "targetSkillId": "route-intent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prompting",
+      "targetSkillId": "route-intent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prompting",
+      "targetSkillId": "automated-testing",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prompting",
+      "targetSkillId": "image-caption",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prompts",
+      "targetSkillId": "computer-use",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prompts",
+      "targetSkillId": "plan-decompose",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "propose",
+      "targetSkillId": "plan-decompose",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "propose",
+      "targetSkillId": "tool-use",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "propose",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposed",
+      "targetSkillId": "parse-pdf",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposed",
+      "targetSkillId": "plan-decompose",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposed",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposer",
+      "targetSkillId": "plan-decompose",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposer",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposer",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposes",
+      "targetSkillId": "parse-json",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposes",
+      "targetSkillId": "plan-decompose",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposes",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prosody",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prosody",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "provisional",
+      "targetSkillId": "parse-json",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "provisional",
+      "targetSkillId": "conversational-agent",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pull",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pure",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pure",
+      "targetSkillId": "summarize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pure",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "python",
+      "targetSkillId": "math-reason",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "python-shell",
+      "targetSkillId": "tool-select",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "python-shell",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "python-shell-5",
+      "targetSkillId": "tool-select",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "python-version",
+      "targetSkillId": "conversational-agent",
+      "score": 0.529,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "python-version",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.514,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "python-version",
+      "targetSkillId": "content-moderation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "quantitative",
+      "targetSkillId": "extract-entities",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "quantitative",
+      "targetSkillId": "document-digitization",
+      "score": 0.485,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "quantitative",
+      "targetSkillId": "translate",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "queries",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "queries",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "queryable",
+      "targetSkillId": "memory-manage",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "question-answering",
+      "targetSkillId": "question-answer",
+      "score": 0.909,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "question-answering",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "question-answering",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.474,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "questions",
+      "targetSkillId": "question-answer",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "questions",
+      "targetSkillId": "automated-testing",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "questions",
+      "targetSkillId": "image-caption",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rag",
+      "targetSkillId": "rank",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "raise",
+      "targetSkillId": "translate",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "raise",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "raise",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "raises",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "raises",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "raises",
+      "targetSkillId": "extract-entities",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "range",
+      "targetSkillId": "rank",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "range",
+      "targetSkillId": "translate",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "range",
+      "targetSkillId": "memory-manage",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ranking",
+      "targetSkillId": "rank",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ranking",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ranks",
+      "targetSkillId": "rank",
+      "score": 0.889,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ranks",
+      "targetSkillId": "translate",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rare",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rare",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rare",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rasa",
+      "targetSkillId": "translate",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rasa",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rate",
+      "targetSkillId": "translate",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rate",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rate",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rated",
+      "targetSkillId": "translate",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rated",
+      "targetSkillId": "generate-sql",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rated",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ratio",
+      "targetSkillId": "code-generation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ratio",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ratio",
+      "targetSkillId": "registry-curation",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "raw",
+      "targetSkillId": "rank",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "re-derived",
+      "targetSkillId": "retrieve",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "re-derived",
+      "targetSkillId": "score-relevance",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "re-exports",
+      "targetSkillId": "write-report",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "re-exports",
+      "targetSkillId": "generate-text",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "re-exports",
+      "targetSkillId": "embed-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reach",
+      "targetSkillId": "research",
+      "score": 0.769,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reach",
+      "targetSkillId": "web-search",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reachable",
+      "targetSkillId": "research",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reachable",
+      "targetSkillId": "api-call",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reachable",
+      "targetSkillId": "refactor-code",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reached",
+      "targetSkillId": "research",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reached",
+      "targetSkillId": "refactor-code",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reached",
+      "targetSkillId": "web-search",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "react-reasoning",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.968,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "react-reasoning",
+      "targetSkillId": "math-reason",
+      "score": 0.692,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "react-reasoning",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.629,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "read",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "read",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "read",
+      "targetSkillId": "refactor-code",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reading",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reading",
+      "targetSkillId": "rank",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ready",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "real",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "real",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "real-time",
+      "targetSkillId": "retrieve",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "real-time",
+      "targetSkillId": "real-time-voice-assistant",
+      "score": 0.529,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "real-time",
+      "targetSkillId": "route-intent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "real-world",
+      "targetSkillId": "refactor-code",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "realistic",
+      "targetSkillId": "research",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "realistic",
+      "targetSkillId": "registry-curation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "realistic",
+      "targetSkillId": "refactor-code",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reason",
+      "targetSkillId": "math-reason",
+      "score": 0.706,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reason",
+      "targetSkillId": "parse-json",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reason",
+      "targetSkillId": "rank",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reasoning",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reasoning",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.621,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reasoning",
+      "targetSkillId": "math-reason",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reasoning-machines",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reasoning-machines",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.474,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reasoning-machines",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.474,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "record",
+      "targetSkillId": "refactor-code",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "records",
+      "targetSkillId": "refactor-code",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "recursive",
+      "targetSkillId": "retrieve",
+      "score": 0.706,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "recursive",
+      "targetSkillId": "recursive-self-improvement",
+      "score": 0.514,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "recursive",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "redirect",
+      "targetSkillId": "route-intent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "redirect",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "redirect",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ref",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refactor",
+      "targetSkillId": "refactor-code",
+      "score": 0.762,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refactor",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refactor",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refactors",
+      "targetSkillId": "refactor-code",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refactors",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refactors",
+      "targetSkillId": "retrieve",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reference",
+      "targetSkillId": "research",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reference",
+      "targetSkillId": "score-relevance",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reference",
+      "targetSkillId": "logical-inference",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "references",
+      "targetSkillId": "score-relevance",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "references",
+      "targetSkillId": "research",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "references",
+      "targetSkillId": "generate-test",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refines",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refines",
+      "targetSkillId": "route-intent",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refines",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "regex",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "regex",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "register",
+      "targetSkillId": "research",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "register",
+      "targetSkillId": "registry-curation",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "register",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registries",
+      "targetSkillId": "retrieve",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registries",
+      "targetSkillId": "ghostwrite",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registries",
+      "targetSkillId": "registry-curation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registry",
+      "targetSkillId": "registry-curation",
+      "score": 0.64,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registry",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registry",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registry-ref",
+      "targetSkillId": "registry-curation",
+      "score": 0.69,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registry-ref",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registry-ref",
+      "targetSkillId": "ghostwrite",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reject",
+      "targetSkillId": "research",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reject",
+      "targetSkillId": "tool-select",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rel",
+      "targetSkillId": "parse-html",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relations",
+      "targetSkillId": "image-caption",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relations",
+      "targetSkillId": "registry-curation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relations",
+      "targetSkillId": "browser-automation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relationships",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relationships",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relationships",
+      "targetSkillId": "registry-curation",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relative",
+      "targetSkillId": "retrieve",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relative",
+      "targetSkillId": "translate",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relative",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relevance",
+      "targetSkillId": "score-relevance",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relevance",
+      "targetSkillId": "retrieve",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relevance",
+      "targetSkillId": "research",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relevant",
+      "targetSkillId": "score-relevance",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relevant",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relevant",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relpath",
+      "targetSkillId": "research",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relpath",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "remote",
+      "targetSkillId": "retrieve",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "remote",
+      "targetSkillId": "embed-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "remove",
+      "targetSkillId": "retrieve",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repeat",
+      "targetSkillId": "research",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "replace",
+      "targetSkillId": "score-relevance",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "replace",
+      "targetSkillId": "research",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "replace",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repo",
+      "targetSkillId": "write-report",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repo",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "report",
+      "targetSkillId": "write-report",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reporting",
+      "targetSkillId": "write-report",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reporting",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reporting",
+      "targetSkillId": "retrieve",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reports",
+      "targetSkillId": "write-report",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repositories",
+      "targetSkillId": "retrieve",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repositories",
+      "targetSkillId": "extract-entities",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repositories",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repository",
+      "targetSkillId": "write-report",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "representation",
+      "targetSkillId": "error-interpretation",
+      "score": 0.647,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "representation",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "representation",
+      "targetSkillId": "browser-automation",
+      "score": 0.562,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "representations",
+      "targetSkillId": "error-interpretation",
+      "score": 0.629,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "representations",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "representations",
+      "targetSkillId": "browser-automation",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "representing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "representing",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "representing",
+      "targetSkillId": "error-interpretation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reproducible",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reproducible",
+      "targetSkillId": "refactor-code",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "request",
+      "targetSkillId": "generate-test",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "request",
+      "targetSkillId": "question-answer",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "requests",
+      "targetSkillId": "question-answer",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "requests",
+      "targetSkillId": "generate-test",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "required",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "requires",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "requiring",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "requiring",
+      "targetSkillId": "retrieve",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rerank",
+      "targetSkillId": "rank",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rerank",
+      "targetSkillId": "score-relevance",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rerank",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reranking",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reranking",
+      "targetSkillId": "rank",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reranking",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "res",
+      "targetSkillId": "research",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "res",
+      "targetSkillId": "parse-json",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "research-backed",
+      "targetSkillId": "research",
+      "score": 0.696,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "research-backed",
+      "targetSkillId": "web-search",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "research-backed",
+      "targetSkillId": "autonomous-research-agent",
+      "score": 0.55,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolution",
+      "targetSkillId": "registry-curation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolution",
+      "targetSkillId": "route-intent",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolution",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolve",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolve",
+      "targetSkillId": "research",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolve",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolved",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolved",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolver",
+      "targetSkillId": "research",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolver",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolves",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolves",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resp",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resp",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "responses",
+      "targetSkillId": "parse-json",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "responses",
+      "targetSkillId": "question-answer",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "responses",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rest",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rest",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rest",
+      "targetSkillId": "generate-test",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retrieval",
+      "targetSkillId": "retrieve",
+      "score": 0.824,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retrieval",
+      "targetSkillId": "score-relevance",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retrieval",
+      "targetSkillId": "refactor-code",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retrieval-augmented",
+      "targetSkillId": "retrieve",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retrieval-augmented",
+      "targetSkillId": "conversational-agent",
+      "score": 0.564,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retrieval-augmented",
+      "targetSkillId": "extract-entities",
+      "score": 0.514,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retrieves",
+      "targetSkillId": "retrieve",
+      "score": 0.941,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retrieves",
+      "targetSkillId": "score-relevance",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retrieves",
+      "targetSkillId": "extract-entities",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retry",
+      "targetSkillId": "retrieve",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retry",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retry",
+      "targetSkillId": "registry-curation",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "return",
+      "targetSkillId": "retrieve",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "return",
+      "targetSkillId": "registry-curation",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "return",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "returncode",
+      "targetSkillId": "refactor-code",
+      "score": 0.696,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "returncode",
+      "targetSkillId": "retrieve",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "returncode",
+      "targetSkillId": "audience-model",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "returned",
+      "targetSkillId": "retrieve",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "returned",
+      "targetSkillId": "structured-output",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "returned",
+      "targetSkillId": "registry-curation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "returns",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "returns",
+      "targetSkillId": "registry-curation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "returns",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reversal",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reversal",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reversal",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reverse",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reverse",
+      "targetSkillId": "research",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "review",
+      "targetSkillId": "retrieve",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "review",
+      "targetSkillId": "code-review-pipeline",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reviewed",
+      "targetSkillId": "retrieve",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reviewed",
+      "targetSkillId": "code-review-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reviews",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rigorous",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "roots",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "round",
+      "targetSkillId": "route-intent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "routes",
+      "targetSkillId": "route-intent",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "routes",
+      "targetSkillId": "computer-use",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "routing",
+      "targetSkillId": "route-intent",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "routing",
+      "targetSkillId": "browser-automation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "routing",
+      "targetSkillId": "code-execution",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rule-based",
+      "targetSkillId": "execute-bash",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rule-based",
+      "targetSkillId": "route-intent",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rules",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "run",
+      "targetSkillId": "rank",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "runner",
+      "targetSkillId": "question-answer",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "running",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "runs",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "runs",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "runs-on",
+      "targetSkillId": "parse-json",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "runs-on",
+      "targetSkillId": "chunk-document",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "runtime",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "runtime",
+      "targetSkillId": "route-intent",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "runtime",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "safe",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "safe",
+      "targetSkillId": "summarize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "same",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "same",
+      "targetSkillId": "summarize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scalars",
+      "targetSkillId": "classify",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scale",
+      "targetSkillId": "web-scrape",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scale",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scan",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scanned",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scanned",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scanner",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scanner",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scanner",
+      "targetSkillId": "question-answer",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "schema-dir",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "schema-valid",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "schema-valid",
+      "targetSkillId": "data-visualize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "science",
+      "targetSkillId": "score-relevance",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "science",
+      "targetSkillId": "cite-sources",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "science",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scientific",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scientific",
+      "targetSkillId": "extract-entities",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "score",
+      "targetSkillId": "web-scrape",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "score",
+      "targetSkillId": "score-relevance",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "score",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scored",
+      "targetSkillId": "web-scrape",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scored",
+      "targetSkillId": "score-relevance",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scores",
+      "targetSkillId": "web-scrape",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scores",
+      "targetSkillId": "score-relevance",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scoring",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scoring",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scoring",
+      "targetSkillId": "code-generation",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scraper",
+      "targetSkillId": "web-scrape",
+      "score": 0.706,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scraper",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scraping",
+      "targetSkillId": "web-scrape",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scraping",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scraping",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "screenshot",
+      "targetSkillId": "speech-to-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "screenshot",
+      "targetSkillId": "score-relevance",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "screenshot",
+      "targetSkillId": "voice-agent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "screenshot-based",
+      "targetSkillId": "speech-to-text",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "screenshot-based",
+      "targetSkillId": "score-relevance",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "screenshots",
+      "targetSkillId": "speech-to-text",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "screenshots",
+      "targetSkillId": "score-relevance",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "screenshots",
+      "targetSkillId": "voice-agent",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "script",
+      "targetSkillId": "self-critique",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "script",
+      "targetSkillId": "web-scrape",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "script",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scripts",
+      "targetSkillId": "self-critique",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scripts",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scripts",
+      "targetSkillId": "ghostwrite",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "search",
+      "targetSkillId": "research",
+      "score": 0.857,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "search",
+      "targetSkillId": "web-search",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "searchable",
+      "targetSkillId": "research",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "searchable",
+      "targetSkillId": "web-search",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "searchable",
+      "targetSkillId": "autonomous-research-agent",
+      "score": 0.457,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "searching",
+      "targetSkillId": "research",
+      "score": 0.706,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "searching",
+      "targetSkillId": "web-search",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "searching",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "second",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "seconds",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "secrets",
+      "targetSkillId": "self-critique",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "secrets",
+      "targetSkillId": "speech-to-text",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "secrets",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "security",
+      "targetSkillId": "self-critique",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "security",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "seed",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "segment",
+      "targetSkillId": "voice-agent",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "segment",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "segment",
+      "targetSkillId": "image-generate",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "segments",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "segments",
+      "targetSkillId": "voice-agent",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "segments",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "selecting",
+      "targetSkillId": "tool-select",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "selecting",
+      "targetSkillId": "self-critique",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "selecting",
+      "targetSkillId": "code-execution",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "selection",
+      "targetSkillId": "code-execution",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "selection",
+      "targetSkillId": "tool-select",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "selection",
+      "targetSkillId": "self-critique",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "selects",
+      "targetSkillId": "tool-select",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "selects",
+      "targetSkillId": "execute-bash",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "selects",
+      "targetSkillId": "speech-to-text",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-evidence",
+      "targetSkillId": "score-relevance",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-evidence",
+      "targetSkillId": "code-review-pipeline",
+      "score": 0.485,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-evidence",
+      "targetSkillId": "self-critique",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-feedback",
+      "targetSkillId": "self-critique",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-generated",
+      "targetSkillId": "image-generate",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-generated",
+      "targetSkillId": "code-generation",
+      "score": 0.621,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-generated",
+      "targetSkillId": "generate-sql",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-hosted",
+      "targetSkillId": "self-critique",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-hosted",
+      "targetSkillId": "speech-to-text",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-hosted",
+      "targetSkillId": "parse-html",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-refine",
+      "targetSkillId": "self-critique",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-refine",
+      "targetSkillId": "score-relevance",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-refine",
+      "targetSkillId": "code-review-pipeline",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-supervised",
+      "targetSkillId": "self-critique",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "semantic",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "semantic",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "semantic",
+      "targetSkillId": "browser-automation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "semantically",
+      "targetSkillId": "api-call",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "semantically",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sensemaking",
+      "targetSkillId": "code-generation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sentence-similarity",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.486,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sentence-similarity",
+      "targetSkillId": "real-time-voice-assistant",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sentence-similarity",
+      "targetSkillId": "generate-sql",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sentence-transformers",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.564,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sentence-transformers",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.514,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sentence-transformers",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.488,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sentiment",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sentiment",
+      "targetSkillId": "tokenize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sentiment",
+      "targetSkillId": "retrieve",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "separated",
+      "targetSkillId": "parse-pdf",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "separated",
+      "targetSkillId": "generate-sql",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "separated",
+      "targetSkillId": "research",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "separately",
+      "targetSkillId": "generate-sql",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "separately",
+      "targetSkillId": "parse-html",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sequence",
+      "targetSkillId": "score-relevance",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sequence",
+      "targetSkillId": "self-critique",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sequence",
+      "targetSkillId": "speech-to-text",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sequences",
+      "targetSkillId": "score-relevance",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sequences",
+      "targetSkillId": "cite-sources",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sequences",
+      "targetSkillId": "self-critique",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "server",
+      "targetSkillId": "retrieve",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "server",
+      "targetSkillId": "score-relevance",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "servers",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "servers",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "session",
+      "targetSkillId": "parse-json",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "session",
+      "targetSkillId": "question-answer",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sessions",
+      "targetSkillId": "parse-json",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sessions",
+      "targetSkillId": "question-answer",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "set",
+      "targetSkillId": "parse-html",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "setup-python",
+      "targetSkillId": "parse-json",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "several",
+      "targetSkillId": "generate-sql",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "shape",
+      "targetSkillId": "web-scrape",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "short",
+      "targetSkillId": "ghostwrite",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "shorter",
+      "targetSkillId": "ghostwrite",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "shorter",
+      "targetSkillId": "speech-to-text",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "shorter",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "showing",
+      "targetSkillId": "ghostwrite",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "showing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "shutil",
+      "targetSkillId": "parse-html",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "signals",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "signals",
+      "targetSkillId": "question-answer",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "signatures",
+      "targetSkillId": "generate-sql",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "signatures",
+      "targetSkillId": "generate-test",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "signatures",
+      "targetSkillId": "image-generate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "silent",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "silent",
+      "targetSkillId": "tool-select",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "silent",
+      "targetSkillId": "conversational-agent",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "similar",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "similarity",
+      "targetSkillId": "summarize",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "simulation",
+      "targetSkillId": "image-caption",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "simulation",
+      "targetSkillId": "registry-curation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "simulation",
+      "targetSkillId": "browser-automation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "size",
+      "targetSkillId": "summarize",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "size",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill-batches",
+      "targetSkillId": "translate",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "slashes",
+      "targetSkillId": "classify",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "slashes",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "smithery",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "software",
+      "targetSkillId": "ghostwrite",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "software",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "some",
+      "targetSkillId": "summarize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sorted",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "source",
+      "targetSkillId": "cite-sources",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "source",
+      "targetSkillId": "summarize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "source",
+      "targetSkillId": "score-relevance",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sources",
+      "targetSkillId": "cite-sources",
+      "score": 0.737,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sources",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sources",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "space",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "spaces",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "spatial",
+      "targetSkillId": "api-call",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "spatial",
+      "targetSkillId": "data-visualize",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "spatial",
+      "targetSkillId": "parse-html",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "spec",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specialized",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specialized",
+      "targetSkillId": "self-critique",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specialized",
+      "targetSkillId": "data-visualize",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specific",
+      "targetSkillId": "self-critique",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specification",
+      "targetSkillId": "image-caption",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specification",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.485,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specification",
+      "targetSkillId": "document-digitization",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specifications",
+      "targetSkillId": "image-caption",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specifications",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specifications",
+      "targetSkillId": "document-digitization",
+      "score": 0.457,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specified",
+      "targetSkillId": "self-critique",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "speech",
+      "targetSkillId": "text-to-speech",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "speech",
+      "targetSkillId": "speech-to-text",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "speech",
+      "targetSkillId": "research",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "splitlines",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "splitlines",
+      "targetSkillId": "self-critique",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "splitlines",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "splitter",
+      "targetSkillId": "self-critique",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "splitter",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "splitter",
+      "targetSkillId": "speech-to-text",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "spoken",
+      "targetSkillId": "tokenize",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "src",
+      "targetSkillId": "research",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "src",
+      "targetSkillId": "web-search",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stack",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "standard",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stars",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "start",
+      "targetSkillId": "ghostwrite",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "start",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "startswith",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "state",
+      "targetSkillId": "translate",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "state",
+      "targetSkillId": "ghostwrite",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "statistical",
+      "targetSkillId": "api-call",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "statistical",
+      "targetSkillId": "data-visualize",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "statistics",
+      "targetSkillId": "extract-entities",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stdout",
+      "targetSkillId": "structured-output",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stem",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "step-by-step",
+      "targetSkillId": "text-to-speech",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "step-by-step",
+      "targetSkillId": "web-search",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "step-by-step",
+      "targetSkillId": "web-scrape",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "still",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "store",
+      "targetSkillId": "ghostwrite",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "store",
+      "targetSkillId": "cite-sources",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "store",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "str",
+      "targetSkillId": "ghostwrite",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strategies",
+      "targetSkillId": "extract-entities",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strategies",
+      "targetSkillId": "translate",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strategies",
+      "targetSkillId": "generate-test",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strftime",
+      "targetSkillId": "ghostwrite",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strftime",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strftime",
+      "targetSkillId": "self-critique",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strict",
+      "targetSkillId": "ghostwrite",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "string",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stringify",
+      "targetSkillId": "classify",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strings",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strings",
+      "targetSkillId": "ghostwrite",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strip",
+      "targetSkillId": "ghostwrite",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strip",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stripped",
+      "targetSkillId": "ghostwrite",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stripped",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stripped",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stripping",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "structure",
+      "targetSkillId": "structured-output",
+      "score": 0.692,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "structure",
+      "targetSkillId": "ghostwrite",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "structure",
+      "targetSkillId": "registry-curation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "structured",
+      "targetSkillId": "structured-output",
+      "score": 0.741,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "structured",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "structures",
+      "targetSkillId": "structured-output",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "structures",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "structures",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stylized",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stylized",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stylized",
+      "targetSkillId": "data-visualize",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sub-agent",
+      "targetSkillId": "voice-agent",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sub-agent",
+      "targetSkillId": "conversational-agent",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sub-agent",
+      "targetSkillId": "route-intent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "submits",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "subparsers",
+      "targetSkillId": "parse-json",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "subparsers",
+      "targetSkillId": "summarize",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "subparsers",
+      "targetSkillId": "parse-pdf",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "subprocess",
+      "targetSkillId": "cite-sources",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "success",
+      "targetSkillId": "cite-sources",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "such",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "suggestions",
+      "targetSkillId": "question-answer",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "suggestions",
+      "targetSkillId": "image-caption",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "suggestions",
+      "targetSkillId": "parse-json",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "suitable",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "suite",
+      "targetSkillId": "summarize",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "suite",
+      "targetSkillId": "ghostwrite",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "suites",
+      "targetSkillId": "summarize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "suites",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sum",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summaries",
+      "targetSkillId": "summarize",
+      "score": 0.889,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summaries",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summaries",
+      "targetSkillId": "cite-sources",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summarization",
+      "targetSkillId": "summarize",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summarization",
+      "targetSkillId": "image-caption",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summarization",
+      "targetSkillId": "registry-curation",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summarizer",
+      "targetSkillId": "summarize",
+      "score": 0.947,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summarizer",
+      "targetSkillId": "data-visualize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summarizes",
+      "targetSkillId": "summarize",
+      "score": 0.947,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summarizes",
+      "targetSkillId": "data-visualize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summarizes",
+      "targetSkillId": "math-reason",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summary",
+      "targetSkillId": "summarize",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "supervision",
+      "targetSkillId": "parse-json",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sure",
+      "targetSkillId": "summarize",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sure",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "surpasses",
+      "targetSkillId": "parse-json",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "surpasses",
+      "targetSkillId": "cite-sources",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "survey",
+      "targetSkillId": "summarize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "syntactically",
+      "targetSkillId": "api-call",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "syntactically",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "synthesis",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "synthesis",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "synthesising",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "synthesising",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "synthesizes",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "synthesizes",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tables",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tags",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tail",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tail",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tarball",
+      "targetSkillId": "api-call",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "target",
+      "targetSkillId": "parse-html",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "target",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "task",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "task",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tasks",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "taxonomy",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "teaching",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "teaching",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "template",
+      "targetSkillId": "translate",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "terminal",
+      "targetSkillId": "memory-manage",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "terminal",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "test",
+      "targetSkillId": "generate-test",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "testable",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "testing",
+      "targetSkillId": "automated-testing",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "testing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "testing",
+      "targetSkillId": "question-answer",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tests",
+      "targetSkillId": "cite-sources",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text",
+      "targetSkillId": "embed-text",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text",
+      "targetSkillId": "generate-text",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-based",
+      "targetSkillId": "text-to-speech",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-based",
+      "targetSkillId": "execute-bash",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-based",
+      "targetSkillId": "text-to-sql-pipeline",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-classification",
+      "targetSkillId": "classify",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-classification",
+      "targetSkillId": "image-caption",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-classification",
+      "targetSkillId": "document-digitization",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-generation",
+      "targetSkillId": "code-generation",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-generation",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-generation",
+      "targetSkillId": "content-moderation",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-to",
+      "targetSkillId": "text-to-speech",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-to",
+      "targetSkillId": "text-to-sql-pipeline",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-to",
+      "targetSkillId": "content-moderation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text2text-generation",
+      "targetSkillId": "code-generation",
+      "score": 0.686,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text2text-generation",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.585,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text2text-generation",
+      "targetSkillId": "structured-output",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "texts",
+      "targetSkillId": "embed-text",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "texts",
+      "targetSkillId": "text-to-speech",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "than",
+      "targetSkillId": "math-reason",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "than",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "than",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "then",
+      "targetSkillId": "math-reason",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "then",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "these",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "these",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "these",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "threshold",
+      "targetSkillId": "math-reason",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "threshold",
+      "targetSkillId": "research",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "thresholds",
+      "targetSkillId": "math-reason",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "through",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "throughput",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "throughput",
+      "targetSkillId": "format-output",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "throughput",
+      "targetSkillId": "structured-output",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "throw",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tier",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tier",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "time",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "time",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "timed",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "timed",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "timeout",
+      "targetSkillId": "evaluate-output",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "timezone",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "timezone",
+      "targetSkillId": "memory-manage",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "timezone",
+      "targetSkillId": "image-generate",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "title",
+      "targetSkillId": "ghostwrite",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "title",
+      "targetSkillId": "route-intent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "title",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "to-end",
+      "targetSkillId": "tool-use",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "to-end",
+      "targetSkillId": "tokenize",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "to-end",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "to-markdown",
+      "targetSkillId": "math-reason",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "token",
+      "targetSkillId": "tokenize",
+      "score": 0.769,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "token",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "token-classification",
+      "targetSkillId": "document-digitization",
+      "score": 0.537,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "token-classification",
+      "targetSkillId": "classify",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "token-classification",
+      "targetSkillId": "image-caption",
+      "score": 0.485,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tokenization",
+      "targetSkillId": "tokenize",
+      "score": 0.7,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tokenization",
+      "targetSkillId": "document-digitization",
+      "score": 0.606,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tokenization",
+      "targetSkillId": "code-generation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tokenizer",
+      "targetSkillId": "tokenize",
+      "score": 0.941,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tokens",
+      "targetSkillId": "tokenize",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tolist",
+      "targetSkillId": "tool-select",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tolist",
+      "targetSkillId": "tool-use",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tone",
+      "targetSkillId": "tokenize",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tone",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tone",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tool",
+      "targetSkillId": "tool-use",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tool",
+      "targetSkillId": "tool-select",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tools",
+      "targetSkillId": "tool-use",
+      "score": 0.769,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tools",
+      "targetSkillId": "tool-select",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "top-k",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "top-k",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "top-level",
+      "targetSkillId": "tool-select",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "top-level",
+      "targetSkillId": "score-relevance",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "top-level",
+      "targetSkillId": "tool-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "topic",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "topic",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "total",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "traces",
+      "targetSkillId": "cite-sources",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "traces",
+      "targetSkillId": "extract-entities",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "traces",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "training",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "training",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "training",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "transcribes",
+      "targetSkillId": "translate",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "transcribes",
+      "targetSkillId": "extract-entities",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "transcribes",
+      "targetSkillId": "data-analysis",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "transformer",
+      "targetSkillId": "translate",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "transformer",
+      "targetSkillId": "question-answer",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "transformer",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "translation",
+      "targetSkillId": "translate",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "translation",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.71,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "translation",
+      "targetSkillId": "registry-curation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "treat",
+      "targetSkillId": "translate",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "treat",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "treat",
+      "targetSkillId": "write-report",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tree",
+      "targetSkillId": "retrieve",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tree",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tree",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "trees",
+      "targetSkillId": "retrieve",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "trees",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "trees",
+      "targetSkillId": "extract-entities",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "trim",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "true",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "true",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "true",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tsserver",
+      "targetSkillId": "write-report",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tsserver",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tuple",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "turns",
+      "targetSkillId": "translate",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "turns",
+      "targetSkillId": "cite-sources",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "turns",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "two-pass",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "two-pass",
+      "targetSkillId": "data-analysis",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "typescript",
+      "targetSkillId": "web-scrape",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "typescript-5",
+      "targetSkillId": "web-scrape",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ubuntu-latest",
+      "targetSkillId": "generate-test",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ubuntu-latest",
+      "targetSkillId": "document-analyst",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ubuntu-latest",
+      "targetSkillId": "automated-testing",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "unanswerable",
+      "targetSkillId": "question-answer",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "unanswerable",
+      "targetSkillId": "web-scrape",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "unbounded",
+      "targetSkillId": "autonomous-debug",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "uncommon",
+      "targetSkillId": "plan-decompose",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "uncommon",
+      "targetSkillId": "chunk-document",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "uncommon",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "undici-types",
+      "targetSkillId": "audience-model",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "uninstall",
+      "targetSkillId": "api-call",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "unlocked",
+      "targetSkillId": "chunk-document",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "unstructured",
+      "targetSkillId": "structured-output",
+      "score": 0.69,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "unstructured",
+      "targetSkillId": "ghostwrite",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "update-tree",
+      "targetSkillId": "retrieve",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "update-tree",
+      "targetSkillId": "route-intent",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "update-tree",
+      "targetSkillId": "generate-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "updates",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "uppercase",
+      "targetSkillId": "computer-use",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "usage",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "use",
+      "targetSkillId": "tool-use",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "used",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "used",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "user",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "user",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "username",
+      "targetSkillId": "memory-manage",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "username",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "users",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "users",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "uses",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "using",
+      "targetSkillId": "automated-testing",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "utilities",
+      "targetSkillId": "extract-entities",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "utilities",
+      "targetSkillId": "route-intent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "utilities",
+      "targetSkillId": "self-critique",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "valence",
+      "targetSkillId": "logical-inference",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "valence",
+      "targetSkillId": "audience-model",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "valence",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validate",
+      "targetSkillId": "translate",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validate",
+      "targetSkillId": "evaluate-output",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validate",
+      "targetSkillId": "data-visualize",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validated",
+      "targetSkillId": "translate",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validated",
+      "targetSkillId": "evaluate-output",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validates",
+      "targetSkillId": "translate",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validates",
+      "targetSkillId": "evaluate-output",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validation",
+      "targetSkillId": "image-caption",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validation",
+      "targetSkillId": "evaluate-output",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validation",
+      "targetSkillId": "code-generation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "value",
+      "targetSkillId": "evaluate-output",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "value",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "values",
+      "targetSkillId": "evaluate-output",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "variables",
+      "targetSkillId": "api-call",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "vector",
+      "targetSkillId": "refactor-code",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "vectors",
+      "targetSkillId": "refactor-code",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "verified",
+      "targetSkillId": "self-critique",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "verifying",
+      "targetSkillId": "memory-manage",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "version",
+      "targetSkillId": "conversational-agent",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "version",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "version",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "versions",
+      "targetSkillId": "question-answer",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "versions",
+      "targetSkillId": "conversational-agent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "virtual",
+      "targetSkillId": "data-visualize",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "vision-language",
+      "targetSkillId": "question-answer",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "vision-language",
+      "targetSkillId": "conversational-agent",
+      "score": 0.514,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "vision-language",
+      "targetSkillId": "memory-manage",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "visual",
+      "targetSkillId": "data-visualize",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "visualization",
+      "targetSkillId": "data-visualize",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "visualization",
+      "targetSkillId": "image-caption",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "visualization",
+      "targetSkillId": "registry-curation",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "visualizations",
+      "targetSkillId": "data-visualize",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "visualizations",
+      "targetSkillId": "image-caption",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "visualizations",
+      "targetSkillId": "registry-curation",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "visualstudio",
+      "targetSkillId": "data-visualize",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "visualstudio",
+      "targetSkillId": "registry-curation",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "voice",
+      "targetSkillId": "voice-agent",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "voice",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "vscode-marketplace",
+      "targetSkillId": "code-review-pipeline",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "vscode-marketplace",
+      "targetSkillId": "score-relevance",
+      "score": 0.485,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "vscode-marketplace",
+      "targetSkillId": "voice-agent",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "walk",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "want",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "want",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "warnings",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "weak",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "web",
+      "targetSkillId": "web-search",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "web",
+      "targetSkillId": "web-scrape",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "web-arena-x",
+      "targetSkillId": "web-search",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "web-arena-x",
+      "targetSkillId": "web-scrape",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "web-arena-x",
+      "targetSkillId": "embed-text",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "webarena",
+      "targetSkillId": "web-search",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "webarena",
+      "targetSkillId": "web-scrape",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "webp",
+      "targetSkillId": "web-scrape",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "websites",
+      "targetSkillId": "web-search",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "websites",
+      "targetSkillId": "web-scrape",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "well-formed",
+      "targetSkillId": "web-scrape",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "wet-lab",
+      "targetSkillId": "web-search",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "wet-lab",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "whenever",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "where",
+      "targetSkillId": "web-scrape",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "where",
+      "targetSkillId": "write-report",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "whisper",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "will",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "without",
+      "targetSkillId": "write-report",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "without",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "wrapper",
+      "targetSkillId": "web-scrape",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "wrapper",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "write",
+      "targetSkillId": "ghostwrite",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "write",
+      "targetSkillId": "write-report",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "write",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "writes",
+      "targetSkillId": "ghostwrite",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "writes",
+      "targetSkillId": "write-report",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "writes",
+      "targetSkillId": "extract-entities",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "writing",
+      "targetSkillId": "ghostwrite",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "writing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "written",
+      "targetSkillId": "ghostwrite",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "written",
+      "targetSkillId": "write-report",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "written",
+      "targetSkillId": "route-intent",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "zero-config",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "zero-shot",
+      "targetSkillId": "generate-test",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "zero-shot-classification",
+      "targetSkillId": "error-interpretation",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    }
+  ]
+}

--- a/intake/skill-batches/20260429135058-gaiabot-gaia-skill-tree.json
+++ b/intake/skill-batches/20260429135058-gaiabot-gaia-skill-tree.json
@@ -1,0 +1,30468 @@
+{
+  "batchId": "20260429135058-gaiabot-gaia-skill-tree",
+  "userId": "gaiabot",
+  "sourceRepo": "mbtiongson1/gaia-skill-tree",
+  "generatedAt": "2026-04-29T13:50:58Z",
+  "knownSkills": [
+    {
+      "skillId": "audience-model"
+    },
+    {
+      "skillId": "autonomous-debug"
+    },
+    {
+      "skillId": "autonomous-research-agent"
+    },
+    {
+      "skillId": "browser-automation"
+    },
+    {
+      "skillId": "chain-of-thought"
+    },
+    {
+      "skillId": "chunk-document"
+    },
+    {
+      "skillId": "cite-sources"
+    },
+    {
+      "skillId": "classify"
+    },
+    {
+      "skillId": "code-execution"
+    },
+    {
+      "skillId": "code-generation"
+    },
+    {
+      "skillId": "computer-use"
+    },
+    {
+      "skillId": "diff-content"
+    },
+    {
+      "skillId": "document-analyst"
+    },
+    {
+      "skillId": "embed-text"
+    },
+    {
+      "skillId": "error-interpretation"
+    },
+    {
+      "skillId": "evaluate-output"
+    },
+    {
+      "skillId": "execute-bash"
+    },
+    {
+      "skillId": "extract-entities"
+    },
+    {
+      "skillId": "format-output"
+    },
+    {
+      "skillId": "generate-text"
+    },
+    {
+      "skillId": "ghostwrite"
+    },
+    {
+      "skillId": "hypothesis-generate"
+    },
+    {
+      "skillId": "knowledge-graph-build"
+    },
+    {
+      "skillId": "knowledge-harvest"
+    },
+    {
+      "skillId": "logical-inference"
+    },
+    {
+      "skillId": "math-reason"
+    },
+    {
+      "skillId": "multi-agent-orchestration-v"
+    },
+    {
+      "skillId": "parse-html"
+    },
+    {
+      "skillId": "parse-json"
+    },
+    {
+      "skillId": "plan-and-execute"
+    },
+    {
+      "skillId": "plan-decompose"
+    },
+    {
+      "skillId": "rag-pipeline"
+    },
+    {
+      "skillId": "rank"
+    },
+    {
+      "skillId": "recursive-self-improvement"
+    },
+    {
+      "skillId": "registry-curation"
+    },
+    {
+      "skillId": "research"
+    },
+    {
+      "skillId": "retrieve"
+    },
+    {
+      "skillId": "route-intent"
+    },
+    {
+      "skillId": "scientific-discovery"
+    },
+    {
+      "skillId": "score-relevance"
+    },
+    {
+      "skillId": "self-critique"
+    },
+    {
+      "skillId": "structured-output"
+    },
+    {
+      "skillId": "summarize"
+    },
+    {
+      "skillId": "text-to-sql-pipeline"
+    },
+    {
+      "skillId": "tokenize"
+    },
+    {
+      "skillId": "tool-select"
+    },
+    {
+      "skillId": "tool-use"
+    },
+    {
+      "skillId": "translate"
+    },
+    {
+      "skillId": "web-scrape"
+    },
+    {
+      "skillId": "web-search"
+    },
+    {
+      "skillId": "write-report"
+    }
+  ],
+  "proposedSkills": [
+    {
+      "id": "a-z",
+      "name": "A-z",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: A-z.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "a-z0-9",
+      "name": "A-z0-9",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: A-z0-9.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "abductive",
+      "name": "Abductive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Abductive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "above",
+      "name": "Above",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Above.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "abs",
+      "name": "Abs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Abs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "absolute",
+      "name": "Absolute",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Absolute.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "abspath",
+      "name": "Abspath",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Abspath.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "accents",
+      "name": "Accents",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Accents.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "accept",
+      "name": "Accept",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Accept.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "accepted",
+      "name": "Accepted",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Accepted.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "access",
+      "name": "Access",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Access.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "accidentally",
+      "name": "Accidentally",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Accidentally.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "accuracy",
+      "name": "Accuracy",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Accuracy.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "accurate",
+      "name": "Accurate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Accurate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "achieves",
+      "name": "Achieves",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Achieves.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "achieving",
+      "name": "Achieving",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Achieving.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "across",
+      "name": "Across",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Across.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "act",
+      "name": "Act",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Act.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "acting",
+      "name": "Acting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Acting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "action",
+      "name": "Action",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Action.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "actions",
+      "name": "Actions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Actions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "actual",
+      "name": "Actual",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Actual.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "adapting",
+      "name": "Adapting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Adapting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "add",
+      "name": "Add",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Add.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "added",
+      "name": "Added",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Added.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "additions",
+      "name": "Additions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Additions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "adjacency",
+      "name": "Adjacency",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Adjacency.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "advancement",
+      "name": "Advancement",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Advancement.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "after",
+      "name": "After",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: After.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "against",
+      "name": "Against",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Against.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "agent",
+      "name": "Agent",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Agent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "agent-native",
+      "name": "Agent-native",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Agent-native.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "agent-related",
+      "name": "Agent-related",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Agent-related.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "agents",
+      "name": "Agents",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Agents.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ahead",
+      "name": "Ahead",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ahead.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ai-agent",
+      "name": "Ai-agent",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ai-agent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ai-agent-tool",
+      "name": "Ai-agent-tool",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ai-agent-tool.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "algebra",
+      "name": "Algebra",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Algebra.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "alive",
+      "name": "Alive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Alive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "all",
+      "name": "All",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: All.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "allocation",
+      "name": "Allocation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Allocation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "allowed",
+      "name": "Allowed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Allowed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "also",
+      "name": "Also",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Also.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "analyses",
+      "name": "Analyses",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Analyses.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "analysis",
+      "name": "Analysis",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Analysis.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "anomaly",
+      "name": "Anomaly",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Anomaly.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "another",
+      "name": "Another",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Another.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "answer",
+      "name": "Answer",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Answer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "answers",
+      "name": "Answers",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Answers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "any",
+      "name": "Any",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Any.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "api",
+      "name": "Api",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Api.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "api-version",
+      "name": "Api-version",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Api-version.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "appears",
+      "name": "Appears",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Appears.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "append",
+      "name": "Append",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Append.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "application",
+      "name": "Application",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Application.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "apply",
+      "name": "Apply",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Apply.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "approach",
+      "name": "Approach",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Approach.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "appropriate",
+      "name": "Appropriate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Appropriate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "approval",
+      "name": "Approval",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Approval.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "archived",
+      "name": "Archived",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Archived.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "argparse",
+      "name": "Argparse",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Argparse.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.483
+        }
+      ]
+    },
+    {
+      "id": "args",
+      "name": "Args",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Args.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "arguments",
+      "name": "Arguments",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Arguments.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "argv",
+      "name": "Argv",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Argv.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "arithmetic",
+      "name": "Arithmetic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Arithmetic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "array",
+      "name": "Array",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Array.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "arrays",
+      "name": "Arrays",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Arrays.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "arriving",
+      "name": "Arriving",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Arriving.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "artifact",
+      "name": "Artifact",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Artifact.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "artifacts",
+      "name": "Artifacts",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Artifacts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "arxiv",
+      "name": "Arxiv",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Arxiv.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "asdict",
+      "name": "Asdict",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Asdict.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "assembles",
+      "name": "Assembles",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Assembles.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "assert",
+      "name": "Assert",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Assert.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "assistant",
+      "name": "Assistant",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Assistant.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "assistants",
+      "name": "Assistants",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Assistants.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "async",
+      "name": "Async",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Async.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "atomic",
+      "name": "Atomic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Atomic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "atomics",
+      "name": "Atomics",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Atomics.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "attrib",
+      "name": "Attrib",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Attrib.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "attribute",
+      "name": "Attribute",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Attribute.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "attributes",
+      "name": "Attributes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Attributes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "attvalue",
+      "name": "Attvalue",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Attvalue.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "attvalues",
+      "name": "Attvalues",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Attvalues.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "audience",
+      "name": "Audience",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Audience.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "audience-tailored",
+      "name": "Audience-tailored",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Audience-tailored.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "audio",
+      "name": "Audio",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Audio.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "augmented",
+      "name": "Augmented",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Augmented.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "auth",
+      "name": "Auth",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Auth.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "authenticated",
+      "name": "Authenticated",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Authenticated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "author",
+      "name": "Author",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Author.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.556
+        }
+      ]
+    },
+    {
+      "id": "authoritative",
+      "name": "Authoritative",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Authoritative.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.48
+        }
+      ]
+    },
+    {
+      "id": "auto-generated",
+      "name": "Auto-generated",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Auto-generated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.538
+        }
+      ]
+    },
+    {
+      "id": "auto-prompt-combinations",
+      "name": "Auto-prompt-combinations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Auto-prompt-combinations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "autogen",
+      "name": "Autogen",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Autogen.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.526
+        },
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "automated",
+      "name": "Automated",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Automated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.522
+        },
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "automatic",
+      "name": "Automatic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Automatic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.571
+        }
+      ]
+    },
+    {
+      "id": "automatically",
+      "name": "Automatically",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Automatically.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.48
+        }
+      ]
+    },
+    {
+      "id": "autonomous",
+      "name": "Autonomous",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Autonomous.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.833
+        },
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "autonomously",
+      "name": "Autonomously",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Autonomously.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.769
+        }
+      ]
+    },
+    {
+      "id": "autoregressive",
+      "name": "Autoregressive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Autoregressive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.538
+        }
+      ]
+    },
+    {
+      "id": "autoresearch",
+      "name": "Autoresearch",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Autoresearch.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 1.0
+        }
+      ]
+    },
+    {
+      "id": "availability",
+      "name": "Availability",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Availability.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "available",
+      "name": "Available",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Available.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "await",
+      "name": "Await",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Await.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "awakened",
+      "name": "Awakened",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Awakened.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "awareness",
+      "name": "Awareness",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Awareness.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "back",
+      "name": "Back",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Back.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "backends",
+      "name": "Backends",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Backends.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "based",
+      "name": "Based",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Based.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "baseline",
+      "name": "Baseline",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Baseline.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "baselines",
+      "name": "Baselines",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Baselines.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bash",
+      "name": "Bash",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bash.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "batch",
+      "name": "Batch",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Batch.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "batched",
+      "name": "Batched",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Batched.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "batches",
+      "name": "Batches",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Batches.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "becomes",
+      "name": "Becomes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Becomes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "been",
+      "name": "Been",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Been.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "before",
+      "name": "Before",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Before.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "begin",
+      "name": "Begin",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Begin.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "behavior",
+      "name": "Behavior",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Behavior.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "being",
+      "name": "Being",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Being.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "beliefs",
+      "name": "Beliefs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Beliefs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bench",
+      "name": "Bench",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bench.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "benchmark",
+      "name": "Benchmark",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Benchmark.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "benchmarked",
+      "name": "Benchmarked",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Benchmarked.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "benchmarks",
+      "name": "Benchmarks",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Benchmarks.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "between",
+      "name": "Between",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Between.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bibliographic",
+      "name": "Bibliographic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bibliographic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bin",
+      "name": "Bin",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bin.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "binary",
+      "name": "Binary",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Binary.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "blob",
+      "name": "Blob",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Blob.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "block",
+      "name": "Block",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Block.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "body",
+      "name": "Body",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Body.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "body-file",
+      "name": "Body-file",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Body-file.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bool",
+      "name": "Bool",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bool.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "boolean",
+      "name": "Boolean",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Boolean.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "booleans",
+      "name": "Booleans",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Booleans.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bootstrapped",
+      "name": "Bootstrapped",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bootstrapped.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bot",
+      "name": "Bot",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bot.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bot-proposal",
+      "name": "Bot-proposal",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bot-proposal.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bpush",
+      "name": "Bpush",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bpush.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "branch",
+      "name": "Branch",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Branch.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "break",
+      "name": "Break",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Break.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "broken",
+      "name": "Broken",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Broken.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "browsers",
+      "name": "Browsers",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Browsers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bucket",
+      "name": "Bucket",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bucket.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "buckets",
+      "name": "Buckets",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Buckets.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "buffer",
+      "name": "Buffer",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Buffer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bugs",
+      "name": "Bugs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bugs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "build",
+      "name": "Build",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Build.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "built",
+      "name": "Built",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Built.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bundler",
+      "name": "Bundler",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bundler.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "but",
+      "name": "But",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: But.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bytecode",
+      "name": "Bytecode",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bytecode.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cache",
+      "name": "Cache",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cache.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "calculus",
+      "name": "Calculus",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Calculus.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "call",
+      "name": "Call",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Call.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "calling",
+      "name": "Calling",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Calling.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "calls",
+      "name": "Calls",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Calls.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "came",
+      "name": "Came",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Came.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "can",
+      "name": "Can",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Can.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "candidate",
+      "name": "Candidate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Candidate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "candidates",
+      "name": "Candidates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Candidates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cannot",
+      "name": "Cannot",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cannot.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "canonical",
+      "name": "Canonical",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Canonical.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "capability",
+      "name": "Capability",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Capability.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "capitalize",
+      "name": "Capitalize",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Capitalize.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "caps",
+      "name": "Caps",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Caps.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "captures",
+      "name": "Captures",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Captures.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "capturing",
+      "name": "Capturing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Capturing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "case",
+      "name": "Case",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Case.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cases",
+      "name": "Cases",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cases.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "catch",
+      "name": "Catch",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Catch.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "catches",
+      "name": "Catches",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Catches.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "categorical",
+      "name": "Categorical",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Categorical.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "categories",
+      "name": "Categories",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Categories.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.545
+        }
+      ]
+    },
+    {
+      "id": "categorization",
+      "name": "Categorization",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Categorization.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "category",
+      "name": "Category",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Category.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "caught",
+      "name": "Caught",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Caught.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "causes",
+      "name": "Causes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Causes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "chain",
+      "name": "Chain",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Chain.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "chain-of-thought-hub",
+      "name": "Chain-of-thought-hub",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Chain-of-thought-hub.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "chain-of-thought-only",
+      "name": "Chain-of-thought-only",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Chain-of-thought-only.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "chains",
+      "name": "Chains",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Chains.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "change",
+      "name": "Change",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Change.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "changed",
+      "name": "Changed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Changed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "changes",
+      "name": "Changes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Changes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "changing",
+      "name": "Changing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Changing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "charts",
+      "name": "Charts",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Charts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "check",
+      "name": "Check",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Check.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "checker",
+      "name": "Checker",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Checker.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "checkout",
+      "name": "Checkout",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Checkout.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "checks",
+      "name": "Checks",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Checks.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "chemistry",
+      "name": "Chemistry",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Chemistry.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "chemists",
+      "name": "Chemists",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Chemists.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "child",
+      "name": "Child",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Child.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "children",
+      "name": "Children",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Children.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "chr",
+      "name": "Chr",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Chr.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "chunk",
+      "name": "Chunk",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Chunk.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "chunking",
+      "name": "Chunking",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Chunking.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "citation",
+      "name": "Citation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Citation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "citations",
+      "name": "Citations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Citations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "claims",
+      "name": "Claims",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Claims.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "clarity",
+      "name": "Clarity",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Clarity.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "class",
+      "name": "Class",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Class.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "classification",
+      "name": "Classification",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Classification.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "classifier",
+      "name": "Classifier",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Classifier.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cleaned",
+      "name": "Cleaned",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cleaned.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cli",
+      "name": "Cli",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cli.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "click",
+      "name": "Click",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Click.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "clicks",
+      "name": "Clicks",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Clicks.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "clone",
+      "name": "Clone",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Clone.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cloning",
+      "name": "Cloning",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cloning.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "closing",
+      "name": "Closing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Closing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "clustering",
+      "name": "Clustering",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Clustering.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cmd",
+      "name": "Cmd",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cmd.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "co-references",
+      "name": "Co-references",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Co-references.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.48
+        }
+      ]
+    },
+    {
+      "id": "code",
+      "name": "Code",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Code.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "codec",
+      "name": "Codec",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Codec.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "codegen",
+      "name": "Codegen",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Codegen.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "codes",
+      "name": "Codes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Codes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "coherent",
+      "name": "Coherent",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Coherent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "collections",
+      "name": "Collections",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Collections.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "color",
+      "name": "Color",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Color.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "com",
+      "name": "Com",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Com.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "combination",
+      "name": "Combination",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Combination.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "combinations",
+      "name": "Combinations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Combinations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "combinator",
+      "name": "Combinator",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Combinator.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "combine",
+      "name": "Combine",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Combine.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "combining",
+      "name": "Combining",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Combining.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "combo",
+      "name": "Combo",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Combo.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "combos",
+      "name": "Combos",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Combos.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "command",
+      "name": "Command",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Command.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "commands",
+      "name": "Commands",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Commands.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "comment",
+      "name": "Comment",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Comment.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "commit",
+      "name": "Commit",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Commit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "common",
+      "name": "Common",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Common.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "community",
+      "name": "Community",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Community.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "comparisons",
+      "name": "Comparisons",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Comparisons.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "compatible",
+      "name": "Compatible",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Compatible.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "competition",
+      "name": "Competition",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Competition.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "compile",
+      "name": "Compile",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Compile.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "complete",
+      "name": "Complete",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Complete.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "completes",
+      "name": "Completes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Completes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "completing",
+      "name": "Completing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Completing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "completion",
+      "name": "Completion",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Completion.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "complex",
+      "name": "Complex",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Complex.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "complexity",
+      "name": "Complexity",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Complexity.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "composite",
+      "name": "Composite",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Composite.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "composites",
+      "name": "Composites",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Composites.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "comprehension",
+      "name": "Comprehension",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Comprehension.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "comprehensive",
+      "name": "Comprehensive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Comprehensive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "computation",
+      "name": "Computation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Computation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "compute",
+      "name": "Compute",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Compute.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "computer",
+      "name": "Computer",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Computer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "computes",
+      "name": "Computes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Computes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "conclusions",
+      "name": "Conclusions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Conclusions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "condition",
+      "name": "Condition",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Condition.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "conditions",
+      "name": "Conditions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Conditions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "conducts",
+      "name": "Conducts",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Conducts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "config",
+      "name": "Config",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Config.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "configurable",
+      "name": "Configurable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Configurable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "configuration",
+      "name": "Configuration",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Configuration.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "configured",
+      "name": "Configured",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Configured.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "confirm",
+      "name": "Confirm",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Confirm.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "confirmed",
+      "name": "Confirmed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Confirmed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "conflict",
+      "name": "Conflict",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Conflict.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "conform",
+      "name": "Conform",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Conform.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "connector",
+      "name": "Connector",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Connector.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "consecutive",
+      "name": "Consecutive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Consecutive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "console",
+      "name": "Console",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Console.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "const",
+      "name": "Const",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Const.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "constrained",
+      "name": "Constrained",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Constrained.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "constraints",
+      "name": "Constraints",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Constraints.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "construction",
+      "name": "Construction",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Construction.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "contain",
+      "name": "Contain",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Contain.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "containing",
+      "name": "Containing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Containing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "content",
+      "name": "Content",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Content.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "context",
+      "name": "Context",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Context.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "context-grounded",
+      "name": "Context-grounded",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Context-grounded.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "contextually",
+      "name": "Contextually",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Contextually.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "continuation",
+      "name": "Continuation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Continuation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "continue",
+      "name": "Continue",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Continue.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "contributor",
+      "name": "Contributor",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Contributor.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "control",
+      "name": "Control",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Control.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "controlled",
+      "name": "Controlled",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Controlled.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "convention",
+      "name": "Convention",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Convention.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "conversation",
+      "name": "Conversation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Conversation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "conversational",
+      "name": "Conversational",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Conversational.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "conversations",
+      "name": "Conversations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Conversations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "convert",
+      "name": "Convert",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Convert.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "copilot",
+      "name": "Copilot",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Copilot.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "copy",
+      "name": "Copy",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Copy.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "copy2",
+      "name": "Copy2",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Copy2.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "core",
+      "name": "Core",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Core.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "corpora",
+      "name": "Corpora",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Corpora.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "corpus",
+      "name": "Corpus",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Corpus.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "correct",
+      "name": "Correct",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Correct.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "correctness",
+      "name": "Correctness",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Correctness.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cosine",
+      "name": "Cosine",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cosine.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "could",
+      "name": "Could",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Could.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "count",
+      "name": "Count",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Count.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "coupling",
+      "name": "Coupling",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Coupling.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "coverage",
+      "name": "Coverage",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Coverage.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "covering",
+      "name": "Covering",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Covering.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "crawl",
+      "name": "Crawl",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Crawl.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "crawler",
+      "name": "Crawler",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Crawler.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "crawlers",
+      "name": "Crawlers",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Crawlers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "crawling",
+      "name": "Crawling",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Crawling.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "create",
+      "name": "Create",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Create.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "created",
+      "name": "Created",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Created.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "creating",
+      "name": "Creating",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Creating.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "creation",
+      "name": "Creation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Creation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "creator",
+      "name": "Creator",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Creator.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "criteria",
+      "name": "Criteria",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Criteria.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cross-domain",
+      "name": "Cross-domain",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cross-domain.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "curation",
+      "name": "Curation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Curation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "current",
+      "name": "Current",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Current.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cwd",
+      "name": "Cwd",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cwd.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cycle",
+      "name": "Cycle",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cycle.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cycles",
+      "name": "Cycles",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cycles.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dash",
+      "name": "Dash",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dash.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "data",
+      "name": "Data",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Data.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dataclass",
+      "name": "Dataclass",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dataclass.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dataclasses",
+      "name": "Dataclasses",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dataclasses.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dataset",
+      "name": "Dataset",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dataset.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "datasets",
+      "name": "Datasets",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Datasets.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "date",
+      "name": "Date",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Date.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dates",
+      "name": "Dates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "datetime",
+      "name": "Datetime",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Datetime.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "days",
+      "name": "Days",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Days.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dead",
+      "name": "Dead",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dead.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "debugging",
+      "name": "Debugging",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Debugging.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "decay",
+      "name": "Decay",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Decay.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "decide",
+      "name": "Decide",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Decide.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "declaration",
+      "name": "Declaration",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Declaration.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "decoding",
+      "name": "Decoding",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Decoding.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "decomposed",
+      "name": "Decomposed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Decomposed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "decomposition",
+      "name": "Decomposition",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Decomposition.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "deductive",
+      "name": "Deductive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Deductive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dedup",
+      "name": "Dedup",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dedup.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "deduplicate",
+      "name": "Deduplicate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Deduplicate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "def",
+      "name": "Def",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Def.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "default",
+      "name": "Default",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Default.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "defaultdict",
+      "name": "Defaultdict",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Defaultdict.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "defaultedgetype",
+      "name": "Defaultedgetype",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Defaultedgetype.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "defaults",
+      "name": "Defaults",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Defaults.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "defined",
+      "name": "Defined",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Defined.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "definitions",
+      "name": "Definitions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Definitions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.529
+        }
+      ]
+    },
+    {
+      "id": "delegates",
+      "name": "Delegates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Delegates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "deletions",
+      "name": "Deletions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Deletions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "delimiter",
+      "name": "Delimiter",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Delimiter.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "delta",
+      "name": "Delta",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Delta.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "demonstrates",
+      "name": "Demonstrates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Demonstrates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "demonstrating",
+      "name": "Demonstrating",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Demonstrating.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "demos",
+      "name": "Demos",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Demos.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dense",
+      "name": "Dense",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dense.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dependencies",
+      "name": "Dependencies",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dependencies.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "depth",
+      "name": "Depth",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Depth.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "deriv",
+      "name": "Deriv",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Deriv.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "derivative",
+      "name": "Derivative",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Derivative.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "derivatives",
+      "name": "Derivatives",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Derivatives.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "derive",
+      "name": "Derive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Derive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "desc",
+      "name": "Desc",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Desc.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "descending",
+      "name": "Descending",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Descending.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "description",
+      "name": "Description",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Description.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "descriptions",
+      "name": "Descriptions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Descriptions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "design",
+      "name": "Design",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Design.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "designs",
+      "name": "Designs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Designs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "desktop",
+      "name": "Desktop",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Desktop.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dest",
+      "name": "Dest",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dest.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "detail",
+      "name": "Detail",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Detail.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "detect",
+      "name": "Detect",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Detect.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "detected",
+      "name": "Detected",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Detected.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "detection",
+      "name": "Detection",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Detection.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "detects",
+      "name": "Detects",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Detects.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dev",
+      "name": "Dev",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dev.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "development",
+      "name": "Development",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Development.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "deviations",
+      "name": "Deviations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Deviations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.545
+        }
+      ]
+    },
+    {
+      "id": "dfs",
+      "name": "Dfs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dfs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "diagnoses",
+      "name": "Diagnoses",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Diagnoses.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dialogue",
+      "name": "Dialogue",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dialogue.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dict",
+      "name": "Dict",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dict.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dicts",
+      "name": "Dicts",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dicts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "diff",
+      "name": "Diff",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Diff.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "diffing",
+      "name": "Diffing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Diffing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "difflib",
+      "name": "Difflib",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Difflib.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "diffusion",
+      "name": "Diffusion",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Diffusion.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "diffusion-based",
+      "name": "Diffusion-based",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Diffusion-based.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dimensions",
+      "name": "Dimensions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dimensions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dir",
+      "name": "Dir",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dir.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "direct",
+      "name": "Direct",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Direct.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "directed",
+      "name": "Directed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Directed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "directionally",
+      "name": "Directionally",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Directionally.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "directly",
+      "name": "Directly",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Directly.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "directory",
+      "name": "Directory",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Directory.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "directs",
+      "name": "Directs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Directs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dirname",
+      "name": "Dirname",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dirname.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dirs",
+      "name": "Dirs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dirs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "discovered",
+      "name": "Discovered",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Discovered.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "discrete",
+      "name": "Discrete",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Discrete.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "display",
+      "name": "Display",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Display.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dist",
+      "name": "Dist",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dist.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "distance",
+      "name": "Distance",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Distance.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "diverse",
+      "name": "Diverse",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Diverse.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "docs",
+      "name": "Docs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Docs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "doctor",
+      "name": "Doctor",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Doctor.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "document",
+      "name": "Document",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Document.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "documentation",
+      "name": "Documentation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Documentation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "documented",
+      "name": "Documented",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Documented.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "documents",
+      "name": "Documents",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Documents.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "does",
+      "name": "Does",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Does.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "doesn",
+      "name": "Doesn",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Doesn.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dom",
+      "name": "Dom",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dom.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "don",
+      "name": "Don",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Don.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dot",
+      "name": "Dot",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dot.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "download",
+      "name": "Download",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Download.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "downloads",
+      "name": "Downloads",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Downloads.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "downstream",
+      "name": "Downstream",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Downstream.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "draft",
+      "name": "Draft",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Draft.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "draft-skills",
+      "name": "Draft-skills",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Draft-skills.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dramatically",
+      "name": "Dramatically",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dramatically.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dry",
+      "name": "Dry",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dry.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dry-run",
+      "name": "Dry-run",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dry-run.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dtype",
+      "name": "Dtype",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dtype.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dual-layer",
+      "name": "Dual-layer",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dual-layer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dump",
+      "name": "Dump",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dump.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dumps",
+      "name": "Dumps",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dumps.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "duplicate",
+      "name": "Duplicate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Duplicate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "duplicates",
+      "name": "Duplicates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Duplicates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dynamic",
+      "name": "Dynamic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dynamic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "each",
+      "name": "Each",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Each.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "echo",
+      "name": "Echo",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Echo.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "edge",
+      "name": "Edge",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Edge.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "edge-case",
+      "name": "Edge-case",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Edge-case.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "edges",
+      "name": "Edges",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Edges.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "edit",
+      "name": "Edit",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Edit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "edits",
+      "name": "Edits",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Edits.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "elem",
+      "name": "Elem",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Elem.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "elements",
+      "name": "Elements",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Elements.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "elicits",
+      "name": "Elicits",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Elicits.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "elif",
+      "name": "Elif",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Elif.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "else",
+      "name": "Else",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Else.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "embed",
+      "name": "Embed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Embed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "embedding",
+      "name": "Embedding",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Embedding.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "embeddings",
+      "name": "Embeddings",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Embeddings.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "embeds",
+      "name": "Embeds",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Embeds.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "emotional",
+      "name": "Emotional",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Emotional.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "empty",
+      "name": "Empty",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Empty.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "enables",
+      "name": "Enables",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Enables.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "enabling",
+      "name": "Enabling",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Enabling.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "encode",
+      "name": "Encode",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Encode.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "encoding",
+      "name": "Encoding",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Encoding.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "end",
+      "name": "End",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: End.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "end-to-end",
+      "name": "End-to-end",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: End-to-end.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "endpoints",
+      "name": "Endpoints",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Endpoints.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "endswith",
+      "name": "Endswith",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Endswith.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "engine",
+      "name": "Engine",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Engine.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "engineering",
+      "name": "Engineering",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Engineering.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "engines",
+      "name": "Engines",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Engines.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "enhances",
+      "name": "Enhances",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Enhances.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "entities",
+      "name": "Entities",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Entities.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "entity",
+      "name": "Entity",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Entity.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "entries",
+      "name": "Entries",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Entries.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "entry",
+      "name": "Entry",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Entry.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "enumerate",
+      "name": "Enumerate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Enumerate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "env",
+      "name": "Env",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Env.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "environ",
+      "name": "Environ",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Environ.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "environment",
+      "name": "Environment",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Environment.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "environments",
+      "name": "Environments",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Environments.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "epic",
+      "name": "Epic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Epic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "equal",
+      "name": "Equal",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Equal.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "equations",
+      "name": "Equations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Equations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "err",
+      "name": "Err",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Err.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "error",
+      "name": "Error",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Error.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "errors",
+      "name": "Errors",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Errors.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "establishes",
+      "name": "Establishes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Establishes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "establishing",
+      "name": "Establishing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Establishing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "etc",
+      "name": "Etc",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Etc.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "etree",
+      "name": "Etree",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Etree.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "eval",
+      "name": "Eval",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Eval.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "evaluated",
+      "name": "Evaluated",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Evaluated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "evaluates",
+      "name": "Evaluates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Evaluates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "evaluating",
+      "name": "Evaluating",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Evaluating.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "evaluation",
+      "name": "Evaluation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Evaluation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "evaluator",
+      "name": "Evaluator",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Evaluator.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "every",
+      "name": "Every",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Every.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "evidence",
+      "name": "Evidence",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Evidence.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "evidence-health",
+      "name": "Evidence-health",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Evidence-health.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "exact",
+      "name": "Exact",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exact.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "exc",
+      "name": "Exc",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exc.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "exceed",
+      "name": "Exceed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exceed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "except",
+      "name": "Except",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Except.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "exclude",
+      "name": "Exclude",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exclude.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "excludes",
+      "name": "Excludes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Excludes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "executable",
+      "name": "Executable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Executable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "executed",
+      "name": "Executed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Executed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "executes",
+      "name": "Executes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Executes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "execution",
+      "name": "Execution",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Execution.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "executor",
+      "name": "Executor",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Executor.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "exhausted",
+      "name": "Exhausted",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exhausted.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "exist",
+      "name": "Exist",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exist.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "existing",
+      "name": "Existing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Existing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "exists",
+      "name": "Exists",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exists.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "exit",
+      "name": "Exit",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "expand",
+      "name": "Expand",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Expand.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "expanduser",
+      "name": "Expanduser",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Expanduser.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "expected",
+      "name": "Expected",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Expected.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "experiments",
+      "name": "Experiments",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Experiments.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "expert-level",
+      "name": "Expert-level",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Expert-level.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "explanations",
+      "name": "Explanations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Explanations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "explicit",
+      "name": "Explicit",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Explicit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "export",
+      "name": "Export",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Export.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "exposes",
+      "name": "Exposes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exposes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ext",
+      "name": "Ext",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ext.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "extend",
+      "name": "Extend",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Extend.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "extension",
+      "name": "Extension",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Extension.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "extensionquery",
+      "name": "Extensionquery",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Extensionquery.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "extensions",
+      "name": "Extensions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Extensions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "extensive",
+      "name": "Extensive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Extensive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "external",
+      "name": "External",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: External.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "extracting",
+      "name": "Extracting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Extracting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "extraction",
+      "name": "Extraction",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Extraction.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "extracts",
+      "name": "Extracts",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Extracts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "failure",
+      "name": "Failure",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Failure.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "failures",
+      "name": "Failures",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Failures.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "fallback",
+      "name": "Fallback",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fallback.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "falls",
+      "name": "Falls",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Falls.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "false",
+      "name": "False",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: False.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "feature",
+      "name": "Feature",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Feature.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "feature-extraction",
+      "name": "Feature-extraction",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Feature-extraction.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "features",
+      "name": "Features",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Features.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "feedback",
+      "name": "Feedback",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Feedback.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "few-shot",
+      "name": "Few-shot",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Few-shot.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "field",
+      "name": "Field",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Field.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fields",
+      "name": "Fields",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fields.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "file",
+      "name": "File",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: File.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "filename",
+      "name": "Filename",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Filename.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "filepath",
+      "name": "Filepath",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Filepath.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "files",
+      "name": "Files",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Files.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fill-mask",
+      "name": "Fill-mask",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fill-mask.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fills",
+      "name": "Fills",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fills.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "filter",
+      "name": "Filter",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Filter.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "filtered",
+      "name": "Filtered",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Filtered.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "filters",
+      "name": "Filters",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Filters.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "final",
+      "name": "Final",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Final.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "finally",
+      "name": "Finally",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Finally.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "findings",
+      "name": "Findings",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Findings.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "finditer",
+      "name": "Finditer",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Finditer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "finite-state",
+      "name": "Finite-state",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Finite-state.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "first",
+      "name": "First",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: First.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fitness",
+      "name": "Fitness",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fitness.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fix",
+      "name": "Fix",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fix.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fixes",
+      "name": "Fixes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fixes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "flags",
+      "name": "Flags",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Flags.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "float",
+      "name": "Float",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Float.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "floats",
+      "name": "Floats",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Floats.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "floor",
+      "name": "Floor",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Floor.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "flow",
+      "name": "Flow",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Flow.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "flush",
+      "name": "Flush",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Flush.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fname",
+      "name": "Fname",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fname.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "follow-up",
+      "name": "Follow-up",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Follow-up.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "follows",
+      "name": "Follows",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Follows.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "force",
+      "name": "Force",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Force.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "form",
+      "name": "Form",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Form.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "format",
+      "name": "Format",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Format.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "formats",
+      "name": "Formats",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Formats.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "formatted",
+      "name": "Formatted",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Formatted.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "formatting",
+      "name": "Formatting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Formatting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "forms",
+      "name": "Forms",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Forms.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "forward",
+      "name": "Forward",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Forward.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "forwarded",
+      "name": "Forwarded",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Forwarded.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "found",
+      "name": "Found",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Found.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "foundation",
+      "name": "Foundation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Foundation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "foundational",
+      "name": "Foundational",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Foundational.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fpath",
+      "name": "Fpath",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fpath.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "framework",
+      "name": "Framework",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Framework.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "framing",
+      "name": "Framing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Framing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fraud",
+      "name": "Fraud",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fraud.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "free-form",
+      "name": "Free-form",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Free-form.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fromisoformat",
+      "name": "Fromisoformat",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fromisoformat.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "frontmatter",
+      "name": "Frontmatter",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Frontmatter.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "full",
+      "name": "Full",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Full.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "full-cycle",
+      "name": "Full-cycle",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Full-cycle.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "function",
+      "name": "Function",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Function.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "functionality",
+      "name": "Functionality",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Functionality.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "functionally",
+      "name": "Functionally",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Functionally.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "functions",
+      "name": "Functions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Functions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fundamentally",
+      "name": "Fundamentally",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fundamentally.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fuse",
+      "name": "Fuse",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fuse.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fusions",
+      "name": "Fusions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fusions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "future",
+      "name": "Future",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Future.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gaia",
+      "name": "Gaia",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaia.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gaia-cli",
+      "name": "Gaia-cli",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaia-cli.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gaia-cli-test",
+      "name": "Gaia-cli-test",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaia-cli-test.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gaia-intake-pr-body",
+      "name": "Gaia-intake-pr-body",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaia-intake-pr-body.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gaia-registry",
+      "name": "Gaia-registry",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaia-registry.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gaia-skill-tree",
+      "name": "Gaia-skill-tree",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaia-skill-tree.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gaiabot",
+      "name": "Gaiabot",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaiabot.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gallery",
+      "name": "Gallery",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gallery.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gaps",
+      "name": "Gaps",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaps.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gathering",
+      "name": "Gathering",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gathering.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gen",
+      "name": "Gen",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gen.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "generate",
+      "name": "Generate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Generate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "generated",
+      "name": "Generated",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Generated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "generates",
+      "name": "Generates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Generates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "generating",
+      "name": "Generating",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Generating.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "generation",
+      "name": "Generation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Generation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "generative",
+      "name": "Generative",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Generative.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "generator",
+      "name": "Generator",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Generator.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "get",
+      "name": "Get",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Get.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "getcode",
+      "name": "Getcode",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Getcode.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gets",
+      "name": "Gets",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gets.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gexf",
+      "name": "Gexf",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gexf.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gif",
+      "name": "Gif",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gif.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "git",
+      "name": "Git",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Git.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "github",
+      "name": "Github",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Github.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "github-action",
+      "name": "Github-action",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Github-action.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "given",
+      "name": "Given",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Given.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "glob",
+      "name": "Glob",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Glob.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "global",
+      "name": "Global",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Global.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gmtime",
+      "name": "Gmtime",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gmtime.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "goal-directed",
+      "name": "Goal-directed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Goal-directed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "got",
+      "name": "Got",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Got.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gracefully",
+      "name": "Gracefully",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gracefully.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "grammar-guided",
+      "name": "Grammar-guided",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Grammar-guided.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "grammars",
+      "name": "Grammars",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Grammars.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "graph",
+      "name": "Graph",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Graph.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "graphrag",
+      "name": "Graphrag",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Graphrag.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "graphs",
+      "name": "Graphs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Graphs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ground-truth",
+      "name": "Ground-truth",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ground-truth.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "grounding",
+      "name": "Grounding",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Grounding.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "group",
+      "name": "Group",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Group.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "groups",
+      "name": "Groups",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Groups.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "guaranteed",
+      "name": "Guaranteed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Guaranteed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "guarantees",
+      "name": "Guarantees",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Guarantees.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "guides",
+      "name": "Guides",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Guides.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "hand-crafted",
+      "name": "Hand-crafted",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hand-crafted.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "handle",
+      "name": "Handle",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Handle.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "handled",
+      "name": "Handled",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Handled.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "handler",
+      "name": "Handler",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Handler.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "handles",
+      "name": "Handles",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Handles.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "handling",
+      "name": "Handling",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Handling.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "happen",
+      "name": "Happen",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Happen.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "harness",
+      "name": "Harness",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Harness.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "has",
+      "name": "Has",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Has.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "hashlib",
+      "name": "Hashlib",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hashlib.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "have",
+      "name": "Have",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Have.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "header",
+      "name": "Header",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Header.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "headers",
+      "name": "Headers",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Headers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "headings",
+      "name": "Headings",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Headings.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "health",
+      "name": "Health",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Health.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "healthy",
+      "name": "Healthy",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Healthy.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "help",
+      "name": "Help",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Help.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "helpful",
+      "name": "Helpful",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Helpful.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "hexdigest",
+      "name": "Hexdigest",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hexdigest.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "highlighting",
+      "name": "Highlighting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Highlighting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "hints",
+      "name": "Hints",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hints.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "hit",
+      "name": "Hit",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "homepage",
+      "name": "Homepage",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Homepage.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "hours",
+      "name": "Hours",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hours.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "html",
+      "name": "Html",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Html.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "http",
+      "name": "Http",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Http.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "https",
+      "name": "Https",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Https.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "huggingface",
+      "name": "Huggingface",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Huggingface.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "human",
+      "name": "Human",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Human.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "human-level",
+      "name": "Human-level",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Human-level.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "hypotheses",
+      "name": "Hypotheses",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hypotheses.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "hypothesis",
+      "name": "Hypothesis",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hypothesis.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ico",
+      "name": "Ico",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ico.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "icon",
+      "name": "Icon",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Icon.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "idea",
+      "name": "Idea",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Idea.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ideas",
+      "name": "Ideas",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ideas.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "identifies",
+      "name": "Identifies",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Identifies.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "identify",
+      "name": "Identify",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Identify.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "identifying",
+      "name": "Identifying",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Identifying.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ids",
+      "name": "Ids",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ids.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "idx",
+      "name": "Idx",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Idx.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ignore",
+      "name": "Ignore",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ignore.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "images",
+      "name": "Images",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Images.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "implementation",
+      "name": "Implementation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Implementation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "implements",
+      "name": "Implements",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Implements.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "import",
+      "name": "Import",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Import.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "importlib",
+      "name": "Importlib",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Importlib.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "improve",
+      "name": "Improve",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Improve.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "improvement",
+      "name": "Improvement",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Improvement.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "improves",
+      "name": "Improves",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Improves.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "improving",
+      "name": "Improving",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Improving.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "in-context",
+      "name": "In-context",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: In-context.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "in-place",
+      "name": "In-place",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: In-place.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "include",
+      "name": "Include",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Include.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "included",
+      "name": "Included",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Included.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "includes",
+      "name": "Includes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Includes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "including",
+      "name": "Including",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Including.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "incorporating",
+      "name": "Incorporating",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Incorporating.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "indent",
+      "name": "Indent",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Indent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "independently",
+      "name": "Independently",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Independently.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "index",
+      "name": "Index",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Index.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "indexed",
+      "name": "Indexed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Indexed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "indexes",
+      "name": "Indexes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Indexes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "inductive",
+      "name": "Inductive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Inductive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "inference",
+      "name": "Inference",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Inference.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "info",
+      "name": "Info",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Info.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "information",
+      "name": "Information",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Information.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "inherit",
+      "name": "Inherit",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Inherit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "init",
+      "name": "Init",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Init.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "initialized",
+      "name": "Initialized",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Initialized.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "inject",
+      "name": "Inject",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Inject.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "injects",
+      "name": "Injects",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Injects.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "inline",
+      "name": "Inline",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Inline.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "inner",
+      "name": "Inner",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Inner.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "input",
+      "name": "Input",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Input.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "inputs",
+      "name": "Inputs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Inputs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "insert",
+      "name": "Insert",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Insert.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "insight",
+      "name": "Insight",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Insight.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "install",
+      "name": "Install",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Install.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "install-manifest",
+      "name": "Install-manifest",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Install-manifest.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "installation",
+      "name": "Installation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Installation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "installed",
+      "name": "Installed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Installed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "installs",
+      "name": "Installs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Installs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "instance",
+      "name": "Instance",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Instance.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "instruction",
+      "name": "Instruction",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Instruction.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "instructions",
+      "name": "Instructions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Instructions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "int",
+      "name": "Int",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Int.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "intake",
+      "name": "Intake",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Intake.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "intake-dir",
+      "name": "Intake-dir",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Intake-dir.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "integrates",
+      "name": "Integrates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Integrates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "integration",
+      "name": "Integration",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Integration.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "integrations",
+      "name": "Integrations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Integrations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "integrity",
+      "name": "Integrity",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Integrity.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "intensity",
+      "name": "Intensity",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Intensity.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "intent",
+      "name": "Intent",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Intent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "interactions",
+      "name": "Interactions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Interactions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "interface",
+      "name": "Interface",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Interface.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "intermediate",
+      "name": "Intermediate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Intermediate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "interpreter",
+      "name": "Interpreter",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Interpreter.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "interpreting",
+      "name": "Interpreting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Interpreting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "interprets",
+      "name": "Interprets",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Interprets.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "intersection",
+      "name": "Intersection",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Intersection.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "intervention",
+      "name": "Intervention",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Intervention.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "into",
+      "name": "Into",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Into.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "intrusion",
+      "name": "Intrusion",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Intrusion.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "invalid",
+      "name": "Invalid",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Invalid.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "isdir",
+      "name": "Isdir",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Isdir.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "isfile",
+      "name": "Isfile",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Isfile.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "isinstance",
+      "name": "Isinstance",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Isinstance.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "islink",
+      "name": "Islink",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Islink.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "isoformat",
+      "name": "Isoformat",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Isoformat.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "issues",
+      "name": "Issues",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Issues.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "issuing",
+      "name": "Issuing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Issuing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "item",
+      "name": "Item",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Item.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "items",
+      "name": "Items",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Items.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "iter",
+      "name": "Iter",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Iter.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "iterates",
+      "name": "Iterates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Iterates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "iteration",
+      "name": "Iteration",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Iteration.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "iterative",
+      "name": "Iterative",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Iterative.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "iteratively",
+      "name": "Iteratively",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Iteratively.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "its",
+      "name": "Its",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Its.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "jobs",
+      "name": "Jobs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Jobs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "join",
+      "name": "Join",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Join.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "jpeg",
+      "name": "Jpeg",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Jpeg.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "jpg",
+      "name": "Jpg",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Jpg.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "json",
+      "name": "Json",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Json.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "jsonschema",
+      "name": "Jsonschema",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Jsonschema.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "karpathy",
+      "name": "Karpathy",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Karpathy.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.552
+        }
+      ]
+    },
+    {
+      "id": "kebab-case",
+      "name": "Kebab-case",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Kebab-case.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "key",
+      "name": "Key",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Key.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "keyboard",
+      "name": "Keyboard",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Keyboard.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "keys",
+      "name": "Keys",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Keys.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "keyword",
+      "name": "Keyword",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Keyword.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "keywords",
+      "name": "Keywords",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Keywords.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "knowledge",
+      "name": "Knowledge",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Knowledge.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "known",
+      "name": "Known",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Known.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "label",
+      "name": "Label",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Label.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "labels",
+      "name": "Labels",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Labels.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "laboratory",
+      "name": "Laboratory",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Laboratory.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lambda",
+      "name": "Lambda",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lambda.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "langchain",
+      "name": "Langchain",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Langchain.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "langchain-ai",
+      "name": "Langchain-ai",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Langchain-ai.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "langchain-tool",
+      "name": "Langchain-tool",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Langchain-tool.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "language",
+      "name": "Language",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Language.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "language-image",
+      "name": "Language-image",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Language-image.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "languages",
+      "name": "Languages",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Languages.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "large",
+      "name": "Large",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Large.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "large-scale",
+      "name": "Large-scale",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Large-scale.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "last",
+      "name": "Last",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Last.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "last-week",
+      "name": "Last-week",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Last-week.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lastmodifieddate",
+      "name": "Lastmodifieddate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lastmodifieddate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "latency",
+      "name": "Latency",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Latency.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "later",
+      "name": "Later",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Later.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "layout",
+      "name": "Layout",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Layout.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "leading",
+      "name": "Leading",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Leading.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "learn",
+      "name": "Learn",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Learn.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "learned",
+      "name": "Learned",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Learned.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "learning",
+      "name": "Learning",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Learning.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "least",
+      "name": "Least",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Least.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "left",
+      "name": "Left",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Left.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "legendaries",
+      "name": "Legendaries",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Legendaries.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "legendary",
+      "name": "Legendary",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Legendary.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "legendary-specific",
+      "name": "Legendary-specific",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Legendary-specific.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "len",
+      "name": "Len",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Len.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "less",
+      "name": "Less",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Less.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "let",
+      "name": "Let",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Let.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "letters",
+      "name": "Letters",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Letters.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "level",
+      "name": "Level",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Level.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lexically",
+      "name": "Lexically",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lexically.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "library",
+      "name": "Library",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Library.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "libs",
+      "name": "Libs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Libs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "license",
+      "name": "License",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: License.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lid",
+      "name": "Lid",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lid.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lida",
+      "name": "Lida",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lida.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lifecycle",
+      "name": "Lifecycle",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lifecycle.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "like",
+      "name": "Like",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Like.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "likes",
+      "name": "Likes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Likes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "limit",
+      "name": "Limit",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Limit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "linalg",
+      "name": "Linalg",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Linalg.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "line",
+      "name": "Line",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Line.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lineage",
+      "name": "Lineage",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lineage.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "linear",
+      "name": "Linear",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Linear.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lines",
+      "name": "Lines",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lines.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "link",
+      "name": "Link",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Link.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "links",
+      "name": "Links",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Links.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "list",
+      "name": "List",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: List.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "listdir",
+      "name": "Listdir",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Listdir.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "literature",
+      "name": "Literature",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Literature.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "llevel",
+      "name": "Llevel",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Llevel.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "llm",
+      "name": "Llm",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Llm.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "llm-tool",
+      "name": "Llm-tool",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Llm-tool.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lname",
+      "name": "Lname",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lname.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "load",
+      "name": "Load",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Load.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "loaded",
+      "name": "Loaded",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Loaded.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "loader",
+      "name": "Loader",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Loader.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "local",
+      "name": "Local",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Local.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "local-repo",
+      "name": "Local-repo",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Local-repo.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "locally",
+      "name": "Locally",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Locally.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "locate",
+      "name": "Locate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Locate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "locations",
+      "name": "Locations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Locations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "log-scaled",
+      "name": "Log-scaled",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Log-scaled.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "log10",
+      "name": "Log10",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Log10.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "log2",
+      "name": "Log2",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Log2.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "logging",
+      "name": "Logging",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Logging.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "logic",
+      "name": "Logic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Logic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "logical",
+      "name": "Logical",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Logical.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "logs",
+      "name": "Logs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Logs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "long-form",
+      "name": "Long-form",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Long-form.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "long-term",
+      "name": "Long-term",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Long-term.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "longer",
+      "name": "Longer",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Longer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "look",
+      "name": "Look",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Look.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "loop",
+      "name": "Loop",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Loop.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "loops",
+      "name": "Loops",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Loops.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "low-latency",
+      "name": "Low-latency",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Low-latency.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lower",
+      "name": "Lower",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lower.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lowercase-dash",
+      "name": "Lowercase-dash",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lowercase-dash.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lvl",
+      "name": "Lvl",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lvl.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "machine",
+      "name": "Machine",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Machine.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "machine-readable",
+      "name": "Machine-readable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Machine-readable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "madaan",
+      "name": "Madaan",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Madaan.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "main",
+      "name": "Main",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Main.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "maintainability",
+      "name": "Maintainability",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Maintainability.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "maintaining",
+      "name": "Maintaining",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Maintaining.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "makedirs",
+      "name": "Makedirs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Makedirs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "malformed",
+      "name": "Malformed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Malformed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "management",
+      "name": "Management",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Management.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "managing",
+      "name": "Managing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Managing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "manifest",
+      "name": "Manifest",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Manifest.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "manual",
+      "name": "Manual",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Manual.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "manually",
+      "name": "Manually",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Manually.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "manuscripts",
+      "name": "Manuscripts",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Manuscripts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "map",
+      "name": "Map",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Map.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mapping",
+      "name": "Mapping",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mapping.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mappings",
+      "name": "Mappings",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mappings.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "maps",
+      "name": "Maps",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Maps.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mark",
+      "name": "Mark",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mark.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "markdown",
+      "name": "Markdown",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Markdown.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "marked",
+      "name": "Marked",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Marked.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "marker",
+      "name": "Marker",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Marker.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "markers",
+      "name": "Markers",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Markers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "marketplace",
+      "name": "Marketplace",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Marketplace.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "markup",
+      "name": "Markup",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Markup.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "master",
+      "name": "Master",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Master.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "match",
+      "name": "Match",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Match.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "matching",
+      "name": "Matching",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Matching.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "math",
+      "name": "Math",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Math.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mathematical",
+      "name": "Mathematical",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mathematical.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mathematics",
+      "name": "Mathematics",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mathematics.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "max",
+      "name": "Max",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Max.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "may",
+      "name": "May",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: May.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mbtiongson1",
+      "name": "Mbtiongson1",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mbtiongson1.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mcp",
+      "name": "Mcp",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mcp.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mcp-registry",
+      "name": "Mcp-registry",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mcp-registry.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mcp-server",
+      "name": "Mcp-server",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mcp-server.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "meaning",
+      "name": "Meaning",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Meaning.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "meaningful",
+      "name": "Meaningful",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Meaningful.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mechanistic",
+      "name": "Mechanistic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mechanistic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "media",
+      "name": "Media",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Media.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "medical",
+      "name": "Medical",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Medical.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "meets",
+      "name": "Meets",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Meets.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "memory",
+      "name": "Memory",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Memory.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "merged",
+      "name": "Merged",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Merged.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "message",
+      "name": "Message",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Message.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "messages",
+      "name": "Messages",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Messages.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "meta",
+      "name": "Meta",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Meta.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "metadata",
+      "name": "Metadata",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Metadata.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "metavar",
+      "name": "Metavar",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Metavar.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "method",
+      "name": "Method",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Method.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "methodology",
+      "name": "Methodology",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Methodology.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "methods",
+      "name": "Methods",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Methods.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "microsecond",
+      "name": "Microsecond",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Microsecond.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "microsoft",
+      "name": "Microsoft",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Microsoft.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "might",
+      "name": "Might",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Might.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "migration",
+      "name": "Migration",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Migration.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "min",
+      "name": "Min",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Min.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "minimum",
+      "name": "Minimum",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Minimum.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "missing",
+      "name": "Missing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Missing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mixed",
+      "name": "Mixed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mixed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mjs",
+      "name": "Mjs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mjs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mod",
+      "name": "Mod",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mod.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "modalities",
+      "name": "Modalities",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Modalities.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mode",
+      "name": "Mode",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mode.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "model",
+      "name": "Model",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Model.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "modeling",
+      "name": "Modeling",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Modeling.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "models",
+      "name": "Models",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Models.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "moderation",
+      "name": "Moderation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Moderation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "modern",
+      "name": "Modern",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Modern.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "modes",
+      "name": "Modes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Modes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "modifications",
+      "name": "Modifications",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Modifications.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "modified",
+      "name": "Modified",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Modified.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "module",
+      "name": "Module",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Module.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "molecular",
+      "name": "Molecular",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Molecular.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "more",
+      "name": "More",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: More.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "most",
+      "name": "Most",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Most.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mouse",
+      "name": "Mouse",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mouse.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.526
+        }
+      ]
+    },
+    {
+      "id": "multi-agent",
+      "name": "Multi-agent",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multi-agent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "multi-category",
+      "name": "Multi-category",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multi-category.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "multi-section",
+      "name": "Multi-section",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multi-section.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "multi-session",
+      "name": "Multi-session",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multi-session.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "multi-source",
+      "name": "Multi-source",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multi-source.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "multi-step",
+      "name": "Multi-step",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multi-step.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "multi-system",
+      "name": "Multi-system",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multi-system.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "multi-turn",
+      "name": "Multi-turn",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multi-turn.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "multilingual",
+      "name": "Multilingual",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multilingual.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "multimodal",
+      "name": "Multimodal",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multimodal.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "multiple",
+      "name": "Multiple",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multiple.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "must",
+      "name": "Must",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Must.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "name",
+      "name": "Name",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Name.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "named",
+      "name": "Named",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Named.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "named-dir",
+      "name": "Named-dir",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Named-dir.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "named-skills",
+      "name": "Named-skills",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Named-skills.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "names",
+      "name": "Names",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Names.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "nargs",
+      "name": "Nargs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Nargs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "narrative",
+      "name": "Narrative",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Narrative.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "natural",
+      "name": "Natural",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Natural.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "natural-language",
+      "name": "Natural-language",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Natural-language.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "natural-sounding",
+      "name": "Natural-sounding",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Natural-sounding.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "navigating",
+      "name": "Navigating",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Navigating.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "near-human",
+      "name": "Near-human",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Near-human.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "need",
+      "name": "Need",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Need.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "needed",
+      "name": "Needed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Needed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "needs",
+      "name": "Needs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Needs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "needs-review",
+      "name": "Needs-review",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Needs-review.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "negative",
+      "name": "Negative",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Negative.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ner",
+      "name": "Ner",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ner.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "nested",
+      "name": "Nested",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Nested.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "nesting",
+      "name": "Nesting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Nesting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "net",
+      "name": "Net",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Net.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "neural",
+      "name": "Neural",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Neural.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "neutral",
+      "name": "Neutral",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Neutral.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "new",
+      "name": "New",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: New.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "next",
+      "name": "Next",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Next.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "nline",
+      "name": "Nline",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Nline.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "no-pr",
+      "name": "No-pr",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: No-pr.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "node",
+      "name": "Node",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Node.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "node-20",
+      "name": "Node-20",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Node-20.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "nodes",
+      "name": "Nodes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Nodes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "noise",
+      "name": "Noise",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Noise.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "non-interactive",
+      "name": "Non-interactive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Non-interactive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "non-overlap",
+      "name": "Non-overlap",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Non-overlap.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "none",
+      "name": "None",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: None.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "nonlocal",
+      "name": "Nonlocal",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Nonlocal.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "noqa",
+      "name": "Noqa",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Noqa.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "norm",
+      "name": "Norm",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Norm.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "normally",
+      "name": "Normally",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Normally.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "not",
+      "name": "Not",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Not.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "notebooks",
+      "name": "Notebooks",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Notebooks.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "notes",
+      "name": "Notes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Notes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "nothing",
+      "name": "Nothing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Nothing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "novel",
+      "name": "Novel",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Novel.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "now",
+      "name": "Now",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Now.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "npm",
+      "name": "Npm",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Npm.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "npmjs",
+      "name": "Npmjs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Npmjs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "number",
+      "name": "Number",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Number.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "numeric",
+      "name": "Numeric",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Numeric.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "numerical",
+      "name": "Numerical",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Numerical.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "numpy",
+      "name": "Numpy",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Numpy.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "nuxt",
+      "name": "Nuxt",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Nuxt.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "objective",
+      "name": "Objective",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Objective.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "objectives",
+      "name": "Objectives",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Objectives.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "objects",
+      "name": "Objects",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Objects.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "observable",
+      "name": "Observable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Observable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "observation",
+      "name": "Observation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Observation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "observe",
+      "name": "Observe",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Observe.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "occurrence",
+      "name": "Occurrence",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Occurrence.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "old",
+      "name": "Old",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Old.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "once",
+      "name": "Once",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Once.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "one",
+      "name": "One",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: One.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "only",
+      "name": "Only",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Only.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "open",
+      "name": "Open",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Open.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "open-ended",
+      "name": "Open-ended",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Open-ended.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "open-source",
+      "name": "Open-source",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Open-source.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "openai",
+      "name": "Openai",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Openai.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "opened",
+      "name": "Opened",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Opened.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "opening",
+      "name": "Opening",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Opening.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "opens",
+      "name": "Opens",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Opens.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "optimized",
+      "name": "Optimized",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Optimized.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "optional",
+      "name": "Optional",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Optional.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "options",
+      "name": "Options",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Options.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "orchestrates",
+      "name": "Orchestrates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Orchestrates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "order",
+      "name": "Order",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Order.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "ordered",
+      "name": "Ordered",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ordered.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "org",
+      "name": "Org",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Org.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "organizations",
+      "name": "Organizations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Organizations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "origin",
+      "name": "Origin",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Origin.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "origins",
+      "name": "Origins",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Origins.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "orphaned",
+      "name": "Orphaned",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Orphaned.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "otherwise",
+      "name": "Otherwise",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Otherwise.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "our",
+      "name": "Our",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Our.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "out",
+      "name": "Out",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Out.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "outliers",
+      "name": "Outliers",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Outliers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "outlines",
+      "name": "Outlines",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Outlines.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "outlines-dev",
+      "name": "Outlines-dev",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Outlines-dev.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "outperforms",
+      "name": "Outperforms",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Outperforms.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "output",
+      "name": "Output",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Output.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "outputs",
+      "name": "Outputs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Outputs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "outside",
+      "name": "Outside",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Outside.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "over",
+      "name": "Over",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Over.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "overhead",
+      "name": "Overhead",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Overhead.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "overwritten",
+      "name": "Overwritten",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Overwritten.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "own",
+      "name": "Own",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Own.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "owned",
+      "name": "Owned",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Owned.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "owner",
+      "name": "Owner",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Owner.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pack",
+      "name": "Pack",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pack.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "package",
+      "name": "Package",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Package.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "packages",
+      "name": "Packages",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Packages.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "packed",
+      "name": "Packed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Packed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pages",
+      "name": "Pages",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pages.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pair",
+      "name": "Pair",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pair.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pairs",
+      "name": "Pairs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pairs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pairwise",
+      "name": "Pairwise",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pairwise.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pal",
+      "name": "Pal",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pal.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pandas",
+      "name": "Pandas",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pandas.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pandas-ai",
+      "name": "Pandas-ai",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pandas-ai.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "paper",
+      "name": "Paper",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Paper.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "papers",
+      "name": "Papers",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Papers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "paradigm",
+      "name": "Paradigm",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Paradigm.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "parameters",
+      "name": "Parameters",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Parameters.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "params",
+      "name": "Params",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Params.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "parent",
+      "name": "Parent",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Parent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "parents",
+      "name": "Parents",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Parents.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "parse",
+      "name": "Parse",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Parse.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "parsed",
+      "name": "Parsed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Parsed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "parser",
+      "name": "Parser",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Parser.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "parses",
+      "name": "Parses",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Parses.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "parsing",
+      "name": "Parsing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Parsing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "partition",
+      "name": "Partition",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Partition.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "parts",
+      "name": "Parts",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Parts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pass",
+      "name": "Pass",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pass.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "passages",
+      "name": "Passages",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Passages.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "passed",
+      "name": "Passed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Passed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "passing",
+      "name": "Passing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Passing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "patch",
+      "name": "Patch",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Patch.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "patched",
+      "name": "Patched",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Patched.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "patches",
+      "name": "Patches",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Patches.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "path",
+      "name": "Path",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Path.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "paths",
+      "name": "Paths",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Paths.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pattern",
+      "name": "Pattern",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pattern.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "patterns",
+      "name": "Patterns",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Patterns.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "payload",
+      "name": "Payload",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Payload.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pdf",
+      "name": "Pdf",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pdf.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pending",
+      "name": "Pending",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pending.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "people",
+      "name": "People",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: People.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "per",
+      "name": "Per",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Per.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "percentage",
+      "name": "Percentage",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Percentage.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "performance",
+      "name": "Performance",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Performance.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "persistent",
+      "name": "Persistent",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Persistent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "photorealistic",
+      "name": "Photorealistic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Photorealistic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "pid",
+      "name": "Pid",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pid.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pip",
+      "name": "Pip",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pip.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pipe",
+      "name": "Pipe",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pipe.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pipeline",
+      "name": "Pipeline",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pipeline.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pipelines",
+      "name": "Pipelines",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pipelines.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pixel-space",
+      "name": "Pixel-space",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pixel-space.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pkg",
+      "name": "Pkg",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pkg.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "placeholder",
+      "name": "Placeholder",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Placeholder.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "plain-text",
+      "name": "Plain-text",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Plain-text.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "plan",
+      "name": "Plan",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Plan.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "planned",
+      "name": "Planned",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Planned.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "planning",
+      "name": "Planning",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Planning.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "platform",
+      "name": "Platform",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Platform.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "plugin",
+      "name": "Plugin",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Plugin.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "plus",
+      "name": "Plus",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Plus.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "png",
+      "name": "Png",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Png.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "point",
+      "name": "Point",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Point.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "points",
+      "name": "Points",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Points.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "policy-violating",
+      "name": "Policy-violating",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Policy-violating.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "popular",
+      "name": "Popular",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Popular.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "popularity",
+      "name": "Popularity",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Popularity.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "positive",
+      "name": "Positive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Positive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "post",
+      "name": "Post",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Post.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pre-computed",
+      "name": "Pre-computed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pre-computed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pre-trained",
+      "name": "Pre-trained",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pre-trained.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pre-training",
+      "name": "Pre-training",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pre-training.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prediction",
+      "name": "Prediction",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prediction.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prefix",
+      "name": "Prefix",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prefix.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "premises",
+      "name": "Premises",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Premises.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prepare",
+      "name": "Prepare",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prepare.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prereq",
+      "name": "Prereq",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prereq.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prereqs",
+      "name": "Prereqs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prereqs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prerequisite",
+      "name": "Prerequisite",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prerequisite.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prerequisites",
+      "name": "Prerequisites",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prerequisites.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "present",
+      "name": "Present",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Present.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "preserves",
+      "name": "Preserves",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Preserves.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "preserving",
+      "name": "Preserving",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Preserving.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "prevalence",
+      "name": "Prevalence",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prevalence.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "preview",
+      "name": "Preview",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Preview.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "princeton-nlp",
+      "name": "Princeton-nlp",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Princeton-nlp.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "print",
+      "name": "Print",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Print.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prints",
+      "name": "Prints",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prints.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "problems",
+      "name": "Problems",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Problems.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "process",
+      "name": "Process",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Process.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "processing",
+      "name": "Processing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Processing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "produce",
+      "name": "Produce",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Produce.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "produces",
+      "name": "Produces",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Produces.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "production",
+      "name": "Production",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Production.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "production-grade",
+      "name": "Production-grade",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Production-grade.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "profile",
+      "name": "Profile",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Profile.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prog",
+      "name": "Prog",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prog.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "programmatic",
+      "name": "Programmatic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Programmatic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "programming",
+      "name": "Programming",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Programming.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "project",
+      "name": "Project",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Project.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "projections",
+      "name": "Projections",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Projections.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "promoted",
+      "name": "Promoted",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Promoted.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "promotion",
+      "name": "Promotion",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Promotion.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prompt",
+      "name": "Prompt",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prompt.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prompting",
+      "name": "Prompting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prompting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prompts",
+      "name": "Prompts",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prompts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "proper",
+      "name": "Proper",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Proper.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "proposals",
+      "name": "Proposals",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Proposals.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "propose",
+      "name": "Propose",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Propose.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "proposed",
+      "name": "Proposed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Proposed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "proposer",
+      "name": "Proposer",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Proposer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "proposes",
+      "name": "Proposes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Proposes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "proposing",
+      "name": "Proposing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Proposing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prosody",
+      "name": "Prosody",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prosody.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "provide",
+      "name": "Provide",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Provide.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "provided",
+      "name": "Provided",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Provided.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "provides",
+      "name": "Provides",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Provides.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "providing",
+      "name": "Providing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Providing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "provisional",
+      "name": "Provisional",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Provisional.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "public",
+      "name": "Public",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Public.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "publicly",
+      "name": "Publicly",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Publicly.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "published",
+      "name": "Published",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Published.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "publisher",
+      "name": "Publisher",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Publisher.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pull",
+      "name": "Pull",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pull.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pure",
+      "name": "Pure",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pure.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "push",
+      "name": "Push",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Push.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pyc",
+      "name": "Pyc",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pyc.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "python",
+      "name": "Python",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Python.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "python-shell",
+      "name": "Python-shell",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Python-shell.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "python-shell-5",
+      "name": "Python-shell-5",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Python-shell-5.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "python-version",
+      "name": "Python-version",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Python-version.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "python3",
+      "name": "Python3",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Python3.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "quality",
+      "name": "Quality",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Quality.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "quantitative",
+      "name": "Quantitative",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Quantitative.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "queries",
+      "name": "Queries",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Queries.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "query",
+      "name": "Query",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Query.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "queryable",
+      "name": "Queryable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Queryable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "question-answering",
+      "name": "Question-answering",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Question-answering.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "questions",
+      "name": "Questions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Questions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "quoted",
+      "name": "Quoted",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Quoted.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rag",
+      "name": "Rag",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rag.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "raise",
+      "name": "Raise",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Raise.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "raises",
+      "name": "Raises",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Raises.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "range",
+      "name": "Range",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Range.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ranking",
+      "name": "Ranking",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ranking.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ranks",
+      "name": "Ranks",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ranks.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rare",
+      "name": "Rare",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rare.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rarity",
+      "name": "Rarity",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rarity.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rasa",
+      "name": "Rasa",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rasa.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rate",
+      "name": "Rate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rated",
+      "name": "Rated",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ratio",
+      "name": "Ratio",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ratio.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "raw",
+      "name": "Raw",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Raw.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "re-derived",
+      "name": "Re-derived",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Re-derived.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "re-exports",
+      "name": "Re-exports",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Re-exports.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reach",
+      "name": "Reach",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reach.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.588
+        }
+      ]
+    },
+    {
+      "id": "reachable",
+      "name": "Reachable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reachable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "reached",
+      "name": "Reached",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reached.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.526
+        }
+      ]
+    },
+    {
+      "id": "react-reasoning",
+      "name": "React-reasoning",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: React-reasoning.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "read",
+      "name": "Read",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Read.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "readability",
+      "name": "Readability",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Readability.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reading",
+      "name": "Reading",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reading.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ready",
+      "name": "Ready",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ready.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "real",
+      "name": "Real",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Real.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "real-time",
+      "name": "Real-time",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Real-time.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "real-world",
+      "name": "Real-world",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Real-world.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "realistic",
+      "name": "Realistic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Realistic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reason",
+      "name": "Reason",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reason.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reasoning",
+      "name": "Reasoning",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reasoning.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reasoning-machines",
+      "name": "Reasoning-machines",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reasoning-machines.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "record",
+      "name": "Record",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Record.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "records",
+      "name": "Records",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Records.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "recursive",
+      "name": "Recursive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Recursive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "redirect",
+      "name": "Redirect",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Redirect.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ref",
+      "name": "Ref",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ref.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "refactor",
+      "name": "Refactor",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Refactor.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "refactors",
+      "name": "Refactors",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Refactors.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "reference",
+      "name": "Reference",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reference.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "references",
+      "name": "References",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: References.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "refines",
+      "name": "Refines",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Refines.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "regex",
+      "name": "Regex",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Regex.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "register",
+      "name": "Register",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Register.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "registries",
+      "name": "Registries",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Registries.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "registry",
+      "name": "Registry",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Registry.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "registry-ref",
+      "name": "Registry-ref",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Registry-ref.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reject",
+      "name": "Reject",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reject.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rel",
+      "name": "Rel",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rel.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "relations",
+      "name": "Relations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Relations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "relationships",
+      "name": "Relationships",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Relationships.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "relative",
+      "name": "Relative",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Relative.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "relevance",
+      "name": "Relevance",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Relevance.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "relevant",
+      "name": "Relevant",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Relevant.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "relpath",
+      "name": "Relpath",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Relpath.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "remote",
+      "name": "Remote",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Remote.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "remove",
+      "name": "Remove",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Remove.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "removesuffix",
+      "name": "Removesuffix",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Removesuffix.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rename",
+      "name": "Rename",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rename.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "repeat",
+      "name": "Repeat",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Repeat.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "replace",
+      "name": "Replace",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Replace.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "repo",
+      "name": "Repo",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Repo.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "report",
+      "name": "Report",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Report.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reporting",
+      "name": "Reporting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reporting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reports",
+      "name": "Reports",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reports.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "repositories",
+      "name": "Repositories",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Repositories.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "repository",
+      "name": "Repository",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Repository.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "representation",
+      "name": "Representation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Representation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "representations",
+      "name": "Representations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Representations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "representing",
+      "name": "Representing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Representing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reproducible",
+      "name": "Reproducible",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reproducible.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "req",
+      "name": "Req",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Req.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "request",
+      "name": "Request",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Request.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "requests",
+      "name": "Requests",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Requests.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "required",
+      "name": "Required",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Required.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "requires",
+      "name": "Requires",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Requires.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "requiring",
+      "name": "Requiring",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Requiring.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rerank",
+      "name": "Rerank",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rerank.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reranking",
+      "name": "Reranking",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reranking.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "res",
+      "name": "Res",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Res.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "research-backed",
+      "name": "Research-backed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Research-backed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.593
+        }
+      ]
+    },
+    {
+      "id": "resolution",
+      "name": "Resolution",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Resolution.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "resolve",
+      "name": "Resolve",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Resolve.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "resolved",
+      "name": "Resolved",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Resolved.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "resolver",
+      "name": "Resolver",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Resolver.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "resolves",
+      "name": "Resolves",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Resolves.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "resp",
+      "name": "Resp",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Resp.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "responses",
+      "name": "Responses",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Responses.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rest",
+      "name": "Rest",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rest.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "result",
+      "name": "Result",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Result.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "results",
+      "name": "Results",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Results.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "retrieval",
+      "name": "Retrieval",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Retrieval.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "retrieval-augmented",
+      "name": "Retrieval-augmented",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Retrieval-augmented.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "retrieves",
+      "name": "Retrieves",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Retrieves.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "retry",
+      "name": "Retry",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Retry.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "return",
+      "name": "Return",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Return.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "returncode",
+      "name": "Returncode",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Returncode.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "returned",
+      "name": "Returned",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Returned.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "returns",
+      "name": "Returns",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Returns.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reversal",
+      "name": "Reversal",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reversal.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reverse",
+      "name": "Reverse",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reverse.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "review",
+      "name": "Review",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Review.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reviewed",
+      "name": "Reviewed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reviewed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reviews",
+      "name": "Reviews",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reviews.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rigorous",
+      "name": "Rigorous",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rigorous.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "root",
+      "name": "Root",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Root.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "roots",
+      "name": "Roots",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Roots.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "round",
+      "name": "Round",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Round.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "routes",
+      "name": "Routes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Routes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "routing",
+      "name": "Routing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Routing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "row",
+      "name": "Row",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Row.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rule-based",
+      "name": "Rule-based",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rule-based.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rules",
+      "name": "Rules",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rules.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "run",
+      "name": "Run",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Run.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "run-gaia",
+      "name": "Run-gaia",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Run-gaia.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "runner",
+      "name": "Runner",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Runner.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "running",
+      "name": "Running",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Running.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "runs",
+      "name": "Runs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Runs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "runs-on",
+      "name": "Runs-on",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Runs-on.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "runtime",
+      "name": "Runtime",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Runtime.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "s-q-l",
+      "name": "S-q-l",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: S-q-l.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "safe",
+      "name": "Safe",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Safe.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "safely",
+      "name": "Safely",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Safely.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "safety",
+      "name": "Safety",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Safety.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "same",
+      "name": "Same",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Same.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sandbox",
+      "name": "Sandbox",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sandbox.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sandboxed",
+      "name": "Sandboxed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sandboxed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scalar",
+      "name": "Scalar",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scalar.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scalars",
+      "name": "Scalars",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scalars.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scale",
+      "name": "Scale",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scale.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scan",
+      "name": "Scan",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scan.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scanned",
+      "name": "Scanned",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scanned.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scanner",
+      "name": "Scanner",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scanner.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "schema",
+      "name": "Schema",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Schema.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "schema-dir",
+      "name": "Schema-dir",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Schema-dir.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "schema-valid",
+      "name": "Schema-valid",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Schema-valid.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "science",
+      "name": "Science",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Science.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scientific",
+      "name": "Scientific",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scientific.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "score",
+      "name": "Score",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Score.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scored",
+      "name": "Scored",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scored.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scores",
+      "name": "Scores",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scores.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scoring",
+      "name": "Scoring",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scoring.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scraper",
+      "name": "Scraper",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scraper.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scraping",
+      "name": "Scraping",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scraping.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "screenshot",
+      "name": "Screenshot",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Screenshot.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "screenshot-based",
+      "name": "Screenshot-based",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Screenshot-based.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "screenshots",
+      "name": "Screenshots",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Screenshots.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "script",
+      "name": "Script",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Script.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scripts",
+      "name": "Scripts",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scripts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scroll",
+      "name": "Scroll",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scroll.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "search",
+      "name": "Search",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Search.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.667
+        }
+      ]
+    },
+    {
+      "id": "searchable",
+      "name": "Searchable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Searchable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.545
+        }
+      ]
+    },
+    {
+      "id": "searching",
+      "name": "Searching",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Searching.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.571
+        }
+      ]
+    },
+    {
+      "id": "second",
+      "name": "Second",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Second.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "seconds",
+      "name": "Seconds",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Seconds.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "secrets",
+      "name": "Secrets",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Secrets.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "security",
+      "name": "Security",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Security.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "see",
+      "name": "See",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: See.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "seed",
+      "name": "Seed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Seed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "seen",
+      "name": "Seen",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Seen.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "segment",
+      "name": "Segment",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Segment.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "segments",
+      "name": "Segments",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Segments.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "selecting",
+      "name": "Selecting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Selecting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "selection",
+      "name": "Selection",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Selection.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "selects",
+      "name": "Selects",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Selects.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "self-evidence",
+      "name": "Self-evidence",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Self-evidence.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "self-feedback",
+      "name": "Self-feedback",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Self-feedback.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "self-generated",
+      "name": "Self-generated",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Self-generated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "self-hosted",
+      "name": "Self-hosted",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Self-hosted.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "self-refine",
+      "name": "Self-refine",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Self-refine.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "self-supervised",
+      "name": "Self-supervised",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Self-supervised.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "semantic",
+      "name": "Semantic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Semantic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "semantically",
+      "name": "Semantically",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Semantically.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sensemaking",
+      "name": "Sensemaking",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sensemaking.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sentence-similarity",
+      "name": "Sentence-similarity",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sentence-similarity.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sentence-transformers",
+      "name": "Sentence-transformers",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sentence-transformers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sentiment",
+      "name": "Sentiment",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sentiment.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "separated",
+      "name": "Separated",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Separated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "separately",
+      "name": "Separately",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Separately.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sequence",
+      "name": "Sequence",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sequence.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sequences",
+      "name": "Sequences",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sequences.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "server",
+      "name": "Server",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Server.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "servers",
+      "name": "Servers",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Servers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "session",
+      "name": "Session",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Session.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sessions",
+      "name": "Sessions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sessions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "set",
+      "name": "Set",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Set.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "setdefault",
+      "name": "Setdefault",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Setdefault.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sets",
+      "name": "Sets",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sets.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "setup-python",
+      "name": "Setup-python",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Setup-python.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "several",
+      "name": "Several",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Several.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sha",
+      "name": "Sha",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sha.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sha256",
+      "name": "Sha256",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sha256.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sha512",
+      "name": "Sha512",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sha512.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "shape",
+      "name": "Shape",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Shape.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "shell",
+      "name": "Shell",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Shell.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "shells",
+      "name": "Shells",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Shells.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "short",
+      "name": "Short",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Short.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "shorter",
+      "name": "Shorter",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Shorter.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "shot",
+      "name": "Shot",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Shot.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "should",
+      "name": "Should",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Should.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "shouldn",
+      "name": "Shouldn",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Shouldn.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "showing",
+      "name": "Showing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Showing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "shows",
+      "name": "Shows",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Shows.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "shutil",
+      "name": "Shutil",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Shutil.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sid",
+      "name": "Sid",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sid.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "signals",
+      "name": "Signals",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Signals.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "signatures",
+      "name": "Signatures",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Signatures.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "silent",
+      "name": "Silent",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Silent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "similar",
+      "name": "Similar",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Similar.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "similarity",
+      "name": "Similarity",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Similarity.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "simple",
+      "name": "Simple",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Simple.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "simply",
+      "name": "Simply",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Simply.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "simulation",
+      "name": "Simulation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Simulation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "single",
+      "name": "Single",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Single.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "single-pass",
+      "name": "Single-pass",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Single-pass.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "size",
+      "name": "Size",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Size.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "skill",
+      "name": "Skill",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skill.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "skill-batches",
+      "name": "Skill-batches",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skill-batches.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "skill-index",
+      "name": "Skill-index",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skill-index.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "skill-name",
+      "name": "Skill-name",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skill-name.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "skill-tree",
+      "name": "Skill-tree",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skill-tree.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "skills",
+      "name": "Skills",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skills.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "skip",
+      "name": "Skip",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skip.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "skipped",
+      "name": "Skipped",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skipped.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "skipping",
+      "name": "Skipping",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skipping.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "slashes",
+      "name": "Slashes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Slashes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "slice",
+      "name": "Slice",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Slice.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "slug",
+      "name": "Slug",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Slug.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "smithery",
+      "name": "Smithery",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Smithery.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "software",
+      "name": "Software",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Software.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "some",
+      "name": "Some",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Some.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sort",
+      "name": "Sort",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sort.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sorted",
+      "name": "Sorted",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sorted.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "source",
+      "name": "Source",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Source.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sources",
+      "name": "Sources",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sources.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "space",
+      "name": "Space",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Space.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "spaces",
+      "name": "Spaces",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Spaces.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "spatial",
+      "name": "Spatial",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Spatial.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "spawn",
+      "name": "Spawn",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Spawn.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "spec",
+      "name": "Spec",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Spec.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "specialized",
+      "name": "Specialized",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Specialized.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "specific",
+      "name": "Specific",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Specific.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "specification",
+      "name": "Specification",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Specification.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "specifications",
+      "name": "Specifications",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Specifications.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "specified",
+      "name": "Specified",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Specified.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "speech",
+      "name": "Speech",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Speech.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "split",
+      "name": "Split",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Split.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "splitlines",
+      "name": "Splitlines",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Splitlines.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "splitter",
+      "name": "Splitter",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Splitter.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "spoken",
+      "name": "Spoken",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Spoken.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sqrt",
+      "name": "Sqrt",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sqrt.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "src",
+      "name": "Src",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Src.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stack",
+      "name": "Stack",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stack.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "standard",
+      "name": "Standard",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Standard.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stars",
+      "name": "Stars",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stars.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "start",
+      "name": "Start",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Start.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "startswith",
+      "name": "Startswith",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Startswith.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "state",
+      "name": "State",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: State.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "static",
+      "name": "Static",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Static.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "statistical",
+      "name": "Statistical",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Statistical.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "statistics",
+      "name": "Statistics",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Statistics.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stats",
+      "name": "Stats",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stats.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "status",
+      "name": "Status",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Status.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stderr",
+      "name": "Stderr",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stderr.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stdio",
+      "name": "Stdio",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stdio.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stdout",
+      "name": "Stdout",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stdout.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stem",
+      "name": "Stem",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stem.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "step-by-step",
+      "name": "Step-by-step",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Step-by-step.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "steps",
+      "name": "Steps",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Steps.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "still",
+      "name": "Still",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Still.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "store",
+      "name": "Store",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Store.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "str",
+      "name": "Str",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Str.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "strategies",
+      "name": "Strategies",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Strategies.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "strftime",
+      "name": "Strftime",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Strftime.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "strict",
+      "name": "Strict",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Strict.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "string",
+      "name": "String",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: String.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stringify",
+      "name": "Stringify",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stringify.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "strings",
+      "name": "Strings",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Strings.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "strip",
+      "name": "Strip",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Strip.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stripped",
+      "name": "Stripped",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stripped.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stripping",
+      "name": "Stripping",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stripping.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "structure",
+      "name": "Structure",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Structure.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "structured",
+      "name": "Structured",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Structured.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "structures",
+      "name": "Structures",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Structures.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stub",
+      "name": "Stub",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stub.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stubs",
+      "name": "Stubs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stubs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "style",
+      "name": "Style",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Style.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stylized",
+      "name": "Stylized",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stylized.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sub",
+      "name": "Sub",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sub.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sub-agent",
+      "name": "Sub-agent",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sub-agent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sub-tasks",
+      "name": "Sub-tasks",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sub-tasks.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "submits",
+      "name": "Submits",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Submits.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "subparsers",
+      "name": "Subparsers",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Subparsers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "subprocess",
+      "name": "Subprocess",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Subprocess.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "success",
+      "name": "Success",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Success.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "such",
+      "name": "Such",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Such.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "suggest",
+      "name": "Suggest",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Suggest.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "suggestions",
+      "name": "Suggestions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Suggestions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "suitable",
+      "name": "Suitable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Suitable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "suite",
+      "name": "Suite",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Suite.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "suites",
+      "name": "Suites",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Suites.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sum",
+      "name": "Sum",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sum.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "summaries",
+      "name": "Summaries",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Summaries.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "summarization",
+      "name": "Summarization",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Summarization.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "summarizer",
+      "name": "Summarizer",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Summarizer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "summarizes",
+      "name": "Summarizes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Summarizes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "summary",
+      "name": "Summary",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Summary.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "supervision",
+      "name": "Supervision",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Supervision.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "supporting",
+      "name": "Supporting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Supporting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sure",
+      "name": "Sure",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sure.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "surpasses",
+      "name": "Surpasses",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Surpasses.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "survey",
+      "name": "Survey",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Survey.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "svn",
+      "name": "Svn",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Svn.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "symbol",
+      "name": "Symbol",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Symbol.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "symbolic",
+      "name": "Symbolic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Symbolic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "symlink",
+      "name": "Symlink",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Symlink.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sync",
+      "name": "Sync",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sync.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "synergy",
+      "name": "Synergy",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Synergy.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "syntactically",
+      "name": "Syntactically",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Syntactically.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "synthesis",
+      "name": "Synthesis",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Synthesis.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "synthesising",
+      "name": "Synthesising",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Synthesising.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "synthesizes",
+      "name": "Synthesizes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Synthesizes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sys",
+      "name": "Sys",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sys.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "system",
+      "name": "System",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: System.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "systematic",
+      "name": "Systematic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Systematic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tables",
+      "name": "Tables",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tables.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tags",
+      "name": "Tags",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tags.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tail",
+      "name": "Tail",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tail.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tarball",
+      "name": "Tarball",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tarball.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "target",
+      "name": "Target",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Target.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "task",
+      "name": "Task",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Task.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tasks",
+      "name": "Tasks",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tasks.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "taxonomy",
+      "name": "Taxonomy",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Taxonomy.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "teaching",
+      "name": "Teaching",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Teaching.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "template",
+      "name": "Template",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Template.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "terminal",
+      "name": "Terminal",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Terminal.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "test",
+      "name": "Test",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Test.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "testable",
+      "name": "Testable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Testable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "testing",
+      "name": "Testing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Testing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tests",
+      "name": "Tests",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tests.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "text",
+      "name": "Text",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Text.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "text-based",
+      "name": "Text-based",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Text-based.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "text-classification",
+      "name": "Text-classification",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Text-classification.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "text-generation",
+      "name": "Text-generation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Text-generation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "text-to",
+      "name": "Text-to",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Text-to.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "text2text-generation",
+      "name": "Text2text-generation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Text2text-generation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "texts",
+      "name": "Texts",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Texts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tgz",
+      "name": "Tgz",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tgz.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "than",
+      "name": "Than",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Than.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "them",
+      "name": "Them",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Them.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "then",
+      "name": "Then",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Then.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "these",
+      "name": "These",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: These.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "this",
+      "name": "This",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: This.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "threshold",
+      "name": "Threshold",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Threshold.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "thresholds",
+      "name": "Thresholds",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Thresholds.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "through",
+      "name": "Through",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Through.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "throughput",
+      "name": "Throughput",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Throughput.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "throw",
+      "name": "Throw",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Throw.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tier",
+      "name": "Tier",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tier.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "time",
+      "name": "Time",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Time.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "timed",
+      "name": "Timed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Timed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "timeout",
+      "name": "Timeout",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Timeout.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "timestamp",
+      "name": "Timestamp",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Timestamp.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "timezone",
+      "name": "Timezone",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Timezone.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "title",
+      "name": "Title",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Title.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tmpdir",
+      "name": "Tmpdir",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tmpdir.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "to-end",
+      "name": "To-end",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: To-end.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "to-markdown",
+      "name": "To-markdown",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: To-markdown.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "today",
+      "name": "Today",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Today.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "token",
+      "name": "Token",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Token.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "token-classification",
+      "name": "Token-classification",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Token-classification.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tokenization",
+      "name": "Tokenization",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tokenization.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tokenizer",
+      "name": "Tokenizer",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tokenizer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "tokens",
+      "name": "Tokens",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tokens.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tolist",
+      "name": "Tolist",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tolist.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tone",
+      "name": "Tone",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tone.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tool",
+      "name": "Tool",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tool.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tools",
+      "name": "Tools",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tools.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "top",
+      "name": "Top",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Top.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "top-k",
+      "name": "Top-k",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Top-k.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "top-level",
+      "name": "Top-level",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Top-level.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "topic",
+      "name": "Topic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Topic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "total",
+      "name": "Total",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Total.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "traces",
+      "name": "Traces",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Traces.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "training",
+      "name": "Training",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Training.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "transcribes",
+      "name": "Transcribes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Transcribes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "transformer",
+      "name": "Transformer",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Transformer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "translation",
+      "name": "Translation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Translation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "treat",
+      "name": "Treat",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Treat.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "tree",
+      "name": "Tree",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tree.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "trees",
+      "name": "Trees",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Trees.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "trim",
+      "name": "Trim",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Trim.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "true",
+      "name": "True",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: True.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "try",
+      "name": "Try",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Try.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tsc",
+      "name": "Tsc",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tsc.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tsserver",
+      "name": "Tsserver",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tsserver.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tuple",
+      "name": "Tuple",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tuple.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tuples",
+      "name": "Tuples",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tuples.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "turbo",
+      "name": "Turbo",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Turbo.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "turns",
+      "name": "Turns",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Turns.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "two",
+      "name": "Two",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Two.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "two-pass",
+      "name": "Two-pass",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Two-pass.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "type",
+      "name": "Type",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Type.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "typed",
+      "name": "Typed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Typed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "types",
+      "name": "Types",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Types.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "typescript",
+      "name": "Typescript",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Typescript.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "typescript-5",
+      "name": "Typescript-5",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Typescript-5.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "typing",
+      "name": "Typing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Typing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ubuntu-latest",
+      "name": "Ubuntu-latest",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ubuntu-latest.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unanswerable",
+      "name": "Unanswerable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unanswerable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unbounded",
+      "name": "Unbounded",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unbounded.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "uncommon",
+      "name": "Uncommon",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Uncommon.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "under",
+      "name": "Under",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Under.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "undici-types",
+      "name": "Undici-types",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Undici-types.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "undici-types-6",
+      "name": "Undici-types-6",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Undici-types-6.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unified",
+      "name": "Unified",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unified.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "uninstall",
+      "name": "Uninstall",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Uninstall.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "union",
+      "name": "Union",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Union.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unique",
+      "name": "Unique",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unique.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "uniqueness",
+      "name": "Uniqueness",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Uniqueness.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unit",
+      "name": "Unit",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unknown",
+      "name": "Unknown",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unknown.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unlikely",
+      "name": "Unlikely",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unlikely.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unlock",
+      "name": "Unlock",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unlock.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unlocked",
+      "name": "Unlocked",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unlocked.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unlocks",
+      "name": "Unlocks",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unlocks.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unstructured",
+      "name": "Unstructured",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unstructured.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "until",
+      "name": "Until",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Until.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "update",
+      "name": "Update",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Update.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "update-tree",
+      "name": "Update-tree",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Update-tree.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "updated",
+      "name": "Updated",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Updated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "updates",
+      "name": "Updates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Updates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "upper",
+      "name": "Upper",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Upper.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "uppercase",
+      "name": "Uppercase",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Uppercase.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "url",
+      "name": "Url",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Url.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "urllib",
+      "name": "Urllib",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Urllib.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "urlopen",
+      "name": "Urlopen",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Urlopen.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "usable",
+      "name": "Usable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Usable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "usage",
+      "name": "Usage",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Usage.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "use",
+      "name": "Use",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Use.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "used",
+      "name": "Used",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Used.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "useful",
+      "name": "Useful",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Useful.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "user",
+      "name": "User",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: User.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "username",
+      "name": "Username",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Username.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "users",
+      "name": "Users",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Users.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "users-dir",
+      "name": "Users-dir",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Users-dir.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "uses",
+      "name": "Uses",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Uses.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "using",
+      "name": "Using",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Using.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "usr",
+      "name": "Usr",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Usr.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "usually",
+      "name": "Usually",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Usually.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "utc",
+      "name": "Utc",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Utc.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "utf-8",
+      "name": "Utf-8",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Utf-8.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "utf8",
+      "name": "Utf8",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Utf8.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "util",
+      "name": "Util",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Util.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "utilities",
+      "name": "Utilities",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Utilities.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "valence",
+      "name": "Valence",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Valence.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "valid",
+      "name": "Valid",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Valid.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "validate",
+      "name": "Validate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Validate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "validated",
+      "name": "Validated",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Validated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "validates",
+      "name": "Validates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Validates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "validation",
+      "name": "Validation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Validation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "value",
+      "name": "Value",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Value.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "values",
+      "name": "Values",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Values.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "variables",
+      "name": "Variables",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Variables.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "vector",
+      "name": "Vector",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Vector.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "vectors",
+      "name": "Vectors",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Vectors.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "vendor",
+      "name": "Vendor",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Vendor.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "venv",
+      "name": "Venv",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Venv.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "verified",
+      "name": "Verified",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Verified.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "verify",
+      "name": "Verify",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Verify.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "verifying",
+      "name": "Verifying",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Verifying.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "version",
+      "name": "Version",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Version.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "versions",
+      "name": "Versions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Versions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "via",
+      "name": "Via",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Via.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "virtual",
+      "name": "Virtual",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Virtual.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "vision",
+      "name": "Vision",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Vision.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "vision-language",
+      "name": "Vision-language",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Vision-language.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "visual",
+      "name": "Visual",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Visual.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "visualization",
+      "name": "Visualization",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Visualization.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "visualizations",
+      "name": "Visualizations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Visualizations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "visualstudio",
+      "name": "Visualstudio",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Visualstudio.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "voice",
+      "name": "Voice",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Voice.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "vscode",
+      "name": "Vscode",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Vscode.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "vscode-marketplace",
+      "name": "Vscode-marketplace",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Vscode-marketplace.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "walk",
+      "name": "Walk",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Walk.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "want",
+      "name": "Want",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Want.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "warnings",
+      "name": "Warnings",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Warnings.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "weak",
+      "name": "Weak",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Weak.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "web",
+      "name": "Web",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Web.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "web-arena-x",
+      "name": "Web-arena-x",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Web-arena-x.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "webarena",
+      "name": "Webarena",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Webarena.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "webp",
+      "name": "Webp",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Webp.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "websites",
+      "name": "Websites",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Websites.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "well-formed",
+      "name": "Well-formed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Well-formed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "wet-lab",
+      "name": "Wet-lab",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Wet-lab.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "what",
+      "name": "What",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: What.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "when",
+      "name": "When",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: When.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "whenever",
+      "name": "Whenever",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Whenever.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "where",
+      "name": "Where",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Where.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "which",
+      "name": "Which",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Which.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "while",
+      "name": "While",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: While.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "whisper",
+      "name": "Whisper",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Whisper.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "width",
+      "name": "Width",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Width.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "will",
+      "name": "Will",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Will.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "win32",
+      "name": "Win32",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Win32.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "window",
+      "name": "Window",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Window.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "within",
+      "name": "Within",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Within.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "without",
+      "name": "Without",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Without.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "words",
+      "name": "Words",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Words.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "workflows",
+      "name": "Workflows",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Workflows.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "wrapper",
+      "name": "Wrapper",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Wrapper.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "write",
+      "name": "Write",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Write.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "writes",
+      "name": "Writes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Writes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "writing",
+      "name": "Writing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Writing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "written",
+      "name": "Written",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Written.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "www",
+      "name": "Www",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Www.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "xlang-ai",
+      "name": "Xlang-ai",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Xlang-ai.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "xml",
+      "name": "Xml",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Xml.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "xmlns",
+      "name": "Xmlns",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Xmlns.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "yaml",
+      "name": "Yaml",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Yaml.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "yes",
+      "name": "Yes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Yes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "yet",
+      "name": "Yet",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Yet.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "yml",
+      "name": "Yml",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Yml.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "you",
+      "name": "You",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: You.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "your",
+      "name": "Your",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Your.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "your-github-username",
+      "name": "Your-github-username",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Your-github-username.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ysymyth",
+      "name": "Ysymyth",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ysymyth.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "zero-config",
+      "name": "Zero-config",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Zero-config.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "zero-shot",
+      "name": "Zero-shot",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Zero-shot.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "zero-shot-classification",
+      "name": "Zero-shot-classification",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Zero-shot-classification.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "zip",
+      "name": "Zip",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Zip.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    }
+  ],
+  "similarity": [
+    {
+      "sourceSkillId": "abductive",
+      "targetSkillId": "retrieve",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "absolute",
+      "targetSkillId": "translate",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "absolute",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "abspath",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accents",
+      "targetSkillId": "extract-entities",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accents",
+      "targetSkillId": "chunk-document",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accepted",
+      "targetSkillId": "parse-pdf",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accidentally",
+      "targetSkillId": "document-analyst",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accidentally",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accidentally",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accurate",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accurate",
+      "targetSkillId": "image-generate",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "achieves",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "achieves",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "achieving",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "achieving",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "acting",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "acting",
+      "targetSkillId": "image-caption",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "action",
+      "targetSkillId": "image-caption",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "action",
+      "targetSkillId": "code-execution",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "action",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "actions",
+      "targetSkillId": "image-caption",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "actions",
+      "targetSkillId": "code-execution",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "actions",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "actual",
+      "targetSkillId": "api-call",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "actual",
+      "targetSkillId": "data-visualize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "adapting",
+      "targetSkillId": "image-caption",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "adapting",
+      "targetSkillId": "automated-testing",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "additions",
+      "targetSkillId": "document-digitization",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "additions",
+      "targetSkillId": "image-caption",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "advancement",
+      "targetSkillId": "audience-model",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "advancement",
+      "targetSkillId": "voice-agent",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "advancement",
+      "targetSkillId": "chunk-document",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "against",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "against",
+      "targetSkillId": "image-caption",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agent",
+      "targetSkillId": "voice-agent",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agent",
+      "targetSkillId": "image-generate",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agent",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agent-native",
+      "targetSkillId": "image-caption",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agent-native",
+      "targetSkillId": "image-generate",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agent-native",
+      "targetSkillId": "multi-agent-orchestration-v",
+      "score": 0.513,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agent-related",
+      "targetSkillId": "image-generate",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agent-related",
+      "targetSkillId": "generate-sql",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agent-related",
+      "targetSkillId": "translate",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agents",
+      "targetSkillId": "voice-agent",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agents",
+      "targetSkillId": "generate-sql",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agents",
+      "targetSkillId": "generate-test",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ahead",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ai-agent",
+      "targetSkillId": "voice-agent",
+      "score": 0.737,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ai-agent",
+      "targetSkillId": "conversational-agent",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ai-agent",
+      "targetSkillId": "image-generate",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ai-agent-tool",
+      "targetSkillId": "voice-agent",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ai-agent-tool",
+      "targetSkillId": "audience-model",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ai-agent-tool",
+      "targetSkillId": "multi-agent-orchestration-v",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "algebra",
+      "targetSkillId": "image-generate",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "algebra",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "alive",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "alive",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "all",
+      "targetSkillId": "api-call",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "allocation",
+      "targetSkillId": "image-caption",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "allocation",
+      "targetSkillId": "code-execution",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "allocation",
+      "targetSkillId": "browser-automation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "analyses",
+      "targetSkillId": "data-analysis",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "analyses",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "analyses",
+      "targetSkillId": "document-analyst",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "analysis",
+      "targetSkillId": "data-analysis",
+      "score": 0.762,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "analysis",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "analysis",
+      "targetSkillId": "document-analyst",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "anomaly",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "anomaly",
+      "targetSkillId": "data-analysis",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "another",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "answer",
+      "targetSkillId": "question-answer",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "answer",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "answers",
+      "targetSkillId": "question-answer",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "answers",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "any",
+      "targetSkillId": "rank",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "api",
+      "targetSkillId": "api-call",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "api-version",
+      "targetSkillId": "math-reason",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "api-version",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "api-version",
+      "targetSkillId": "parse-json",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "appears",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "appears",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "appears",
+      "targetSkillId": "parse-html",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "append",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "application",
+      "targetSkillId": "api-call",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "application",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "application",
+      "targetSkillId": "registry-curation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "apply",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "apply",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "approach",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "appropriate",
+      "targetSkillId": "ghostwrite",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "approval",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "archived",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "archived",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "archived",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "argparse",
+      "targetSkillId": "parse-pdf",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "argparse",
+      "targetSkillId": "parse-json",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "argparse",
+      "targetSkillId": "parse-html",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "args",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "arguments",
+      "targetSkillId": "voice-agent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "arguments",
+      "targetSkillId": "document-analyst",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "arguments",
+      "targetSkillId": "route-intent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "arithmetic",
+      "targetSkillId": "write-report",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "arithmetic",
+      "targetSkillId": "route-intent",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "arrays",
+      "targetSkillId": "math-reason",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "arriving",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "artifact",
+      "targetSkillId": "refactor-code",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "artifacts",
+      "targetSkillId": "refactor-code",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "arxiv",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "assembles",
+      "targetSkillId": "parse-html",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "assert",
+      "targetSkillId": "parse-html",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "assistant",
+      "targetSkillId": "real-time-voice-assistant",
+      "score": 0.529,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "assistant",
+      "targetSkillId": "classify",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "assistants",
+      "targetSkillId": "real-time-voice-assistant",
+      "score": 0.514,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "async",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attribute",
+      "targetSkillId": "ghostwrite",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attribute",
+      "targetSkillId": "retrieve",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attributes",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attributes",
+      "targetSkillId": "math-reason",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attributes",
+      "targetSkillId": "extract-entities",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attvalue",
+      "targetSkillId": "data-visualize",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attvalue",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attvalues",
+      "targetSkillId": "data-visualize",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attvalues",
+      "targetSkillId": "tool-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attvalues",
+      "targetSkillId": "generate-test",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "audience",
+      "targetSkillId": "audience-model",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "audience",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "audience",
+      "targetSkillId": "logical-inference",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "audience-tailored",
+      "targetSkillId": "audience-model",
+      "score": 0.645,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "audio",
+      "targetSkillId": "audience-model",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "augmented",
+      "targetSkillId": "image-generate",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "augmented",
+      "targetSkillId": "audience-model",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "augmented",
+      "targetSkillId": "voice-agent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "authenticated",
+      "targetSkillId": "extract-entities",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "authenticated",
+      "targetSkillId": "audience-model",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "authenticated",
+      "targetSkillId": "tokenize",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "author",
+      "targetSkillId": "math-reason",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "authoritative",
+      "targetSkillId": "ghostwrite",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "authoritative",
+      "targetSkillId": "retrieve",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "authoritative",
+      "targetSkillId": "automated-testing",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "auto-generated",
+      "targetSkillId": "image-generate",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "auto-generated",
+      "targetSkillId": "code-generation",
+      "score": 0.621,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "auto-generated",
+      "targetSkillId": "generate-sql",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "auto-prompt-combinations",
+      "targetSkillId": "autonomous-data-scientist",
+      "score": 0.49,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "auto-prompt-combinations",
+      "targetSkillId": "browser-automation",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autogen",
+      "targetSkillId": "tokenize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "automated",
+      "targetSkillId": "automated-testing",
+      "score": 0.692,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "automated",
+      "targetSkillId": "browser-automation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "automated",
+      "targetSkillId": "autonomous-debug",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "automatic",
+      "targetSkillId": "automated-testing",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "automatic",
+      "targetSkillId": "browser-automation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "automatic",
+      "targetSkillId": "autonomous-data-scientist",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "automatically",
+      "targetSkillId": "api-call",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "automatically",
+      "targetSkillId": "automated-testing",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "automatically",
+      "targetSkillId": "browser-automation",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autonomous",
+      "targetSkillId": "autonomous-debug",
+      "score": 0.769,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autonomous",
+      "targetSkillId": "autonomous-research-agent",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autonomous",
+      "targetSkillId": "autonomous-data-scientist",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autonomously",
+      "targetSkillId": "autonomous-debug",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autonomously",
+      "targetSkillId": "autonomous-research-agent",
+      "score": 0.541,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autonomously",
+      "targetSkillId": "autonomous-data-scientist",
+      "score": 0.541,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autoregressive",
+      "targetSkillId": "retrieve",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autoregressive",
+      "targetSkillId": "automated-testing",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autoregressive",
+      "targetSkillId": "score-relevance",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autoresearch",
+      "targetSkillId": "research",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autoresearch",
+      "targetSkillId": "autonomous-research-agent",
+      "score": 0.649,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autoresearch",
+      "targetSkillId": "web-search",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "available",
+      "targetSkillId": "api-call",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "awakened",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "awakened",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "awareness",
+      "targetSkillId": "data-analysis",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "back",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "based",
+      "targetSkillId": "parse-pdf",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "baseline",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "baseline",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "baseline",
+      "targetSkillId": "self-critique",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "baselines",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "baselines",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "baselines",
+      "targetSkillId": "self-critique",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "bash",
+      "targetSkillId": "execute-bash",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "batch",
+      "targetSkillId": "web-search",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "batch",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "batched",
+      "targetSkillId": "web-search",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "batches",
+      "targetSkillId": "math-reason",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "batches",
+      "targetSkillId": "web-search",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "becomes",
+      "targetSkillId": "computer-use",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "becomes",
+      "targetSkillId": "plan-decompose",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "before",
+      "targetSkillId": "refactor-code",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "bench",
+      "targetSkillId": "web-search",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "bench",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "between",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "between",
+      "targetSkillId": "embed-text",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "bool",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "boolean",
+      "targetSkillId": "tool-use",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "boolean",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "booleans",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "bootstrapped",
+      "targetSkillId": "web-scrape",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "bootstrapped",
+      "targetSkillId": "ghostwrite",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "branch",
+      "targetSkillId": "rank",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "branch",
+      "targetSkillId": "research",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "branch",
+      "targetSkillId": "web-search",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "break",
+      "targetSkillId": "rank",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "break",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "broken",
+      "targetSkillId": "tokenize",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "browsers",
+      "targetSkillId": "browser-automation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "browsers",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "bytecode",
+      "targetSkillId": "refactor-code",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "bytecode",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cache",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "calculus",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "call",
+      "targetSkillId": "api-call",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "calling",
+      "targetSkillId": "api-call",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "calling",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "calls",
+      "targetSkillId": "api-call",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "calls",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "can",
+      "targetSkillId": "rank",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "candidate",
+      "targetSkillId": "translate",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "candidates",
+      "targetSkillId": "translate",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "candidates",
+      "targetSkillId": "extract-entities",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "candidates",
+      "targetSkillId": "generate-sql",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cannot",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cannot",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "canonical",
+      "targetSkillId": "api-call",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "canonical",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "capability",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "capitalize",
+      "targetSkillId": "data-visualize",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "capitalize",
+      "targetSkillId": "api-call",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "capitalize",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "caps",
+      "targetSkillId": "classify",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "captures",
+      "targetSkillId": "cite-sources",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "captures",
+      "targetSkillId": "math-reason",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "captures",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "capturing",
+      "targetSkillId": "image-caption",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "capturing",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.457,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "case",
+      "targetSkillId": "classify",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "case",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "case",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cases",
+      "targetSkillId": "classify",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cases",
+      "targetSkillId": "parse-json",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cases",
+      "targetSkillId": "cite-sources",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "catch",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "catches",
+      "targetSkillId": "math-reason",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "catches",
+      "targetSkillId": "cite-sources",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "categorical",
+      "targetSkillId": "api-call",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "categorical",
+      "targetSkillId": "cite-sources",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "categories",
+      "targetSkillId": "cite-sources",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "categories",
+      "targetSkillId": "extract-entities",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "categories",
+      "targetSkillId": "computer-use",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "categorization",
+      "targetSkillId": "content-moderation",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "categorization",
+      "targetSkillId": "code-generation",
+      "score": 0.621,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "categorization",
+      "targetSkillId": "document-digitization",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "category",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "caught",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "caught",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "causes",
+      "targetSkillId": "classify",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "causes",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "chain",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "chain",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "chain-of-thought-hub",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.889,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "chain-of-thought-only",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.865,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "chains",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "change",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "change",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "changing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "changing",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "checkout",
+      "targetSkillId": "code-execution",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "chemistry",
+      "targetSkillId": "registry-curation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "children",
+      "targetSkillId": "chunk-document",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "chunk",
+      "targetSkillId": "chunk-document",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "chunking",
+      "targetSkillId": "chunk-document",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "citation",
+      "targetSkillId": "image-caption",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "citation",
+      "targetSkillId": "document-digitization",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "citation",
+      "targetSkillId": "content-moderation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "citations",
+      "targetSkillId": "image-caption",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "citations",
+      "targetSkillId": "document-digitization",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "citations",
+      "targetSkillId": "content-moderation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "claims",
+      "targetSkillId": "classify",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "clarity",
+      "targetSkillId": "classify",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "class",
+      "targetSkillId": "classify",
+      "score": 0.769,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "classification",
+      "targetSkillId": "classify",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "classification",
+      "targetSkillId": "image-caption",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "classification",
+      "targetSkillId": "document-digitization",
+      "score": 0.457,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "classifier",
+      "targetSkillId": "classify",
+      "score": 0.778,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cleaned",
+      "targetSkillId": "score-relevance",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cli",
+      "targetSkillId": "classify",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "click",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "clone",
+      "targetSkillId": "diff-content",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "clone",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cloning",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "closing",
+      "targetSkillId": "classify",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "closing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "clustering",
+      "targetSkillId": "route-intent",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "clustering",
+      "targetSkillId": "computer-use",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "co-references",
+      "targetSkillId": "score-relevance",
+      "score": 0.643,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "co-references",
+      "targetSkillId": "logical-inference",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "co-references",
+      "targetSkillId": "code-review-pipeline",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "code",
+      "targetSkillId": "refactor-code",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "codec",
+      "targetSkillId": "code-execution",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "codegen",
+      "targetSkillId": "code-generation",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "codegen",
+      "targetSkillId": "code-execution",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "codegen",
+      "targetSkillId": "voice-agent",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "codes",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "codes",
+      "targetSkillId": "cite-sources",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "coherent",
+      "targetSkillId": "voice-agent",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "coherent",
+      "targetSkillId": "route-intent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "coherent",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "collections",
+      "targetSkillId": "code-execution",
+      "score": 0.64,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "collections",
+      "targetSkillId": "tool-select",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "collections",
+      "targetSkillId": "code-generation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combination",
+      "targetSkillId": "code-generation",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combination",
+      "targetSkillId": "content-moderation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combination",
+      "targetSkillId": "error-interpretation",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combinations",
+      "targetSkillId": "code-generation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combinations",
+      "targetSkillId": "content-moderation",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combinations",
+      "targetSkillId": "error-interpretation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combinator",
+      "targetSkillId": "code-generation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combinator",
+      "targetSkillId": "computer-use",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combining",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combos",
+      "targetSkillId": "plan-decompose",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comment",
+      "targetSkillId": "chunk-document",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comment",
+      "targetSkillId": "diff-content",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comment",
+      "targetSkillId": "code-generation",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "community",
+      "targetSkillId": "computer-use",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comparisons",
+      "targetSkillId": "parse-json",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comparisons",
+      "targetSkillId": "math-reason",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comparisons",
+      "targetSkillId": "computer-use",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "compatible",
+      "targetSkillId": "computer-use",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "compatible",
+      "targetSkillId": "conversational-agent",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "competition",
+      "targetSkillId": "document-digitization",
+      "score": 0.562,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "competition",
+      "targetSkillId": "code-execution",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "competition",
+      "targetSkillId": "content-moderation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "compile",
+      "targetSkillId": "computer-use",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "compile",
+      "targetSkillId": "plan-decompose",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "complete",
+      "targetSkillId": "computer-use",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "complete",
+      "targetSkillId": "plan-decompose",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "complete",
+      "targetSkillId": "chunk-document",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "completes",
+      "targetSkillId": "computer-use",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "completes",
+      "targetSkillId": "automated-testing",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "completing",
+      "targetSkillId": "automated-testing",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "completing",
+      "targetSkillId": "content-moderation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "completing",
+      "targetSkillId": "code-execution",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "completion",
+      "targetSkillId": "code-execution",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "completion",
+      "targetSkillId": "content-moderation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "completion",
+      "targetSkillId": "code-generation",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "complex",
+      "targetSkillId": "computer-use",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "complex",
+      "targetSkillId": "plan-decompose",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "complexity",
+      "targetSkillId": "computer-use",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "composite",
+      "targetSkillId": "plan-decompose",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "composite",
+      "targetSkillId": "computer-use",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "composite",
+      "targetSkillId": "ghostwrite",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "composites",
+      "targetSkillId": "computer-use",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "composites",
+      "targetSkillId": "plan-decompose",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "composites",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comprehension",
+      "targetSkillId": "code-generation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comprehension",
+      "targetSkillId": "parse-json",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comprehension",
+      "targetSkillId": "code-execution",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comprehensive",
+      "targetSkillId": "score-relevance",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comprehensive",
+      "targetSkillId": "computer-use",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comprehensive",
+      "targetSkillId": "tokenize",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "computation",
+      "targetSkillId": "code-execution",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "computation",
+      "targetSkillId": "content-moderation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "computation",
+      "targetSkillId": "code-generation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "compute",
+      "targetSkillId": "computer-use",
+      "score": 0.737,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "compute",
+      "targetSkillId": "format-output",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "compute",
+      "targetSkillId": "plan-decompose",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "computer",
+      "targetSkillId": "computer-use",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "computer",
+      "targetSkillId": "format-output",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "computer",
+      "targetSkillId": "plan-decompose",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "computes",
+      "targetSkillId": "computer-use",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "computes",
+      "targetSkillId": "execute-bash",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "computes",
+      "targetSkillId": "format-output",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conclusions",
+      "targetSkillId": "code-execution",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conclusions",
+      "targetSkillId": "question-answer",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conclusions",
+      "targetSkillId": "code-generation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "condition",
+      "targetSkillId": "code-execution",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "condition",
+      "targetSkillId": "content-moderation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "condition",
+      "targetSkillId": "code-generation",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conditions",
+      "targetSkillId": "code-execution",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conditions",
+      "targetSkillId": "content-moderation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conditions",
+      "targetSkillId": "code-generation",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conducts",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conducts",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "config",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "configuration",
+      "targetSkillId": "code-generation",
+      "score": 0.643,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "configuration",
+      "targetSkillId": "content-moderation",
+      "score": 0.581,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "configuration",
+      "targetSkillId": "conversational-agent",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "configured",
+      "targetSkillId": "computer-use",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "configured",
+      "targetSkillId": "cite-sources",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "confirmed",
+      "targetSkillId": "tokenize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "connector",
+      "targetSkillId": "code-execution",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "connector",
+      "targetSkillId": "content-moderation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "connector",
+      "targetSkillId": "code-generation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "consecutive",
+      "targetSkillId": "code-execution",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "consecutive",
+      "targetSkillId": "retrieve",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "consecutive",
+      "targetSkillId": "self-critique",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "console",
+      "targetSkillId": "tool-use",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "console",
+      "targetSkillId": "conversational-agent",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "console",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "const",
+      "targetSkillId": "diff-content",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "constrained",
+      "targetSkillId": "ghostwrite",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "constrained",
+      "targetSkillId": "content-moderation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "constrained",
+      "targetSkillId": "code-generation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "constraints",
+      "targetSkillId": "ghostwrite",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "constraints",
+      "targetSkillId": "content-moderation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "constraints",
+      "targetSkillId": "code-generation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "construction",
+      "targetSkillId": "knowledge-graph-build",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "construction",
+      "targetSkillId": "content-moderation",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "construction",
+      "targetSkillId": "code-generation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contain",
+      "targetSkillId": "content-moderation",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contain",
+      "targetSkillId": "code-generation",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contain",
+      "targetSkillId": "diff-content",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "containing",
+      "targetSkillId": "content-moderation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "containing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "containing",
+      "targetSkillId": "code-generation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "content",
+      "targetSkillId": "diff-content",
+      "score": 0.737,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "content",
+      "targetSkillId": "route-intent",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "content",
+      "targetSkillId": "content-moderation",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "context",
+      "targetSkillId": "diff-content",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "context",
+      "targetSkillId": "speech-to-text",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "context",
+      "targetSkillId": "route-intent",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "context-grounded",
+      "targetSkillId": "content-moderation",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "context-grounded",
+      "targetSkillId": "code-generation",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "context-grounded",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contextually",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contextually",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contextually",
+      "targetSkillId": "content-moderation",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "continuation",
+      "targetSkillId": "content-moderation",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "continuation",
+      "targetSkillId": "code-generation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "continuation",
+      "targetSkillId": "document-digitization",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "continue",
+      "targetSkillId": "code-generation",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "continue",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "continue",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contributor",
+      "targetSkillId": "content-moderation",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contributor",
+      "targetSkillId": "ghostwrite",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contributor",
+      "targetSkillId": "code-generation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "control",
+      "targetSkillId": "content-moderation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "control",
+      "targetSkillId": "code-generation",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "controlled",
+      "targetSkillId": "tool-select",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "controlled",
+      "targetSkillId": "conversational-agent",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "controlled",
+      "targetSkillId": "diff-content",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "convention",
+      "targetSkillId": "content-moderation",
+      "score": 0.643,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "convention",
+      "targetSkillId": "code-generation",
+      "score": 0.64,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "convention",
+      "targetSkillId": "conversational-agent",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conversation",
+      "targetSkillId": "conversational-agent",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conversation",
+      "targetSkillId": "code-generation",
+      "score": 0.741,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conversation",
+      "targetSkillId": "content-moderation",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conversational",
+      "targetSkillId": "conversational-agent",
+      "score": 0.824,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conversational",
+      "targetSkillId": "code-generation",
+      "score": 0.69,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conversational",
+      "targetSkillId": "content-moderation",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conversations",
+      "targetSkillId": "conversational-agent",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conversations",
+      "targetSkillId": "code-generation",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conversations",
+      "targetSkillId": "content-moderation",
+      "score": 0.645,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "convert",
+      "targetSkillId": "code-generation",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "convert",
+      "targetSkillId": "diff-content",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "convert",
+      "targetSkillId": "conversational-agent",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "core",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "core",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "corpora",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "corpus",
+      "targetSkillId": "computer-use",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "correct",
+      "targetSkillId": "score-relevance",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "correct",
+      "targetSkillId": "code-execution",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "correctness",
+      "targetSkillId": "score-relevance",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "correctness",
+      "targetSkillId": "cite-sources",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "correctness",
+      "targetSkillId": "code-execution",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cosine",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cosine",
+      "targetSkillId": "conversational-agent",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "count",
+      "targetSkillId": "route-intent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "count",
+      "targetSkillId": "diff-content",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "count",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "coupling",
+      "targetSkillId": "code-execution",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "coverage",
+      "targetSkillId": "conversational-agent",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "coverage",
+      "targetSkillId": "voice-agent",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "coverage",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "covering",
+      "targetSkillId": "conversational-agent",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "covering",
+      "targetSkillId": "code-generation",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "covering",
+      "targetSkillId": "content-moderation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "crawl",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "crawler",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "crawler",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "crawlers",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "crawling",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "crawling",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "crawling",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "create",
+      "targetSkillId": "retrieve",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "create",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "create",
+      "targetSkillId": "refactor-code",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "created",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "created",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "created",
+      "targetSkillId": "refactor-code",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "creating",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "creating",
+      "targetSkillId": "code-generation",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "creating",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "creation",
+      "targetSkillId": "code-generation",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "creation",
+      "targetSkillId": "image-caption",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "creation",
+      "targetSkillId": "registry-curation",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "creator",
+      "targetSkillId": "refactor-code",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "creator",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "creator",
+      "targetSkillId": "research",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "criteria",
+      "targetSkillId": "write-report",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "criteria",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "criteria",
+      "targetSkillId": "self-critique",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cross-domain",
+      "targetSkillId": "browser-automation",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cross-domain",
+      "targetSkillId": "chunk-document",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "curation",
+      "targetSkillId": "registry-curation",
+      "score": 0.64,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "curation",
+      "targetSkillId": "code-generation",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "curation",
+      "targetSkillId": "image-caption",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "current",
+      "targetSkillId": "chunk-document",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "data",
+      "targetSkillId": "data-analysis",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dataclass",
+      "targetSkillId": "data-analysis",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dataclass",
+      "targetSkillId": "classify",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dataclasses",
+      "targetSkillId": "data-analysis",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dataclasses",
+      "targetSkillId": "classify",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dataclasses",
+      "targetSkillId": "data-visualize",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dataset",
+      "targetSkillId": "data-visualize",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dataset",
+      "targetSkillId": "data-analysis",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dataset",
+      "targetSkillId": "parse-html",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "datasets",
+      "targetSkillId": "data-analysis",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "datasets",
+      "targetSkillId": "data-visualize",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "datasets",
+      "targetSkillId": "autonomous-data-scientist",
+      "score": 0.485,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "date",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dates",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dates",
+      "targetSkillId": "generate-sql",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "datetime",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "datetime",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "datetime",
+      "targetSkillId": "extract-entities",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "days",
+      "targetSkillId": "data-analysis",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decay",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decay",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "declaration",
+      "targetSkillId": "code-generation",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "declaration",
+      "targetSkillId": "image-caption",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "declaration",
+      "targetSkillId": "registry-curation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decoding",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decoding",
+      "targetSkillId": "code-execution",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decomposed",
+      "targetSkillId": "plan-decompose",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decomposed",
+      "targetSkillId": "computer-use",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decomposition",
+      "targetSkillId": "plan-decompose",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decomposition",
+      "targetSkillId": "image-caption",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decomposition",
+      "targetSkillId": "code-execution",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deductive",
+      "targetSkillId": "retrieve",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deductive",
+      "targetSkillId": "self-critique",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "defaultedgetype",
+      "targetSkillId": "evaluate-output",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "definitions",
+      "targetSkillId": "code-generation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "definitions",
+      "targetSkillId": "document-digitization",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "definitions",
+      "targetSkillId": "code-execution",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "delegates",
+      "targetSkillId": "generate-sql",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "delegates",
+      "targetSkillId": "generate-test",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "delegates",
+      "targetSkillId": "execute-bash",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deletions",
+      "targetSkillId": "code-execution",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deletions",
+      "targetSkillId": "code-generation",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deletions",
+      "targetSkillId": "question-answer",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "delimiter",
+      "targetSkillId": "self-critique",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "demonstrates",
+      "targetSkillId": "generate-sql",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "demonstrates",
+      "targetSkillId": "generate-test",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "demonstrates",
+      "targetSkillId": "ghostwrite",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "demonstrating",
+      "targetSkillId": "code-generation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "demonstrating",
+      "targetSkillId": "error-interpretation",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "demonstrating",
+      "targetSkillId": "registry-curation",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "demos",
+      "targetSkillId": "plan-decompose",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dense",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dense",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deriv",
+      "targetSkillId": "retrieve",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "derivative",
+      "targetSkillId": "retrieve",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "derivative",
+      "targetSkillId": "self-critique",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "derivative",
+      "targetSkillId": "code-generation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "derivatives",
+      "targetSkillId": "retrieve",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "derivatives",
+      "targetSkillId": "generate-sql",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "derivatives",
+      "targetSkillId": "extract-entities",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "derive",
+      "targetSkillId": "retrieve",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "desc",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "descending",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "descending",
+      "targetSkillId": "code-generation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "descending",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "description",
+      "targetSkillId": "image-caption",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "description",
+      "targetSkillId": "registry-curation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "description",
+      "targetSkillId": "code-execution",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "descriptions",
+      "targetSkillId": "image-caption",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "descriptions",
+      "targetSkillId": "registry-curation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "descriptions",
+      "targetSkillId": "code-execution",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "designs",
+      "targetSkillId": "question-answer",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detail",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detail",
+      "targetSkillId": "data-visualize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detail",
+      "targetSkillId": "document-analyst",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detect",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detect",
+      "targetSkillId": "embed-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detect",
+      "targetSkillId": "code-execution",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detected",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detected",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detected",
+      "targetSkillId": "generate-text",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detection",
+      "targetSkillId": "code-execution",
+      "score": 0.696,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detection",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detection",
+      "targetSkillId": "code-generation",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detects",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detects",
+      "targetSkillId": "generate-test",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detects",
+      "targetSkillId": "code-execution",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "development",
+      "targetSkillId": "full-stack-developer",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "development",
+      "targetSkillId": "recursive-self-improvement",
+      "score": 0.486,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "development",
+      "targetSkillId": "chunk-document",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deviations",
+      "targetSkillId": "code-generation",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deviations",
+      "targetSkillId": "image-caption",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deviations",
+      "targetSkillId": "registry-curation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dialogue",
+      "targetSkillId": "data-visualize",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dict",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dicts",
+      "targetSkillId": "diff-content",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "diff",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "diffing",
+      "targetSkillId": "diff-content",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "diffusion",
+      "targetSkillId": "diff-content",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "diffusion-based",
+      "targetSkillId": "question-answer",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "diffusion-based",
+      "targetSkillId": "diff-content",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dimensions",
+      "targetSkillId": "image-caption",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dimensions",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dimensions",
+      "targetSkillId": "question-answer",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directed",
+      "targetSkillId": "audience-model",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directed",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directed",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directionally",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directionally",
+      "targetSkillId": "image-caption",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directionally",
+      "targetSkillId": "code-execution",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directly",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directly",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directory",
+      "targetSkillId": "refactor-code",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directory",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directory",
+      "targetSkillId": "write-report",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directs",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dirname",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dirname",
+      "targetSkillId": "audience-model",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "discovered",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "discovered",
+      "targetSkillId": "diff-content",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "discovered",
+      "targetSkillId": "computer-use",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "discrete",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "discrete",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "discrete",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "distance",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "distance",
+      "targetSkillId": "data-visualize",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "distance",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "document",
+      "targetSkillId": "chunk-document",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "document",
+      "targetSkillId": "document-analyst",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "document",
+      "targetSkillId": "document-digitization",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documentation",
+      "targetSkillId": "document-digitization",
+      "score": 0.765,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documentation",
+      "targetSkillId": "document-analyst",
+      "score": 0.69,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documentation",
+      "targetSkillId": "chunk-document",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documented",
+      "targetSkillId": "chunk-document",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documented",
+      "targetSkillId": "document-analyst",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documented",
+      "targetSkillId": "document-digitization",
+      "score": 0.581,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documents",
+      "targetSkillId": "document-analyst",
+      "score": 0.72,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documents",
+      "targetSkillId": "chunk-document",
+      "score": 0.696,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documents",
+      "targetSkillId": "document-digitization",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "doesn",
+      "targetSkillId": "diff-content",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "doesn",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "downstream",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "downstream",
+      "targetSkillId": "diff-content",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "draft-skills",
+      "targetSkillId": "data-analysis",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "draft-skills",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "draft-skills",
+      "targetSkillId": "data-visualize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dramatically",
+      "targetSkillId": "api-call",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dramatically",
+      "targetSkillId": "data-analysis",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dramatically",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "duplicate",
+      "targetSkillId": "diff-content",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "duplicate",
+      "targetSkillId": "api-call",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "duplicates",
+      "targetSkillId": "diff-content",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "each",
+      "targetSkillId": "research",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "each",
+      "targetSkillId": "web-search",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "echo",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "edge-case",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "edge-case",
+      "targetSkillId": "execute-bash",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "edge-case",
+      "targetSkillId": "image-caption",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "edges",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "elements",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "elicits",
+      "targetSkillId": "self-critique",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "elif",
+      "targetSkillId": "classify",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "else",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "else",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "embed",
+      "targetSkillId": "embed-text",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "embedding",
+      "targetSkillId": "embed-text",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "embedding",
+      "targetSkillId": "automated-testing",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "embeddings",
+      "targetSkillId": "embed-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "embeds",
+      "targetSkillId": "embed-text",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "emotional",
+      "targetSkillId": "content-moderation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "emotional",
+      "targetSkillId": "question-answer",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "emotional",
+      "targetSkillId": "conversational-agent",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enables",
+      "targetSkillId": "generate-test",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "encode",
+      "targetSkillId": "audience-model",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "encode",
+      "targetSkillId": "refactor-code",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "encoding",
+      "targetSkillId": "content-moderation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "encoding",
+      "targetSkillId": "code-execution",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "encoding",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "end-to-end",
+      "targetSkillId": "text-to-speech",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "end-to-end",
+      "targetSkillId": "speech-to-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "end-to-end",
+      "targetSkillId": "embed-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "engine",
+      "targetSkillId": "tokenize",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "engineering",
+      "targetSkillId": "code-generation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "engineering",
+      "targetSkillId": "error-interpretation",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "engines",
+      "targetSkillId": "tokenize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enhances",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enhances",
+      "targetSkillId": "generate-test",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entities",
+      "targetSkillId": "extract-entities",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entities",
+      "targetSkillId": "generate-test",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entities",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entity",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entity",
+      "targetSkillId": "extract-entities",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entries",
+      "targetSkillId": "retrieve",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entries",
+      "targetSkillId": "tokenize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entries",
+      "targetSkillId": "generate-sql",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entry",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enumerate",
+      "targetSkillId": "generate-sql",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enumerate",
+      "targetSkillId": "generate-text",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enumerate",
+      "targetSkillId": "generate-test",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "environ",
+      "targetSkillId": "code-generation",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "environment",
+      "targetSkillId": "route-intent",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "environment",
+      "targetSkillId": "diff-content",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "environment",
+      "targetSkillId": "conversational-agent",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "environments",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "environments",
+      "targetSkillId": "route-intent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "environments",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "epic",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "equations",
+      "targetSkillId": "question-answer",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "equations",
+      "targetSkillId": "image-caption",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "equations",
+      "targetSkillId": "registry-curation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "error",
+      "targetSkillId": "write-report",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "establishes",
+      "targetSkillId": "question-answer",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "etree",
+      "targetSkillId": "retrieve",
+      "score": 0.769,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "etree",
+      "targetSkillId": "extract-entities",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "etree",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluated",
+      "targetSkillId": "evaluate-output",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluated",
+      "targetSkillId": "translate",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluated",
+      "targetSkillId": "automated-testing",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluates",
+      "targetSkillId": "evaluate-output",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluates",
+      "targetSkillId": "translate",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluates",
+      "targetSkillId": "generate-sql",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluating",
+      "targetSkillId": "evaluate-output",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluating",
+      "targetSkillId": "browser-automation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluating",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluation",
+      "targetSkillId": "evaluate-output",
+      "score": 0.64,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluation",
+      "targetSkillId": "browser-automation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluation",
+      "targetSkillId": "image-caption",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluator",
+      "targetSkillId": "evaluate-output",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluator",
+      "targetSkillId": "refactor-code",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "every",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "every",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evidence",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evidence-health",
+      "targetSkillId": "audience-model",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evidence-health",
+      "targetSkillId": "voice-agent",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evidence-health",
+      "targetSkillId": "document-analyst",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "exact",
+      "targetSkillId": "extract-entities",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "exact",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "exceed",
+      "targetSkillId": "extract-entities",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "except",
+      "targetSkillId": "extract-entities",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "exclude",
+      "targetSkillId": "execute-bash",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "excludes",
+      "targetSkillId": "execute-bash",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executable",
+      "targetSkillId": "execute-bash",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executable",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executable",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executed",
+      "targetSkillId": "execute-bash",
+      "score": 0.7,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executed",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executed",
+      "targetSkillId": "code-execution",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executes",
+      "targetSkillId": "execute-bash",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executes",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executes",
+      "targetSkillId": "code-execution",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "execution",
+      "targetSkillId": "code-execution",
+      "score": 0.783,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "execution",
+      "targetSkillId": "execute-bash",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "execution",
+      "targetSkillId": "image-caption",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executor",
+      "targetSkillId": "code-execution",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executor",
+      "targetSkillId": "execute-bash",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executor",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "exhausted",
+      "targetSkillId": "execute-bash",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "existing",
+      "targetSkillId": "registry-curation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "existing",
+      "targetSkillId": "automated-testing",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "existing",
+      "targetSkillId": "code-execution",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "expanduser",
+      "targetSkillId": "plan-decompose",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "expanduser",
+      "targetSkillId": "question-answer",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "expanduser",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "expected",
+      "targetSkillId": "execute-bash",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "expected",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "expected",
+      "targetSkillId": "text-to-speech",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "experiments",
+      "targetSkillId": "extract-entities",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "experiments",
+      "targetSkillId": "generate-test",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "experiments",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "expert-level",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "expert-level",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "expert-level",
+      "targetSkillId": "extract-entities",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "explanations",
+      "targetSkillId": "code-generation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "explanations",
+      "targetSkillId": "extract-entities",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "explanations",
+      "targetSkillId": "image-caption",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "explicit",
+      "targetSkillId": "self-critique",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "export",
+      "targetSkillId": "write-report",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "exposes",
+      "targetSkillId": "plan-decompose",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "exposes",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ext",
+      "targetSkillId": "embed-text",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extend",
+      "targetSkillId": "extract-entities",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extension",
+      "targetSkillId": "code-execution",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extension",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extension",
+      "targetSkillId": "code-generation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extensionquery",
+      "targetSkillId": "question-answer",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extensionquery",
+      "targetSkillId": "cite-sources",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extensionquery",
+      "targetSkillId": "tokenize",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extensions",
+      "targetSkillId": "code-execution",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extensions",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extensions",
+      "targetSkillId": "question-answer",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extensive",
+      "targetSkillId": "tokenize",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extensive",
+      "targetSkillId": "retrieve",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extensive",
+      "targetSkillId": "extract-entities",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "external",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "external",
+      "targetSkillId": "execute-bash",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "external",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extracting",
+      "targetSkillId": "extract-entities",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extracting",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extracting",
+      "targetSkillId": "registry-curation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extraction",
+      "targetSkillId": "extract-entities",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extraction",
+      "targetSkillId": "registry-curation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extraction",
+      "targetSkillId": "code-execution",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extracts",
+      "targetSkillId": "extract-entities",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extracts",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extracts",
+      "targetSkillId": "execute-bash",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "failures",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "falls",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "false",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "feature",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "feature-extraction",
+      "targetSkillId": "code-execution",
+      "score": 0.562,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "feature-extraction",
+      "targetSkillId": "code-generation",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "feature-extraction",
+      "targetSkillId": "error-interpretation",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "features",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "features",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "features",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "feedback",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "filename",
+      "targetSkillId": "image-generate",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "filename",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "fills",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "filtered",
+      "targetSkillId": "write-report",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "filtered",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "filters",
+      "targetSkillId": "cite-sources",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "final",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "finally",
+      "targetSkillId": "api-call",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "finite-state",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "finite-state",
+      "targetSkillId": "generate-text",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "finite-state",
+      "targetSkillId": "generate-test",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "flags",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "flush",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "follow-up",
+      "targetSkillId": "tool-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "follow-up",
+      "targetSkillId": "format-output",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "force",
+      "targetSkillId": "refactor-code",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "force",
+      "targetSkillId": "cite-sources",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "form",
+      "targetSkillId": "format-output",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "format",
+      "targetSkillId": "format-output",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "formats",
+      "targetSkillId": "format-output",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "formatted",
+      "targetSkillId": "format-output",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "formatted",
+      "targetSkillId": "automated-testing",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "formatted",
+      "targetSkillId": "memory-manage",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "formatting",
+      "targetSkillId": "format-output",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "formatting",
+      "targetSkillId": "automated-testing",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "formatting",
+      "targetSkillId": "memory-manage",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "forwarded",
+      "targetSkillId": "refactor-code",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "foundation",
+      "targetSkillId": "document-digitization",
+      "score": 0.581,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "foundation",
+      "targetSkillId": "content-moderation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "foundation",
+      "targetSkillId": "code-generation",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "foundational",
+      "targetSkillId": "conversational-agent",
+      "score": 0.562,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "foundational",
+      "targetSkillId": "document-digitization",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "foundational",
+      "targetSkillId": "content-moderation",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "framework",
+      "targetSkillId": "rank",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "framing",
+      "targetSkillId": "rank",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "framing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "free-form",
+      "targetSkillId": "research",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "free-form",
+      "targetSkillId": "refactor-code",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "fromisoformat",
+      "targetSkillId": "format-output",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "fromisoformat",
+      "targetSkillId": "browser-automation",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "frontmatter",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "frontmatter",
+      "targetSkillId": "format-output",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "full-cycle",
+      "targetSkillId": "full-stack-developer",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "function",
+      "targetSkillId": "image-caption",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "function",
+      "targetSkillId": "code-execution",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "functionality",
+      "targetSkillId": "conversational-agent",
+      "score": 0.485,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "functionality",
+      "targetSkillId": "document-analyst",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "functionality",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "functionally",
+      "targetSkillId": "document-analyst",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "functionally",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "functionally",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "functions",
+      "targetSkillId": "question-answer",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "functions",
+      "targetSkillId": "image-caption",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "fundamentally",
+      "targetSkillId": "document-analyst",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "fundamentally",
+      "targetSkillId": "chunk-document",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "fundamentally",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "fuse",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "fusions",
+      "targetSkillId": "question-answer",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-cli",
+      "targetSkillId": "api-call",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-cli",
+      "targetSkillId": "data-analysis",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-cli",
+      "targetSkillId": "data-visualize",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-cli-test",
+      "targetSkillId": "generate-test",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-cli-test",
+      "targetSkillId": "diff-content",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-cli-test",
+      "targetSkillId": "api-call",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-registry",
+      "targetSkillId": "registry-curation",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-registry",
+      "targetSkillId": "generate-test",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gathering",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gathering",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gathering",
+      "targetSkillId": "automated-testing",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generate",
+      "targetSkillId": "generate-sql",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generate",
+      "targetSkillId": "generate-text",
+      "score": 0.762,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generate",
+      "targetSkillId": "generate-test",
+      "score": 0.762,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generated",
+      "targetSkillId": "generate-sql",
+      "score": 0.762,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generated",
+      "targetSkillId": "generate-text",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generated",
+      "targetSkillId": "generate-test",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generates",
+      "targetSkillId": "generate-sql",
+      "score": 0.857,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generates",
+      "targetSkillId": "generate-test",
+      "score": 0.818,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generates",
+      "targetSkillId": "generate-text",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generating",
+      "targetSkillId": "code-generation",
+      "score": 0.72,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generating",
+      "targetSkillId": "generate-sql",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generating",
+      "targetSkillId": "generate-text",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generation",
+      "targetSkillId": "code-generation",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generation",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.645,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generation",
+      "targetSkillId": "content-moderation",
+      "score": 0.643,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generative",
+      "targetSkillId": "generate-sql",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generative",
+      "targetSkillId": "generate-text",
+      "score": 0.696,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generative",
+      "targetSkillId": "generate-test",
+      "score": 0.696,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generator",
+      "targetSkillId": "generate-sql",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generator",
+      "targetSkillId": "code-generation",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generator",
+      "targetSkillId": "generate-text",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "getcode",
+      "targetSkillId": "refactor-code",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "getcode",
+      "targetSkillId": "audience-model",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gets",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gets",
+      "targetSkillId": "generate-test",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "git",
+      "targetSkillId": "ghostwrite",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "github-action",
+      "targetSkillId": "registry-curation",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "github-action",
+      "targetSkillId": "image-caption",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "github-action",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "given",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "given",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gmtime",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "goal-directed",
+      "targetSkillId": "logical-inference",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "goal-directed",
+      "targetSkillId": "audience-model",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "goal-directed",
+      "targetSkillId": "tool-select",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "got",
+      "targetSkillId": "ghostwrite",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gracefully",
+      "targetSkillId": "generate-sql",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "grammar-guided",
+      "targetSkillId": "summarize",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "grammars",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "graph",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ground-truth",
+      "targetSkillId": "route-intent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ground-truth",
+      "targetSkillId": "format-output",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "grounding",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "grounding",
+      "targetSkillId": "route-intent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "guaranteed",
+      "targetSkillId": "translate",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "guaranteed",
+      "targetSkillId": "generate-text",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "guaranteed",
+      "targetSkillId": "generate-test",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "guarantees",
+      "targetSkillId": "generate-test",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "guarantees",
+      "targetSkillId": "generate-sql",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "guarantees",
+      "targetSkillId": "translate",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hand-crafted",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hand-crafted",
+      "targetSkillId": "translate",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hand-crafted",
+      "targetSkillId": "image-generate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "handle",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "handled",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "handler",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "handles",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "handles",
+      "targetSkillId": "plan-decompose",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "happen",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "highlighting",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.474,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hit",
+      "targetSkillId": "ghostwrite",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "homepage",
+      "targetSkillId": "voice-agent",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "homepage",
+      "targetSkillId": "memory-manage",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hours",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hours",
+      "targetSkillId": "cite-sources",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hours",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "html",
+      "targetSkillId": "parse-html",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "human-level",
+      "targetSkillId": "full-stack-developer",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hypotheses",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.621,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hypotheses",
+      "targetSkillId": "computer-use",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hypothesis",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.69,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "icon",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "icon",
+      "targetSkillId": "image-caption",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "identifies",
+      "targetSkillId": "extract-entities",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "identifies",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "identifies",
+      "targetSkillId": "generate-sql",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "identify",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "identifying",
+      "targetSkillId": "code-generation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "identifying",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ignore",
+      "targetSkillId": "image-generate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "images",
+      "targetSkillId": "image-caption",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "images",
+      "targetSkillId": "image-generate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "images",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "implementation",
+      "targetSkillId": "code-generation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "implementation",
+      "targetSkillId": "error-interpretation",
+      "score": 0.529,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "implementation",
+      "targetSkillId": "image-caption",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "implements",
+      "targetSkillId": "image-generate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "implements",
+      "targetSkillId": "voice-agent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "import",
+      "targetSkillId": "write-report",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "importlib",
+      "targetSkillId": "write-report",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "improvement",
+      "targetSkillId": "recursive-self-improvement",
+      "score": 0.595,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "improvement",
+      "targetSkillId": "route-intent",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "improvement",
+      "targetSkillId": "image-generate",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "improving",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "improving",
+      "targetSkillId": "image-caption",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "in-context",
+      "targetSkillId": "diff-content",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "in-context",
+      "targetSkillId": "generate-text",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "in-context",
+      "targetSkillId": "speech-to-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "in-place",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "in-place",
+      "targetSkillId": "plan-decompose",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "include",
+      "targetSkillId": "audience-model",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "included",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "includes",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "incorporating",
+      "targetSkillId": "error-interpretation",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "incorporating",
+      "targetSkillId": "content-moderation",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "incorporating",
+      "targetSkillId": "code-generation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "indent",
+      "targetSkillId": "route-intent",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "indent",
+      "targetSkillId": "diff-content",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "indent",
+      "targetSkillId": "chunk-document",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "inference",
+      "targetSkillId": "logical-inference",
+      "score": 0.692,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "inference",
+      "targetSkillId": "cite-sources",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "inference",
+      "targetSkillId": "generate-text",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "information",
+      "targetSkillId": "image-caption",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "information",
+      "targetSkillId": "format-output",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "information",
+      "targetSkillId": "content-moderation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "inherit",
+      "targetSkillId": "image-generate",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "inherit",
+      "targetSkillId": "ghostwrite",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "initialized",
+      "targetSkillId": "data-visualize",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "inline",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "inline",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "inner",
+      "targetSkillId": "question-answer",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "insert",
+      "targetSkillId": "image-generate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "insert",
+      "targetSkillId": "question-answer",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "install",
+      "targetSkillId": "api-call",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "install-manifest",
+      "targetSkillId": "data-analysis",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "installation",
+      "targetSkillId": "image-caption",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "installation",
+      "targetSkillId": "registry-curation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "installation",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "installed",
+      "targetSkillId": "api-call",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "installs",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "installs",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "instance",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "instruction",
+      "targetSkillId": "registry-curation",
+      "score": 0.643,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "instruction",
+      "targetSkillId": "error-interpretation",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "instruction",
+      "targetSkillId": "knowledge-graph-build",
+      "score": 0.513,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "instructions",
+      "targetSkillId": "registry-curation",
+      "score": 0.621,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "instructions",
+      "targetSkillId": "knowledge-graph-build",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "instructions",
+      "targetSkillId": "error-interpretation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intake-dir",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intake-dir",
+      "targetSkillId": "write-report",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intake-dir",
+      "targetSkillId": "cite-sources",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integrates",
+      "targetSkillId": "generate-sql",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integrates",
+      "targetSkillId": "generate-test",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integrates",
+      "targetSkillId": "image-generate",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integration",
+      "targetSkillId": "error-interpretation",
+      "score": 0.645,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integration",
+      "targetSkillId": "content-moderation",
+      "score": 0.621,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integration",
+      "targetSkillId": "code-generation",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integrations",
+      "targetSkillId": "error-interpretation",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integrations",
+      "targetSkillId": "content-moderation",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integrations",
+      "targetSkillId": "code-generation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integrity",
+      "targetSkillId": "route-intent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integrity",
+      "targetSkillId": "diff-content",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intensity",
+      "targetSkillId": "route-intent",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intensity",
+      "targetSkillId": "diff-content",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intensity",
+      "targetSkillId": "tokenize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intent",
+      "targetSkillId": "route-intent",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intent",
+      "targetSkillId": "diff-content",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intent",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interactions",
+      "targetSkillId": "error-interpretation",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interactions",
+      "targetSkillId": "content-moderation",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interactions",
+      "targetSkillId": "code-generation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interface",
+      "targetSkillId": "cite-sources",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interface",
+      "targetSkillId": "write-report",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interface",
+      "targetSkillId": "logical-inference",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intermediate",
+      "targetSkillId": "image-generate",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intermediate",
+      "targetSkillId": "write-report",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intermediate",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interpreter",
+      "targetSkillId": "error-interpretation",
+      "score": 0.581,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interpreter",
+      "targetSkillId": "write-report",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interpreting",
+      "targetSkillId": "error-interpretation",
+      "score": 0.688,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interpreting",
+      "targetSkillId": "write-report",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interpreting",
+      "targetSkillId": "automated-testing",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interprets",
+      "targetSkillId": "error-interpretation",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interprets",
+      "targetSkillId": "write-report",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interprets",
+      "targetSkillId": "cite-sources",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intersection",
+      "targetSkillId": "error-interpretation",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intersection",
+      "targetSkillId": "image-caption",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intersection",
+      "targetSkillId": "registry-curation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intervention",
+      "targetSkillId": "error-interpretation",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intervention",
+      "targetSkillId": "content-moderation",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intervention",
+      "targetSkillId": "code-generation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intrusion",
+      "targetSkillId": "registry-curation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intrusion",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intrusion",
+      "targetSkillId": "error-interpretation",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "isoformat",
+      "targetSkillId": "format-output",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "issues",
+      "targetSkillId": "cite-sources",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "items",
+      "targetSkillId": "cite-sources",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iter",
+      "targetSkillId": "write-report",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iter",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iterates",
+      "targetSkillId": "generate-sql",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iterates",
+      "targetSkillId": "cite-sources",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iterates",
+      "targetSkillId": "translate",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iteration",
+      "targetSkillId": "image-caption",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iteration",
+      "targetSkillId": "error-interpretation",
+      "score": 0.621,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iteration",
+      "targetSkillId": "registry-curation",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iterative",
+      "targetSkillId": "image-generate",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iterative",
+      "targetSkillId": "error-interpretation",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iterative",
+      "targetSkillId": "write-report",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iteratively",
+      "targetSkillId": "generate-sql",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iteratively",
+      "targetSkillId": "image-generate",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iteratively",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "json",
+      "targetSkillId": "parse-json",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "kebab-case",
+      "targetSkillId": "web-search",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "knowledge",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.692,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "knowledge",
+      "targetSkillId": "knowledge-graph-build",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "langchain-ai",
+      "targetSkillId": "multi-agent-orchestration-v",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "langchain-tool",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "language",
+      "targetSkillId": "memory-manage",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "languages",
+      "targetSkillId": "memory-manage",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "large-scale",
+      "targetSkillId": "web-scrape",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "large-scale",
+      "targetSkillId": "api-call",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "large-scale",
+      "targetSkillId": "image-caption",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "last",
+      "targetSkillId": "classify",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "last",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "latency",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "later",
+      "targetSkillId": "translate",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "layout",
+      "targetSkillId": "evaluate-output",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "leading",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "learn",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "learned",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "learned",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "learning",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "learning",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "least",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "least",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "legendaries",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "legendaries",
+      "targetSkillId": "generate-sql",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "legendaries",
+      "targetSkillId": "generate-test",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "legendary",
+      "targetSkillId": "research",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "legendary",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "less",
+      "targetSkillId": "classify",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "level",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lexically",
+      "targetSkillId": "api-call",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "license",
+      "targetSkillId": "logical-inference",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lifecycle",
+      "targetSkillId": "classify",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lifecycle",
+      "targetSkillId": "logical-inference",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "line",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lineage",
+      "targetSkillId": "voice-agent",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lines",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "link",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "literature",
+      "targetSkillId": "cite-sources",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "literature",
+      "targetSkillId": "image-generate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "literature",
+      "targetSkillId": "write-report",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "llevel",
+      "targetSkillId": "full-stack-developer",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "llm-tool",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "local",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "local",
+      "targetSkillId": "logical-inference",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "local-repo",
+      "targetSkillId": "logical-inference",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "local-repo",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "local-repo",
+      "targetSkillId": "math-reason",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "locally",
+      "targetSkillId": "api-call",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "locate",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "locate",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "locations",
+      "targetSkillId": "image-caption",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "locations",
+      "targetSkillId": "code-execution",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "locations",
+      "targetSkillId": "code-generation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "log-scaled",
+      "targetSkillId": "logical-inference",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "log-scaled",
+      "targetSkillId": "web-scrape",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "log-scaled",
+      "targetSkillId": "tool-select",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "logic",
+      "targetSkillId": "logical-inference",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "logical",
+      "targetSkillId": "logical-inference",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "logical",
+      "targetSkillId": "api-call",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "loops",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "low-latency",
+      "targetSkillId": "voice-agent",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lowercase-dash",
+      "targetSkillId": "execute-bash",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lowercase-dash",
+      "targetSkillId": "generate-sql",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lowercase-dash",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "machine",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "machine",
+      "targetSkillId": "image-caption",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "machine-readable",
+      "targetSkillId": "math-reason",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "machine-readable",
+      "targetSkillId": "score-relevance",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "madaan",
+      "targetSkillId": "math-reason",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "main",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "main",
+      "targetSkillId": "image-caption",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "main",
+      "targetSkillId": "summarize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "maintainability",
+      "targetSkillId": "document-analyst",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "maintainability",
+      "targetSkillId": "data-visualize",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "maintaining",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "maintaining",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.486,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "maintaining",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "management",
+      "targetSkillId": "image-generate",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "management",
+      "targetSkillId": "memory-manage",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "management",
+      "targetSkillId": "voice-agent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "managing",
+      "targetSkillId": "memory-manage",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "manifest",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "manifest",
+      "targetSkillId": "image-generate",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "manual",
+      "targetSkillId": "document-analyst",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "manually",
+      "targetSkillId": "document-analyst",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "manually",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "manually",
+      "targetSkillId": "data-analysis",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mapping",
+      "targetSkillId": "image-caption",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mappings",
+      "targetSkillId": "image-caption",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mark",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mark",
+      "targetSkillId": "summarize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "markdown",
+      "targetSkillId": "math-reason",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marked",
+      "targetSkillId": "summarize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marked",
+      "targetSkillId": "parse-pdf",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marked",
+      "targetSkillId": "math-reason",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marker",
+      "targetSkillId": "summarize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marker",
+      "targetSkillId": "math-reason",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "markers",
+      "targetSkillId": "math-reason",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "markers",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "markers",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marketplace",
+      "targetSkillId": "parse-html",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marketplace",
+      "targetSkillId": "math-reason",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "master",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "match",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "match",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "matching",
+      "targetSkillId": "math-reason",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "matching",
+      "targetSkillId": "automated-testing",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "matching",
+      "targetSkillId": "image-caption",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "math",
+      "targetSkillId": "math-reason",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mathematical",
+      "targetSkillId": "math-reason",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mathematical",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mathematical",
+      "targetSkillId": "image-caption",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mathematics",
+      "targetSkillId": "math-reason",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mathematics",
+      "targetSkillId": "image-caption",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mbtiongson1",
+      "targetSkillId": "math-reason",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mbtiongson1",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mcp-registry",
+      "targetSkillId": "registry-curation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mcp-server",
+      "targetSkillId": "computer-use",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "meaning",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "meaning",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "meaning",
+      "targetSkillId": "memory-manage",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "meaningful",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "meaningful",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mechanistic",
+      "targetSkillId": "image-caption",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "medical",
+      "targetSkillId": "api-call",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "meets",
+      "targetSkillId": "embed-text",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "meets",
+      "targetSkillId": "generate-sql",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "meets",
+      "targetSkillId": "execute-bash",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "memory",
+      "targetSkillId": "memory-manage",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "merged",
+      "targetSkillId": "memory-manage",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "message",
+      "targetSkillId": "memory-manage",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "message",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "messages",
+      "targetSkillId": "memory-manage",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "metadata",
+      "targetSkillId": "document-analyst",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "metadata",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "method",
+      "targetSkillId": "math-reason",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "microsecond",
+      "targetSkillId": "code-execution",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "microsecond",
+      "targetSkillId": "parse-json",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "microsecond",
+      "targetSkillId": "math-reason",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "migration",
+      "targetSkillId": "image-caption",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "migration",
+      "targetSkillId": "code-generation",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "migration",
+      "targetSkillId": "registry-curation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "modalities",
+      "targetSkillId": "extract-entities",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "modalities",
+      "targetSkillId": "autonomous-data-scientist",
+      "score": 0.457,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "model",
+      "targetSkillId": "audience-model",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "modeling",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "modeling",
+      "targetSkillId": "automated-testing",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "modeling",
+      "targetSkillId": "content-moderation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "models",
+      "targetSkillId": "audience-model",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "moderation",
+      "targetSkillId": "code-generation",
+      "score": 0.72,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "moderation",
+      "targetSkillId": "content-moderation",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "moderation",
+      "targetSkillId": "image-caption",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "modern",
+      "targetSkillId": "content-moderation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "modern",
+      "targetSkillId": "code-generation",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "modifications",
+      "targetSkillId": "image-caption",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "modifications",
+      "targetSkillId": "document-digitization",
+      "score": 0.529,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "modifications",
+      "targetSkillId": "code-execution",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "more",
+      "targetSkillId": "memory-manage",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "more",
+      "targetSkillId": "summarize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mouse",
+      "targetSkillId": "tool-use",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mouse",
+      "targetSkillId": "autonomous-debug",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mouse",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-agent",
+      "targetSkillId": "voice-agent",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-agent",
+      "targetSkillId": "multi-agent-orchestration-v",
+      "score": 0.579,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-agent",
+      "targetSkillId": "route-intent",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-category",
+      "targetSkillId": "multi-agent-orchestration-v",
+      "score": 0.488,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-category",
+      "targetSkillId": "question-answer",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-category",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-section",
+      "targetSkillId": "multi-agent-orchestration-v",
+      "score": 0.55,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-section",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-section",
+      "targetSkillId": "image-caption",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-session",
+      "targetSkillId": "multi-agent-orchestration-v",
+      "score": 0.55,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-session",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-session",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-source",
+      "targetSkillId": "cite-sources",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-source",
+      "targetSkillId": "multi-agent-orchestration-v",
+      "score": 0.513,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-source",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-step",
+      "targetSkillId": "question-answer",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-step",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-step",
+      "targetSkillId": "full-stack-developer",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-turn",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-turn",
+      "targetSkillId": "multi-agent-orchestration-v",
+      "score": 0.486,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-turn",
+      "targetSkillId": "math-reason",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multilingual",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.562,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multimodal",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multimodal",
+      "targetSkillId": "audience-model",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multiple",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "name",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "named-dir",
+      "targetSkillId": "automated-testing",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "named-skills",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "named-skills",
+      "targetSkillId": "automated-testing",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "names",
+      "targetSkillId": "generate-sql",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "narrative",
+      "targetSkillId": "retrieve",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "narrative",
+      "targetSkillId": "generate-sql",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "narrative",
+      "targetSkillId": "generate-text",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "natural",
+      "targetSkillId": "data-visualize",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "natural-language",
+      "targetSkillId": "conversational-agent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "natural-language",
+      "targetSkillId": "memory-manage",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "natural-sounding",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.645,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "natural-sounding",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "natural-sounding",
+      "targetSkillId": "math-reason",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "navigating",
+      "targetSkillId": "image-caption",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "navigating",
+      "targetSkillId": "conversational-agent",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "navigating",
+      "targetSkillId": "document-digitization",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "near-human",
+      "targetSkillId": "memory-manage",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "near-human",
+      "targetSkillId": "parse-html",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "near-human",
+      "targetSkillId": "browser-automation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "needed",
+      "targetSkillId": "embed-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "needs",
+      "targetSkillId": "generate-sql",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "needs-review",
+      "targetSkillId": "code-review-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "needs-review",
+      "targetSkillId": "embed-text",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "negative",
+      "targetSkillId": "retrieve",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "negative",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "negative",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "nested",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "nesting",
+      "targetSkillId": "conversational-agent",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "nesting",
+      "targetSkillId": "automated-testing",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "nesting",
+      "targetSkillId": "question-answer",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "neural",
+      "targetSkillId": "generate-sql",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "neutral",
+      "targetSkillId": "generate-sql",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "neutral",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "next",
+      "targetSkillId": "generate-text",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "nline",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "nline",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "nodes",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "noise",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "noise",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "non-interactive",
+      "targetSkillId": "error-interpretation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "non-interactive",
+      "targetSkillId": "route-intent",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "non-interactive",
+      "targetSkillId": "logical-inference",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "non-overlap",
+      "targetSkillId": "content-moderation",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "non-overlap",
+      "targetSkillId": "conversational-agent",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "normally",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "notebooks",
+      "targetSkillId": "tool-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "notes",
+      "targetSkillId": "generate-sql",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "notes",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "numeric",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "numerical",
+      "targetSkillId": "generate-sql",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "numerical",
+      "targetSkillId": "api-call",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "objective",
+      "targetSkillId": "retrieve",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "objective",
+      "targetSkillId": "tokenize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "objective",
+      "targetSkillId": "self-critique",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "objectives",
+      "targetSkillId": "retrieve",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "objectives",
+      "targetSkillId": "extract-entities",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "objectives",
+      "targetSkillId": "execute-bash",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "observable",
+      "targetSkillId": "score-relevance",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "observable",
+      "targetSkillId": "tool-select",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "observation",
+      "targetSkillId": "browser-automation",
+      "score": 0.621,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "observation",
+      "targetSkillId": "code-generation",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "observation",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.562,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "observe",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "observe",
+      "targetSkillId": "web-search",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "observe",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "occurrence",
+      "targetSkillId": "logical-inference",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "occurrence",
+      "targetSkillId": "score-relevance",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "occurrence",
+      "targetSkillId": "cite-sources",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "once",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "one",
+      "targetSkillId": "tokenize",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "open",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "open-ended",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "open-ended",
+      "targetSkillId": "computer-use",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "open-source",
+      "targetSkillId": "cite-sources",
+      "score": 0.696,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "open-source",
+      "targetSkillId": "computer-use",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "open-source",
+      "targetSkillId": "web-search",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "openai",
+      "targetSkillId": "tokenize",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "openai",
+      "targetSkillId": "code-generation",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "opened",
+      "targetSkillId": "tokenize",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "opening",
+      "targetSkillId": "tokenize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "opening",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "opening",
+      "targetSkillId": "code-generation",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "opens",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "opens",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "optimized",
+      "targetSkillId": "tokenize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "optional",
+      "targetSkillId": "conversational-agent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "optional",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "optional",
+      "targetSkillId": "image-caption",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "options",
+      "targetSkillId": "image-caption",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "options",
+      "targetSkillId": "code-execution",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "options",
+      "targetSkillId": "question-answer",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "orchestrates",
+      "targetSkillId": "ghostwrite",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "orchestrates",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "orchestrates",
+      "targetSkillId": "multi-agent-orchestration-v",
+      "score": 0.513,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "order",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "order",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ordered",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "organizations",
+      "targetSkillId": "registry-curation",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "organizations",
+      "targetSkillId": "document-digitization",
+      "score": 0.529,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "organizations",
+      "targetSkillId": "browser-automation",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "origin",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "orphaned",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "orphaned",
+      "targetSkillId": "memory-manage",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "orphaned",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "otherwise",
+      "targetSkillId": "computer-use",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "otherwise",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "otherwise",
+      "targetSkillId": "route-intent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outliers",
+      "targetSkillId": "computer-use",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outliers",
+      "targetSkillId": "route-intent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outlines",
+      "targetSkillId": "route-intent",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outlines",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outlines",
+      "targetSkillId": "code-execution",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outlines-dev",
+      "targetSkillId": "route-intent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outlines-dev",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outperforms",
+      "targetSkillId": "computer-use",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "output",
+      "targetSkillId": "format-output",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "output",
+      "targetSkillId": "evaluate-output",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "output",
+      "targetSkillId": "structured-output",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outputs",
+      "targetSkillId": "format-output",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outputs",
+      "targetSkillId": "evaluate-output",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outputs",
+      "targetSkillId": "computer-use",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outside",
+      "targetSkillId": "tool-use",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outside",
+      "targetSkillId": "route-intent",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outside",
+      "targetSkillId": "computer-use",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "overwritten",
+      "targetSkillId": "ghostwrite",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "overwritten",
+      "targetSkillId": "route-intent",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "overwritten",
+      "targetSkillId": "error-interpretation",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "owned",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "owner",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pack",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "packed",
+      "targetSkillId": "parse-pdf",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pages",
+      "targetSkillId": "parse-json",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pair",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pairs",
+      "targetSkillId": "parse-pdf",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pairs",
+      "targetSkillId": "parse-json",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pairs",
+      "targetSkillId": "parse-html",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pairwise",
+      "targetSkillId": "parse-pdf",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pairwise",
+      "targetSkillId": "parse-json",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pairwise",
+      "targetSkillId": "parse-html",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pal",
+      "targetSkillId": "api-call",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pal",
+      "targetSkillId": "parse-html",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pandas",
+      "targetSkillId": "plan-decompose",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pandas-ai",
+      "targetSkillId": "data-analysis",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "papers",
+      "targetSkillId": "parse-pdf",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "papers",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "papers",
+      "targetSkillId": "parse-html",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "paradigm",
+      "targetSkillId": "parse-pdf",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parameters",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parameters",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parameters",
+      "targetSkillId": "extract-entities",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "params",
+      "targetSkillId": "parse-pdf",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "params",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "params",
+      "targetSkillId": "parse-html",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parent",
+      "targetSkillId": "parse-json",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parent",
+      "targetSkillId": "parse-html",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parent",
+      "targetSkillId": "parse-pdf",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parents",
+      "targetSkillId": "parse-json",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parents",
+      "targetSkillId": "parse-html",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parents",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parse",
+      "targetSkillId": "parse-pdf",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parse",
+      "targetSkillId": "parse-json",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parse",
+      "targetSkillId": "parse-html",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parsed",
+      "targetSkillId": "parse-pdf",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parsed",
+      "targetSkillId": "parse-json",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parsed",
+      "targetSkillId": "parse-html",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parser",
+      "targetSkillId": "parse-pdf",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parser",
+      "targetSkillId": "parse-json",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parser",
+      "targetSkillId": "parse-html",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parses",
+      "targetSkillId": "parse-json",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parses",
+      "targetSkillId": "parse-pdf",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parses",
+      "targetSkillId": "parse-html",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parsing",
+      "targetSkillId": "parse-json",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parsing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parsing",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "partition",
+      "targetSkillId": "parse-json",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "partition",
+      "targetSkillId": "route-intent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "partition",
+      "targetSkillId": "image-caption",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parts",
+      "targetSkillId": "parse-pdf",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parts",
+      "targetSkillId": "parse-json",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parts",
+      "targetSkillId": "parse-html",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pass",
+      "targetSkillId": "parse-json",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pass",
+      "targetSkillId": "classify",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pass",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "passages",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "passages",
+      "targetSkillId": "parse-pdf",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "passed",
+      "targetSkillId": "parse-pdf",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "passed",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "passed",
+      "targetSkillId": "parse-html",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "passing",
+      "targetSkillId": "parse-json",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "passing",
+      "targetSkillId": "classify",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "passing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "patch",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "patched",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "patches",
+      "targetSkillId": "math-reason",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "patches",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "paths",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pattern",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "patterns",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "patterns",
+      "targetSkillId": "generate-test",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pdf",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pending",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "percentage",
+      "targetSkillId": "extract-entities",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "percentage",
+      "targetSkillId": "memory-manage",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "performance",
+      "targetSkillId": "memory-manage",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "performance",
+      "targetSkillId": "refactor-code",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "performance",
+      "targetSkillId": "score-relevance",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "persistent",
+      "targetSkillId": "route-intent",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "persistent",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "persistent",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "photorealistic",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.457,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pipe",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pipeline",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pipeline",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pipeline",
+      "targetSkillId": "text-to-sql-pipeline",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pipelines",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.762,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pipelines",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pipelines",
+      "targetSkillId": "text-to-sql-pipeline",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pixel-space",
+      "targetSkillId": "cite-sources",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pixel-space",
+      "targetSkillId": "web-search",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pixel-space",
+      "targetSkillId": "web-scrape",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "placeholder",
+      "targetSkillId": "audience-model",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "plain-text",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "plain-text",
+      "targetSkillId": "generate-text",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "plain-text",
+      "targetSkillId": "speech-to-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "plan",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "planned",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "planned",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "planned",
+      "targetSkillId": "plan-decompose",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "platform",
+      "targetSkillId": "plan-decompose",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "plus",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "point",
+      "targetSkillId": "voice-agent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "point",
+      "targetSkillId": "route-intent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "points",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "positive",
+      "targetSkillId": "ghostwrite",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "positive",
+      "targetSkillId": "self-critique",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pre-computed",
+      "targetSkillId": "computer-use",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pre-computed",
+      "targetSkillId": "parse-pdf",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pre-computed",
+      "targetSkillId": "plan-decompose",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pre-trained",
+      "targetSkillId": "retrieve",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pre-trained",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pre-trained",
+      "targetSkillId": "score-relevance",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pre-training",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pre-training",
+      "targetSkillId": "route-intent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pre-training",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prediction",
+      "targetSkillId": "registry-curation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prediction",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prediction",
+      "targetSkillId": "code-execution",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prefix",
+      "targetSkillId": "parse-pdf",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "premises",
+      "targetSkillId": "parse-json",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "premises",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "premises",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prepare",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prepare",
+      "targetSkillId": "research",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prepare",
+      "targetSkillId": "refactor-code",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prereq",
+      "targetSkillId": "retrieve",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prereqs",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prereqs",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prereqs",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prerequisite",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prerequisites",
+      "targetSkillId": "execute-bash",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prerequisites",
+      "targetSkillId": "retrieve",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prerequisites",
+      "targetSkillId": "generate-test",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "present",
+      "targetSkillId": "parse-json",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "present",
+      "targetSkillId": "parse-html",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "present",
+      "targetSkillId": "research",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "preserves",
+      "targetSkillId": "retrieve",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "preserves",
+      "targetSkillId": "research",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "preserves",
+      "targetSkillId": "parse-json",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "preserving",
+      "targetSkillId": "research",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "preserving",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "preserving",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prevalence",
+      "targetSkillId": "score-relevance",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "preview",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "princeton-nlp",
+      "targetSkillId": "parse-pdf",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "print",
+      "targetSkillId": "route-intent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "processing",
+      "targetSkillId": "real-time-voice-assistant",
+      "score": 0.457,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "processing",
+      "targetSkillId": "route-intent",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "processing",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "production",
+      "targetSkillId": "code-execution",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "production",
+      "targetSkillId": "route-intent",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "production",
+      "targetSkillId": "browser-automation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "production-grade",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.514,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "production-grade",
+      "targetSkillId": "route-intent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "production-grade",
+      "targetSkillId": "code-execution",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "programmatic",
+      "targetSkillId": "browser-automation",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "programming",
+      "targetSkillId": "browser-automation",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "programming",
+      "targetSkillId": "code-generation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "project",
+      "targetSkillId": "parse-html",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "projections",
+      "targetSkillId": "code-execution",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "projections",
+      "targetSkillId": "registry-curation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "projections",
+      "targetSkillId": "browser-automation",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "promoted",
+      "targetSkillId": "parse-pdf",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "promoted",
+      "targetSkillId": "plan-decompose",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "promotion",
+      "targetSkillId": "content-moderation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "promotion",
+      "targetSkillId": "browser-automation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "promotion",
+      "targetSkillId": "route-intent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prompting",
+      "targetSkillId": "route-intent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prompting",
+      "targetSkillId": "automated-testing",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prompting",
+      "targetSkillId": "image-caption",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prompts",
+      "targetSkillId": "computer-use",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prompts",
+      "targetSkillId": "plan-decompose",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "propose",
+      "targetSkillId": "plan-decompose",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "propose",
+      "targetSkillId": "tool-use",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "propose",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposed",
+      "targetSkillId": "parse-pdf",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposed",
+      "targetSkillId": "plan-decompose",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposed",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposer",
+      "targetSkillId": "plan-decompose",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposer",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposer",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposes",
+      "targetSkillId": "parse-json",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposes",
+      "targetSkillId": "plan-decompose",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposes",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prosody",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prosody",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "provisional",
+      "targetSkillId": "parse-json",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "provisional",
+      "targetSkillId": "conversational-agent",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pull",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pure",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pure",
+      "targetSkillId": "summarize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pure",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "python",
+      "targetSkillId": "math-reason",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "python-shell",
+      "targetSkillId": "tool-select",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "python-shell",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "python-shell-5",
+      "targetSkillId": "tool-select",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "python-version",
+      "targetSkillId": "conversational-agent",
+      "score": 0.529,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "python-version",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.514,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "python-version",
+      "targetSkillId": "content-moderation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "quantitative",
+      "targetSkillId": "extract-entities",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "quantitative",
+      "targetSkillId": "document-digitization",
+      "score": 0.485,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "quantitative",
+      "targetSkillId": "translate",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "queries",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "queries",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "queryable",
+      "targetSkillId": "memory-manage",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "question-answering",
+      "targetSkillId": "question-answer",
+      "score": 0.909,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "question-answering",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "question-answering",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.474,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "questions",
+      "targetSkillId": "question-answer",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "questions",
+      "targetSkillId": "automated-testing",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "questions",
+      "targetSkillId": "image-caption",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rag",
+      "targetSkillId": "rank",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "raise",
+      "targetSkillId": "translate",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "raise",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "raise",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "raises",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "raises",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "raises",
+      "targetSkillId": "extract-entities",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "range",
+      "targetSkillId": "rank",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "range",
+      "targetSkillId": "translate",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "range",
+      "targetSkillId": "memory-manage",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ranking",
+      "targetSkillId": "rank",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ranking",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ranks",
+      "targetSkillId": "rank",
+      "score": 0.889,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ranks",
+      "targetSkillId": "translate",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rare",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rare",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rare",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rasa",
+      "targetSkillId": "translate",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rasa",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rate",
+      "targetSkillId": "translate",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rate",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rate",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rated",
+      "targetSkillId": "translate",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rated",
+      "targetSkillId": "generate-sql",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rated",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ratio",
+      "targetSkillId": "code-generation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ratio",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ratio",
+      "targetSkillId": "registry-curation",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "raw",
+      "targetSkillId": "rank",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "re-derived",
+      "targetSkillId": "retrieve",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "re-derived",
+      "targetSkillId": "score-relevance",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "re-exports",
+      "targetSkillId": "write-report",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "re-exports",
+      "targetSkillId": "generate-text",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "re-exports",
+      "targetSkillId": "embed-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reach",
+      "targetSkillId": "research",
+      "score": 0.769,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reach",
+      "targetSkillId": "web-search",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reachable",
+      "targetSkillId": "research",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reachable",
+      "targetSkillId": "api-call",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reachable",
+      "targetSkillId": "refactor-code",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reached",
+      "targetSkillId": "research",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reached",
+      "targetSkillId": "refactor-code",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reached",
+      "targetSkillId": "web-search",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "react-reasoning",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.968,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "react-reasoning",
+      "targetSkillId": "math-reason",
+      "score": 0.692,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "react-reasoning",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.629,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "read",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "read",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "read",
+      "targetSkillId": "refactor-code",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reading",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reading",
+      "targetSkillId": "rank",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ready",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "real",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "real",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "real-time",
+      "targetSkillId": "retrieve",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "real-time",
+      "targetSkillId": "real-time-voice-assistant",
+      "score": 0.529,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "real-time",
+      "targetSkillId": "route-intent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "real-world",
+      "targetSkillId": "refactor-code",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "realistic",
+      "targetSkillId": "research",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "realistic",
+      "targetSkillId": "registry-curation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "realistic",
+      "targetSkillId": "refactor-code",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reason",
+      "targetSkillId": "math-reason",
+      "score": 0.706,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reason",
+      "targetSkillId": "parse-json",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reason",
+      "targetSkillId": "rank",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reasoning",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reasoning",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.621,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reasoning",
+      "targetSkillId": "math-reason",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reasoning-machines",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reasoning-machines",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.474,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reasoning-machines",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.474,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "record",
+      "targetSkillId": "refactor-code",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "records",
+      "targetSkillId": "refactor-code",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "recursive",
+      "targetSkillId": "retrieve",
+      "score": 0.706,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "recursive",
+      "targetSkillId": "recursive-self-improvement",
+      "score": 0.514,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "recursive",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "redirect",
+      "targetSkillId": "route-intent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "redirect",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "redirect",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ref",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refactor",
+      "targetSkillId": "refactor-code",
+      "score": 0.762,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refactor",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refactor",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refactors",
+      "targetSkillId": "refactor-code",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refactors",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refactors",
+      "targetSkillId": "retrieve",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reference",
+      "targetSkillId": "research",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reference",
+      "targetSkillId": "score-relevance",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reference",
+      "targetSkillId": "logical-inference",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "references",
+      "targetSkillId": "score-relevance",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "references",
+      "targetSkillId": "research",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "references",
+      "targetSkillId": "generate-test",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refines",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refines",
+      "targetSkillId": "route-intent",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refines",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "regex",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "regex",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "register",
+      "targetSkillId": "research",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "register",
+      "targetSkillId": "registry-curation",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "register",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registries",
+      "targetSkillId": "retrieve",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registries",
+      "targetSkillId": "ghostwrite",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registries",
+      "targetSkillId": "registry-curation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registry",
+      "targetSkillId": "registry-curation",
+      "score": 0.64,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registry",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registry",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registry-ref",
+      "targetSkillId": "registry-curation",
+      "score": 0.69,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registry-ref",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registry-ref",
+      "targetSkillId": "ghostwrite",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reject",
+      "targetSkillId": "research",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reject",
+      "targetSkillId": "tool-select",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rel",
+      "targetSkillId": "parse-html",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relations",
+      "targetSkillId": "image-caption",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relations",
+      "targetSkillId": "registry-curation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relations",
+      "targetSkillId": "browser-automation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relationships",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relationships",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relationships",
+      "targetSkillId": "registry-curation",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relative",
+      "targetSkillId": "retrieve",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relative",
+      "targetSkillId": "translate",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relative",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relevance",
+      "targetSkillId": "score-relevance",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relevance",
+      "targetSkillId": "retrieve",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relevance",
+      "targetSkillId": "research",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relevant",
+      "targetSkillId": "score-relevance",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relevant",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relevant",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relpath",
+      "targetSkillId": "research",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relpath",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "remote",
+      "targetSkillId": "retrieve",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "remote",
+      "targetSkillId": "embed-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "remove",
+      "targetSkillId": "retrieve",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repeat",
+      "targetSkillId": "research",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "replace",
+      "targetSkillId": "score-relevance",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "replace",
+      "targetSkillId": "research",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "replace",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repo",
+      "targetSkillId": "write-report",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repo",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "report",
+      "targetSkillId": "write-report",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reporting",
+      "targetSkillId": "write-report",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reporting",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reporting",
+      "targetSkillId": "retrieve",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reports",
+      "targetSkillId": "write-report",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repositories",
+      "targetSkillId": "retrieve",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repositories",
+      "targetSkillId": "extract-entities",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repositories",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repository",
+      "targetSkillId": "write-report",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "representation",
+      "targetSkillId": "error-interpretation",
+      "score": 0.647,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "representation",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "representation",
+      "targetSkillId": "browser-automation",
+      "score": 0.562,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "representations",
+      "targetSkillId": "error-interpretation",
+      "score": 0.629,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "representations",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "representations",
+      "targetSkillId": "browser-automation",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "representing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "representing",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "representing",
+      "targetSkillId": "error-interpretation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reproducible",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reproducible",
+      "targetSkillId": "refactor-code",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "request",
+      "targetSkillId": "generate-test",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "request",
+      "targetSkillId": "question-answer",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "requests",
+      "targetSkillId": "question-answer",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "requests",
+      "targetSkillId": "generate-test",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "required",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "requires",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "requiring",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "requiring",
+      "targetSkillId": "retrieve",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rerank",
+      "targetSkillId": "rank",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rerank",
+      "targetSkillId": "score-relevance",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rerank",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reranking",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reranking",
+      "targetSkillId": "rank",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reranking",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "res",
+      "targetSkillId": "research",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "res",
+      "targetSkillId": "parse-json",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "research-backed",
+      "targetSkillId": "research",
+      "score": 0.696,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "research-backed",
+      "targetSkillId": "web-search",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "research-backed",
+      "targetSkillId": "autonomous-research-agent",
+      "score": 0.55,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolution",
+      "targetSkillId": "registry-curation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolution",
+      "targetSkillId": "route-intent",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolution",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolve",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolve",
+      "targetSkillId": "research",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolve",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolved",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolved",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolver",
+      "targetSkillId": "research",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolver",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolves",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolves",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resp",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resp",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "responses",
+      "targetSkillId": "parse-json",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "responses",
+      "targetSkillId": "question-answer",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "responses",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rest",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rest",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rest",
+      "targetSkillId": "generate-test",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retrieval",
+      "targetSkillId": "retrieve",
+      "score": 0.824,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retrieval",
+      "targetSkillId": "score-relevance",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retrieval",
+      "targetSkillId": "refactor-code",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retrieval-augmented",
+      "targetSkillId": "retrieve",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retrieval-augmented",
+      "targetSkillId": "conversational-agent",
+      "score": 0.564,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retrieval-augmented",
+      "targetSkillId": "extract-entities",
+      "score": 0.514,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retrieves",
+      "targetSkillId": "retrieve",
+      "score": 0.941,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retrieves",
+      "targetSkillId": "score-relevance",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retrieves",
+      "targetSkillId": "extract-entities",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retry",
+      "targetSkillId": "retrieve",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retry",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retry",
+      "targetSkillId": "registry-curation",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "return",
+      "targetSkillId": "retrieve",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "return",
+      "targetSkillId": "registry-curation",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "return",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "returncode",
+      "targetSkillId": "refactor-code",
+      "score": 0.696,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "returncode",
+      "targetSkillId": "retrieve",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "returncode",
+      "targetSkillId": "audience-model",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "returned",
+      "targetSkillId": "retrieve",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "returned",
+      "targetSkillId": "structured-output",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "returned",
+      "targetSkillId": "registry-curation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "returns",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "returns",
+      "targetSkillId": "registry-curation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "returns",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reversal",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reversal",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reversal",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reverse",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reverse",
+      "targetSkillId": "research",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "review",
+      "targetSkillId": "retrieve",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "review",
+      "targetSkillId": "code-review-pipeline",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reviewed",
+      "targetSkillId": "retrieve",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reviewed",
+      "targetSkillId": "code-review-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reviews",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rigorous",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "roots",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "round",
+      "targetSkillId": "route-intent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "routes",
+      "targetSkillId": "route-intent",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "routes",
+      "targetSkillId": "computer-use",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "routing",
+      "targetSkillId": "route-intent",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "routing",
+      "targetSkillId": "browser-automation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "routing",
+      "targetSkillId": "code-execution",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rule-based",
+      "targetSkillId": "execute-bash",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rule-based",
+      "targetSkillId": "route-intent",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rules",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "run",
+      "targetSkillId": "rank",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "runner",
+      "targetSkillId": "question-answer",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "running",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "runs",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "runs",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "runs-on",
+      "targetSkillId": "parse-json",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "runs-on",
+      "targetSkillId": "chunk-document",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "runtime",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "runtime",
+      "targetSkillId": "route-intent",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "runtime",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "safe",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "safe",
+      "targetSkillId": "summarize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "same",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "same",
+      "targetSkillId": "summarize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scalars",
+      "targetSkillId": "classify",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scale",
+      "targetSkillId": "web-scrape",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scale",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scan",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scanned",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scanned",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scanner",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scanner",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scanner",
+      "targetSkillId": "question-answer",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "schema-dir",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "schema-valid",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "schema-valid",
+      "targetSkillId": "data-visualize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "science",
+      "targetSkillId": "score-relevance",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "science",
+      "targetSkillId": "cite-sources",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "science",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scientific",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scientific",
+      "targetSkillId": "extract-entities",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "score",
+      "targetSkillId": "web-scrape",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "score",
+      "targetSkillId": "score-relevance",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "score",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scored",
+      "targetSkillId": "web-scrape",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scored",
+      "targetSkillId": "score-relevance",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scores",
+      "targetSkillId": "web-scrape",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scores",
+      "targetSkillId": "score-relevance",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scoring",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scoring",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scoring",
+      "targetSkillId": "code-generation",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scraper",
+      "targetSkillId": "web-scrape",
+      "score": 0.706,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scraper",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scraping",
+      "targetSkillId": "web-scrape",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scraping",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scraping",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "screenshot",
+      "targetSkillId": "speech-to-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "screenshot",
+      "targetSkillId": "score-relevance",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "screenshot",
+      "targetSkillId": "voice-agent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "screenshot-based",
+      "targetSkillId": "speech-to-text",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "screenshot-based",
+      "targetSkillId": "score-relevance",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "screenshots",
+      "targetSkillId": "speech-to-text",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "screenshots",
+      "targetSkillId": "score-relevance",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "screenshots",
+      "targetSkillId": "voice-agent",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "script",
+      "targetSkillId": "self-critique",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "script",
+      "targetSkillId": "web-scrape",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "script",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scripts",
+      "targetSkillId": "self-critique",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scripts",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scripts",
+      "targetSkillId": "ghostwrite",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "search",
+      "targetSkillId": "research",
+      "score": 0.857,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "search",
+      "targetSkillId": "web-search",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "searchable",
+      "targetSkillId": "research",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "searchable",
+      "targetSkillId": "web-search",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "searchable",
+      "targetSkillId": "autonomous-research-agent",
+      "score": 0.457,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "searching",
+      "targetSkillId": "research",
+      "score": 0.706,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "searching",
+      "targetSkillId": "web-search",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "searching",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "second",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "seconds",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "secrets",
+      "targetSkillId": "self-critique",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "secrets",
+      "targetSkillId": "speech-to-text",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "secrets",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "security",
+      "targetSkillId": "self-critique",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "security",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "seed",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "segment",
+      "targetSkillId": "voice-agent",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "segment",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "segment",
+      "targetSkillId": "image-generate",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "segments",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "segments",
+      "targetSkillId": "voice-agent",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "segments",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "selecting",
+      "targetSkillId": "tool-select",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "selecting",
+      "targetSkillId": "self-critique",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "selecting",
+      "targetSkillId": "code-execution",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "selection",
+      "targetSkillId": "code-execution",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "selection",
+      "targetSkillId": "tool-select",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "selection",
+      "targetSkillId": "self-critique",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "selects",
+      "targetSkillId": "tool-select",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "selects",
+      "targetSkillId": "execute-bash",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "selects",
+      "targetSkillId": "speech-to-text",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-evidence",
+      "targetSkillId": "score-relevance",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-evidence",
+      "targetSkillId": "code-review-pipeline",
+      "score": 0.485,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-evidence",
+      "targetSkillId": "self-critique",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-feedback",
+      "targetSkillId": "self-critique",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-generated",
+      "targetSkillId": "image-generate",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-generated",
+      "targetSkillId": "code-generation",
+      "score": 0.621,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-generated",
+      "targetSkillId": "generate-sql",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-hosted",
+      "targetSkillId": "self-critique",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-hosted",
+      "targetSkillId": "speech-to-text",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-hosted",
+      "targetSkillId": "parse-html",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-refine",
+      "targetSkillId": "self-critique",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-refine",
+      "targetSkillId": "score-relevance",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-refine",
+      "targetSkillId": "code-review-pipeline",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-supervised",
+      "targetSkillId": "self-critique",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "semantic",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "semantic",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "semantic",
+      "targetSkillId": "browser-automation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "semantically",
+      "targetSkillId": "api-call",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "semantically",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sensemaking",
+      "targetSkillId": "code-generation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sentence-similarity",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.486,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sentence-similarity",
+      "targetSkillId": "real-time-voice-assistant",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sentence-similarity",
+      "targetSkillId": "generate-sql",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sentence-transformers",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.564,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sentence-transformers",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.514,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sentence-transformers",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.488,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sentiment",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sentiment",
+      "targetSkillId": "tokenize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sentiment",
+      "targetSkillId": "retrieve",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "separated",
+      "targetSkillId": "parse-pdf",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "separated",
+      "targetSkillId": "generate-sql",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "separated",
+      "targetSkillId": "research",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "separately",
+      "targetSkillId": "generate-sql",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "separately",
+      "targetSkillId": "parse-html",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sequence",
+      "targetSkillId": "score-relevance",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sequence",
+      "targetSkillId": "self-critique",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sequence",
+      "targetSkillId": "speech-to-text",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sequences",
+      "targetSkillId": "score-relevance",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sequences",
+      "targetSkillId": "cite-sources",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sequences",
+      "targetSkillId": "self-critique",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "server",
+      "targetSkillId": "retrieve",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "server",
+      "targetSkillId": "score-relevance",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "servers",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "servers",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "session",
+      "targetSkillId": "parse-json",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "session",
+      "targetSkillId": "question-answer",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sessions",
+      "targetSkillId": "parse-json",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sessions",
+      "targetSkillId": "question-answer",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "set",
+      "targetSkillId": "parse-html",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "setup-python",
+      "targetSkillId": "parse-json",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "several",
+      "targetSkillId": "generate-sql",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "shape",
+      "targetSkillId": "web-scrape",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "short",
+      "targetSkillId": "ghostwrite",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "shorter",
+      "targetSkillId": "ghostwrite",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "shorter",
+      "targetSkillId": "speech-to-text",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "shorter",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "showing",
+      "targetSkillId": "ghostwrite",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "showing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "shutil",
+      "targetSkillId": "parse-html",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "signals",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "signals",
+      "targetSkillId": "question-answer",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "signatures",
+      "targetSkillId": "generate-sql",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "signatures",
+      "targetSkillId": "generate-test",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "signatures",
+      "targetSkillId": "image-generate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "silent",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "silent",
+      "targetSkillId": "tool-select",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "silent",
+      "targetSkillId": "conversational-agent",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "similar",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "similarity",
+      "targetSkillId": "summarize",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "simulation",
+      "targetSkillId": "image-caption",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "simulation",
+      "targetSkillId": "registry-curation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "simulation",
+      "targetSkillId": "browser-automation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "size",
+      "targetSkillId": "summarize",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "size",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill-batches",
+      "targetSkillId": "translate",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "slashes",
+      "targetSkillId": "classify",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "slashes",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "smithery",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "software",
+      "targetSkillId": "ghostwrite",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "software",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "some",
+      "targetSkillId": "summarize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sorted",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "source",
+      "targetSkillId": "cite-sources",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "source",
+      "targetSkillId": "summarize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "source",
+      "targetSkillId": "score-relevance",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sources",
+      "targetSkillId": "cite-sources",
+      "score": 0.737,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sources",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sources",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "space",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "spaces",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "spatial",
+      "targetSkillId": "api-call",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "spatial",
+      "targetSkillId": "data-visualize",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "spatial",
+      "targetSkillId": "parse-html",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "spec",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specialized",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specialized",
+      "targetSkillId": "self-critique",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specialized",
+      "targetSkillId": "data-visualize",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specific",
+      "targetSkillId": "self-critique",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specification",
+      "targetSkillId": "image-caption",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specification",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.485,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specification",
+      "targetSkillId": "document-digitization",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specifications",
+      "targetSkillId": "image-caption",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specifications",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specifications",
+      "targetSkillId": "document-digitization",
+      "score": 0.457,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specified",
+      "targetSkillId": "self-critique",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "speech",
+      "targetSkillId": "text-to-speech",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "speech",
+      "targetSkillId": "speech-to-text",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "speech",
+      "targetSkillId": "research",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "splitlines",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "splitlines",
+      "targetSkillId": "self-critique",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "splitlines",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "splitter",
+      "targetSkillId": "self-critique",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "splitter",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "splitter",
+      "targetSkillId": "speech-to-text",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "spoken",
+      "targetSkillId": "tokenize",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "src",
+      "targetSkillId": "research",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "src",
+      "targetSkillId": "web-search",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stack",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "standard",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stars",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "start",
+      "targetSkillId": "ghostwrite",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "start",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "startswith",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "state",
+      "targetSkillId": "translate",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "state",
+      "targetSkillId": "ghostwrite",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "statistical",
+      "targetSkillId": "api-call",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "statistical",
+      "targetSkillId": "data-visualize",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "statistics",
+      "targetSkillId": "extract-entities",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stdout",
+      "targetSkillId": "structured-output",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stem",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "step-by-step",
+      "targetSkillId": "text-to-speech",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "step-by-step",
+      "targetSkillId": "web-search",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "step-by-step",
+      "targetSkillId": "web-scrape",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "still",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "store",
+      "targetSkillId": "ghostwrite",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "store",
+      "targetSkillId": "cite-sources",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "store",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "str",
+      "targetSkillId": "ghostwrite",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strategies",
+      "targetSkillId": "extract-entities",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strategies",
+      "targetSkillId": "translate",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strategies",
+      "targetSkillId": "generate-test",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strftime",
+      "targetSkillId": "ghostwrite",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strftime",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strftime",
+      "targetSkillId": "self-critique",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strict",
+      "targetSkillId": "ghostwrite",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "string",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stringify",
+      "targetSkillId": "classify",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strings",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strings",
+      "targetSkillId": "ghostwrite",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strip",
+      "targetSkillId": "ghostwrite",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strip",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stripped",
+      "targetSkillId": "ghostwrite",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stripped",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stripped",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stripping",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "structure",
+      "targetSkillId": "structured-output",
+      "score": 0.692,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "structure",
+      "targetSkillId": "ghostwrite",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "structure",
+      "targetSkillId": "registry-curation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "structured",
+      "targetSkillId": "structured-output",
+      "score": 0.741,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "structured",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "structures",
+      "targetSkillId": "structured-output",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "structures",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "structures",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stylized",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stylized",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stylized",
+      "targetSkillId": "data-visualize",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sub-agent",
+      "targetSkillId": "voice-agent",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sub-agent",
+      "targetSkillId": "conversational-agent",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sub-agent",
+      "targetSkillId": "route-intent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "submits",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "subparsers",
+      "targetSkillId": "parse-json",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "subparsers",
+      "targetSkillId": "summarize",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "subparsers",
+      "targetSkillId": "parse-pdf",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "subprocess",
+      "targetSkillId": "cite-sources",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "success",
+      "targetSkillId": "cite-sources",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "such",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "suggestions",
+      "targetSkillId": "question-answer",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "suggestions",
+      "targetSkillId": "image-caption",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "suggestions",
+      "targetSkillId": "parse-json",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "suitable",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "suite",
+      "targetSkillId": "summarize",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "suite",
+      "targetSkillId": "ghostwrite",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "suites",
+      "targetSkillId": "summarize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "suites",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sum",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summaries",
+      "targetSkillId": "summarize",
+      "score": 0.889,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summaries",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summaries",
+      "targetSkillId": "cite-sources",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summarization",
+      "targetSkillId": "summarize",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summarization",
+      "targetSkillId": "image-caption",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summarization",
+      "targetSkillId": "registry-curation",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summarizer",
+      "targetSkillId": "summarize",
+      "score": 0.947,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summarizer",
+      "targetSkillId": "data-visualize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summarizes",
+      "targetSkillId": "summarize",
+      "score": 0.947,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summarizes",
+      "targetSkillId": "data-visualize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summarizes",
+      "targetSkillId": "math-reason",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summary",
+      "targetSkillId": "summarize",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "supervision",
+      "targetSkillId": "parse-json",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sure",
+      "targetSkillId": "summarize",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sure",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "surpasses",
+      "targetSkillId": "parse-json",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "surpasses",
+      "targetSkillId": "cite-sources",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "survey",
+      "targetSkillId": "summarize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "syntactically",
+      "targetSkillId": "api-call",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "syntactically",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "synthesis",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "synthesis",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "synthesising",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "synthesising",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "synthesizes",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "synthesizes",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tables",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tags",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tail",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tail",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tarball",
+      "targetSkillId": "api-call",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "target",
+      "targetSkillId": "parse-html",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "target",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "task",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "task",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tasks",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "taxonomy",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "teaching",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "teaching",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "template",
+      "targetSkillId": "translate",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "terminal",
+      "targetSkillId": "memory-manage",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "terminal",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "test",
+      "targetSkillId": "generate-test",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "testable",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "testing",
+      "targetSkillId": "automated-testing",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "testing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "testing",
+      "targetSkillId": "question-answer",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tests",
+      "targetSkillId": "cite-sources",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text",
+      "targetSkillId": "embed-text",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text",
+      "targetSkillId": "generate-text",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-based",
+      "targetSkillId": "text-to-speech",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-based",
+      "targetSkillId": "execute-bash",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-based",
+      "targetSkillId": "text-to-sql-pipeline",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-classification",
+      "targetSkillId": "classify",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-classification",
+      "targetSkillId": "image-caption",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-classification",
+      "targetSkillId": "document-digitization",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-generation",
+      "targetSkillId": "code-generation",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-generation",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-generation",
+      "targetSkillId": "content-moderation",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-to",
+      "targetSkillId": "text-to-speech",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-to",
+      "targetSkillId": "text-to-sql-pipeline",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-to",
+      "targetSkillId": "content-moderation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text2text-generation",
+      "targetSkillId": "code-generation",
+      "score": 0.686,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text2text-generation",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.585,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text2text-generation",
+      "targetSkillId": "structured-output",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "texts",
+      "targetSkillId": "embed-text",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "texts",
+      "targetSkillId": "text-to-speech",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "than",
+      "targetSkillId": "math-reason",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "than",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "than",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "then",
+      "targetSkillId": "math-reason",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "then",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "these",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "these",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "these",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "threshold",
+      "targetSkillId": "math-reason",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "threshold",
+      "targetSkillId": "research",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "thresholds",
+      "targetSkillId": "math-reason",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "through",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "throughput",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "throughput",
+      "targetSkillId": "format-output",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "throughput",
+      "targetSkillId": "structured-output",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "throw",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tier",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tier",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "time",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "time",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "timed",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "timed",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "timeout",
+      "targetSkillId": "evaluate-output",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "timezone",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "timezone",
+      "targetSkillId": "memory-manage",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "timezone",
+      "targetSkillId": "image-generate",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "title",
+      "targetSkillId": "ghostwrite",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "title",
+      "targetSkillId": "route-intent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "title",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "to-end",
+      "targetSkillId": "tool-use",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "to-end",
+      "targetSkillId": "tokenize",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "to-end",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "to-markdown",
+      "targetSkillId": "math-reason",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "token",
+      "targetSkillId": "tokenize",
+      "score": 0.769,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "token",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "token-classification",
+      "targetSkillId": "document-digitization",
+      "score": 0.537,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "token-classification",
+      "targetSkillId": "classify",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "token-classification",
+      "targetSkillId": "image-caption",
+      "score": 0.485,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tokenization",
+      "targetSkillId": "tokenize",
+      "score": 0.7,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tokenization",
+      "targetSkillId": "document-digitization",
+      "score": 0.606,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tokenization",
+      "targetSkillId": "code-generation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tokenizer",
+      "targetSkillId": "tokenize",
+      "score": 0.941,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tokens",
+      "targetSkillId": "tokenize",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tolist",
+      "targetSkillId": "tool-select",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tolist",
+      "targetSkillId": "tool-use",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tone",
+      "targetSkillId": "tokenize",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tone",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tone",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tool",
+      "targetSkillId": "tool-use",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tool",
+      "targetSkillId": "tool-select",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tools",
+      "targetSkillId": "tool-use",
+      "score": 0.769,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tools",
+      "targetSkillId": "tool-select",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "top-k",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "top-k",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "top-level",
+      "targetSkillId": "tool-select",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "top-level",
+      "targetSkillId": "score-relevance",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "top-level",
+      "targetSkillId": "tool-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "topic",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "topic",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "total",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "traces",
+      "targetSkillId": "cite-sources",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "traces",
+      "targetSkillId": "extract-entities",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "traces",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "training",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "training",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "training",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "transcribes",
+      "targetSkillId": "translate",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "transcribes",
+      "targetSkillId": "extract-entities",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "transcribes",
+      "targetSkillId": "data-analysis",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "transformer",
+      "targetSkillId": "translate",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "transformer",
+      "targetSkillId": "question-answer",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "transformer",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "translation",
+      "targetSkillId": "translate",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "translation",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.71,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "translation",
+      "targetSkillId": "registry-curation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "treat",
+      "targetSkillId": "translate",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "treat",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "treat",
+      "targetSkillId": "write-report",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tree",
+      "targetSkillId": "retrieve",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tree",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tree",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "trees",
+      "targetSkillId": "retrieve",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "trees",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "trees",
+      "targetSkillId": "extract-entities",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "trim",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "true",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "true",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "true",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tsserver",
+      "targetSkillId": "write-report",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tsserver",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tuple",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "turns",
+      "targetSkillId": "translate",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "turns",
+      "targetSkillId": "cite-sources",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "turns",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "two-pass",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "two-pass",
+      "targetSkillId": "data-analysis",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "typescript",
+      "targetSkillId": "web-scrape",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "typescript-5",
+      "targetSkillId": "web-scrape",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ubuntu-latest",
+      "targetSkillId": "generate-test",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ubuntu-latest",
+      "targetSkillId": "document-analyst",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ubuntu-latest",
+      "targetSkillId": "automated-testing",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "unanswerable",
+      "targetSkillId": "question-answer",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "unanswerable",
+      "targetSkillId": "web-scrape",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "unbounded",
+      "targetSkillId": "autonomous-debug",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "uncommon",
+      "targetSkillId": "plan-decompose",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "uncommon",
+      "targetSkillId": "chunk-document",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "uncommon",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "undici-types",
+      "targetSkillId": "audience-model",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "uninstall",
+      "targetSkillId": "api-call",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "unlocked",
+      "targetSkillId": "chunk-document",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "unstructured",
+      "targetSkillId": "structured-output",
+      "score": 0.69,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "unstructured",
+      "targetSkillId": "ghostwrite",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "update-tree",
+      "targetSkillId": "retrieve",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "update-tree",
+      "targetSkillId": "route-intent",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "update-tree",
+      "targetSkillId": "generate-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "updates",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "uppercase",
+      "targetSkillId": "computer-use",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "usage",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "use",
+      "targetSkillId": "tool-use",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "used",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "used",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "user",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "user",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "username",
+      "targetSkillId": "memory-manage",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "username",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "users",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "users",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "uses",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "using",
+      "targetSkillId": "automated-testing",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "utilities",
+      "targetSkillId": "extract-entities",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "utilities",
+      "targetSkillId": "route-intent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "utilities",
+      "targetSkillId": "self-critique",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "valence",
+      "targetSkillId": "logical-inference",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "valence",
+      "targetSkillId": "audience-model",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "valence",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validate",
+      "targetSkillId": "translate",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validate",
+      "targetSkillId": "evaluate-output",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validate",
+      "targetSkillId": "data-visualize",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validated",
+      "targetSkillId": "translate",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validated",
+      "targetSkillId": "evaluate-output",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validates",
+      "targetSkillId": "translate",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validates",
+      "targetSkillId": "evaluate-output",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validation",
+      "targetSkillId": "image-caption",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validation",
+      "targetSkillId": "evaluate-output",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validation",
+      "targetSkillId": "code-generation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "value",
+      "targetSkillId": "evaluate-output",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "value",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "values",
+      "targetSkillId": "evaluate-output",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "variables",
+      "targetSkillId": "api-call",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "vector",
+      "targetSkillId": "refactor-code",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "vectors",
+      "targetSkillId": "refactor-code",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "verified",
+      "targetSkillId": "self-critique",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "verifying",
+      "targetSkillId": "memory-manage",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "version",
+      "targetSkillId": "conversational-agent",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "version",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "version",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "versions",
+      "targetSkillId": "question-answer",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "versions",
+      "targetSkillId": "conversational-agent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "virtual",
+      "targetSkillId": "data-visualize",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "vision-language",
+      "targetSkillId": "question-answer",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "vision-language",
+      "targetSkillId": "conversational-agent",
+      "score": 0.514,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "vision-language",
+      "targetSkillId": "memory-manage",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "visual",
+      "targetSkillId": "data-visualize",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "visualization",
+      "targetSkillId": "data-visualize",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "visualization",
+      "targetSkillId": "image-caption",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "visualization",
+      "targetSkillId": "registry-curation",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "visualizations",
+      "targetSkillId": "data-visualize",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "visualizations",
+      "targetSkillId": "image-caption",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "visualizations",
+      "targetSkillId": "registry-curation",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "visualstudio",
+      "targetSkillId": "data-visualize",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "visualstudio",
+      "targetSkillId": "registry-curation",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "voice",
+      "targetSkillId": "voice-agent",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "voice",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "vscode-marketplace",
+      "targetSkillId": "code-review-pipeline",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "vscode-marketplace",
+      "targetSkillId": "score-relevance",
+      "score": 0.485,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "vscode-marketplace",
+      "targetSkillId": "voice-agent",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "walk",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "want",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "want",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "warnings",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "weak",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "web",
+      "targetSkillId": "web-search",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "web",
+      "targetSkillId": "web-scrape",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "web-arena-x",
+      "targetSkillId": "web-search",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "web-arena-x",
+      "targetSkillId": "web-scrape",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "web-arena-x",
+      "targetSkillId": "embed-text",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "webarena",
+      "targetSkillId": "web-search",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "webarena",
+      "targetSkillId": "web-scrape",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "webp",
+      "targetSkillId": "web-scrape",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "websites",
+      "targetSkillId": "web-search",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "websites",
+      "targetSkillId": "web-scrape",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "well-formed",
+      "targetSkillId": "web-scrape",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "wet-lab",
+      "targetSkillId": "web-search",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "wet-lab",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "whenever",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "where",
+      "targetSkillId": "web-scrape",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "where",
+      "targetSkillId": "write-report",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "whisper",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "will",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "without",
+      "targetSkillId": "write-report",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "without",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "wrapper",
+      "targetSkillId": "web-scrape",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "wrapper",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "write",
+      "targetSkillId": "ghostwrite",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "write",
+      "targetSkillId": "write-report",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "write",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "writes",
+      "targetSkillId": "ghostwrite",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "writes",
+      "targetSkillId": "write-report",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "writes",
+      "targetSkillId": "extract-entities",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "writing",
+      "targetSkillId": "ghostwrite",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "writing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "written",
+      "targetSkillId": "ghostwrite",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "written",
+      "targetSkillId": "write-report",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "written",
+      "targetSkillId": "route-intent",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "zero-config",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "zero-shot",
+      "targetSkillId": "generate-test",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "zero-shot-classification",
+      "targetSkillId": "error-interpretation",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    }
+  ]
+}

--- a/intake/skill-batches/20260429135145-gaiabot-gaia-skill-tree.json
+++ b/intake/skill-batches/20260429135145-gaiabot-gaia-skill-tree.json
@@ -1,0 +1,30468 @@
+{
+  "batchId": "20260429135145-gaiabot-gaia-skill-tree",
+  "userId": "gaiabot",
+  "sourceRepo": "mbtiongson1/gaia-skill-tree",
+  "generatedAt": "2026-04-29T13:51:45Z",
+  "knownSkills": [
+    {
+      "skillId": "audience-model"
+    },
+    {
+      "skillId": "autonomous-debug"
+    },
+    {
+      "skillId": "autonomous-research-agent"
+    },
+    {
+      "skillId": "browser-automation"
+    },
+    {
+      "skillId": "chain-of-thought"
+    },
+    {
+      "skillId": "chunk-document"
+    },
+    {
+      "skillId": "cite-sources"
+    },
+    {
+      "skillId": "classify"
+    },
+    {
+      "skillId": "code-execution"
+    },
+    {
+      "skillId": "code-generation"
+    },
+    {
+      "skillId": "computer-use"
+    },
+    {
+      "skillId": "diff-content"
+    },
+    {
+      "skillId": "document-analyst"
+    },
+    {
+      "skillId": "embed-text"
+    },
+    {
+      "skillId": "error-interpretation"
+    },
+    {
+      "skillId": "evaluate-output"
+    },
+    {
+      "skillId": "execute-bash"
+    },
+    {
+      "skillId": "extract-entities"
+    },
+    {
+      "skillId": "format-output"
+    },
+    {
+      "skillId": "generate-text"
+    },
+    {
+      "skillId": "ghostwrite"
+    },
+    {
+      "skillId": "hypothesis-generate"
+    },
+    {
+      "skillId": "knowledge-graph-build"
+    },
+    {
+      "skillId": "knowledge-harvest"
+    },
+    {
+      "skillId": "logical-inference"
+    },
+    {
+      "skillId": "math-reason"
+    },
+    {
+      "skillId": "multi-agent-orchestration-v"
+    },
+    {
+      "skillId": "parse-html"
+    },
+    {
+      "skillId": "parse-json"
+    },
+    {
+      "skillId": "plan-and-execute"
+    },
+    {
+      "skillId": "plan-decompose"
+    },
+    {
+      "skillId": "rag-pipeline"
+    },
+    {
+      "skillId": "rank"
+    },
+    {
+      "skillId": "recursive-self-improvement"
+    },
+    {
+      "skillId": "registry-curation"
+    },
+    {
+      "skillId": "research"
+    },
+    {
+      "skillId": "retrieve"
+    },
+    {
+      "skillId": "route-intent"
+    },
+    {
+      "skillId": "scientific-discovery"
+    },
+    {
+      "skillId": "score-relevance"
+    },
+    {
+      "skillId": "self-critique"
+    },
+    {
+      "skillId": "structured-output"
+    },
+    {
+      "skillId": "summarize"
+    },
+    {
+      "skillId": "text-to-sql-pipeline"
+    },
+    {
+      "skillId": "tokenize"
+    },
+    {
+      "skillId": "tool-select"
+    },
+    {
+      "skillId": "tool-use"
+    },
+    {
+      "skillId": "translate"
+    },
+    {
+      "skillId": "web-scrape"
+    },
+    {
+      "skillId": "web-search"
+    },
+    {
+      "skillId": "write-report"
+    }
+  ],
+  "proposedSkills": [
+    {
+      "id": "a-z",
+      "name": "A-z",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: A-z.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "a-z0-9",
+      "name": "A-z0-9",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: A-z0-9.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "abductive",
+      "name": "Abductive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Abductive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "above",
+      "name": "Above",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Above.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "abs",
+      "name": "Abs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Abs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "absolute",
+      "name": "Absolute",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Absolute.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "abspath",
+      "name": "Abspath",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Abspath.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "accents",
+      "name": "Accents",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Accents.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "accept",
+      "name": "Accept",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Accept.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "accepted",
+      "name": "Accepted",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Accepted.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "access",
+      "name": "Access",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Access.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "accidentally",
+      "name": "Accidentally",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Accidentally.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "accuracy",
+      "name": "Accuracy",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Accuracy.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "accurate",
+      "name": "Accurate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Accurate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "achieves",
+      "name": "Achieves",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Achieves.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "achieving",
+      "name": "Achieving",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Achieving.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "across",
+      "name": "Across",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Across.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "act",
+      "name": "Act",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Act.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "acting",
+      "name": "Acting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Acting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "action",
+      "name": "Action",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Action.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "actions",
+      "name": "Actions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Actions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "actual",
+      "name": "Actual",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Actual.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "adapting",
+      "name": "Adapting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Adapting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "add",
+      "name": "Add",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Add.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "added",
+      "name": "Added",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Added.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "additions",
+      "name": "Additions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Additions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "adjacency",
+      "name": "Adjacency",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Adjacency.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "advancement",
+      "name": "Advancement",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Advancement.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "after",
+      "name": "After",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: After.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "against",
+      "name": "Against",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Against.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "agent",
+      "name": "Agent",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Agent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "agent-native",
+      "name": "Agent-native",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Agent-native.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "agent-related",
+      "name": "Agent-related",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Agent-related.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "agents",
+      "name": "Agents",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Agents.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ahead",
+      "name": "Ahead",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ahead.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ai-agent",
+      "name": "Ai-agent",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ai-agent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ai-agent-tool",
+      "name": "Ai-agent-tool",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ai-agent-tool.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "algebra",
+      "name": "Algebra",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Algebra.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "alive",
+      "name": "Alive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Alive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "all",
+      "name": "All",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: All.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "allocation",
+      "name": "Allocation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Allocation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "allowed",
+      "name": "Allowed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Allowed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "also",
+      "name": "Also",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Also.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "analyses",
+      "name": "Analyses",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Analyses.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "analysis",
+      "name": "Analysis",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Analysis.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "anomaly",
+      "name": "Anomaly",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Anomaly.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "another",
+      "name": "Another",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Another.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "answer",
+      "name": "Answer",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Answer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "answers",
+      "name": "Answers",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Answers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "any",
+      "name": "Any",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Any.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "api",
+      "name": "Api",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Api.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "api-version",
+      "name": "Api-version",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Api-version.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "appears",
+      "name": "Appears",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Appears.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "append",
+      "name": "Append",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Append.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "application",
+      "name": "Application",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Application.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "apply",
+      "name": "Apply",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Apply.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "approach",
+      "name": "Approach",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Approach.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "appropriate",
+      "name": "Appropriate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Appropriate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "approval",
+      "name": "Approval",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Approval.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "archived",
+      "name": "Archived",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Archived.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "argparse",
+      "name": "Argparse",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Argparse.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.483
+        }
+      ]
+    },
+    {
+      "id": "args",
+      "name": "Args",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Args.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "arguments",
+      "name": "Arguments",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Arguments.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "argv",
+      "name": "Argv",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Argv.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "arithmetic",
+      "name": "Arithmetic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Arithmetic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "array",
+      "name": "Array",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Array.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "arrays",
+      "name": "Arrays",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Arrays.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "arriving",
+      "name": "Arriving",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Arriving.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "artifact",
+      "name": "Artifact",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Artifact.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "artifacts",
+      "name": "Artifacts",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Artifacts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "arxiv",
+      "name": "Arxiv",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Arxiv.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "asdict",
+      "name": "Asdict",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Asdict.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "assembles",
+      "name": "Assembles",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Assembles.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "assert",
+      "name": "Assert",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Assert.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "assistant",
+      "name": "Assistant",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Assistant.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "assistants",
+      "name": "Assistants",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Assistants.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "async",
+      "name": "Async",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Async.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "atomic",
+      "name": "Atomic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Atomic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "atomics",
+      "name": "Atomics",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Atomics.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "attrib",
+      "name": "Attrib",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Attrib.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "attribute",
+      "name": "Attribute",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Attribute.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "attributes",
+      "name": "Attributes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Attributes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "attvalue",
+      "name": "Attvalue",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Attvalue.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "attvalues",
+      "name": "Attvalues",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Attvalues.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "audience",
+      "name": "Audience",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Audience.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "audience-tailored",
+      "name": "Audience-tailored",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Audience-tailored.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "audio",
+      "name": "Audio",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Audio.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "augmented",
+      "name": "Augmented",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Augmented.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "auth",
+      "name": "Auth",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Auth.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "authenticated",
+      "name": "Authenticated",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Authenticated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "author",
+      "name": "Author",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Author.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.556
+        }
+      ]
+    },
+    {
+      "id": "authoritative",
+      "name": "Authoritative",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Authoritative.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.48
+        }
+      ]
+    },
+    {
+      "id": "auto-generated",
+      "name": "Auto-generated",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Auto-generated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.538
+        }
+      ]
+    },
+    {
+      "id": "auto-prompt-combinations",
+      "name": "Auto-prompt-combinations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Auto-prompt-combinations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "autogen",
+      "name": "Autogen",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Autogen.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.526
+        },
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "automated",
+      "name": "Automated",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Automated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.522
+        },
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "automatic",
+      "name": "Automatic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Automatic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.571
+        }
+      ]
+    },
+    {
+      "id": "automatically",
+      "name": "Automatically",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Automatically.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.48
+        }
+      ]
+    },
+    {
+      "id": "autonomous",
+      "name": "Autonomous",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Autonomous.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.833
+        },
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "autonomously",
+      "name": "Autonomously",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Autonomously.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.769
+        }
+      ]
+    },
+    {
+      "id": "autoregressive",
+      "name": "Autoregressive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Autoregressive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.538
+        }
+      ]
+    },
+    {
+      "id": "autoresearch",
+      "name": "Autoresearch",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Autoresearch.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 1.0
+        }
+      ]
+    },
+    {
+      "id": "availability",
+      "name": "Availability",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Availability.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "available",
+      "name": "Available",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Available.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "await",
+      "name": "Await",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Await.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "awakened",
+      "name": "Awakened",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Awakened.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "awareness",
+      "name": "Awareness",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Awareness.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "back",
+      "name": "Back",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Back.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "backends",
+      "name": "Backends",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Backends.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "based",
+      "name": "Based",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Based.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "baseline",
+      "name": "Baseline",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Baseline.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "baselines",
+      "name": "Baselines",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Baselines.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bash",
+      "name": "Bash",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bash.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "batch",
+      "name": "Batch",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Batch.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "batched",
+      "name": "Batched",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Batched.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "batches",
+      "name": "Batches",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Batches.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "becomes",
+      "name": "Becomes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Becomes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "been",
+      "name": "Been",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Been.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "before",
+      "name": "Before",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Before.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "begin",
+      "name": "Begin",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Begin.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "behavior",
+      "name": "Behavior",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Behavior.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "being",
+      "name": "Being",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Being.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "beliefs",
+      "name": "Beliefs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Beliefs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bench",
+      "name": "Bench",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bench.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "benchmark",
+      "name": "Benchmark",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Benchmark.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "benchmarked",
+      "name": "Benchmarked",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Benchmarked.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "benchmarks",
+      "name": "Benchmarks",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Benchmarks.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "between",
+      "name": "Between",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Between.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bibliographic",
+      "name": "Bibliographic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bibliographic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bin",
+      "name": "Bin",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bin.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "binary",
+      "name": "Binary",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Binary.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "blob",
+      "name": "Blob",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Blob.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "block",
+      "name": "Block",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Block.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "body",
+      "name": "Body",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Body.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "body-file",
+      "name": "Body-file",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Body-file.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bool",
+      "name": "Bool",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bool.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "boolean",
+      "name": "Boolean",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Boolean.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "booleans",
+      "name": "Booleans",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Booleans.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bootstrapped",
+      "name": "Bootstrapped",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bootstrapped.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bot",
+      "name": "Bot",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bot.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bot-proposal",
+      "name": "Bot-proposal",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bot-proposal.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bpush",
+      "name": "Bpush",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bpush.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "branch",
+      "name": "Branch",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Branch.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "break",
+      "name": "Break",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Break.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "broken",
+      "name": "Broken",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Broken.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "browsers",
+      "name": "Browsers",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Browsers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bucket",
+      "name": "Bucket",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bucket.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "buckets",
+      "name": "Buckets",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Buckets.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "buffer",
+      "name": "Buffer",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Buffer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bugs",
+      "name": "Bugs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bugs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "build",
+      "name": "Build",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Build.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "built",
+      "name": "Built",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Built.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bundler",
+      "name": "Bundler",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bundler.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "but",
+      "name": "But",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: But.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bytecode",
+      "name": "Bytecode",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bytecode.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cache",
+      "name": "Cache",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cache.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "calculus",
+      "name": "Calculus",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Calculus.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "call",
+      "name": "Call",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Call.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "calling",
+      "name": "Calling",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Calling.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "calls",
+      "name": "Calls",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Calls.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "came",
+      "name": "Came",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Came.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "can",
+      "name": "Can",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Can.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "candidate",
+      "name": "Candidate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Candidate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "candidates",
+      "name": "Candidates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Candidates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cannot",
+      "name": "Cannot",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cannot.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "canonical",
+      "name": "Canonical",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Canonical.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "capability",
+      "name": "Capability",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Capability.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "capitalize",
+      "name": "Capitalize",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Capitalize.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "caps",
+      "name": "Caps",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Caps.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "captures",
+      "name": "Captures",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Captures.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "capturing",
+      "name": "Capturing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Capturing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "case",
+      "name": "Case",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Case.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cases",
+      "name": "Cases",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cases.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "catch",
+      "name": "Catch",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Catch.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "catches",
+      "name": "Catches",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Catches.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "categorical",
+      "name": "Categorical",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Categorical.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "categories",
+      "name": "Categories",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Categories.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.545
+        }
+      ]
+    },
+    {
+      "id": "categorization",
+      "name": "Categorization",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Categorization.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "category",
+      "name": "Category",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Category.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "caught",
+      "name": "Caught",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Caught.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "causes",
+      "name": "Causes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Causes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "chain",
+      "name": "Chain",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Chain.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "chain-of-thought-hub",
+      "name": "Chain-of-thought-hub",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Chain-of-thought-hub.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "chain-of-thought-only",
+      "name": "Chain-of-thought-only",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Chain-of-thought-only.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "chains",
+      "name": "Chains",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Chains.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "change",
+      "name": "Change",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Change.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "changed",
+      "name": "Changed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Changed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "changes",
+      "name": "Changes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Changes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "changing",
+      "name": "Changing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Changing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "charts",
+      "name": "Charts",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Charts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "check",
+      "name": "Check",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Check.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "checker",
+      "name": "Checker",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Checker.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "checkout",
+      "name": "Checkout",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Checkout.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "checks",
+      "name": "Checks",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Checks.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "chemistry",
+      "name": "Chemistry",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Chemistry.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "chemists",
+      "name": "Chemists",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Chemists.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "child",
+      "name": "Child",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Child.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "children",
+      "name": "Children",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Children.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "chr",
+      "name": "Chr",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Chr.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "chunk",
+      "name": "Chunk",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Chunk.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "chunking",
+      "name": "Chunking",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Chunking.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "citation",
+      "name": "Citation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Citation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "citations",
+      "name": "Citations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Citations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "claims",
+      "name": "Claims",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Claims.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "clarity",
+      "name": "Clarity",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Clarity.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "class",
+      "name": "Class",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Class.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "classification",
+      "name": "Classification",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Classification.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "classifier",
+      "name": "Classifier",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Classifier.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cleaned",
+      "name": "Cleaned",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cleaned.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cli",
+      "name": "Cli",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cli.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "click",
+      "name": "Click",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Click.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "clicks",
+      "name": "Clicks",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Clicks.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "clone",
+      "name": "Clone",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Clone.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cloning",
+      "name": "Cloning",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cloning.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "closing",
+      "name": "Closing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Closing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "clustering",
+      "name": "Clustering",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Clustering.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cmd",
+      "name": "Cmd",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cmd.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "co-references",
+      "name": "Co-references",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Co-references.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.48
+        }
+      ]
+    },
+    {
+      "id": "code",
+      "name": "Code",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Code.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "codec",
+      "name": "Codec",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Codec.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "codegen",
+      "name": "Codegen",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Codegen.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "codes",
+      "name": "Codes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Codes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "coherent",
+      "name": "Coherent",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Coherent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "collections",
+      "name": "Collections",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Collections.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "color",
+      "name": "Color",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Color.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "com",
+      "name": "Com",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Com.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "combination",
+      "name": "Combination",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Combination.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "combinations",
+      "name": "Combinations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Combinations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "combinator",
+      "name": "Combinator",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Combinator.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "combine",
+      "name": "Combine",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Combine.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "combining",
+      "name": "Combining",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Combining.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "combo",
+      "name": "Combo",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Combo.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "combos",
+      "name": "Combos",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Combos.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "command",
+      "name": "Command",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Command.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "commands",
+      "name": "Commands",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Commands.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "comment",
+      "name": "Comment",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Comment.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "commit",
+      "name": "Commit",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Commit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "common",
+      "name": "Common",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Common.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "community",
+      "name": "Community",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Community.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "comparisons",
+      "name": "Comparisons",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Comparisons.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "compatible",
+      "name": "Compatible",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Compatible.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "competition",
+      "name": "Competition",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Competition.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "compile",
+      "name": "Compile",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Compile.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "complete",
+      "name": "Complete",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Complete.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "completes",
+      "name": "Completes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Completes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "completing",
+      "name": "Completing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Completing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "completion",
+      "name": "Completion",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Completion.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "complex",
+      "name": "Complex",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Complex.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "complexity",
+      "name": "Complexity",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Complexity.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "composite",
+      "name": "Composite",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Composite.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "composites",
+      "name": "Composites",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Composites.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "comprehension",
+      "name": "Comprehension",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Comprehension.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "comprehensive",
+      "name": "Comprehensive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Comprehensive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "computation",
+      "name": "Computation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Computation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "compute",
+      "name": "Compute",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Compute.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "computer",
+      "name": "Computer",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Computer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "computes",
+      "name": "Computes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Computes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "conclusions",
+      "name": "Conclusions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Conclusions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "condition",
+      "name": "Condition",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Condition.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "conditions",
+      "name": "Conditions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Conditions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "conducts",
+      "name": "Conducts",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Conducts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "config",
+      "name": "Config",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Config.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "configurable",
+      "name": "Configurable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Configurable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "configuration",
+      "name": "Configuration",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Configuration.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "configured",
+      "name": "Configured",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Configured.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "confirm",
+      "name": "Confirm",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Confirm.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "confirmed",
+      "name": "Confirmed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Confirmed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "conflict",
+      "name": "Conflict",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Conflict.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "conform",
+      "name": "Conform",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Conform.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "connector",
+      "name": "Connector",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Connector.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "consecutive",
+      "name": "Consecutive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Consecutive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "console",
+      "name": "Console",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Console.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "const",
+      "name": "Const",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Const.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "constrained",
+      "name": "Constrained",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Constrained.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "constraints",
+      "name": "Constraints",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Constraints.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "construction",
+      "name": "Construction",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Construction.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "contain",
+      "name": "Contain",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Contain.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "containing",
+      "name": "Containing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Containing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "content",
+      "name": "Content",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Content.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "context",
+      "name": "Context",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Context.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "context-grounded",
+      "name": "Context-grounded",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Context-grounded.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "contextually",
+      "name": "Contextually",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Contextually.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "continuation",
+      "name": "Continuation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Continuation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "continue",
+      "name": "Continue",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Continue.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "contributor",
+      "name": "Contributor",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Contributor.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "control",
+      "name": "Control",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Control.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "controlled",
+      "name": "Controlled",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Controlled.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "convention",
+      "name": "Convention",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Convention.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "conversation",
+      "name": "Conversation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Conversation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "conversational",
+      "name": "Conversational",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Conversational.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "conversations",
+      "name": "Conversations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Conversations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "convert",
+      "name": "Convert",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Convert.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "copilot",
+      "name": "Copilot",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Copilot.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "copy",
+      "name": "Copy",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Copy.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "copy2",
+      "name": "Copy2",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Copy2.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "core",
+      "name": "Core",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Core.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "corpora",
+      "name": "Corpora",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Corpora.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "corpus",
+      "name": "Corpus",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Corpus.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "correct",
+      "name": "Correct",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Correct.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "correctness",
+      "name": "Correctness",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Correctness.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cosine",
+      "name": "Cosine",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cosine.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "could",
+      "name": "Could",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Could.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "count",
+      "name": "Count",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Count.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "coupling",
+      "name": "Coupling",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Coupling.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "coverage",
+      "name": "Coverage",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Coverage.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "covering",
+      "name": "Covering",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Covering.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "crawl",
+      "name": "Crawl",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Crawl.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "crawler",
+      "name": "Crawler",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Crawler.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "crawlers",
+      "name": "Crawlers",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Crawlers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "crawling",
+      "name": "Crawling",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Crawling.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "create",
+      "name": "Create",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Create.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "created",
+      "name": "Created",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Created.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "creating",
+      "name": "Creating",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Creating.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "creation",
+      "name": "Creation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Creation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "creator",
+      "name": "Creator",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Creator.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "criteria",
+      "name": "Criteria",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Criteria.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cross-domain",
+      "name": "Cross-domain",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cross-domain.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "curation",
+      "name": "Curation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Curation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "current",
+      "name": "Current",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Current.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cwd",
+      "name": "Cwd",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cwd.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cycle",
+      "name": "Cycle",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cycle.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cycles",
+      "name": "Cycles",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cycles.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dash",
+      "name": "Dash",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dash.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "data",
+      "name": "Data",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Data.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dataclass",
+      "name": "Dataclass",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dataclass.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dataclasses",
+      "name": "Dataclasses",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dataclasses.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dataset",
+      "name": "Dataset",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dataset.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "datasets",
+      "name": "Datasets",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Datasets.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "date",
+      "name": "Date",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Date.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dates",
+      "name": "Dates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "datetime",
+      "name": "Datetime",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Datetime.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "days",
+      "name": "Days",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Days.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dead",
+      "name": "Dead",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dead.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "debugging",
+      "name": "Debugging",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Debugging.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "decay",
+      "name": "Decay",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Decay.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "decide",
+      "name": "Decide",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Decide.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "declaration",
+      "name": "Declaration",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Declaration.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "decoding",
+      "name": "Decoding",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Decoding.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "decomposed",
+      "name": "Decomposed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Decomposed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "decomposition",
+      "name": "Decomposition",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Decomposition.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "deductive",
+      "name": "Deductive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Deductive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dedup",
+      "name": "Dedup",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dedup.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "deduplicate",
+      "name": "Deduplicate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Deduplicate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "def",
+      "name": "Def",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Def.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "default",
+      "name": "Default",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Default.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "defaultdict",
+      "name": "Defaultdict",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Defaultdict.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "defaultedgetype",
+      "name": "Defaultedgetype",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Defaultedgetype.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "defaults",
+      "name": "Defaults",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Defaults.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "defined",
+      "name": "Defined",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Defined.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "definitions",
+      "name": "Definitions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Definitions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.529
+        }
+      ]
+    },
+    {
+      "id": "delegates",
+      "name": "Delegates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Delegates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "deletions",
+      "name": "Deletions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Deletions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "delimiter",
+      "name": "Delimiter",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Delimiter.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "delta",
+      "name": "Delta",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Delta.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "demonstrates",
+      "name": "Demonstrates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Demonstrates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "demonstrating",
+      "name": "Demonstrating",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Demonstrating.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "demos",
+      "name": "Demos",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Demos.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dense",
+      "name": "Dense",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dense.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dependencies",
+      "name": "Dependencies",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dependencies.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "depth",
+      "name": "Depth",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Depth.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "deriv",
+      "name": "Deriv",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Deriv.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "derivative",
+      "name": "Derivative",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Derivative.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "derivatives",
+      "name": "Derivatives",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Derivatives.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "derive",
+      "name": "Derive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Derive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "desc",
+      "name": "Desc",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Desc.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "descending",
+      "name": "Descending",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Descending.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "description",
+      "name": "Description",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Description.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "descriptions",
+      "name": "Descriptions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Descriptions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "design",
+      "name": "Design",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Design.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "designs",
+      "name": "Designs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Designs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "desktop",
+      "name": "Desktop",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Desktop.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dest",
+      "name": "Dest",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dest.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "detail",
+      "name": "Detail",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Detail.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "detect",
+      "name": "Detect",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Detect.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "detected",
+      "name": "Detected",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Detected.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "detection",
+      "name": "Detection",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Detection.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "detects",
+      "name": "Detects",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Detects.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dev",
+      "name": "Dev",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dev.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "development",
+      "name": "Development",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Development.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "deviations",
+      "name": "Deviations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Deviations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.545
+        }
+      ]
+    },
+    {
+      "id": "dfs",
+      "name": "Dfs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dfs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "diagnoses",
+      "name": "Diagnoses",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Diagnoses.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dialogue",
+      "name": "Dialogue",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dialogue.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dict",
+      "name": "Dict",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dict.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dicts",
+      "name": "Dicts",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dicts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "diff",
+      "name": "Diff",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Diff.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "diffing",
+      "name": "Diffing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Diffing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "difflib",
+      "name": "Difflib",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Difflib.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "diffusion",
+      "name": "Diffusion",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Diffusion.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "diffusion-based",
+      "name": "Diffusion-based",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Diffusion-based.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dimensions",
+      "name": "Dimensions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dimensions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dir",
+      "name": "Dir",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dir.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "direct",
+      "name": "Direct",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Direct.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "directed",
+      "name": "Directed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Directed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "directionally",
+      "name": "Directionally",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Directionally.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "directly",
+      "name": "Directly",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Directly.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "directory",
+      "name": "Directory",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Directory.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "directs",
+      "name": "Directs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Directs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dirname",
+      "name": "Dirname",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dirname.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dirs",
+      "name": "Dirs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dirs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "discovered",
+      "name": "Discovered",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Discovered.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "discrete",
+      "name": "Discrete",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Discrete.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "display",
+      "name": "Display",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Display.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dist",
+      "name": "Dist",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dist.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "distance",
+      "name": "Distance",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Distance.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "diverse",
+      "name": "Diverse",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Diverse.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "docs",
+      "name": "Docs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Docs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "doctor",
+      "name": "Doctor",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Doctor.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "document",
+      "name": "Document",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Document.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "documentation",
+      "name": "Documentation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Documentation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "documented",
+      "name": "Documented",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Documented.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "documents",
+      "name": "Documents",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Documents.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "does",
+      "name": "Does",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Does.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "doesn",
+      "name": "Doesn",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Doesn.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dom",
+      "name": "Dom",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dom.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "don",
+      "name": "Don",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Don.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dot",
+      "name": "Dot",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dot.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "download",
+      "name": "Download",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Download.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "downloads",
+      "name": "Downloads",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Downloads.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "downstream",
+      "name": "Downstream",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Downstream.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "draft",
+      "name": "Draft",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Draft.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "draft-skills",
+      "name": "Draft-skills",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Draft-skills.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dramatically",
+      "name": "Dramatically",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dramatically.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dry",
+      "name": "Dry",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dry.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dry-run",
+      "name": "Dry-run",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dry-run.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dtype",
+      "name": "Dtype",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dtype.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dual-layer",
+      "name": "Dual-layer",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dual-layer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dump",
+      "name": "Dump",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dump.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dumps",
+      "name": "Dumps",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dumps.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "duplicate",
+      "name": "Duplicate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Duplicate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "duplicates",
+      "name": "Duplicates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Duplicates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dynamic",
+      "name": "Dynamic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dynamic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "each",
+      "name": "Each",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Each.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "echo",
+      "name": "Echo",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Echo.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "edge",
+      "name": "Edge",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Edge.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "edge-case",
+      "name": "Edge-case",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Edge-case.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "edges",
+      "name": "Edges",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Edges.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "edit",
+      "name": "Edit",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Edit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "edits",
+      "name": "Edits",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Edits.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "elem",
+      "name": "Elem",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Elem.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "elements",
+      "name": "Elements",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Elements.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "elicits",
+      "name": "Elicits",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Elicits.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "elif",
+      "name": "Elif",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Elif.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "else",
+      "name": "Else",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Else.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "embed",
+      "name": "Embed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Embed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "embedding",
+      "name": "Embedding",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Embedding.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "embeddings",
+      "name": "Embeddings",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Embeddings.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "embeds",
+      "name": "Embeds",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Embeds.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "emotional",
+      "name": "Emotional",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Emotional.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "empty",
+      "name": "Empty",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Empty.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "enables",
+      "name": "Enables",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Enables.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "enabling",
+      "name": "Enabling",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Enabling.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "encode",
+      "name": "Encode",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Encode.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "encoding",
+      "name": "Encoding",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Encoding.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "end",
+      "name": "End",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: End.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "end-to-end",
+      "name": "End-to-end",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: End-to-end.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "endpoints",
+      "name": "Endpoints",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Endpoints.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "endswith",
+      "name": "Endswith",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Endswith.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "engine",
+      "name": "Engine",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Engine.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "engineering",
+      "name": "Engineering",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Engineering.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "engines",
+      "name": "Engines",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Engines.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "enhances",
+      "name": "Enhances",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Enhances.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "entities",
+      "name": "Entities",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Entities.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "entity",
+      "name": "Entity",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Entity.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "entries",
+      "name": "Entries",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Entries.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "entry",
+      "name": "Entry",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Entry.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "enumerate",
+      "name": "Enumerate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Enumerate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "env",
+      "name": "Env",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Env.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "environ",
+      "name": "Environ",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Environ.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "environment",
+      "name": "Environment",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Environment.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "environments",
+      "name": "Environments",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Environments.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "epic",
+      "name": "Epic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Epic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "equal",
+      "name": "Equal",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Equal.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "equations",
+      "name": "Equations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Equations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "err",
+      "name": "Err",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Err.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "error",
+      "name": "Error",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Error.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "errors",
+      "name": "Errors",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Errors.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "establishes",
+      "name": "Establishes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Establishes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "establishing",
+      "name": "Establishing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Establishing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "etc",
+      "name": "Etc",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Etc.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "etree",
+      "name": "Etree",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Etree.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "eval",
+      "name": "Eval",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Eval.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "evaluated",
+      "name": "Evaluated",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Evaluated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "evaluates",
+      "name": "Evaluates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Evaluates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "evaluating",
+      "name": "Evaluating",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Evaluating.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "evaluation",
+      "name": "Evaluation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Evaluation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "evaluator",
+      "name": "Evaluator",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Evaluator.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "every",
+      "name": "Every",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Every.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "evidence",
+      "name": "Evidence",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Evidence.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "evidence-health",
+      "name": "Evidence-health",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Evidence-health.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "exact",
+      "name": "Exact",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exact.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "exc",
+      "name": "Exc",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exc.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "exceed",
+      "name": "Exceed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exceed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "except",
+      "name": "Except",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Except.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "exclude",
+      "name": "Exclude",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exclude.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "excludes",
+      "name": "Excludes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Excludes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "executable",
+      "name": "Executable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Executable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "executed",
+      "name": "Executed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Executed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "executes",
+      "name": "Executes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Executes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "execution",
+      "name": "Execution",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Execution.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "executor",
+      "name": "Executor",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Executor.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "exhausted",
+      "name": "Exhausted",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exhausted.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "exist",
+      "name": "Exist",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exist.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "existing",
+      "name": "Existing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Existing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "exists",
+      "name": "Exists",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exists.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "exit",
+      "name": "Exit",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "expand",
+      "name": "Expand",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Expand.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "expanduser",
+      "name": "Expanduser",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Expanduser.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "expected",
+      "name": "Expected",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Expected.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "experiments",
+      "name": "Experiments",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Experiments.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "expert-level",
+      "name": "Expert-level",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Expert-level.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "explanations",
+      "name": "Explanations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Explanations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "explicit",
+      "name": "Explicit",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Explicit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "export",
+      "name": "Export",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Export.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "exposes",
+      "name": "Exposes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exposes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ext",
+      "name": "Ext",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ext.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "extend",
+      "name": "Extend",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Extend.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "extension",
+      "name": "Extension",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Extension.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "extensionquery",
+      "name": "Extensionquery",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Extensionquery.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "extensions",
+      "name": "Extensions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Extensions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "extensive",
+      "name": "Extensive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Extensive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "external",
+      "name": "External",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: External.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "extracting",
+      "name": "Extracting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Extracting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "extraction",
+      "name": "Extraction",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Extraction.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "extracts",
+      "name": "Extracts",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Extracts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "failure",
+      "name": "Failure",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Failure.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "failures",
+      "name": "Failures",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Failures.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "fallback",
+      "name": "Fallback",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fallback.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "falls",
+      "name": "Falls",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Falls.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "false",
+      "name": "False",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: False.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "feature",
+      "name": "Feature",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Feature.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "feature-extraction",
+      "name": "Feature-extraction",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Feature-extraction.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "features",
+      "name": "Features",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Features.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "feedback",
+      "name": "Feedback",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Feedback.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "few-shot",
+      "name": "Few-shot",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Few-shot.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "field",
+      "name": "Field",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Field.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fields",
+      "name": "Fields",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fields.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "file",
+      "name": "File",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: File.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "filename",
+      "name": "Filename",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Filename.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "filepath",
+      "name": "Filepath",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Filepath.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "files",
+      "name": "Files",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Files.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fill-mask",
+      "name": "Fill-mask",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fill-mask.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fills",
+      "name": "Fills",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fills.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "filter",
+      "name": "Filter",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Filter.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "filtered",
+      "name": "Filtered",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Filtered.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "filters",
+      "name": "Filters",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Filters.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "final",
+      "name": "Final",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Final.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "finally",
+      "name": "Finally",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Finally.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "findings",
+      "name": "Findings",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Findings.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "finditer",
+      "name": "Finditer",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Finditer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "finite-state",
+      "name": "Finite-state",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Finite-state.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "first",
+      "name": "First",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: First.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fitness",
+      "name": "Fitness",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fitness.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fix",
+      "name": "Fix",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fix.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fixes",
+      "name": "Fixes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fixes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "flags",
+      "name": "Flags",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Flags.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "float",
+      "name": "Float",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Float.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "floats",
+      "name": "Floats",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Floats.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "floor",
+      "name": "Floor",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Floor.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "flow",
+      "name": "Flow",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Flow.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "flush",
+      "name": "Flush",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Flush.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fname",
+      "name": "Fname",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fname.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "follow-up",
+      "name": "Follow-up",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Follow-up.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "follows",
+      "name": "Follows",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Follows.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "force",
+      "name": "Force",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Force.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "form",
+      "name": "Form",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Form.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "format",
+      "name": "Format",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Format.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "formats",
+      "name": "Formats",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Formats.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "formatted",
+      "name": "Formatted",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Formatted.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "formatting",
+      "name": "Formatting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Formatting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "forms",
+      "name": "Forms",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Forms.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "forward",
+      "name": "Forward",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Forward.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "forwarded",
+      "name": "Forwarded",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Forwarded.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "found",
+      "name": "Found",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Found.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "foundation",
+      "name": "Foundation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Foundation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "foundational",
+      "name": "Foundational",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Foundational.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fpath",
+      "name": "Fpath",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fpath.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "framework",
+      "name": "Framework",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Framework.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "framing",
+      "name": "Framing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Framing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fraud",
+      "name": "Fraud",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fraud.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "free-form",
+      "name": "Free-form",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Free-form.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fromisoformat",
+      "name": "Fromisoformat",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fromisoformat.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "frontmatter",
+      "name": "Frontmatter",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Frontmatter.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "full",
+      "name": "Full",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Full.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "full-cycle",
+      "name": "Full-cycle",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Full-cycle.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "function",
+      "name": "Function",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Function.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "functionality",
+      "name": "Functionality",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Functionality.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "functionally",
+      "name": "Functionally",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Functionally.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "functions",
+      "name": "Functions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Functions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fundamentally",
+      "name": "Fundamentally",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fundamentally.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fuse",
+      "name": "Fuse",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fuse.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fusions",
+      "name": "Fusions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fusions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "future",
+      "name": "Future",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Future.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gaia",
+      "name": "Gaia",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaia.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gaia-cli",
+      "name": "Gaia-cli",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaia-cli.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gaia-cli-test",
+      "name": "Gaia-cli-test",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaia-cli-test.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gaia-intake-pr-body",
+      "name": "Gaia-intake-pr-body",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaia-intake-pr-body.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gaia-registry",
+      "name": "Gaia-registry",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaia-registry.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gaia-skill-tree",
+      "name": "Gaia-skill-tree",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaia-skill-tree.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gaiabot",
+      "name": "Gaiabot",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaiabot.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gallery",
+      "name": "Gallery",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gallery.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gaps",
+      "name": "Gaps",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaps.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gathering",
+      "name": "Gathering",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gathering.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gen",
+      "name": "Gen",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gen.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "generate",
+      "name": "Generate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Generate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "generated",
+      "name": "Generated",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Generated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "generates",
+      "name": "Generates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Generates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "generating",
+      "name": "Generating",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Generating.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "generation",
+      "name": "Generation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Generation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "generative",
+      "name": "Generative",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Generative.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "generator",
+      "name": "Generator",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Generator.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "get",
+      "name": "Get",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Get.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "getcode",
+      "name": "Getcode",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Getcode.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gets",
+      "name": "Gets",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gets.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gexf",
+      "name": "Gexf",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gexf.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gif",
+      "name": "Gif",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gif.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "git",
+      "name": "Git",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Git.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "github",
+      "name": "Github",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Github.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "github-action",
+      "name": "Github-action",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Github-action.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "given",
+      "name": "Given",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Given.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "glob",
+      "name": "Glob",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Glob.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "global",
+      "name": "Global",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Global.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gmtime",
+      "name": "Gmtime",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gmtime.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "goal-directed",
+      "name": "Goal-directed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Goal-directed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "got",
+      "name": "Got",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Got.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gracefully",
+      "name": "Gracefully",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gracefully.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "grammar-guided",
+      "name": "Grammar-guided",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Grammar-guided.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "grammars",
+      "name": "Grammars",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Grammars.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "graph",
+      "name": "Graph",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Graph.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "graphrag",
+      "name": "Graphrag",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Graphrag.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "graphs",
+      "name": "Graphs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Graphs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ground-truth",
+      "name": "Ground-truth",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ground-truth.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "grounding",
+      "name": "Grounding",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Grounding.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "group",
+      "name": "Group",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Group.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "groups",
+      "name": "Groups",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Groups.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "guaranteed",
+      "name": "Guaranteed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Guaranteed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "guarantees",
+      "name": "Guarantees",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Guarantees.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "guides",
+      "name": "Guides",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Guides.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "hand-crafted",
+      "name": "Hand-crafted",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hand-crafted.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "handle",
+      "name": "Handle",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Handle.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "handled",
+      "name": "Handled",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Handled.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "handler",
+      "name": "Handler",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Handler.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "handles",
+      "name": "Handles",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Handles.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "handling",
+      "name": "Handling",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Handling.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "happen",
+      "name": "Happen",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Happen.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "harness",
+      "name": "Harness",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Harness.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "has",
+      "name": "Has",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Has.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "hashlib",
+      "name": "Hashlib",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hashlib.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "have",
+      "name": "Have",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Have.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "header",
+      "name": "Header",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Header.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "headers",
+      "name": "Headers",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Headers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "headings",
+      "name": "Headings",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Headings.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "health",
+      "name": "Health",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Health.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "healthy",
+      "name": "Healthy",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Healthy.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "help",
+      "name": "Help",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Help.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "helpful",
+      "name": "Helpful",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Helpful.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "hexdigest",
+      "name": "Hexdigest",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hexdigest.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "highlighting",
+      "name": "Highlighting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Highlighting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "hints",
+      "name": "Hints",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hints.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "hit",
+      "name": "Hit",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "homepage",
+      "name": "Homepage",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Homepage.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "hours",
+      "name": "Hours",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hours.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "html",
+      "name": "Html",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Html.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "http",
+      "name": "Http",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Http.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "https",
+      "name": "Https",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Https.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "huggingface",
+      "name": "Huggingface",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Huggingface.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "human",
+      "name": "Human",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Human.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "human-level",
+      "name": "Human-level",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Human-level.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "hypotheses",
+      "name": "Hypotheses",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hypotheses.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "hypothesis",
+      "name": "Hypothesis",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hypothesis.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ico",
+      "name": "Ico",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ico.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "icon",
+      "name": "Icon",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Icon.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "idea",
+      "name": "Idea",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Idea.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ideas",
+      "name": "Ideas",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ideas.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "identifies",
+      "name": "Identifies",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Identifies.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "identify",
+      "name": "Identify",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Identify.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "identifying",
+      "name": "Identifying",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Identifying.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ids",
+      "name": "Ids",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ids.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "idx",
+      "name": "Idx",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Idx.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ignore",
+      "name": "Ignore",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ignore.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "images",
+      "name": "Images",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Images.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "implementation",
+      "name": "Implementation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Implementation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "implements",
+      "name": "Implements",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Implements.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "import",
+      "name": "Import",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Import.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "importlib",
+      "name": "Importlib",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Importlib.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "improve",
+      "name": "Improve",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Improve.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "improvement",
+      "name": "Improvement",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Improvement.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "improves",
+      "name": "Improves",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Improves.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "improving",
+      "name": "Improving",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Improving.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "in-context",
+      "name": "In-context",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: In-context.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "in-place",
+      "name": "In-place",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: In-place.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "include",
+      "name": "Include",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Include.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "included",
+      "name": "Included",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Included.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "includes",
+      "name": "Includes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Includes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "including",
+      "name": "Including",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Including.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "incorporating",
+      "name": "Incorporating",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Incorporating.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "indent",
+      "name": "Indent",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Indent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "independently",
+      "name": "Independently",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Independently.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "index",
+      "name": "Index",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Index.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "indexed",
+      "name": "Indexed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Indexed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "indexes",
+      "name": "Indexes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Indexes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "inductive",
+      "name": "Inductive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Inductive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "inference",
+      "name": "Inference",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Inference.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "info",
+      "name": "Info",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Info.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "information",
+      "name": "Information",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Information.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "inherit",
+      "name": "Inherit",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Inherit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "init",
+      "name": "Init",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Init.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "initialized",
+      "name": "Initialized",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Initialized.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "inject",
+      "name": "Inject",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Inject.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "injects",
+      "name": "Injects",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Injects.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "inline",
+      "name": "Inline",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Inline.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "inner",
+      "name": "Inner",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Inner.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "input",
+      "name": "Input",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Input.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "inputs",
+      "name": "Inputs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Inputs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "insert",
+      "name": "Insert",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Insert.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "insight",
+      "name": "Insight",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Insight.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "install",
+      "name": "Install",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Install.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "install-manifest",
+      "name": "Install-manifest",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Install-manifest.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "installation",
+      "name": "Installation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Installation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "installed",
+      "name": "Installed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Installed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "installs",
+      "name": "Installs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Installs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "instance",
+      "name": "Instance",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Instance.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "instruction",
+      "name": "Instruction",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Instruction.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "instructions",
+      "name": "Instructions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Instructions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "int",
+      "name": "Int",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Int.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "intake",
+      "name": "Intake",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Intake.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "intake-dir",
+      "name": "Intake-dir",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Intake-dir.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "integrates",
+      "name": "Integrates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Integrates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "integration",
+      "name": "Integration",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Integration.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "integrations",
+      "name": "Integrations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Integrations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "integrity",
+      "name": "Integrity",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Integrity.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "intensity",
+      "name": "Intensity",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Intensity.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "intent",
+      "name": "Intent",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Intent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "interactions",
+      "name": "Interactions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Interactions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "interface",
+      "name": "Interface",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Interface.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "intermediate",
+      "name": "Intermediate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Intermediate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "interpreter",
+      "name": "Interpreter",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Interpreter.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "interpreting",
+      "name": "Interpreting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Interpreting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "interprets",
+      "name": "Interprets",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Interprets.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "intersection",
+      "name": "Intersection",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Intersection.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "intervention",
+      "name": "Intervention",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Intervention.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "into",
+      "name": "Into",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Into.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "intrusion",
+      "name": "Intrusion",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Intrusion.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "invalid",
+      "name": "Invalid",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Invalid.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "isdir",
+      "name": "Isdir",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Isdir.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "isfile",
+      "name": "Isfile",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Isfile.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "isinstance",
+      "name": "Isinstance",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Isinstance.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "islink",
+      "name": "Islink",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Islink.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "isoformat",
+      "name": "Isoformat",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Isoformat.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "issues",
+      "name": "Issues",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Issues.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "issuing",
+      "name": "Issuing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Issuing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "item",
+      "name": "Item",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Item.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "items",
+      "name": "Items",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Items.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "iter",
+      "name": "Iter",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Iter.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "iterates",
+      "name": "Iterates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Iterates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "iteration",
+      "name": "Iteration",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Iteration.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "iterative",
+      "name": "Iterative",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Iterative.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "iteratively",
+      "name": "Iteratively",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Iteratively.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "its",
+      "name": "Its",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Its.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "jobs",
+      "name": "Jobs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Jobs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "join",
+      "name": "Join",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Join.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "jpeg",
+      "name": "Jpeg",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Jpeg.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "jpg",
+      "name": "Jpg",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Jpg.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "json",
+      "name": "Json",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Json.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "jsonschema",
+      "name": "Jsonschema",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Jsonschema.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "karpathy",
+      "name": "Karpathy",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Karpathy.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.552
+        }
+      ]
+    },
+    {
+      "id": "kebab-case",
+      "name": "Kebab-case",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Kebab-case.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "key",
+      "name": "Key",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Key.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "keyboard",
+      "name": "Keyboard",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Keyboard.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "keys",
+      "name": "Keys",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Keys.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "keyword",
+      "name": "Keyword",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Keyword.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "keywords",
+      "name": "Keywords",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Keywords.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "knowledge",
+      "name": "Knowledge",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Knowledge.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "known",
+      "name": "Known",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Known.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "label",
+      "name": "Label",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Label.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "labels",
+      "name": "Labels",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Labels.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "laboratory",
+      "name": "Laboratory",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Laboratory.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lambda",
+      "name": "Lambda",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lambda.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "langchain",
+      "name": "Langchain",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Langchain.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "langchain-ai",
+      "name": "Langchain-ai",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Langchain-ai.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "langchain-tool",
+      "name": "Langchain-tool",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Langchain-tool.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "language",
+      "name": "Language",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Language.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "language-image",
+      "name": "Language-image",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Language-image.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "languages",
+      "name": "Languages",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Languages.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "large",
+      "name": "Large",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Large.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "large-scale",
+      "name": "Large-scale",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Large-scale.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "last",
+      "name": "Last",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Last.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "last-week",
+      "name": "Last-week",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Last-week.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lastmodifieddate",
+      "name": "Lastmodifieddate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lastmodifieddate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "latency",
+      "name": "Latency",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Latency.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "later",
+      "name": "Later",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Later.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "layout",
+      "name": "Layout",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Layout.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "leading",
+      "name": "Leading",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Leading.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "learn",
+      "name": "Learn",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Learn.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "learned",
+      "name": "Learned",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Learned.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "learning",
+      "name": "Learning",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Learning.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "least",
+      "name": "Least",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Least.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "left",
+      "name": "Left",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Left.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "legendaries",
+      "name": "Legendaries",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Legendaries.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "legendary",
+      "name": "Legendary",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Legendary.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "legendary-specific",
+      "name": "Legendary-specific",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Legendary-specific.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "len",
+      "name": "Len",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Len.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "less",
+      "name": "Less",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Less.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "let",
+      "name": "Let",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Let.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "letters",
+      "name": "Letters",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Letters.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "level",
+      "name": "Level",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Level.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lexically",
+      "name": "Lexically",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lexically.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "library",
+      "name": "Library",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Library.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "libs",
+      "name": "Libs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Libs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "license",
+      "name": "License",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: License.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lid",
+      "name": "Lid",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lid.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lida",
+      "name": "Lida",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lida.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lifecycle",
+      "name": "Lifecycle",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lifecycle.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "like",
+      "name": "Like",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Like.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "likes",
+      "name": "Likes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Likes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "limit",
+      "name": "Limit",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Limit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "linalg",
+      "name": "Linalg",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Linalg.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "line",
+      "name": "Line",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Line.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lineage",
+      "name": "Lineage",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lineage.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "linear",
+      "name": "Linear",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Linear.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lines",
+      "name": "Lines",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lines.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "link",
+      "name": "Link",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Link.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "links",
+      "name": "Links",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Links.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "list",
+      "name": "List",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: List.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "listdir",
+      "name": "Listdir",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Listdir.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "literature",
+      "name": "Literature",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Literature.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "llevel",
+      "name": "Llevel",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Llevel.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "llm",
+      "name": "Llm",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Llm.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "llm-tool",
+      "name": "Llm-tool",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Llm-tool.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lname",
+      "name": "Lname",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lname.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "load",
+      "name": "Load",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Load.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "loaded",
+      "name": "Loaded",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Loaded.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "loader",
+      "name": "Loader",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Loader.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "local",
+      "name": "Local",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Local.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "local-repo",
+      "name": "Local-repo",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Local-repo.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "locally",
+      "name": "Locally",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Locally.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "locate",
+      "name": "Locate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Locate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "locations",
+      "name": "Locations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Locations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "log-scaled",
+      "name": "Log-scaled",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Log-scaled.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "log10",
+      "name": "Log10",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Log10.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "log2",
+      "name": "Log2",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Log2.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "logging",
+      "name": "Logging",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Logging.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "logic",
+      "name": "Logic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Logic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "logical",
+      "name": "Logical",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Logical.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "logs",
+      "name": "Logs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Logs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "long-form",
+      "name": "Long-form",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Long-form.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "long-term",
+      "name": "Long-term",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Long-term.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "longer",
+      "name": "Longer",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Longer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "look",
+      "name": "Look",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Look.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "loop",
+      "name": "Loop",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Loop.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "loops",
+      "name": "Loops",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Loops.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "low-latency",
+      "name": "Low-latency",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Low-latency.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lower",
+      "name": "Lower",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lower.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lowercase-dash",
+      "name": "Lowercase-dash",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lowercase-dash.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lvl",
+      "name": "Lvl",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lvl.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "machine",
+      "name": "Machine",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Machine.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "machine-readable",
+      "name": "Machine-readable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Machine-readable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "madaan",
+      "name": "Madaan",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Madaan.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "main",
+      "name": "Main",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Main.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "maintainability",
+      "name": "Maintainability",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Maintainability.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "maintaining",
+      "name": "Maintaining",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Maintaining.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "makedirs",
+      "name": "Makedirs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Makedirs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "malformed",
+      "name": "Malformed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Malformed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "management",
+      "name": "Management",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Management.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "managing",
+      "name": "Managing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Managing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "manifest",
+      "name": "Manifest",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Manifest.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "manual",
+      "name": "Manual",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Manual.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "manually",
+      "name": "Manually",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Manually.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "manuscripts",
+      "name": "Manuscripts",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Manuscripts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "map",
+      "name": "Map",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Map.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mapping",
+      "name": "Mapping",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mapping.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mappings",
+      "name": "Mappings",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mappings.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "maps",
+      "name": "Maps",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Maps.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mark",
+      "name": "Mark",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mark.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "markdown",
+      "name": "Markdown",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Markdown.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "marked",
+      "name": "Marked",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Marked.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "marker",
+      "name": "Marker",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Marker.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "markers",
+      "name": "Markers",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Markers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "marketplace",
+      "name": "Marketplace",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Marketplace.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "markup",
+      "name": "Markup",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Markup.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "master",
+      "name": "Master",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Master.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "match",
+      "name": "Match",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Match.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "matching",
+      "name": "Matching",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Matching.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "math",
+      "name": "Math",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Math.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mathematical",
+      "name": "Mathematical",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mathematical.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mathematics",
+      "name": "Mathematics",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mathematics.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "max",
+      "name": "Max",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Max.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "may",
+      "name": "May",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: May.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mbtiongson1",
+      "name": "Mbtiongson1",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mbtiongson1.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mcp",
+      "name": "Mcp",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mcp.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mcp-registry",
+      "name": "Mcp-registry",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mcp-registry.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mcp-server",
+      "name": "Mcp-server",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mcp-server.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "meaning",
+      "name": "Meaning",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Meaning.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "meaningful",
+      "name": "Meaningful",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Meaningful.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mechanistic",
+      "name": "Mechanistic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mechanistic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "media",
+      "name": "Media",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Media.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "medical",
+      "name": "Medical",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Medical.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "meets",
+      "name": "Meets",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Meets.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "memory",
+      "name": "Memory",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Memory.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "merged",
+      "name": "Merged",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Merged.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "message",
+      "name": "Message",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Message.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "messages",
+      "name": "Messages",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Messages.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "meta",
+      "name": "Meta",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Meta.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "metadata",
+      "name": "Metadata",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Metadata.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "metavar",
+      "name": "Metavar",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Metavar.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "method",
+      "name": "Method",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Method.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "methodology",
+      "name": "Methodology",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Methodology.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "methods",
+      "name": "Methods",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Methods.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "microsecond",
+      "name": "Microsecond",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Microsecond.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "microsoft",
+      "name": "Microsoft",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Microsoft.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "might",
+      "name": "Might",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Might.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "migration",
+      "name": "Migration",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Migration.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "min",
+      "name": "Min",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Min.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "minimum",
+      "name": "Minimum",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Minimum.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "missing",
+      "name": "Missing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Missing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mixed",
+      "name": "Mixed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mixed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mjs",
+      "name": "Mjs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mjs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mod",
+      "name": "Mod",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mod.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "modalities",
+      "name": "Modalities",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Modalities.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mode",
+      "name": "Mode",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mode.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "model",
+      "name": "Model",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Model.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "modeling",
+      "name": "Modeling",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Modeling.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "models",
+      "name": "Models",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Models.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "moderation",
+      "name": "Moderation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Moderation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "modern",
+      "name": "Modern",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Modern.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "modes",
+      "name": "Modes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Modes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "modifications",
+      "name": "Modifications",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Modifications.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "modified",
+      "name": "Modified",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Modified.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "module",
+      "name": "Module",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Module.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "molecular",
+      "name": "Molecular",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Molecular.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "more",
+      "name": "More",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: More.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "most",
+      "name": "Most",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Most.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mouse",
+      "name": "Mouse",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mouse.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.526
+        }
+      ]
+    },
+    {
+      "id": "multi-agent",
+      "name": "Multi-agent",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multi-agent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "multi-category",
+      "name": "Multi-category",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multi-category.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "multi-section",
+      "name": "Multi-section",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multi-section.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "multi-session",
+      "name": "Multi-session",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multi-session.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "multi-source",
+      "name": "Multi-source",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multi-source.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "multi-step",
+      "name": "Multi-step",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multi-step.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "multi-system",
+      "name": "Multi-system",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multi-system.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "multi-turn",
+      "name": "Multi-turn",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multi-turn.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "multilingual",
+      "name": "Multilingual",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multilingual.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "multimodal",
+      "name": "Multimodal",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multimodal.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "multiple",
+      "name": "Multiple",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multiple.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "must",
+      "name": "Must",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Must.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "name",
+      "name": "Name",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Name.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "named",
+      "name": "Named",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Named.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "named-dir",
+      "name": "Named-dir",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Named-dir.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "named-skills",
+      "name": "Named-skills",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Named-skills.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "names",
+      "name": "Names",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Names.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "nargs",
+      "name": "Nargs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Nargs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "narrative",
+      "name": "Narrative",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Narrative.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "natural",
+      "name": "Natural",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Natural.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "natural-language",
+      "name": "Natural-language",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Natural-language.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "natural-sounding",
+      "name": "Natural-sounding",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Natural-sounding.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "navigating",
+      "name": "Navigating",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Navigating.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "near-human",
+      "name": "Near-human",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Near-human.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "need",
+      "name": "Need",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Need.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "needed",
+      "name": "Needed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Needed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "needs",
+      "name": "Needs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Needs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "needs-review",
+      "name": "Needs-review",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Needs-review.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "negative",
+      "name": "Negative",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Negative.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ner",
+      "name": "Ner",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ner.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "nested",
+      "name": "Nested",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Nested.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "nesting",
+      "name": "Nesting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Nesting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "net",
+      "name": "Net",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Net.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "neural",
+      "name": "Neural",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Neural.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "neutral",
+      "name": "Neutral",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Neutral.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "new",
+      "name": "New",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: New.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "next",
+      "name": "Next",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Next.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "nline",
+      "name": "Nline",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Nline.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "no-pr",
+      "name": "No-pr",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: No-pr.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "node",
+      "name": "Node",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Node.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "node-20",
+      "name": "Node-20",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Node-20.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "nodes",
+      "name": "Nodes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Nodes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "noise",
+      "name": "Noise",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Noise.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "non-interactive",
+      "name": "Non-interactive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Non-interactive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "non-overlap",
+      "name": "Non-overlap",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Non-overlap.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "none",
+      "name": "None",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: None.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "nonlocal",
+      "name": "Nonlocal",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Nonlocal.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "noqa",
+      "name": "Noqa",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Noqa.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "norm",
+      "name": "Norm",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Norm.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "normally",
+      "name": "Normally",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Normally.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "not",
+      "name": "Not",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Not.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "notebooks",
+      "name": "Notebooks",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Notebooks.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "notes",
+      "name": "Notes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Notes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "nothing",
+      "name": "Nothing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Nothing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "novel",
+      "name": "Novel",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Novel.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "now",
+      "name": "Now",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Now.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "npm",
+      "name": "Npm",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Npm.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "npmjs",
+      "name": "Npmjs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Npmjs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "number",
+      "name": "Number",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Number.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "numeric",
+      "name": "Numeric",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Numeric.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "numerical",
+      "name": "Numerical",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Numerical.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "numpy",
+      "name": "Numpy",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Numpy.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "nuxt",
+      "name": "Nuxt",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Nuxt.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "objective",
+      "name": "Objective",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Objective.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "objectives",
+      "name": "Objectives",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Objectives.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "objects",
+      "name": "Objects",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Objects.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "observable",
+      "name": "Observable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Observable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "observation",
+      "name": "Observation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Observation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "observe",
+      "name": "Observe",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Observe.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "occurrence",
+      "name": "Occurrence",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Occurrence.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "old",
+      "name": "Old",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Old.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "once",
+      "name": "Once",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Once.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "one",
+      "name": "One",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: One.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "only",
+      "name": "Only",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Only.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "open",
+      "name": "Open",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Open.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "open-ended",
+      "name": "Open-ended",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Open-ended.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "open-source",
+      "name": "Open-source",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Open-source.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "openai",
+      "name": "Openai",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Openai.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "opened",
+      "name": "Opened",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Opened.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "opening",
+      "name": "Opening",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Opening.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "opens",
+      "name": "Opens",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Opens.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "optimized",
+      "name": "Optimized",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Optimized.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "optional",
+      "name": "Optional",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Optional.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "options",
+      "name": "Options",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Options.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "orchestrates",
+      "name": "Orchestrates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Orchestrates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "order",
+      "name": "Order",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Order.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "ordered",
+      "name": "Ordered",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ordered.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "org",
+      "name": "Org",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Org.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "organizations",
+      "name": "Organizations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Organizations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "origin",
+      "name": "Origin",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Origin.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "origins",
+      "name": "Origins",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Origins.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "orphaned",
+      "name": "Orphaned",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Orphaned.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "otherwise",
+      "name": "Otherwise",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Otherwise.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "our",
+      "name": "Our",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Our.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "out",
+      "name": "Out",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Out.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "outliers",
+      "name": "Outliers",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Outliers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "outlines",
+      "name": "Outlines",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Outlines.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "outlines-dev",
+      "name": "Outlines-dev",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Outlines-dev.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "outperforms",
+      "name": "Outperforms",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Outperforms.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "output",
+      "name": "Output",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Output.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "outputs",
+      "name": "Outputs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Outputs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "outside",
+      "name": "Outside",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Outside.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "over",
+      "name": "Over",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Over.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "overhead",
+      "name": "Overhead",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Overhead.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "overwritten",
+      "name": "Overwritten",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Overwritten.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "own",
+      "name": "Own",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Own.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "owned",
+      "name": "Owned",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Owned.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "owner",
+      "name": "Owner",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Owner.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pack",
+      "name": "Pack",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pack.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "package",
+      "name": "Package",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Package.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "packages",
+      "name": "Packages",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Packages.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "packed",
+      "name": "Packed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Packed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pages",
+      "name": "Pages",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pages.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pair",
+      "name": "Pair",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pair.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pairs",
+      "name": "Pairs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pairs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pairwise",
+      "name": "Pairwise",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pairwise.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pal",
+      "name": "Pal",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pal.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pandas",
+      "name": "Pandas",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pandas.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pandas-ai",
+      "name": "Pandas-ai",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pandas-ai.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "paper",
+      "name": "Paper",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Paper.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "papers",
+      "name": "Papers",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Papers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "paradigm",
+      "name": "Paradigm",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Paradigm.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "parameters",
+      "name": "Parameters",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Parameters.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "params",
+      "name": "Params",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Params.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "parent",
+      "name": "Parent",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Parent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "parents",
+      "name": "Parents",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Parents.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "parse",
+      "name": "Parse",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Parse.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "parsed",
+      "name": "Parsed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Parsed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "parser",
+      "name": "Parser",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Parser.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "parses",
+      "name": "Parses",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Parses.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "parsing",
+      "name": "Parsing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Parsing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "partition",
+      "name": "Partition",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Partition.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "parts",
+      "name": "Parts",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Parts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pass",
+      "name": "Pass",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pass.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "passages",
+      "name": "Passages",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Passages.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "passed",
+      "name": "Passed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Passed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "passing",
+      "name": "Passing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Passing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "patch",
+      "name": "Patch",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Patch.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "patched",
+      "name": "Patched",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Patched.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "patches",
+      "name": "Patches",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Patches.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "path",
+      "name": "Path",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Path.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "paths",
+      "name": "Paths",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Paths.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pattern",
+      "name": "Pattern",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pattern.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "patterns",
+      "name": "Patterns",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Patterns.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "payload",
+      "name": "Payload",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Payload.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pdf",
+      "name": "Pdf",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pdf.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pending",
+      "name": "Pending",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pending.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "people",
+      "name": "People",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: People.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "per",
+      "name": "Per",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Per.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "percentage",
+      "name": "Percentage",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Percentage.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "performance",
+      "name": "Performance",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Performance.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "persistent",
+      "name": "Persistent",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Persistent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "photorealistic",
+      "name": "Photorealistic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Photorealistic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "pid",
+      "name": "Pid",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pid.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pip",
+      "name": "Pip",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pip.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pipe",
+      "name": "Pipe",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pipe.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pipeline",
+      "name": "Pipeline",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pipeline.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pipelines",
+      "name": "Pipelines",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pipelines.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pixel-space",
+      "name": "Pixel-space",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pixel-space.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pkg",
+      "name": "Pkg",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pkg.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "placeholder",
+      "name": "Placeholder",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Placeholder.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "plain-text",
+      "name": "Plain-text",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Plain-text.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "plan",
+      "name": "Plan",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Plan.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "planned",
+      "name": "Planned",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Planned.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "planning",
+      "name": "Planning",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Planning.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "platform",
+      "name": "Platform",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Platform.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "plugin",
+      "name": "Plugin",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Plugin.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "plus",
+      "name": "Plus",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Plus.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "png",
+      "name": "Png",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Png.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "point",
+      "name": "Point",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Point.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "points",
+      "name": "Points",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Points.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "policy-violating",
+      "name": "Policy-violating",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Policy-violating.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "popular",
+      "name": "Popular",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Popular.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "popularity",
+      "name": "Popularity",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Popularity.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "positive",
+      "name": "Positive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Positive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "post",
+      "name": "Post",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Post.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pre-computed",
+      "name": "Pre-computed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pre-computed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pre-trained",
+      "name": "Pre-trained",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pre-trained.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pre-training",
+      "name": "Pre-training",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pre-training.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prediction",
+      "name": "Prediction",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prediction.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prefix",
+      "name": "Prefix",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prefix.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "premises",
+      "name": "Premises",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Premises.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prepare",
+      "name": "Prepare",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prepare.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prereq",
+      "name": "Prereq",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prereq.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prereqs",
+      "name": "Prereqs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prereqs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prerequisite",
+      "name": "Prerequisite",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prerequisite.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prerequisites",
+      "name": "Prerequisites",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prerequisites.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "present",
+      "name": "Present",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Present.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "preserves",
+      "name": "Preserves",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Preserves.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "preserving",
+      "name": "Preserving",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Preserving.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "prevalence",
+      "name": "Prevalence",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prevalence.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "preview",
+      "name": "Preview",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Preview.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "princeton-nlp",
+      "name": "Princeton-nlp",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Princeton-nlp.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "print",
+      "name": "Print",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Print.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prints",
+      "name": "Prints",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prints.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "problems",
+      "name": "Problems",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Problems.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "process",
+      "name": "Process",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Process.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "processing",
+      "name": "Processing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Processing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "produce",
+      "name": "Produce",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Produce.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "produces",
+      "name": "Produces",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Produces.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "production",
+      "name": "Production",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Production.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "production-grade",
+      "name": "Production-grade",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Production-grade.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "profile",
+      "name": "Profile",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Profile.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prog",
+      "name": "Prog",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prog.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "programmatic",
+      "name": "Programmatic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Programmatic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "programming",
+      "name": "Programming",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Programming.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "project",
+      "name": "Project",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Project.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "projections",
+      "name": "Projections",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Projections.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "promoted",
+      "name": "Promoted",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Promoted.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "promotion",
+      "name": "Promotion",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Promotion.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prompt",
+      "name": "Prompt",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prompt.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prompting",
+      "name": "Prompting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prompting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prompts",
+      "name": "Prompts",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prompts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "proper",
+      "name": "Proper",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Proper.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "proposals",
+      "name": "Proposals",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Proposals.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "propose",
+      "name": "Propose",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Propose.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "proposed",
+      "name": "Proposed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Proposed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "proposer",
+      "name": "Proposer",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Proposer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "proposes",
+      "name": "Proposes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Proposes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "proposing",
+      "name": "Proposing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Proposing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prosody",
+      "name": "Prosody",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prosody.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "provide",
+      "name": "Provide",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Provide.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "provided",
+      "name": "Provided",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Provided.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "provides",
+      "name": "Provides",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Provides.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "providing",
+      "name": "Providing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Providing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "provisional",
+      "name": "Provisional",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Provisional.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "public",
+      "name": "Public",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Public.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "publicly",
+      "name": "Publicly",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Publicly.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "published",
+      "name": "Published",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Published.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "publisher",
+      "name": "Publisher",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Publisher.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pull",
+      "name": "Pull",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pull.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pure",
+      "name": "Pure",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pure.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "push",
+      "name": "Push",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Push.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pyc",
+      "name": "Pyc",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pyc.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "python",
+      "name": "Python",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Python.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "python-shell",
+      "name": "Python-shell",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Python-shell.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "python-shell-5",
+      "name": "Python-shell-5",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Python-shell-5.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "python-version",
+      "name": "Python-version",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Python-version.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "python3",
+      "name": "Python3",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Python3.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "quality",
+      "name": "Quality",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Quality.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "quantitative",
+      "name": "Quantitative",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Quantitative.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "queries",
+      "name": "Queries",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Queries.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "query",
+      "name": "Query",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Query.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "queryable",
+      "name": "Queryable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Queryable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "question-answering",
+      "name": "Question-answering",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Question-answering.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "questions",
+      "name": "Questions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Questions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "quoted",
+      "name": "Quoted",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Quoted.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rag",
+      "name": "Rag",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rag.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "raise",
+      "name": "Raise",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Raise.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "raises",
+      "name": "Raises",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Raises.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "range",
+      "name": "Range",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Range.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ranking",
+      "name": "Ranking",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ranking.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ranks",
+      "name": "Ranks",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ranks.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rare",
+      "name": "Rare",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rare.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rarity",
+      "name": "Rarity",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rarity.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rasa",
+      "name": "Rasa",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rasa.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rate",
+      "name": "Rate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rated",
+      "name": "Rated",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ratio",
+      "name": "Ratio",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ratio.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "raw",
+      "name": "Raw",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Raw.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "re-derived",
+      "name": "Re-derived",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Re-derived.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "re-exports",
+      "name": "Re-exports",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Re-exports.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reach",
+      "name": "Reach",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reach.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.588
+        }
+      ]
+    },
+    {
+      "id": "reachable",
+      "name": "Reachable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reachable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "reached",
+      "name": "Reached",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reached.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.526
+        }
+      ]
+    },
+    {
+      "id": "react-reasoning",
+      "name": "React-reasoning",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: React-reasoning.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "read",
+      "name": "Read",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Read.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "readability",
+      "name": "Readability",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Readability.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reading",
+      "name": "Reading",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reading.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ready",
+      "name": "Ready",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ready.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "real",
+      "name": "Real",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Real.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "real-time",
+      "name": "Real-time",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Real-time.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "real-world",
+      "name": "Real-world",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Real-world.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "realistic",
+      "name": "Realistic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Realistic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reason",
+      "name": "Reason",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reason.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reasoning",
+      "name": "Reasoning",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reasoning.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reasoning-machines",
+      "name": "Reasoning-machines",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reasoning-machines.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "record",
+      "name": "Record",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Record.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "records",
+      "name": "Records",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Records.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "recursive",
+      "name": "Recursive",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Recursive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "redirect",
+      "name": "Redirect",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Redirect.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ref",
+      "name": "Ref",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ref.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "refactor",
+      "name": "Refactor",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Refactor.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "refactors",
+      "name": "Refactors",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Refactors.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "reference",
+      "name": "Reference",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reference.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "references",
+      "name": "References",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: References.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "refines",
+      "name": "Refines",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Refines.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "regex",
+      "name": "Regex",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Regex.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "register",
+      "name": "Register",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Register.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "registries",
+      "name": "Registries",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Registries.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "registry",
+      "name": "Registry",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Registry.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "registry-ref",
+      "name": "Registry-ref",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Registry-ref.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reject",
+      "name": "Reject",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reject.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rel",
+      "name": "Rel",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rel.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "relations",
+      "name": "Relations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Relations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "relationships",
+      "name": "Relationships",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Relationships.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "relative",
+      "name": "Relative",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Relative.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "relevance",
+      "name": "Relevance",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Relevance.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "relevant",
+      "name": "Relevant",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Relevant.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "relpath",
+      "name": "Relpath",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Relpath.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "remote",
+      "name": "Remote",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Remote.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "remove",
+      "name": "Remove",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Remove.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "removesuffix",
+      "name": "Removesuffix",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Removesuffix.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rename",
+      "name": "Rename",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rename.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "repeat",
+      "name": "Repeat",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Repeat.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "replace",
+      "name": "Replace",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Replace.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "repo",
+      "name": "Repo",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Repo.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "report",
+      "name": "Report",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Report.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reporting",
+      "name": "Reporting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reporting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reports",
+      "name": "Reports",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reports.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "repositories",
+      "name": "Repositories",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Repositories.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "repository",
+      "name": "Repository",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Repository.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "representation",
+      "name": "Representation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Representation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "representations",
+      "name": "Representations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Representations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "representing",
+      "name": "Representing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Representing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reproducible",
+      "name": "Reproducible",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reproducible.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "req",
+      "name": "Req",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Req.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "request",
+      "name": "Request",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Request.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "requests",
+      "name": "Requests",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Requests.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "required",
+      "name": "Required",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Required.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "requires",
+      "name": "Requires",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Requires.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "requiring",
+      "name": "Requiring",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Requiring.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rerank",
+      "name": "Rerank",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rerank.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reranking",
+      "name": "Reranking",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reranking.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "res",
+      "name": "Res",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Res.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "research-backed",
+      "name": "Research-backed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Research-backed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.593
+        }
+      ]
+    },
+    {
+      "id": "resolution",
+      "name": "Resolution",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Resolution.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "resolve",
+      "name": "Resolve",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Resolve.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "resolved",
+      "name": "Resolved",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Resolved.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "resolver",
+      "name": "Resolver",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Resolver.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "resolves",
+      "name": "Resolves",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Resolves.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "resp",
+      "name": "Resp",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Resp.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "responses",
+      "name": "Responses",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Responses.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rest",
+      "name": "Rest",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rest.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "result",
+      "name": "Result",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Result.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "results",
+      "name": "Results",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Results.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "retrieval",
+      "name": "Retrieval",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Retrieval.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "retrieval-augmented",
+      "name": "Retrieval-augmented",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Retrieval-augmented.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "retrieves",
+      "name": "Retrieves",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Retrieves.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "retry",
+      "name": "Retry",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Retry.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "return",
+      "name": "Return",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Return.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "returncode",
+      "name": "Returncode",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Returncode.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "returned",
+      "name": "Returned",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Returned.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "returns",
+      "name": "Returns",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Returns.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reversal",
+      "name": "Reversal",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reversal.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reverse",
+      "name": "Reverse",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reverse.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "review",
+      "name": "Review",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Review.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reviewed",
+      "name": "Reviewed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reviewed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reviews",
+      "name": "Reviews",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reviews.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rigorous",
+      "name": "Rigorous",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rigorous.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "root",
+      "name": "Root",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Root.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "roots",
+      "name": "Roots",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Roots.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "round",
+      "name": "Round",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Round.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "routes",
+      "name": "Routes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Routes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "routing",
+      "name": "Routing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Routing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "row",
+      "name": "Row",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Row.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rule-based",
+      "name": "Rule-based",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rule-based.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rules",
+      "name": "Rules",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rules.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "run",
+      "name": "Run",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Run.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "run-gaia",
+      "name": "Run-gaia",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Run-gaia.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "runner",
+      "name": "Runner",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Runner.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "running",
+      "name": "Running",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Running.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "runs",
+      "name": "Runs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Runs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "runs-on",
+      "name": "Runs-on",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Runs-on.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "runtime",
+      "name": "Runtime",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Runtime.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "s-q-l",
+      "name": "S-q-l",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: S-q-l.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "safe",
+      "name": "Safe",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Safe.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "safely",
+      "name": "Safely",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Safely.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "safety",
+      "name": "Safety",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Safety.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "same",
+      "name": "Same",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Same.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sandbox",
+      "name": "Sandbox",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sandbox.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sandboxed",
+      "name": "Sandboxed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sandboxed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scalar",
+      "name": "Scalar",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scalar.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scalars",
+      "name": "Scalars",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scalars.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scale",
+      "name": "Scale",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scale.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scan",
+      "name": "Scan",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scan.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scanned",
+      "name": "Scanned",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scanned.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scanner",
+      "name": "Scanner",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scanner.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "schema",
+      "name": "Schema",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Schema.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "schema-dir",
+      "name": "Schema-dir",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Schema-dir.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "schema-valid",
+      "name": "Schema-valid",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Schema-valid.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "science",
+      "name": "Science",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Science.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scientific",
+      "name": "Scientific",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scientific.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "score",
+      "name": "Score",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Score.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scored",
+      "name": "Scored",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scored.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scores",
+      "name": "Scores",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scores.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scoring",
+      "name": "Scoring",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scoring.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scraper",
+      "name": "Scraper",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scraper.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scraping",
+      "name": "Scraping",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scraping.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "screenshot",
+      "name": "Screenshot",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Screenshot.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "screenshot-based",
+      "name": "Screenshot-based",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Screenshot-based.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "screenshots",
+      "name": "Screenshots",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Screenshots.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "script",
+      "name": "Script",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Script.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scripts",
+      "name": "Scripts",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scripts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scroll",
+      "name": "Scroll",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scroll.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "search",
+      "name": "Search",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Search.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.667
+        }
+      ]
+    },
+    {
+      "id": "searchable",
+      "name": "Searchable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Searchable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.545
+        }
+      ]
+    },
+    {
+      "id": "searching",
+      "name": "Searching",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Searching.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.571
+        }
+      ]
+    },
+    {
+      "id": "second",
+      "name": "Second",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Second.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "seconds",
+      "name": "Seconds",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Seconds.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "secrets",
+      "name": "Secrets",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Secrets.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "security",
+      "name": "Security",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Security.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "see",
+      "name": "See",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: See.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "seed",
+      "name": "Seed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Seed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "seen",
+      "name": "Seen",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Seen.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "segment",
+      "name": "Segment",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Segment.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "segments",
+      "name": "Segments",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Segments.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "selecting",
+      "name": "Selecting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Selecting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "selection",
+      "name": "Selection",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Selection.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "selects",
+      "name": "Selects",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Selects.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "self-evidence",
+      "name": "Self-evidence",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Self-evidence.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "self-feedback",
+      "name": "Self-feedback",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Self-feedback.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "self-generated",
+      "name": "Self-generated",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Self-generated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "self-hosted",
+      "name": "Self-hosted",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Self-hosted.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "self-refine",
+      "name": "Self-refine",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Self-refine.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "self-supervised",
+      "name": "Self-supervised",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Self-supervised.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "semantic",
+      "name": "Semantic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Semantic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "semantically",
+      "name": "Semantically",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Semantically.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sensemaking",
+      "name": "Sensemaking",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sensemaking.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sentence-similarity",
+      "name": "Sentence-similarity",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sentence-similarity.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sentence-transformers",
+      "name": "Sentence-transformers",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sentence-transformers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sentiment",
+      "name": "Sentiment",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sentiment.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "separated",
+      "name": "Separated",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Separated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "separately",
+      "name": "Separately",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Separately.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sequence",
+      "name": "Sequence",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sequence.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sequences",
+      "name": "Sequences",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sequences.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "server",
+      "name": "Server",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Server.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "servers",
+      "name": "Servers",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Servers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "session",
+      "name": "Session",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Session.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sessions",
+      "name": "Sessions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sessions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "set",
+      "name": "Set",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Set.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "setdefault",
+      "name": "Setdefault",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Setdefault.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sets",
+      "name": "Sets",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sets.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "setup-python",
+      "name": "Setup-python",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Setup-python.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "several",
+      "name": "Several",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Several.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sha",
+      "name": "Sha",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sha.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sha256",
+      "name": "Sha256",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sha256.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sha512",
+      "name": "Sha512",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sha512.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "shape",
+      "name": "Shape",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Shape.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "shell",
+      "name": "Shell",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Shell.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "shells",
+      "name": "Shells",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Shells.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "short",
+      "name": "Short",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Short.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "shorter",
+      "name": "Shorter",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Shorter.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "shot",
+      "name": "Shot",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Shot.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "should",
+      "name": "Should",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Should.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "shouldn",
+      "name": "Shouldn",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Shouldn.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "showing",
+      "name": "Showing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Showing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "shows",
+      "name": "Shows",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Shows.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "shutil",
+      "name": "Shutil",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Shutil.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sid",
+      "name": "Sid",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sid.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "signals",
+      "name": "Signals",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Signals.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "signatures",
+      "name": "Signatures",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Signatures.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "silent",
+      "name": "Silent",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Silent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "similar",
+      "name": "Similar",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Similar.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "similarity",
+      "name": "Similarity",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Similarity.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "simple",
+      "name": "Simple",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Simple.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "simply",
+      "name": "Simply",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Simply.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "simulation",
+      "name": "Simulation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Simulation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "single",
+      "name": "Single",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Single.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "single-pass",
+      "name": "Single-pass",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Single-pass.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "size",
+      "name": "Size",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Size.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "skill",
+      "name": "Skill",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skill.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "skill-batches",
+      "name": "Skill-batches",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skill-batches.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "skill-index",
+      "name": "Skill-index",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skill-index.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "skill-name",
+      "name": "Skill-name",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skill-name.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "skill-tree",
+      "name": "Skill-tree",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skill-tree.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "skills",
+      "name": "Skills",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skills.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "skip",
+      "name": "Skip",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skip.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "skipped",
+      "name": "Skipped",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skipped.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "skipping",
+      "name": "Skipping",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skipping.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "slashes",
+      "name": "Slashes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Slashes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "slice",
+      "name": "Slice",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Slice.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "slug",
+      "name": "Slug",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Slug.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "smithery",
+      "name": "Smithery",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Smithery.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "software",
+      "name": "Software",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Software.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "some",
+      "name": "Some",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Some.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sort",
+      "name": "Sort",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sort.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sorted",
+      "name": "Sorted",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sorted.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "source",
+      "name": "Source",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Source.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sources",
+      "name": "Sources",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sources.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "space",
+      "name": "Space",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Space.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "spaces",
+      "name": "Spaces",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Spaces.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "spatial",
+      "name": "Spatial",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Spatial.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "spawn",
+      "name": "Spawn",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Spawn.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "spec",
+      "name": "Spec",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Spec.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "specialized",
+      "name": "Specialized",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Specialized.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "specific",
+      "name": "Specific",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Specific.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "specification",
+      "name": "Specification",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Specification.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "specifications",
+      "name": "Specifications",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Specifications.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "specified",
+      "name": "Specified",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Specified.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "speech",
+      "name": "Speech",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Speech.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "split",
+      "name": "Split",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Split.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "splitlines",
+      "name": "Splitlines",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Splitlines.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "splitter",
+      "name": "Splitter",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Splitter.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "spoken",
+      "name": "Spoken",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Spoken.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sqrt",
+      "name": "Sqrt",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sqrt.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "src",
+      "name": "Src",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Src.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stack",
+      "name": "Stack",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stack.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "standard",
+      "name": "Standard",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Standard.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stars",
+      "name": "Stars",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stars.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "start",
+      "name": "Start",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Start.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "startswith",
+      "name": "Startswith",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Startswith.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "state",
+      "name": "State",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: State.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "static",
+      "name": "Static",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Static.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "statistical",
+      "name": "Statistical",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Statistical.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "statistics",
+      "name": "Statistics",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Statistics.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stats",
+      "name": "Stats",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stats.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "status",
+      "name": "Status",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Status.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stderr",
+      "name": "Stderr",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stderr.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stdio",
+      "name": "Stdio",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stdio.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stdout",
+      "name": "Stdout",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stdout.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stem",
+      "name": "Stem",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stem.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "step-by-step",
+      "name": "Step-by-step",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Step-by-step.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "steps",
+      "name": "Steps",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Steps.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "still",
+      "name": "Still",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Still.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "store",
+      "name": "Store",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Store.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "str",
+      "name": "Str",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Str.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "strategies",
+      "name": "Strategies",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Strategies.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "strftime",
+      "name": "Strftime",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Strftime.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "strict",
+      "name": "Strict",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Strict.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "string",
+      "name": "String",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: String.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stringify",
+      "name": "Stringify",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stringify.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "strings",
+      "name": "Strings",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Strings.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "strip",
+      "name": "Strip",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Strip.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stripped",
+      "name": "Stripped",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stripped.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stripping",
+      "name": "Stripping",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stripping.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "structure",
+      "name": "Structure",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Structure.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "structured",
+      "name": "Structured",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Structured.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "structures",
+      "name": "Structures",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Structures.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stub",
+      "name": "Stub",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stub.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stubs",
+      "name": "Stubs",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stubs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "style",
+      "name": "Style",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Style.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stylized",
+      "name": "Stylized",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stylized.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sub",
+      "name": "Sub",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sub.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sub-agent",
+      "name": "Sub-agent",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sub-agent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sub-tasks",
+      "name": "Sub-tasks",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sub-tasks.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "submits",
+      "name": "Submits",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Submits.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "subparsers",
+      "name": "Subparsers",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Subparsers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "subprocess",
+      "name": "Subprocess",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Subprocess.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "success",
+      "name": "Success",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Success.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "such",
+      "name": "Such",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Such.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "suggest",
+      "name": "Suggest",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Suggest.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "suggestions",
+      "name": "Suggestions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Suggestions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "suitable",
+      "name": "Suitable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Suitable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "suite",
+      "name": "Suite",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Suite.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "suites",
+      "name": "Suites",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Suites.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sum",
+      "name": "Sum",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sum.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "summaries",
+      "name": "Summaries",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Summaries.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "summarization",
+      "name": "Summarization",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Summarization.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "summarizer",
+      "name": "Summarizer",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Summarizer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "summarizes",
+      "name": "Summarizes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Summarizes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "summary",
+      "name": "Summary",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Summary.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "supervision",
+      "name": "Supervision",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Supervision.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "supporting",
+      "name": "Supporting",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Supporting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sure",
+      "name": "Sure",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sure.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "surpasses",
+      "name": "Surpasses",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Surpasses.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "survey",
+      "name": "Survey",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Survey.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "svn",
+      "name": "Svn",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Svn.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "symbol",
+      "name": "Symbol",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Symbol.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "symbolic",
+      "name": "Symbolic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Symbolic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "symlink",
+      "name": "Symlink",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Symlink.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sync",
+      "name": "Sync",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sync.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "synergy",
+      "name": "Synergy",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Synergy.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "syntactically",
+      "name": "Syntactically",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Syntactically.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "synthesis",
+      "name": "Synthesis",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Synthesis.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "synthesising",
+      "name": "Synthesising",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Synthesising.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "synthesizes",
+      "name": "Synthesizes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Synthesizes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sys",
+      "name": "Sys",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sys.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "system",
+      "name": "System",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: System.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "systematic",
+      "name": "Systematic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Systematic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tables",
+      "name": "Tables",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tables.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tags",
+      "name": "Tags",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tags.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tail",
+      "name": "Tail",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tail.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tarball",
+      "name": "Tarball",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tarball.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "target",
+      "name": "Target",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Target.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "task",
+      "name": "Task",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Task.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tasks",
+      "name": "Tasks",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tasks.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "taxonomy",
+      "name": "Taxonomy",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Taxonomy.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "teaching",
+      "name": "Teaching",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Teaching.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "template",
+      "name": "Template",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Template.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "terminal",
+      "name": "Terminal",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Terminal.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "test",
+      "name": "Test",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Test.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "testable",
+      "name": "Testable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Testable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "testing",
+      "name": "Testing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Testing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tests",
+      "name": "Tests",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tests.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "text",
+      "name": "Text",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Text.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "text-based",
+      "name": "Text-based",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Text-based.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "text-classification",
+      "name": "Text-classification",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Text-classification.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "text-generation",
+      "name": "Text-generation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Text-generation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "text-to",
+      "name": "Text-to",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Text-to.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "text2text-generation",
+      "name": "Text2text-generation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Text2text-generation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "texts",
+      "name": "Texts",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Texts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tgz",
+      "name": "Tgz",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tgz.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "than",
+      "name": "Than",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Than.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "them",
+      "name": "Them",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Them.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "then",
+      "name": "Then",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Then.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "these",
+      "name": "These",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: These.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "this",
+      "name": "This",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: This.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "threshold",
+      "name": "Threshold",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Threshold.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "thresholds",
+      "name": "Thresholds",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Thresholds.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "through",
+      "name": "Through",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Through.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "throughput",
+      "name": "Throughput",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Throughput.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "throw",
+      "name": "Throw",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Throw.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tier",
+      "name": "Tier",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tier.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "time",
+      "name": "Time",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Time.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "timed",
+      "name": "Timed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Timed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "timeout",
+      "name": "Timeout",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Timeout.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "timestamp",
+      "name": "Timestamp",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Timestamp.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "timezone",
+      "name": "Timezone",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Timezone.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "title",
+      "name": "Title",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Title.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tmpdir",
+      "name": "Tmpdir",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tmpdir.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "to-end",
+      "name": "To-end",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: To-end.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "to-markdown",
+      "name": "To-markdown",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: To-markdown.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "today",
+      "name": "Today",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Today.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "token",
+      "name": "Token",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Token.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "token-classification",
+      "name": "Token-classification",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Token-classification.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tokenization",
+      "name": "Tokenization",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tokenization.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tokenizer",
+      "name": "Tokenizer",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tokenizer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "tokens",
+      "name": "Tokens",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tokens.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tolist",
+      "name": "Tolist",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tolist.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tone",
+      "name": "Tone",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tone.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tool",
+      "name": "Tool",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tool.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tools",
+      "name": "Tools",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tools.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "top",
+      "name": "Top",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Top.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "top-k",
+      "name": "Top-k",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Top-k.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "top-level",
+      "name": "Top-level",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Top-level.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "topic",
+      "name": "Topic",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Topic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "total",
+      "name": "Total",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Total.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "traces",
+      "name": "Traces",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Traces.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "training",
+      "name": "Training",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Training.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "transcribes",
+      "name": "Transcribes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Transcribes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "transformer",
+      "name": "Transformer",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Transformer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "translation",
+      "name": "Translation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Translation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "treat",
+      "name": "Treat",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Treat.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "tree",
+      "name": "Tree",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tree.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "trees",
+      "name": "Trees",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Trees.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "trim",
+      "name": "Trim",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Trim.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "true",
+      "name": "True",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: True.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "try",
+      "name": "Try",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Try.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tsc",
+      "name": "Tsc",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tsc.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tsserver",
+      "name": "Tsserver",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tsserver.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tuple",
+      "name": "Tuple",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tuple.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tuples",
+      "name": "Tuples",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tuples.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "turbo",
+      "name": "Turbo",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Turbo.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "turns",
+      "name": "Turns",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Turns.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "two",
+      "name": "Two",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Two.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "two-pass",
+      "name": "Two-pass",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Two-pass.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "type",
+      "name": "Type",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Type.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "typed",
+      "name": "Typed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Typed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "types",
+      "name": "Types",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Types.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "typescript",
+      "name": "Typescript",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Typescript.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "typescript-5",
+      "name": "Typescript-5",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Typescript-5.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "typing",
+      "name": "Typing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Typing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ubuntu-latest",
+      "name": "Ubuntu-latest",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ubuntu-latest.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unanswerable",
+      "name": "Unanswerable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unanswerable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unbounded",
+      "name": "Unbounded",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unbounded.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "uncommon",
+      "name": "Uncommon",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Uncommon.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "under",
+      "name": "Under",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Under.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "undici-types",
+      "name": "Undici-types",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Undici-types.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "undici-types-6",
+      "name": "Undici-types-6",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Undici-types-6.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unified",
+      "name": "Unified",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unified.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "uninstall",
+      "name": "Uninstall",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Uninstall.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "union",
+      "name": "Union",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Union.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unique",
+      "name": "Unique",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unique.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "uniqueness",
+      "name": "Uniqueness",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Uniqueness.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unit",
+      "name": "Unit",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unknown",
+      "name": "Unknown",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unknown.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unlikely",
+      "name": "Unlikely",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unlikely.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unlock",
+      "name": "Unlock",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unlock.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unlocked",
+      "name": "Unlocked",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unlocked.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unlocks",
+      "name": "Unlocks",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unlocks.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unstructured",
+      "name": "Unstructured",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unstructured.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "until",
+      "name": "Until",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Until.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "update",
+      "name": "Update",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Update.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "update-tree",
+      "name": "Update-tree",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Update-tree.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "updated",
+      "name": "Updated",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Updated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "updates",
+      "name": "Updates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Updates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "upper",
+      "name": "Upper",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Upper.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "uppercase",
+      "name": "Uppercase",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Uppercase.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "url",
+      "name": "Url",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Url.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "urllib",
+      "name": "Urllib",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Urllib.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "urlopen",
+      "name": "Urlopen",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Urlopen.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "usable",
+      "name": "Usable",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Usable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "usage",
+      "name": "Usage",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Usage.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "use",
+      "name": "Use",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Use.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "used",
+      "name": "Used",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Used.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "useful",
+      "name": "Useful",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Useful.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "user",
+      "name": "User",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: User.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "username",
+      "name": "Username",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Username.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "users",
+      "name": "Users",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Users.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "users-dir",
+      "name": "Users-dir",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Users-dir.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "uses",
+      "name": "Uses",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Uses.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "using",
+      "name": "Using",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Using.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "usr",
+      "name": "Usr",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Usr.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "usually",
+      "name": "Usually",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Usually.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "utc",
+      "name": "Utc",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Utc.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "utf-8",
+      "name": "Utf-8",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Utf-8.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "utf8",
+      "name": "Utf8",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Utf8.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "util",
+      "name": "Util",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Util.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "utilities",
+      "name": "Utilities",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Utilities.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "valence",
+      "name": "Valence",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Valence.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "valid",
+      "name": "Valid",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Valid.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "validate",
+      "name": "Validate",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Validate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "validated",
+      "name": "Validated",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Validated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "validates",
+      "name": "Validates",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Validates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "validation",
+      "name": "Validation",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Validation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "value",
+      "name": "Value",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Value.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "values",
+      "name": "Values",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Values.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "variables",
+      "name": "Variables",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Variables.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "vector",
+      "name": "Vector",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Vector.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "vectors",
+      "name": "Vectors",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Vectors.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "vendor",
+      "name": "Vendor",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Vendor.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "venv",
+      "name": "Venv",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Venv.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "verified",
+      "name": "Verified",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Verified.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "verify",
+      "name": "Verify",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Verify.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "verifying",
+      "name": "Verifying",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Verifying.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "version",
+      "name": "Version",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Version.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "versions",
+      "name": "Versions",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Versions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "via",
+      "name": "Via",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Via.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "virtual",
+      "name": "Virtual",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Virtual.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "vision",
+      "name": "Vision",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Vision.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "vision-language",
+      "name": "Vision-language",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Vision-language.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "visual",
+      "name": "Visual",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Visual.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "visualization",
+      "name": "Visualization",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Visualization.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "visualizations",
+      "name": "Visualizations",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Visualizations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "visualstudio",
+      "name": "Visualstudio",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Visualstudio.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "voice",
+      "name": "Voice",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Voice.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "vscode",
+      "name": "Vscode",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Vscode.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "vscode-marketplace",
+      "name": "Vscode-marketplace",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Vscode-marketplace.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "walk",
+      "name": "Walk",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Walk.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "want",
+      "name": "Want",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Want.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "warnings",
+      "name": "Warnings",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Warnings.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "weak",
+      "name": "Weak",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Weak.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "web",
+      "name": "Web",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Web.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "web-arena-x",
+      "name": "Web-arena-x",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Web-arena-x.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "webarena",
+      "name": "Webarena",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Webarena.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "webp",
+      "name": "Webp",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Webp.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "websites",
+      "name": "Websites",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Websites.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "well-formed",
+      "name": "Well-formed",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Well-formed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "wet-lab",
+      "name": "Wet-lab",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Wet-lab.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "what",
+      "name": "What",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: What.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "when",
+      "name": "When",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: When.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "whenever",
+      "name": "Whenever",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Whenever.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "where",
+      "name": "Where",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Where.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "which",
+      "name": "Which",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Which.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "while",
+      "name": "While",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: While.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "whisper",
+      "name": "Whisper",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Whisper.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "width",
+      "name": "Width",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Width.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "will",
+      "name": "Will",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Will.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "win32",
+      "name": "Win32",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Win32.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "window",
+      "name": "Window",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Window.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "within",
+      "name": "Within",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Within.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "without",
+      "name": "Without",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Without.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "words",
+      "name": "Words",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Words.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "workflows",
+      "name": "Workflows",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Workflows.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "wrapper",
+      "name": "Wrapper",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Wrapper.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "write",
+      "name": "Write",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Write.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "writes",
+      "name": "Writes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Writes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "writing",
+      "name": "Writing",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Writing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "written",
+      "name": "Written",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Written.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "www",
+      "name": "Www",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Www.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "xlang-ai",
+      "name": "Xlang-ai",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Xlang-ai.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "xml",
+      "name": "Xml",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Xml.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "xmlns",
+      "name": "Xmlns",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Xmlns.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "yaml",
+      "name": "Yaml",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Yaml.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "yes",
+      "name": "Yes",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Yes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "yet",
+      "name": "Yet",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Yet.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "yml",
+      "name": "Yml",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Yml.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "you",
+      "name": "You",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: You.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "your",
+      "name": "Your",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Your.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "your-github-username",
+      "name": "Your-github-username",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Your-github-username.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ysymyth",
+      "name": "Ysymyth",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ysymyth.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "zero-config",
+      "name": "Zero-config",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Zero-config.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "zero-shot",
+      "name": "Zero-shot",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Zero-shot.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "zero-shot-classification",
+      "name": "Zero-shot-classification",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Zero-shot-classification.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "zip",
+      "name": "Zip",
+      "type": "atomic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Zip.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    }
+  ],
+  "similarity": [
+    {
+      "sourceSkillId": "abductive",
+      "targetSkillId": "retrieve",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "absolute",
+      "targetSkillId": "translate",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "absolute",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "abspath",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accents",
+      "targetSkillId": "extract-entities",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accents",
+      "targetSkillId": "chunk-document",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accepted",
+      "targetSkillId": "parse-pdf",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accidentally",
+      "targetSkillId": "document-analyst",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accidentally",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accidentally",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accurate",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accurate",
+      "targetSkillId": "image-generate",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "achieves",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "achieves",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "achieving",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "achieving",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "acting",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "acting",
+      "targetSkillId": "image-caption",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "action",
+      "targetSkillId": "image-caption",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "action",
+      "targetSkillId": "code-execution",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "action",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "actions",
+      "targetSkillId": "image-caption",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "actions",
+      "targetSkillId": "code-execution",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "actions",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "actual",
+      "targetSkillId": "api-call",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "actual",
+      "targetSkillId": "data-visualize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "adapting",
+      "targetSkillId": "image-caption",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "adapting",
+      "targetSkillId": "automated-testing",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "additions",
+      "targetSkillId": "document-digitization",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "additions",
+      "targetSkillId": "image-caption",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "advancement",
+      "targetSkillId": "audience-model",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "advancement",
+      "targetSkillId": "voice-agent",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "advancement",
+      "targetSkillId": "chunk-document",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "against",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "against",
+      "targetSkillId": "image-caption",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agent",
+      "targetSkillId": "voice-agent",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agent",
+      "targetSkillId": "image-generate",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agent",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agent-native",
+      "targetSkillId": "image-caption",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agent-native",
+      "targetSkillId": "image-generate",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agent-native",
+      "targetSkillId": "multi-agent-orchestration-v",
+      "score": 0.513,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agent-related",
+      "targetSkillId": "image-generate",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agent-related",
+      "targetSkillId": "generate-sql",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agent-related",
+      "targetSkillId": "translate",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agents",
+      "targetSkillId": "voice-agent",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agents",
+      "targetSkillId": "generate-sql",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agents",
+      "targetSkillId": "generate-test",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ahead",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ai-agent",
+      "targetSkillId": "voice-agent",
+      "score": 0.737,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ai-agent",
+      "targetSkillId": "conversational-agent",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ai-agent",
+      "targetSkillId": "image-generate",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ai-agent-tool",
+      "targetSkillId": "voice-agent",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ai-agent-tool",
+      "targetSkillId": "audience-model",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ai-agent-tool",
+      "targetSkillId": "multi-agent-orchestration-v",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "algebra",
+      "targetSkillId": "image-generate",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "algebra",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "alive",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "alive",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "all",
+      "targetSkillId": "api-call",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "allocation",
+      "targetSkillId": "image-caption",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "allocation",
+      "targetSkillId": "code-execution",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "allocation",
+      "targetSkillId": "browser-automation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "analyses",
+      "targetSkillId": "data-analysis",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "analyses",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "analyses",
+      "targetSkillId": "document-analyst",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "analysis",
+      "targetSkillId": "data-analysis",
+      "score": 0.762,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "analysis",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "analysis",
+      "targetSkillId": "document-analyst",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "anomaly",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "anomaly",
+      "targetSkillId": "data-analysis",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "another",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "answer",
+      "targetSkillId": "question-answer",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "answer",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "answers",
+      "targetSkillId": "question-answer",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "answers",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "any",
+      "targetSkillId": "rank",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "api",
+      "targetSkillId": "api-call",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "api-version",
+      "targetSkillId": "math-reason",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "api-version",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "api-version",
+      "targetSkillId": "parse-json",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "appears",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "appears",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "appears",
+      "targetSkillId": "parse-html",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "append",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "application",
+      "targetSkillId": "api-call",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "application",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "application",
+      "targetSkillId": "registry-curation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "apply",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "apply",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "approach",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "appropriate",
+      "targetSkillId": "ghostwrite",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "approval",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "archived",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "archived",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "archived",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "argparse",
+      "targetSkillId": "parse-pdf",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "argparse",
+      "targetSkillId": "parse-json",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "argparse",
+      "targetSkillId": "parse-html",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "args",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "arguments",
+      "targetSkillId": "voice-agent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "arguments",
+      "targetSkillId": "document-analyst",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "arguments",
+      "targetSkillId": "route-intent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "arithmetic",
+      "targetSkillId": "write-report",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "arithmetic",
+      "targetSkillId": "route-intent",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "arrays",
+      "targetSkillId": "math-reason",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "arriving",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "artifact",
+      "targetSkillId": "refactor-code",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "artifacts",
+      "targetSkillId": "refactor-code",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "arxiv",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "assembles",
+      "targetSkillId": "parse-html",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "assert",
+      "targetSkillId": "parse-html",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "assistant",
+      "targetSkillId": "real-time-voice-assistant",
+      "score": 0.529,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "assistant",
+      "targetSkillId": "classify",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "assistants",
+      "targetSkillId": "real-time-voice-assistant",
+      "score": 0.514,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "async",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attribute",
+      "targetSkillId": "ghostwrite",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attribute",
+      "targetSkillId": "retrieve",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attributes",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attributes",
+      "targetSkillId": "math-reason",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attributes",
+      "targetSkillId": "extract-entities",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attvalue",
+      "targetSkillId": "data-visualize",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attvalue",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attvalues",
+      "targetSkillId": "data-visualize",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attvalues",
+      "targetSkillId": "tool-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attvalues",
+      "targetSkillId": "generate-test",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "audience",
+      "targetSkillId": "audience-model",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "audience",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "audience",
+      "targetSkillId": "logical-inference",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "audience-tailored",
+      "targetSkillId": "audience-model",
+      "score": 0.645,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "audio",
+      "targetSkillId": "audience-model",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "augmented",
+      "targetSkillId": "image-generate",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "augmented",
+      "targetSkillId": "audience-model",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "augmented",
+      "targetSkillId": "voice-agent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "authenticated",
+      "targetSkillId": "extract-entities",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "authenticated",
+      "targetSkillId": "audience-model",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "authenticated",
+      "targetSkillId": "tokenize",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "author",
+      "targetSkillId": "math-reason",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "authoritative",
+      "targetSkillId": "ghostwrite",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "authoritative",
+      "targetSkillId": "retrieve",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "authoritative",
+      "targetSkillId": "automated-testing",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "auto-generated",
+      "targetSkillId": "image-generate",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "auto-generated",
+      "targetSkillId": "code-generation",
+      "score": 0.621,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "auto-generated",
+      "targetSkillId": "generate-sql",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "auto-prompt-combinations",
+      "targetSkillId": "autonomous-data-scientist",
+      "score": 0.49,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "auto-prompt-combinations",
+      "targetSkillId": "browser-automation",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autogen",
+      "targetSkillId": "tokenize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "automated",
+      "targetSkillId": "automated-testing",
+      "score": 0.692,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "automated",
+      "targetSkillId": "browser-automation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "automated",
+      "targetSkillId": "autonomous-debug",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "automatic",
+      "targetSkillId": "automated-testing",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "automatic",
+      "targetSkillId": "browser-automation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "automatic",
+      "targetSkillId": "autonomous-data-scientist",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "automatically",
+      "targetSkillId": "api-call",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "automatically",
+      "targetSkillId": "automated-testing",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "automatically",
+      "targetSkillId": "browser-automation",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autonomous",
+      "targetSkillId": "autonomous-debug",
+      "score": 0.769,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autonomous",
+      "targetSkillId": "autonomous-research-agent",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autonomous",
+      "targetSkillId": "autonomous-data-scientist",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autonomously",
+      "targetSkillId": "autonomous-debug",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autonomously",
+      "targetSkillId": "autonomous-research-agent",
+      "score": 0.541,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autonomously",
+      "targetSkillId": "autonomous-data-scientist",
+      "score": 0.541,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autoregressive",
+      "targetSkillId": "retrieve",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autoregressive",
+      "targetSkillId": "automated-testing",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autoregressive",
+      "targetSkillId": "score-relevance",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autoresearch",
+      "targetSkillId": "research",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autoresearch",
+      "targetSkillId": "autonomous-research-agent",
+      "score": 0.649,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "autoresearch",
+      "targetSkillId": "web-search",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "available",
+      "targetSkillId": "api-call",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "awakened",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "awakened",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "awareness",
+      "targetSkillId": "data-analysis",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "back",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "based",
+      "targetSkillId": "parse-pdf",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "baseline",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "baseline",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "baseline",
+      "targetSkillId": "self-critique",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "baselines",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "baselines",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "baselines",
+      "targetSkillId": "self-critique",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "bash",
+      "targetSkillId": "execute-bash",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "batch",
+      "targetSkillId": "web-search",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "batch",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "batched",
+      "targetSkillId": "web-search",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "batches",
+      "targetSkillId": "math-reason",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "batches",
+      "targetSkillId": "web-search",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "becomes",
+      "targetSkillId": "computer-use",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "becomes",
+      "targetSkillId": "plan-decompose",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "before",
+      "targetSkillId": "refactor-code",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "bench",
+      "targetSkillId": "web-search",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "bench",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "between",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "between",
+      "targetSkillId": "embed-text",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "bool",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "boolean",
+      "targetSkillId": "tool-use",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "boolean",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "booleans",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "bootstrapped",
+      "targetSkillId": "web-scrape",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "bootstrapped",
+      "targetSkillId": "ghostwrite",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "branch",
+      "targetSkillId": "rank",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "branch",
+      "targetSkillId": "research",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "branch",
+      "targetSkillId": "web-search",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "break",
+      "targetSkillId": "rank",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "break",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "broken",
+      "targetSkillId": "tokenize",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "browsers",
+      "targetSkillId": "browser-automation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "browsers",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "bytecode",
+      "targetSkillId": "refactor-code",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "bytecode",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cache",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "calculus",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "call",
+      "targetSkillId": "api-call",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "calling",
+      "targetSkillId": "api-call",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "calling",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "calls",
+      "targetSkillId": "api-call",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "calls",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "can",
+      "targetSkillId": "rank",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "candidate",
+      "targetSkillId": "translate",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "candidates",
+      "targetSkillId": "translate",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "candidates",
+      "targetSkillId": "extract-entities",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "candidates",
+      "targetSkillId": "generate-sql",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cannot",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cannot",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "canonical",
+      "targetSkillId": "api-call",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "canonical",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "capability",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "capitalize",
+      "targetSkillId": "data-visualize",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "capitalize",
+      "targetSkillId": "api-call",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "capitalize",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "caps",
+      "targetSkillId": "classify",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "captures",
+      "targetSkillId": "cite-sources",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "captures",
+      "targetSkillId": "math-reason",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "captures",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "capturing",
+      "targetSkillId": "image-caption",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "capturing",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.457,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "case",
+      "targetSkillId": "classify",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "case",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "case",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cases",
+      "targetSkillId": "classify",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cases",
+      "targetSkillId": "parse-json",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cases",
+      "targetSkillId": "cite-sources",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "catch",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "catches",
+      "targetSkillId": "math-reason",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "catches",
+      "targetSkillId": "cite-sources",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "categorical",
+      "targetSkillId": "api-call",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "categorical",
+      "targetSkillId": "cite-sources",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "categories",
+      "targetSkillId": "cite-sources",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "categories",
+      "targetSkillId": "extract-entities",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "categories",
+      "targetSkillId": "computer-use",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "categorization",
+      "targetSkillId": "content-moderation",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "categorization",
+      "targetSkillId": "code-generation",
+      "score": 0.621,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "categorization",
+      "targetSkillId": "document-digitization",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "category",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "caught",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "caught",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "causes",
+      "targetSkillId": "classify",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "causes",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "chain",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "chain",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "chain-of-thought-hub",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.889,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "chain-of-thought-only",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.865,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "chains",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "change",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "change",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "changing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "changing",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "checkout",
+      "targetSkillId": "code-execution",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "chemistry",
+      "targetSkillId": "registry-curation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "children",
+      "targetSkillId": "chunk-document",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "chunk",
+      "targetSkillId": "chunk-document",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "chunking",
+      "targetSkillId": "chunk-document",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "citation",
+      "targetSkillId": "image-caption",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "citation",
+      "targetSkillId": "document-digitization",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "citation",
+      "targetSkillId": "content-moderation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "citations",
+      "targetSkillId": "image-caption",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "citations",
+      "targetSkillId": "document-digitization",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "citations",
+      "targetSkillId": "content-moderation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "claims",
+      "targetSkillId": "classify",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "clarity",
+      "targetSkillId": "classify",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "class",
+      "targetSkillId": "classify",
+      "score": 0.769,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "classification",
+      "targetSkillId": "classify",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "classification",
+      "targetSkillId": "image-caption",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "classification",
+      "targetSkillId": "document-digitization",
+      "score": 0.457,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "classifier",
+      "targetSkillId": "classify",
+      "score": 0.778,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cleaned",
+      "targetSkillId": "score-relevance",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cli",
+      "targetSkillId": "classify",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "click",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "clone",
+      "targetSkillId": "diff-content",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "clone",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cloning",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "closing",
+      "targetSkillId": "classify",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "closing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "clustering",
+      "targetSkillId": "route-intent",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "clustering",
+      "targetSkillId": "computer-use",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "co-references",
+      "targetSkillId": "score-relevance",
+      "score": 0.643,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "co-references",
+      "targetSkillId": "logical-inference",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "co-references",
+      "targetSkillId": "code-review-pipeline",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "code",
+      "targetSkillId": "refactor-code",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "codec",
+      "targetSkillId": "code-execution",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "codegen",
+      "targetSkillId": "code-generation",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "codegen",
+      "targetSkillId": "code-execution",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "codegen",
+      "targetSkillId": "voice-agent",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "codes",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "codes",
+      "targetSkillId": "cite-sources",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "coherent",
+      "targetSkillId": "voice-agent",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "coherent",
+      "targetSkillId": "route-intent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "coherent",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "collections",
+      "targetSkillId": "code-execution",
+      "score": 0.64,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "collections",
+      "targetSkillId": "tool-select",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "collections",
+      "targetSkillId": "code-generation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combination",
+      "targetSkillId": "code-generation",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combination",
+      "targetSkillId": "content-moderation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combination",
+      "targetSkillId": "error-interpretation",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combinations",
+      "targetSkillId": "code-generation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combinations",
+      "targetSkillId": "content-moderation",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combinations",
+      "targetSkillId": "error-interpretation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combinator",
+      "targetSkillId": "code-generation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combinator",
+      "targetSkillId": "computer-use",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combining",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combos",
+      "targetSkillId": "plan-decompose",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comment",
+      "targetSkillId": "chunk-document",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comment",
+      "targetSkillId": "diff-content",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comment",
+      "targetSkillId": "code-generation",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "community",
+      "targetSkillId": "computer-use",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comparisons",
+      "targetSkillId": "parse-json",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comparisons",
+      "targetSkillId": "math-reason",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comparisons",
+      "targetSkillId": "computer-use",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "compatible",
+      "targetSkillId": "computer-use",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "compatible",
+      "targetSkillId": "conversational-agent",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "competition",
+      "targetSkillId": "document-digitization",
+      "score": 0.562,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "competition",
+      "targetSkillId": "code-execution",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "competition",
+      "targetSkillId": "content-moderation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "compile",
+      "targetSkillId": "computer-use",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "compile",
+      "targetSkillId": "plan-decompose",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "complete",
+      "targetSkillId": "computer-use",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "complete",
+      "targetSkillId": "plan-decompose",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "complete",
+      "targetSkillId": "chunk-document",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "completes",
+      "targetSkillId": "computer-use",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "completes",
+      "targetSkillId": "automated-testing",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "completing",
+      "targetSkillId": "automated-testing",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "completing",
+      "targetSkillId": "content-moderation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "completing",
+      "targetSkillId": "code-execution",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "completion",
+      "targetSkillId": "code-execution",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "completion",
+      "targetSkillId": "content-moderation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "completion",
+      "targetSkillId": "code-generation",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "complex",
+      "targetSkillId": "computer-use",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "complex",
+      "targetSkillId": "plan-decompose",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "complexity",
+      "targetSkillId": "computer-use",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "composite",
+      "targetSkillId": "plan-decompose",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "composite",
+      "targetSkillId": "computer-use",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "composite",
+      "targetSkillId": "ghostwrite",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "composites",
+      "targetSkillId": "computer-use",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "composites",
+      "targetSkillId": "plan-decompose",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "composites",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comprehension",
+      "targetSkillId": "code-generation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comprehension",
+      "targetSkillId": "parse-json",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comprehension",
+      "targetSkillId": "code-execution",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comprehensive",
+      "targetSkillId": "score-relevance",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comprehensive",
+      "targetSkillId": "computer-use",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comprehensive",
+      "targetSkillId": "tokenize",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "computation",
+      "targetSkillId": "code-execution",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "computation",
+      "targetSkillId": "content-moderation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "computation",
+      "targetSkillId": "code-generation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "compute",
+      "targetSkillId": "computer-use",
+      "score": 0.737,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "compute",
+      "targetSkillId": "format-output",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "compute",
+      "targetSkillId": "plan-decompose",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "computer",
+      "targetSkillId": "computer-use",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "computer",
+      "targetSkillId": "format-output",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "computer",
+      "targetSkillId": "plan-decompose",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "computes",
+      "targetSkillId": "computer-use",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "computes",
+      "targetSkillId": "execute-bash",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "computes",
+      "targetSkillId": "format-output",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conclusions",
+      "targetSkillId": "code-execution",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conclusions",
+      "targetSkillId": "question-answer",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conclusions",
+      "targetSkillId": "code-generation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "condition",
+      "targetSkillId": "code-execution",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "condition",
+      "targetSkillId": "content-moderation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "condition",
+      "targetSkillId": "code-generation",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conditions",
+      "targetSkillId": "code-execution",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conditions",
+      "targetSkillId": "content-moderation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conditions",
+      "targetSkillId": "code-generation",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conducts",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conducts",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "config",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "configuration",
+      "targetSkillId": "code-generation",
+      "score": 0.643,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "configuration",
+      "targetSkillId": "content-moderation",
+      "score": 0.581,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "configuration",
+      "targetSkillId": "conversational-agent",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "configured",
+      "targetSkillId": "computer-use",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "configured",
+      "targetSkillId": "cite-sources",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "confirmed",
+      "targetSkillId": "tokenize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "connector",
+      "targetSkillId": "code-execution",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "connector",
+      "targetSkillId": "content-moderation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "connector",
+      "targetSkillId": "code-generation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "consecutive",
+      "targetSkillId": "code-execution",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "consecutive",
+      "targetSkillId": "retrieve",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "consecutive",
+      "targetSkillId": "self-critique",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "console",
+      "targetSkillId": "tool-use",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "console",
+      "targetSkillId": "conversational-agent",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "console",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "const",
+      "targetSkillId": "diff-content",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "constrained",
+      "targetSkillId": "ghostwrite",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "constrained",
+      "targetSkillId": "content-moderation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "constrained",
+      "targetSkillId": "code-generation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "constraints",
+      "targetSkillId": "ghostwrite",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "constraints",
+      "targetSkillId": "content-moderation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "constraints",
+      "targetSkillId": "code-generation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "construction",
+      "targetSkillId": "knowledge-graph-build",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "construction",
+      "targetSkillId": "content-moderation",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "construction",
+      "targetSkillId": "code-generation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contain",
+      "targetSkillId": "content-moderation",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contain",
+      "targetSkillId": "code-generation",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contain",
+      "targetSkillId": "diff-content",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "containing",
+      "targetSkillId": "content-moderation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "containing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "containing",
+      "targetSkillId": "code-generation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "content",
+      "targetSkillId": "diff-content",
+      "score": 0.737,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "content",
+      "targetSkillId": "route-intent",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "content",
+      "targetSkillId": "content-moderation",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "context",
+      "targetSkillId": "diff-content",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "context",
+      "targetSkillId": "speech-to-text",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "context",
+      "targetSkillId": "route-intent",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "context-grounded",
+      "targetSkillId": "content-moderation",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "context-grounded",
+      "targetSkillId": "code-generation",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "context-grounded",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contextually",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contextually",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contextually",
+      "targetSkillId": "content-moderation",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "continuation",
+      "targetSkillId": "content-moderation",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "continuation",
+      "targetSkillId": "code-generation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "continuation",
+      "targetSkillId": "document-digitization",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "continue",
+      "targetSkillId": "code-generation",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "continue",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "continue",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contributor",
+      "targetSkillId": "content-moderation",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contributor",
+      "targetSkillId": "ghostwrite",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contributor",
+      "targetSkillId": "code-generation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "control",
+      "targetSkillId": "content-moderation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "control",
+      "targetSkillId": "code-generation",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "controlled",
+      "targetSkillId": "tool-select",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "controlled",
+      "targetSkillId": "conversational-agent",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "controlled",
+      "targetSkillId": "diff-content",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "convention",
+      "targetSkillId": "content-moderation",
+      "score": 0.643,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "convention",
+      "targetSkillId": "code-generation",
+      "score": 0.64,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "convention",
+      "targetSkillId": "conversational-agent",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conversation",
+      "targetSkillId": "conversational-agent",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conversation",
+      "targetSkillId": "code-generation",
+      "score": 0.741,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conversation",
+      "targetSkillId": "content-moderation",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conversational",
+      "targetSkillId": "conversational-agent",
+      "score": 0.824,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conversational",
+      "targetSkillId": "code-generation",
+      "score": 0.69,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conversational",
+      "targetSkillId": "content-moderation",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conversations",
+      "targetSkillId": "conversational-agent",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conversations",
+      "targetSkillId": "code-generation",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "conversations",
+      "targetSkillId": "content-moderation",
+      "score": 0.645,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "convert",
+      "targetSkillId": "code-generation",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "convert",
+      "targetSkillId": "diff-content",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "convert",
+      "targetSkillId": "conversational-agent",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "core",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "core",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "corpora",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "corpus",
+      "targetSkillId": "computer-use",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "correct",
+      "targetSkillId": "score-relevance",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "correct",
+      "targetSkillId": "code-execution",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "correctness",
+      "targetSkillId": "score-relevance",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "correctness",
+      "targetSkillId": "cite-sources",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "correctness",
+      "targetSkillId": "code-execution",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cosine",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cosine",
+      "targetSkillId": "conversational-agent",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "count",
+      "targetSkillId": "route-intent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "count",
+      "targetSkillId": "diff-content",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "count",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "coupling",
+      "targetSkillId": "code-execution",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "coverage",
+      "targetSkillId": "conversational-agent",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "coverage",
+      "targetSkillId": "voice-agent",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "coverage",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "covering",
+      "targetSkillId": "conversational-agent",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "covering",
+      "targetSkillId": "code-generation",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "covering",
+      "targetSkillId": "content-moderation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "crawl",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "crawler",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "crawler",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "crawlers",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "crawling",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "crawling",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "crawling",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "create",
+      "targetSkillId": "retrieve",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "create",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "create",
+      "targetSkillId": "refactor-code",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "created",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "created",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "created",
+      "targetSkillId": "refactor-code",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "creating",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "creating",
+      "targetSkillId": "code-generation",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "creating",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "creation",
+      "targetSkillId": "code-generation",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "creation",
+      "targetSkillId": "image-caption",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "creation",
+      "targetSkillId": "registry-curation",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "creator",
+      "targetSkillId": "refactor-code",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "creator",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "creator",
+      "targetSkillId": "research",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "criteria",
+      "targetSkillId": "write-report",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "criteria",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "criteria",
+      "targetSkillId": "self-critique",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cross-domain",
+      "targetSkillId": "browser-automation",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cross-domain",
+      "targetSkillId": "chunk-document",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "curation",
+      "targetSkillId": "registry-curation",
+      "score": 0.64,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "curation",
+      "targetSkillId": "code-generation",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "curation",
+      "targetSkillId": "image-caption",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "current",
+      "targetSkillId": "chunk-document",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "data",
+      "targetSkillId": "data-analysis",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dataclass",
+      "targetSkillId": "data-analysis",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dataclass",
+      "targetSkillId": "classify",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dataclasses",
+      "targetSkillId": "data-analysis",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dataclasses",
+      "targetSkillId": "classify",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dataclasses",
+      "targetSkillId": "data-visualize",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dataset",
+      "targetSkillId": "data-visualize",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dataset",
+      "targetSkillId": "data-analysis",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dataset",
+      "targetSkillId": "parse-html",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "datasets",
+      "targetSkillId": "data-analysis",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "datasets",
+      "targetSkillId": "data-visualize",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "datasets",
+      "targetSkillId": "autonomous-data-scientist",
+      "score": 0.485,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "date",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dates",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dates",
+      "targetSkillId": "generate-sql",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "datetime",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "datetime",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "datetime",
+      "targetSkillId": "extract-entities",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "days",
+      "targetSkillId": "data-analysis",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decay",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decay",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "declaration",
+      "targetSkillId": "code-generation",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "declaration",
+      "targetSkillId": "image-caption",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "declaration",
+      "targetSkillId": "registry-curation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decoding",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decoding",
+      "targetSkillId": "code-execution",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decomposed",
+      "targetSkillId": "plan-decompose",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decomposed",
+      "targetSkillId": "computer-use",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decomposition",
+      "targetSkillId": "plan-decompose",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decomposition",
+      "targetSkillId": "image-caption",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decomposition",
+      "targetSkillId": "code-execution",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deductive",
+      "targetSkillId": "retrieve",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deductive",
+      "targetSkillId": "self-critique",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "defaultedgetype",
+      "targetSkillId": "evaluate-output",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "definitions",
+      "targetSkillId": "code-generation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "definitions",
+      "targetSkillId": "document-digitization",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "definitions",
+      "targetSkillId": "code-execution",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "delegates",
+      "targetSkillId": "generate-sql",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "delegates",
+      "targetSkillId": "generate-test",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "delegates",
+      "targetSkillId": "execute-bash",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deletions",
+      "targetSkillId": "code-execution",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deletions",
+      "targetSkillId": "code-generation",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deletions",
+      "targetSkillId": "question-answer",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "delimiter",
+      "targetSkillId": "self-critique",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "demonstrates",
+      "targetSkillId": "generate-sql",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "demonstrates",
+      "targetSkillId": "generate-test",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "demonstrates",
+      "targetSkillId": "ghostwrite",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "demonstrating",
+      "targetSkillId": "code-generation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "demonstrating",
+      "targetSkillId": "error-interpretation",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "demonstrating",
+      "targetSkillId": "registry-curation",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "demos",
+      "targetSkillId": "plan-decompose",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dense",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dense",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deriv",
+      "targetSkillId": "retrieve",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "derivative",
+      "targetSkillId": "retrieve",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "derivative",
+      "targetSkillId": "self-critique",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "derivative",
+      "targetSkillId": "code-generation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "derivatives",
+      "targetSkillId": "retrieve",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "derivatives",
+      "targetSkillId": "generate-sql",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "derivatives",
+      "targetSkillId": "extract-entities",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "derive",
+      "targetSkillId": "retrieve",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "desc",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "descending",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "descending",
+      "targetSkillId": "code-generation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "descending",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "description",
+      "targetSkillId": "image-caption",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "description",
+      "targetSkillId": "registry-curation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "description",
+      "targetSkillId": "code-execution",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "descriptions",
+      "targetSkillId": "image-caption",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "descriptions",
+      "targetSkillId": "registry-curation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "descriptions",
+      "targetSkillId": "code-execution",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "designs",
+      "targetSkillId": "question-answer",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detail",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detail",
+      "targetSkillId": "data-visualize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detail",
+      "targetSkillId": "document-analyst",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detect",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detect",
+      "targetSkillId": "embed-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detect",
+      "targetSkillId": "code-execution",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detected",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detected",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detected",
+      "targetSkillId": "generate-text",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detection",
+      "targetSkillId": "code-execution",
+      "score": 0.696,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detection",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detection",
+      "targetSkillId": "code-generation",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detects",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detects",
+      "targetSkillId": "generate-test",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detects",
+      "targetSkillId": "code-execution",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "development",
+      "targetSkillId": "full-stack-developer",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "development",
+      "targetSkillId": "recursive-self-improvement",
+      "score": 0.486,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "development",
+      "targetSkillId": "chunk-document",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deviations",
+      "targetSkillId": "code-generation",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deviations",
+      "targetSkillId": "image-caption",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deviations",
+      "targetSkillId": "registry-curation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dialogue",
+      "targetSkillId": "data-visualize",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dict",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dicts",
+      "targetSkillId": "diff-content",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "diff",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "diffing",
+      "targetSkillId": "diff-content",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "diffusion",
+      "targetSkillId": "diff-content",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "diffusion-based",
+      "targetSkillId": "question-answer",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "diffusion-based",
+      "targetSkillId": "diff-content",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dimensions",
+      "targetSkillId": "image-caption",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dimensions",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dimensions",
+      "targetSkillId": "question-answer",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directed",
+      "targetSkillId": "audience-model",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directed",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directed",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directionally",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directionally",
+      "targetSkillId": "image-caption",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directionally",
+      "targetSkillId": "code-execution",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directly",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directly",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directory",
+      "targetSkillId": "refactor-code",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directory",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directory",
+      "targetSkillId": "write-report",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directs",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dirname",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dirname",
+      "targetSkillId": "audience-model",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "discovered",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "discovered",
+      "targetSkillId": "diff-content",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "discovered",
+      "targetSkillId": "computer-use",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "discrete",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "discrete",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "discrete",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "distance",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "distance",
+      "targetSkillId": "data-visualize",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "distance",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "document",
+      "targetSkillId": "chunk-document",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "document",
+      "targetSkillId": "document-analyst",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "document",
+      "targetSkillId": "document-digitization",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documentation",
+      "targetSkillId": "document-digitization",
+      "score": 0.765,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documentation",
+      "targetSkillId": "document-analyst",
+      "score": 0.69,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documentation",
+      "targetSkillId": "chunk-document",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documented",
+      "targetSkillId": "chunk-document",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documented",
+      "targetSkillId": "document-analyst",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documented",
+      "targetSkillId": "document-digitization",
+      "score": 0.581,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documents",
+      "targetSkillId": "document-analyst",
+      "score": 0.72,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documents",
+      "targetSkillId": "chunk-document",
+      "score": 0.696,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documents",
+      "targetSkillId": "document-digitization",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "doesn",
+      "targetSkillId": "diff-content",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "doesn",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "downstream",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "downstream",
+      "targetSkillId": "diff-content",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "draft-skills",
+      "targetSkillId": "data-analysis",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "draft-skills",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "draft-skills",
+      "targetSkillId": "data-visualize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dramatically",
+      "targetSkillId": "api-call",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dramatically",
+      "targetSkillId": "data-analysis",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dramatically",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "duplicate",
+      "targetSkillId": "diff-content",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "duplicate",
+      "targetSkillId": "api-call",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "duplicates",
+      "targetSkillId": "diff-content",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "each",
+      "targetSkillId": "research",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "each",
+      "targetSkillId": "web-search",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "echo",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "edge-case",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "edge-case",
+      "targetSkillId": "execute-bash",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "edge-case",
+      "targetSkillId": "image-caption",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "edges",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "elements",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "elicits",
+      "targetSkillId": "self-critique",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "elif",
+      "targetSkillId": "classify",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "else",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "else",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "embed",
+      "targetSkillId": "embed-text",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "embedding",
+      "targetSkillId": "embed-text",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "embedding",
+      "targetSkillId": "automated-testing",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "embeddings",
+      "targetSkillId": "embed-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "embeds",
+      "targetSkillId": "embed-text",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "emotional",
+      "targetSkillId": "content-moderation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "emotional",
+      "targetSkillId": "question-answer",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "emotional",
+      "targetSkillId": "conversational-agent",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enables",
+      "targetSkillId": "generate-test",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "encode",
+      "targetSkillId": "audience-model",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "encode",
+      "targetSkillId": "refactor-code",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "encoding",
+      "targetSkillId": "content-moderation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "encoding",
+      "targetSkillId": "code-execution",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "encoding",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "end-to-end",
+      "targetSkillId": "text-to-speech",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "end-to-end",
+      "targetSkillId": "speech-to-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "end-to-end",
+      "targetSkillId": "embed-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "engine",
+      "targetSkillId": "tokenize",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "engineering",
+      "targetSkillId": "code-generation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "engineering",
+      "targetSkillId": "error-interpretation",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "engines",
+      "targetSkillId": "tokenize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enhances",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enhances",
+      "targetSkillId": "generate-test",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entities",
+      "targetSkillId": "extract-entities",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entities",
+      "targetSkillId": "generate-test",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entities",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entity",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entity",
+      "targetSkillId": "extract-entities",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entries",
+      "targetSkillId": "retrieve",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entries",
+      "targetSkillId": "tokenize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entries",
+      "targetSkillId": "generate-sql",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entry",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enumerate",
+      "targetSkillId": "generate-sql",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enumerate",
+      "targetSkillId": "generate-text",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enumerate",
+      "targetSkillId": "generate-test",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "environ",
+      "targetSkillId": "code-generation",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "environment",
+      "targetSkillId": "route-intent",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "environment",
+      "targetSkillId": "diff-content",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "environment",
+      "targetSkillId": "conversational-agent",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "environments",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "environments",
+      "targetSkillId": "route-intent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "environments",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "epic",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "equations",
+      "targetSkillId": "question-answer",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "equations",
+      "targetSkillId": "image-caption",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "equations",
+      "targetSkillId": "registry-curation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "error",
+      "targetSkillId": "write-report",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "establishes",
+      "targetSkillId": "question-answer",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "etree",
+      "targetSkillId": "retrieve",
+      "score": 0.769,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "etree",
+      "targetSkillId": "extract-entities",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "etree",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluated",
+      "targetSkillId": "evaluate-output",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluated",
+      "targetSkillId": "translate",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluated",
+      "targetSkillId": "automated-testing",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluates",
+      "targetSkillId": "evaluate-output",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluates",
+      "targetSkillId": "translate",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluates",
+      "targetSkillId": "generate-sql",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluating",
+      "targetSkillId": "evaluate-output",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluating",
+      "targetSkillId": "browser-automation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluating",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluation",
+      "targetSkillId": "evaluate-output",
+      "score": 0.64,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluation",
+      "targetSkillId": "browser-automation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluation",
+      "targetSkillId": "image-caption",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluator",
+      "targetSkillId": "evaluate-output",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluator",
+      "targetSkillId": "refactor-code",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "every",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "every",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evidence",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evidence-health",
+      "targetSkillId": "audience-model",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evidence-health",
+      "targetSkillId": "voice-agent",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evidence-health",
+      "targetSkillId": "document-analyst",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "exact",
+      "targetSkillId": "extract-entities",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "exact",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "exceed",
+      "targetSkillId": "extract-entities",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "except",
+      "targetSkillId": "extract-entities",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "exclude",
+      "targetSkillId": "execute-bash",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "excludes",
+      "targetSkillId": "execute-bash",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executable",
+      "targetSkillId": "execute-bash",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executable",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executable",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executed",
+      "targetSkillId": "execute-bash",
+      "score": 0.7,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executed",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executed",
+      "targetSkillId": "code-execution",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executes",
+      "targetSkillId": "execute-bash",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executes",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executes",
+      "targetSkillId": "code-execution",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "execution",
+      "targetSkillId": "code-execution",
+      "score": 0.783,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "execution",
+      "targetSkillId": "execute-bash",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "execution",
+      "targetSkillId": "image-caption",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executor",
+      "targetSkillId": "code-execution",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executor",
+      "targetSkillId": "execute-bash",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "executor",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "exhausted",
+      "targetSkillId": "execute-bash",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "existing",
+      "targetSkillId": "registry-curation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "existing",
+      "targetSkillId": "automated-testing",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "existing",
+      "targetSkillId": "code-execution",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "expanduser",
+      "targetSkillId": "plan-decompose",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "expanduser",
+      "targetSkillId": "question-answer",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "expanduser",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "expected",
+      "targetSkillId": "execute-bash",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "expected",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "expected",
+      "targetSkillId": "text-to-speech",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "experiments",
+      "targetSkillId": "extract-entities",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "experiments",
+      "targetSkillId": "generate-test",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "experiments",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "expert-level",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "expert-level",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "expert-level",
+      "targetSkillId": "extract-entities",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "explanations",
+      "targetSkillId": "code-generation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "explanations",
+      "targetSkillId": "extract-entities",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "explanations",
+      "targetSkillId": "image-caption",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "explicit",
+      "targetSkillId": "self-critique",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "export",
+      "targetSkillId": "write-report",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "exposes",
+      "targetSkillId": "plan-decompose",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "exposes",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ext",
+      "targetSkillId": "embed-text",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extend",
+      "targetSkillId": "extract-entities",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extension",
+      "targetSkillId": "code-execution",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extension",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extension",
+      "targetSkillId": "code-generation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extensionquery",
+      "targetSkillId": "question-answer",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extensionquery",
+      "targetSkillId": "cite-sources",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extensionquery",
+      "targetSkillId": "tokenize",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extensions",
+      "targetSkillId": "code-execution",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extensions",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extensions",
+      "targetSkillId": "question-answer",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extensive",
+      "targetSkillId": "tokenize",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extensive",
+      "targetSkillId": "retrieve",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extensive",
+      "targetSkillId": "extract-entities",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "external",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "external",
+      "targetSkillId": "execute-bash",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "external",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extracting",
+      "targetSkillId": "extract-entities",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extracting",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extracting",
+      "targetSkillId": "registry-curation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extraction",
+      "targetSkillId": "extract-entities",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extraction",
+      "targetSkillId": "registry-curation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extraction",
+      "targetSkillId": "code-execution",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extracts",
+      "targetSkillId": "extract-entities",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extracts",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extracts",
+      "targetSkillId": "execute-bash",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "failures",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "falls",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "false",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "feature",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "feature-extraction",
+      "targetSkillId": "code-execution",
+      "score": 0.562,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "feature-extraction",
+      "targetSkillId": "code-generation",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "feature-extraction",
+      "targetSkillId": "error-interpretation",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "features",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "features",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "features",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "feedback",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "filename",
+      "targetSkillId": "image-generate",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "filename",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "fills",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "filtered",
+      "targetSkillId": "write-report",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "filtered",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "filters",
+      "targetSkillId": "cite-sources",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "final",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "finally",
+      "targetSkillId": "api-call",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "finite-state",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "finite-state",
+      "targetSkillId": "generate-text",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "finite-state",
+      "targetSkillId": "generate-test",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "flags",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "flush",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "follow-up",
+      "targetSkillId": "tool-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "follow-up",
+      "targetSkillId": "format-output",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "force",
+      "targetSkillId": "refactor-code",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "force",
+      "targetSkillId": "cite-sources",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "form",
+      "targetSkillId": "format-output",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "format",
+      "targetSkillId": "format-output",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "formats",
+      "targetSkillId": "format-output",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "formatted",
+      "targetSkillId": "format-output",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "formatted",
+      "targetSkillId": "automated-testing",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "formatted",
+      "targetSkillId": "memory-manage",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "formatting",
+      "targetSkillId": "format-output",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "formatting",
+      "targetSkillId": "automated-testing",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "formatting",
+      "targetSkillId": "memory-manage",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "forwarded",
+      "targetSkillId": "refactor-code",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "foundation",
+      "targetSkillId": "document-digitization",
+      "score": 0.581,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "foundation",
+      "targetSkillId": "content-moderation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "foundation",
+      "targetSkillId": "code-generation",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "foundational",
+      "targetSkillId": "conversational-agent",
+      "score": 0.562,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "foundational",
+      "targetSkillId": "document-digitization",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "foundational",
+      "targetSkillId": "content-moderation",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "framework",
+      "targetSkillId": "rank",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "framing",
+      "targetSkillId": "rank",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "framing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "free-form",
+      "targetSkillId": "research",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "free-form",
+      "targetSkillId": "refactor-code",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "fromisoformat",
+      "targetSkillId": "format-output",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "fromisoformat",
+      "targetSkillId": "browser-automation",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "frontmatter",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "frontmatter",
+      "targetSkillId": "format-output",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "full-cycle",
+      "targetSkillId": "full-stack-developer",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "function",
+      "targetSkillId": "image-caption",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "function",
+      "targetSkillId": "code-execution",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "functionality",
+      "targetSkillId": "conversational-agent",
+      "score": 0.485,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "functionality",
+      "targetSkillId": "document-analyst",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "functionality",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "functionally",
+      "targetSkillId": "document-analyst",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "functionally",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "functionally",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "functions",
+      "targetSkillId": "question-answer",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "functions",
+      "targetSkillId": "image-caption",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "fundamentally",
+      "targetSkillId": "document-analyst",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "fundamentally",
+      "targetSkillId": "chunk-document",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "fundamentally",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "fuse",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "fusions",
+      "targetSkillId": "question-answer",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-cli",
+      "targetSkillId": "api-call",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-cli",
+      "targetSkillId": "data-analysis",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-cli",
+      "targetSkillId": "data-visualize",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-cli-test",
+      "targetSkillId": "generate-test",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-cli-test",
+      "targetSkillId": "diff-content",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-cli-test",
+      "targetSkillId": "api-call",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-registry",
+      "targetSkillId": "registry-curation",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-registry",
+      "targetSkillId": "generate-test",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gathering",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gathering",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gathering",
+      "targetSkillId": "automated-testing",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generate",
+      "targetSkillId": "generate-sql",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generate",
+      "targetSkillId": "generate-text",
+      "score": 0.762,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generate",
+      "targetSkillId": "generate-test",
+      "score": 0.762,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generated",
+      "targetSkillId": "generate-sql",
+      "score": 0.762,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generated",
+      "targetSkillId": "generate-text",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generated",
+      "targetSkillId": "generate-test",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generates",
+      "targetSkillId": "generate-sql",
+      "score": 0.857,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generates",
+      "targetSkillId": "generate-test",
+      "score": 0.818,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generates",
+      "targetSkillId": "generate-text",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generating",
+      "targetSkillId": "code-generation",
+      "score": 0.72,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generating",
+      "targetSkillId": "generate-sql",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generating",
+      "targetSkillId": "generate-text",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generation",
+      "targetSkillId": "code-generation",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generation",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.645,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generation",
+      "targetSkillId": "content-moderation",
+      "score": 0.643,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generative",
+      "targetSkillId": "generate-sql",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generative",
+      "targetSkillId": "generate-text",
+      "score": 0.696,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generative",
+      "targetSkillId": "generate-test",
+      "score": 0.696,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generator",
+      "targetSkillId": "generate-sql",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generator",
+      "targetSkillId": "code-generation",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generator",
+      "targetSkillId": "generate-text",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "getcode",
+      "targetSkillId": "refactor-code",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "getcode",
+      "targetSkillId": "audience-model",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gets",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gets",
+      "targetSkillId": "generate-test",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "git",
+      "targetSkillId": "ghostwrite",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "github-action",
+      "targetSkillId": "registry-curation",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "github-action",
+      "targetSkillId": "image-caption",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "github-action",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "given",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "given",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gmtime",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "goal-directed",
+      "targetSkillId": "logical-inference",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "goal-directed",
+      "targetSkillId": "audience-model",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "goal-directed",
+      "targetSkillId": "tool-select",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "got",
+      "targetSkillId": "ghostwrite",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gracefully",
+      "targetSkillId": "generate-sql",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "grammar-guided",
+      "targetSkillId": "summarize",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "grammars",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "graph",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ground-truth",
+      "targetSkillId": "route-intent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ground-truth",
+      "targetSkillId": "format-output",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "grounding",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "grounding",
+      "targetSkillId": "route-intent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "guaranteed",
+      "targetSkillId": "translate",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "guaranteed",
+      "targetSkillId": "generate-text",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "guaranteed",
+      "targetSkillId": "generate-test",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "guarantees",
+      "targetSkillId": "generate-test",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "guarantees",
+      "targetSkillId": "generate-sql",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "guarantees",
+      "targetSkillId": "translate",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hand-crafted",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hand-crafted",
+      "targetSkillId": "translate",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hand-crafted",
+      "targetSkillId": "image-generate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "handle",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "handled",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "handler",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "handles",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "handles",
+      "targetSkillId": "plan-decompose",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "happen",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "highlighting",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.474,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hit",
+      "targetSkillId": "ghostwrite",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "homepage",
+      "targetSkillId": "voice-agent",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "homepage",
+      "targetSkillId": "memory-manage",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hours",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hours",
+      "targetSkillId": "cite-sources",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hours",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "html",
+      "targetSkillId": "parse-html",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "human-level",
+      "targetSkillId": "full-stack-developer",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hypotheses",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.621,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hypotheses",
+      "targetSkillId": "computer-use",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hypothesis",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.69,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "icon",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "icon",
+      "targetSkillId": "image-caption",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "identifies",
+      "targetSkillId": "extract-entities",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "identifies",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "identifies",
+      "targetSkillId": "generate-sql",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "identify",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "identifying",
+      "targetSkillId": "code-generation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "identifying",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ignore",
+      "targetSkillId": "image-generate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "images",
+      "targetSkillId": "image-caption",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "images",
+      "targetSkillId": "image-generate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "images",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "implementation",
+      "targetSkillId": "code-generation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "implementation",
+      "targetSkillId": "error-interpretation",
+      "score": 0.529,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "implementation",
+      "targetSkillId": "image-caption",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "implements",
+      "targetSkillId": "image-generate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "implements",
+      "targetSkillId": "voice-agent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "import",
+      "targetSkillId": "write-report",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "importlib",
+      "targetSkillId": "write-report",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "improvement",
+      "targetSkillId": "recursive-self-improvement",
+      "score": 0.595,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "improvement",
+      "targetSkillId": "route-intent",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "improvement",
+      "targetSkillId": "image-generate",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "improving",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "improving",
+      "targetSkillId": "image-caption",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "in-context",
+      "targetSkillId": "diff-content",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "in-context",
+      "targetSkillId": "generate-text",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "in-context",
+      "targetSkillId": "speech-to-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "in-place",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "in-place",
+      "targetSkillId": "plan-decompose",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "include",
+      "targetSkillId": "audience-model",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "included",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "includes",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "incorporating",
+      "targetSkillId": "error-interpretation",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "incorporating",
+      "targetSkillId": "content-moderation",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "incorporating",
+      "targetSkillId": "code-generation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "indent",
+      "targetSkillId": "route-intent",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "indent",
+      "targetSkillId": "diff-content",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "indent",
+      "targetSkillId": "chunk-document",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "inference",
+      "targetSkillId": "logical-inference",
+      "score": 0.692,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "inference",
+      "targetSkillId": "cite-sources",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "inference",
+      "targetSkillId": "generate-text",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "information",
+      "targetSkillId": "image-caption",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "information",
+      "targetSkillId": "format-output",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "information",
+      "targetSkillId": "content-moderation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "inherit",
+      "targetSkillId": "image-generate",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "inherit",
+      "targetSkillId": "ghostwrite",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "initialized",
+      "targetSkillId": "data-visualize",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "inline",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "inline",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "inner",
+      "targetSkillId": "question-answer",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "insert",
+      "targetSkillId": "image-generate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "insert",
+      "targetSkillId": "question-answer",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "install",
+      "targetSkillId": "api-call",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "install-manifest",
+      "targetSkillId": "data-analysis",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "installation",
+      "targetSkillId": "image-caption",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "installation",
+      "targetSkillId": "registry-curation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "installation",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "installed",
+      "targetSkillId": "api-call",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "installs",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "installs",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "instance",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "instruction",
+      "targetSkillId": "registry-curation",
+      "score": 0.643,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "instruction",
+      "targetSkillId": "error-interpretation",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "instruction",
+      "targetSkillId": "knowledge-graph-build",
+      "score": 0.513,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "instructions",
+      "targetSkillId": "registry-curation",
+      "score": 0.621,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "instructions",
+      "targetSkillId": "knowledge-graph-build",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "instructions",
+      "targetSkillId": "error-interpretation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intake-dir",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intake-dir",
+      "targetSkillId": "write-report",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intake-dir",
+      "targetSkillId": "cite-sources",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integrates",
+      "targetSkillId": "generate-sql",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integrates",
+      "targetSkillId": "generate-test",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integrates",
+      "targetSkillId": "image-generate",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integration",
+      "targetSkillId": "error-interpretation",
+      "score": 0.645,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integration",
+      "targetSkillId": "content-moderation",
+      "score": 0.621,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integration",
+      "targetSkillId": "code-generation",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integrations",
+      "targetSkillId": "error-interpretation",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integrations",
+      "targetSkillId": "content-moderation",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integrations",
+      "targetSkillId": "code-generation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integrity",
+      "targetSkillId": "route-intent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "integrity",
+      "targetSkillId": "diff-content",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intensity",
+      "targetSkillId": "route-intent",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intensity",
+      "targetSkillId": "diff-content",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intensity",
+      "targetSkillId": "tokenize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intent",
+      "targetSkillId": "route-intent",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intent",
+      "targetSkillId": "diff-content",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intent",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interactions",
+      "targetSkillId": "error-interpretation",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interactions",
+      "targetSkillId": "content-moderation",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interactions",
+      "targetSkillId": "code-generation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interface",
+      "targetSkillId": "cite-sources",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interface",
+      "targetSkillId": "write-report",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interface",
+      "targetSkillId": "logical-inference",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intermediate",
+      "targetSkillId": "image-generate",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intermediate",
+      "targetSkillId": "write-report",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intermediate",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interpreter",
+      "targetSkillId": "error-interpretation",
+      "score": 0.581,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interpreter",
+      "targetSkillId": "write-report",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interpreting",
+      "targetSkillId": "error-interpretation",
+      "score": 0.688,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interpreting",
+      "targetSkillId": "write-report",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interpreting",
+      "targetSkillId": "automated-testing",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interprets",
+      "targetSkillId": "error-interpretation",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interprets",
+      "targetSkillId": "write-report",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "interprets",
+      "targetSkillId": "cite-sources",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intersection",
+      "targetSkillId": "error-interpretation",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intersection",
+      "targetSkillId": "image-caption",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intersection",
+      "targetSkillId": "registry-curation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intervention",
+      "targetSkillId": "error-interpretation",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intervention",
+      "targetSkillId": "content-moderation",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intervention",
+      "targetSkillId": "code-generation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intrusion",
+      "targetSkillId": "registry-curation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intrusion",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intrusion",
+      "targetSkillId": "error-interpretation",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "isoformat",
+      "targetSkillId": "format-output",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "issues",
+      "targetSkillId": "cite-sources",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "items",
+      "targetSkillId": "cite-sources",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iter",
+      "targetSkillId": "write-report",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iter",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iterates",
+      "targetSkillId": "generate-sql",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iterates",
+      "targetSkillId": "cite-sources",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iterates",
+      "targetSkillId": "translate",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iteration",
+      "targetSkillId": "image-caption",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iteration",
+      "targetSkillId": "error-interpretation",
+      "score": 0.621,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iteration",
+      "targetSkillId": "registry-curation",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iterative",
+      "targetSkillId": "image-generate",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iterative",
+      "targetSkillId": "error-interpretation",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iterative",
+      "targetSkillId": "write-report",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iteratively",
+      "targetSkillId": "generate-sql",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iteratively",
+      "targetSkillId": "image-generate",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "iteratively",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "json",
+      "targetSkillId": "parse-json",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "kebab-case",
+      "targetSkillId": "web-search",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "knowledge",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.692,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "knowledge",
+      "targetSkillId": "knowledge-graph-build",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "langchain-ai",
+      "targetSkillId": "multi-agent-orchestration-v",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "langchain-tool",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "language",
+      "targetSkillId": "memory-manage",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "languages",
+      "targetSkillId": "memory-manage",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "large-scale",
+      "targetSkillId": "web-scrape",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "large-scale",
+      "targetSkillId": "api-call",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "large-scale",
+      "targetSkillId": "image-caption",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "last",
+      "targetSkillId": "classify",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "last",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "latency",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "later",
+      "targetSkillId": "translate",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "layout",
+      "targetSkillId": "evaluate-output",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "leading",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "learn",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "learned",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "learned",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "learning",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "learning",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "least",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "least",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "legendaries",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "legendaries",
+      "targetSkillId": "generate-sql",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "legendaries",
+      "targetSkillId": "generate-test",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "legendary",
+      "targetSkillId": "research",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "legendary",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "less",
+      "targetSkillId": "classify",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "level",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lexically",
+      "targetSkillId": "api-call",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "license",
+      "targetSkillId": "logical-inference",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lifecycle",
+      "targetSkillId": "classify",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lifecycle",
+      "targetSkillId": "logical-inference",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "line",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lineage",
+      "targetSkillId": "voice-agent",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lines",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "link",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "literature",
+      "targetSkillId": "cite-sources",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "literature",
+      "targetSkillId": "image-generate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "literature",
+      "targetSkillId": "write-report",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "llevel",
+      "targetSkillId": "full-stack-developer",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "llm-tool",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "local",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "local",
+      "targetSkillId": "logical-inference",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "local-repo",
+      "targetSkillId": "logical-inference",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "local-repo",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "local-repo",
+      "targetSkillId": "math-reason",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "locally",
+      "targetSkillId": "api-call",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "locate",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "locate",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "locations",
+      "targetSkillId": "image-caption",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "locations",
+      "targetSkillId": "code-execution",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "locations",
+      "targetSkillId": "code-generation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "log-scaled",
+      "targetSkillId": "logical-inference",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "log-scaled",
+      "targetSkillId": "web-scrape",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "log-scaled",
+      "targetSkillId": "tool-select",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "logic",
+      "targetSkillId": "logical-inference",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "logical",
+      "targetSkillId": "logical-inference",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "logical",
+      "targetSkillId": "api-call",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "loops",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "low-latency",
+      "targetSkillId": "voice-agent",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lowercase-dash",
+      "targetSkillId": "execute-bash",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lowercase-dash",
+      "targetSkillId": "generate-sql",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lowercase-dash",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "machine",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "machine",
+      "targetSkillId": "image-caption",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "machine-readable",
+      "targetSkillId": "math-reason",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "machine-readable",
+      "targetSkillId": "score-relevance",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "madaan",
+      "targetSkillId": "math-reason",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "main",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "main",
+      "targetSkillId": "image-caption",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "main",
+      "targetSkillId": "summarize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "maintainability",
+      "targetSkillId": "document-analyst",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "maintainability",
+      "targetSkillId": "data-visualize",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "maintaining",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "maintaining",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.486,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "maintaining",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "management",
+      "targetSkillId": "image-generate",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "management",
+      "targetSkillId": "memory-manage",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "management",
+      "targetSkillId": "voice-agent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "managing",
+      "targetSkillId": "memory-manage",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "manifest",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "manifest",
+      "targetSkillId": "image-generate",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "manual",
+      "targetSkillId": "document-analyst",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "manually",
+      "targetSkillId": "document-analyst",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "manually",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "manually",
+      "targetSkillId": "data-analysis",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mapping",
+      "targetSkillId": "image-caption",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mappings",
+      "targetSkillId": "image-caption",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mark",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mark",
+      "targetSkillId": "summarize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "markdown",
+      "targetSkillId": "math-reason",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marked",
+      "targetSkillId": "summarize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marked",
+      "targetSkillId": "parse-pdf",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marked",
+      "targetSkillId": "math-reason",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marker",
+      "targetSkillId": "summarize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marker",
+      "targetSkillId": "math-reason",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "markers",
+      "targetSkillId": "math-reason",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "markers",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "markers",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marketplace",
+      "targetSkillId": "parse-html",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marketplace",
+      "targetSkillId": "math-reason",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "master",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "match",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "match",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "matching",
+      "targetSkillId": "math-reason",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "matching",
+      "targetSkillId": "automated-testing",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "matching",
+      "targetSkillId": "image-caption",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "math",
+      "targetSkillId": "math-reason",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mathematical",
+      "targetSkillId": "math-reason",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mathematical",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mathematical",
+      "targetSkillId": "image-caption",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mathematics",
+      "targetSkillId": "math-reason",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mathematics",
+      "targetSkillId": "image-caption",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mbtiongson1",
+      "targetSkillId": "math-reason",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mbtiongson1",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mcp-registry",
+      "targetSkillId": "registry-curation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mcp-server",
+      "targetSkillId": "computer-use",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "meaning",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "meaning",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "meaning",
+      "targetSkillId": "memory-manage",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "meaningful",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "meaningful",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mechanistic",
+      "targetSkillId": "image-caption",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "medical",
+      "targetSkillId": "api-call",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "meets",
+      "targetSkillId": "embed-text",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "meets",
+      "targetSkillId": "generate-sql",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "meets",
+      "targetSkillId": "execute-bash",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "memory",
+      "targetSkillId": "memory-manage",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "merged",
+      "targetSkillId": "memory-manage",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "message",
+      "targetSkillId": "memory-manage",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "message",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "messages",
+      "targetSkillId": "memory-manage",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "metadata",
+      "targetSkillId": "document-analyst",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "metadata",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "method",
+      "targetSkillId": "math-reason",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "microsecond",
+      "targetSkillId": "code-execution",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "microsecond",
+      "targetSkillId": "parse-json",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "microsecond",
+      "targetSkillId": "math-reason",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "migration",
+      "targetSkillId": "image-caption",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "migration",
+      "targetSkillId": "code-generation",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "migration",
+      "targetSkillId": "registry-curation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "modalities",
+      "targetSkillId": "extract-entities",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "modalities",
+      "targetSkillId": "autonomous-data-scientist",
+      "score": 0.457,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "model",
+      "targetSkillId": "audience-model",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "modeling",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "modeling",
+      "targetSkillId": "automated-testing",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "modeling",
+      "targetSkillId": "content-moderation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "models",
+      "targetSkillId": "audience-model",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "moderation",
+      "targetSkillId": "code-generation",
+      "score": 0.72,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "moderation",
+      "targetSkillId": "content-moderation",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "moderation",
+      "targetSkillId": "image-caption",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "modern",
+      "targetSkillId": "content-moderation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "modern",
+      "targetSkillId": "code-generation",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "modifications",
+      "targetSkillId": "image-caption",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "modifications",
+      "targetSkillId": "document-digitization",
+      "score": 0.529,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "modifications",
+      "targetSkillId": "code-execution",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "more",
+      "targetSkillId": "memory-manage",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "more",
+      "targetSkillId": "summarize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mouse",
+      "targetSkillId": "tool-use",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mouse",
+      "targetSkillId": "autonomous-debug",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mouse",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-agent",
+      "targetSkillId": "voice-agent",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-agent",
+      "targetSkillId": "multi-agent-orchestration-v",
+      "score": 0.579,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-agent",
+      "targetSkillId": "route-intent",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-category",
+      "targetSkillId": "multi-agent-orchestration-v",
+      "score": 0.488,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-category",
+      "targetSkillId": "question-answer",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-category",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-section",
+      "targetSkillId": "multi-agent-orchestration-v",
+      "score": 0.55,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-section",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-section",
+      "targetSkillId": "image-caption",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-session",
+      "targetSkillId": "multi-agent-orchestration-v",
+      "score": 0.55,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-session",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-session",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-source",
+      "targetSkillId": "cite-sources",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-source",
+      "targetSkillId": "multi-agent-orchestration-v",
+      "score": 0.513,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-source",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-step",
+      "targetSkillId": "question-answer",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-step",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-step",
+      "targetSkillId": "full-stack-developer",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-turn",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-turn",
+      "targetSkillId": "multi-agent-orchestration-v",
+      "score": 0.486,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multi-turn",
+      "targetSkillId": "math-reason",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multilingual",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.562,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multimodal",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multimodal",
+      "targetSkillId": "audience-model",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multiple",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "name",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "named-dir",
+      "targetSkillId": "automated-testing",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "named-skills",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "named-skills",
+      "targetSkillId": "automated-testing",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "names",
+      "targetSkillId": "generate-sql",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "narrative",
+      "targetSkillId": "retrieve",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "narrative",
+      "targetSkillId": "generate-sql",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "narrative",
+      "targetSkillId": "generate-text",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "natural",
+      "targetSkillId": "data-visualize",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "natural-language",
+      "targetSkillId": "conversational-agent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "natural-language",
+      "targetSkillId": "memory-manage",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "natural-sounding",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.645,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "natural-sounding",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "natural-sounding",
+      "targetSkillId": "math-reason",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "navigating",
+      "targetSkillId": "image-caption",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "navigating",
+      "targetSkillId": "conversational-agent",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "navigating",
+      "targetSkillId": "document-digitization",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "near-human",
+      "targetSkillId": "memory-manage",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "near-human",
+      "targetSkillId": "parse-html",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "near-human",
+      "targetSkillId": "browser-automation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "needed",
+      "targetSkillId": "embed-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "needs",
+      "targetSkillId": "generate-sql",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "needs-review",
+      "targetSkillId": "code-review-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "needs-review",
+      "targetSkillId": "embed-text",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "negative",
+      "targetSkillId": "retrieve",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "negative",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "negative",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "nested",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "nesting",
+      "targetSkillId": "conversational-agent",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "nesting",
+      "targetSkillId": "automated-testing",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "nesting",
+      "targetSkillId": "question-answer",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "neural",
+      "targetSkillId": "generate-sql",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "neutral",
+      "targetSkillId": "generate-sql",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "neutral",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "next",
+      "targetSkillId": "generate-text",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "nline",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "nline",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "nodes",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "noise",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "noise",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "non-interactive",
+      "targetSkillId": "error-interpretation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "non-interactive",
+      "targetSkillId": "route-intent",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "non-interactive",
+      "targetSkillId": "logical-inference",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "non-overlap",
+      "targetSkillId": "content-moderation",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "non-overlap",
+      "targetSkillId": "conversational-agent",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "normally",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "notebooks",
+      "targetSkillId": "tool-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "notes",
+      "targetSkillId": "generate-sql",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "notes",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "numeric",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "numerical",
+      "targetSkillId": "generate-sql",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "numerical",
+      "targetSkillId": "api-call",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "objective",
+      "targetSkillId": "retrieve",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "objective",
+      "targetSkillId": "tokenize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "objective",
+      "targetSkillId": "self-critique",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "objectives",
+      "targetSkillId": "retrieve",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "objectives",
+      "targetSkillId": "extract-entities",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "objectives",
+      "targetSkillId": "execute-bash",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "observable",
+      "targetSkillId": "score-relevance",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "observable",
+      "targetSkillId": "tool-select",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "observation",
+      "targetSkillId": "browser-automation",
+      "score": 0.621,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "observation",
+      "targetSkillId": "code-generation",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "observation",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.562,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "observe",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "observe",
+      "targetSkillId": "web-search",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "observe",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "occurrence",
+      "targetSkillId": "logical-inference",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "occurrence",
+      "targetSkillId": "score-relevance",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "occurrence",
+      "targetSkillId": "cite-sources",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "once",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "one",
+      "targetSkillId": "tokenize",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "open",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "open-ended",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "open-ended",
+      "targetSkillId": "computer-use",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "open-source",
+      "targetSkillId": "cite-sources",
+      "score": 0.696,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "open-source",
+      "targetSkillId": "computer-use",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "open-source",
+      "targetSkillId": "web-search",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "openai",
+      "targetSkillId": "tokenize",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "openai",
+      "targetSkillId": "code-generation",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "opened",
+      "targetSkillId": "tokenize",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "opening",
+      "targetSkillId": "tokenize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "opening",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "opening",
+      "targetSkillId": "code-generation",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "opens",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "opens",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "optimized",
+      "targetSkillId": "tokenize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "optional",
+      "targetSkillId": "conversational-agent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "optional",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "optional",
+      "targetSkillId": "image-caption",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "options",
+      "targetSkillId": "image-caption",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "options",
+      "targetSkillId": "code-execution",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "options",
+      "targetSkillId": "question-answer",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "orchestrates",
+      "targetSkillId": "ghostwrite",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "orchestrates",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "orchestrates",
+      "targetSkillId": "multi-agent-orchestration-v",
+      "score": 0.513,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "order",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "order",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ordered",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "organizations",
+      "targetSkillId": "registry-curation",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "organizations",
+      "targetSkillId": "document-digitization",
+      "score": 0.529,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "organizations",
+      "targetSkillId": "browser-automation",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "origin",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "orphaned",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "orphaned",
+      "targetSkillId": "memory-manage",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "orphaned",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "otherwise",
+      "targetSkillId": "computer-use",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "otherwise",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "otherwise",
+      "targetSkillId": "route-intent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outliers",
+      "targetSkillId": "computer-use",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outliers",
+      "targetSkillId": "route-intent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outlines",
+      "targetSkillId": "route-intent",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outlines",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outlines",
+      "targetSkillId": "code-execution",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outlines-dev",
+      "targetSkillId": "route-intent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outlines-dev",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outperforms",
+      "targetSkillId": "computer-use",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "output",
+      "targetSkillId": "format-output",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "output",
+      "targetSkillId": "evaluate-output",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "output",
+      "targetSkillId": "structured-output",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outputs",
+      "targetSkillId": "format-output",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outputs",
+      "targetSkillId": "evaluate-output",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outputs",
+      "targetSkillId": "computer-use",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outside",
+      "targetSkillId": "tool-use",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outside",
+      "targetSkillId": "route-intent",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outside",
+      "targetSkillId": "computer-use",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "overwritten",
+      "targetSkillId": "ghostwrite",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "overwritten",
+      "targetSkillId": "route-intent",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "overwritten",
+      "targetSkillId": "error-interpretation",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "owned",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "owner",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pack",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "packed",
+      "targetSkillId": "parse-pdf",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pages",
+      "targetSkillId": "parse-json",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pair",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pairs",
+      "targetSkillId": "parse-pdf",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pairs",
+      "targetSkillId": "parse-json",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pairs",
+      "targetSkillId": "parse-html",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pairwise",
+      "targetSkillId": "parse-pdf",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pairwise",
+      "targetSkillId": "parse-json",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pairwise",
+      "targetSkillId": "parse-html",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pal",
+      "targetSkillId": "api-call",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pal",
+      "targetSkillId": "parse-html",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pandas",
+      "targetSkillId": "plan-decompose",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pandas-ai",
+      "targetSkillId": "data-analysis",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "papers",
+      "targetSkillId": "parse-pdf",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "papers",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "papers",
+      "targetSkillId": "parse-html",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "paradigm",
+      "targetSkillId": "parse-pdf",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parameters",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parameters",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parameters",
+      "targetSkillId": "extract-entities",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "params",
+      "targetSkillId": "parse-pdf",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "params",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "params",
+      "targetSkillId": "parse-html",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parent",
+      "targetSkillId": "parse-json",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parent",
+      "targetSkillId": "parse-html",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parent",
+      "targetSkillId": "parse-pdf",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parents",
+      "targetSkillId": "parse-json",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parents",
+      "targetSkillId": "parse-html",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parents",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parse",
+      "targetSkillId": "parse-pdf",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parse",
+      "targetSkillId": "parse-json",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parse",
+      "targetSkillId": "parse-html",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parsed",
+      "targetSkillId": "parse-pdf",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parsed",
+      "targetSkillId": "parse-json",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parsed",
+      "targetSkillId": "parse-html",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parser",
+      "targetSkillId": "parse-pdf",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parser",
+      "targetSkillId": "parse-json",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parser",
+      "targetSkillId": "parse-html",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parses",
+      "targetSkillId": "parse-json",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parses",
+      "targetSkillId": "parse-pdf",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parses",
+      "targetSkillId": "parse-html",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parsing",
+      "targetSkillId": "parse-json",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parsing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parsing",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "partition",
+      "targetSkillId": "parse-json",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "partition",
+      "targetSkillId": "route-intent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "partition",
+      "targetSkillId": "image-caption",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parts",
+      "targetSkillId": "parse-pdf",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parts",
+      "targetSkillId": "parse-json",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parts",
+      "targetSkillId": "parse-html",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pass",
+      "targetSkillId": "parse-json",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pass",
+      "targetSkillId": "classify",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pass",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "passages",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "passages",
+      "targetSkillId": "parse-pdf",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "passed",
+      "targetSkillId": "parse-pdf",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "passed",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "passed",
+      "targetSkillId": "parse-html",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "passing",
+      "targetSkillId": "parse-json",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "passing",
+      "targetSkillId": "classify",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "passing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "patch",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "patched",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "patches",
+      "targetSkillId": "math-reason",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "patches",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "paths",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pattern",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "patterns",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "patterns",
+      "targetSkillId": "generate-test",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pdf",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pending",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "percentage",
+      "targetSkillId": "extract-entities",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "percentage",
+      "targetSkillId": "memory-manage",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "performance",
+      "targetSkillId": "memory-manage",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "performance",
+      "targetSkillId": "refactor-code",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "performance",
+      "targetSkillId": "score-relevance",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "persistent",
+      "targetSkillId": "route-intent",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "persistent",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "persistent",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "photorealistic",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.457,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pipe",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pipeline",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pipeline",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pipeline",
+      "targetSkillId": "text-to-sql-pipeline",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pipelines",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.762,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pipelines",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pipelines",
+      "targetSkillId": "text-to-sql-pipeline",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pixel-space",
+      "targetSkillId": "cite-sources",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pixel-space",
+      "targetSkillId": "web-search",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pixel-space",
+      "targetSkillId": "web-scrape",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "placeholder",
+      "targetSkillId": "audience-model",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "plain-text",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "plain-text",
+      "targetSkillId": "generate-text",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "plain-text",
+      "targetSkillId": "speech-to-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "plan",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "planned",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "planned",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "planned",
+      "targetSkillId": "plan-decompose",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "platform",
+      "targetSkillId": "plan-decompose",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "plus",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "point",
+      "targetSkillId": "voice-agent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "point",
+      "targetSkillId": "route-intent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "points",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "positive",
+      "targetSkillId": "ghostwrite",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "positive",
+      "targetSkillId": "self-critique",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pre-computed",
+      "targetSkillId": "computer-use",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pre-computed",
+      "targetSkillId": "parse-pdf",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pre-computed",
+      "targetSkillId": "plan-decompose",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pre-trained",
+      "targetSkillId": "retrieve",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pre-trained",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pre-trained",
+      "targetSkillId": "score-relevance",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pre-training",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pre-training",
+      "targetSkillId": "route-intent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pre-training",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prediction",
+      "targetSkillId": "registry-curation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prediction",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prediction",
+      "targetSkillId": "code-execution",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prefix",
+      "targetSkillId": "parse-pdf",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "premises",
+      "targetSkillId": "parse-json",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "premises",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "premises",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prepare",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prepare",
+      "targetSkillId": "research",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prepare",
+      "targetSkillId": "refactor-code",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prereq",
+      "targetSkillId": "retrieve",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prereqs",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prereqs",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prereqs",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prerequisite",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prerequisites",
+      "targetSkillId": "execute-bash",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prerequisites",
+      "targetSkillId": "retrieve",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prerequisites",
+      "targetSkillId": "generate-test",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "present",
+      "targetSkillId": "parse-json",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "present",
+      "targetSkillId": "parse-html",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "present",
+      "targetSkillId": "research",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "preserves",
+      "targetSkillId": "retrieve",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "preserves",
+      "targetSkillId": "research",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "preserves",
+      "targetSkillId": "parse-json",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "preserving",
+      "targetSkillId": "research",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "preserving",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "preserving",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prevalence",
+      "targetSkillId": "score-relevance",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "preview",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "princeton-nlp",
+      "targetSkillId": "parse-pdf",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "print",
+      "targetSkillId": "route-intent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "processing",
+      "targetSkillId": "real-time-voice-assistant",
+      "score": 0.457,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "processing",
+      "targetSkillId": "route-intent",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "processing",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "production",
+      "targetSkillId": "code-execution",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "production",
+      "targetSkillId": "route-intent",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "production",
+      "targetSkillId": "browser-automation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "production-grade",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.514,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "production-grade",
+      "targetSkillId": "route-intent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "production-grade",
+      "targetSkillId": "code-execution",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "programmatic",
+      "targetSkillId": "browser-automation",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "programming",
+      "targetSkillId": "browser-automation",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "programming",
+      "targetSkillId": "code-generation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "project",
+      "targetSkillId": "parse-html",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "projections",
+      "targetSkillId": "code-execution",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "projections",
+      "targetSkillId": "registry-curation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "projections",
+      "targetSkillId": "browser-automation",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "promoted",
+      "targetSkillId": "parse-pdf",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "promoted",
+      "targetSkillId": "plan-decompose",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "promotion",
+      "targetSkillId": "content-moderation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "promotion",
+      "targetSkillId": "browser-automation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "promotion",
+      "targetSkillId": "route-intent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prompting",
+      "targetSkillId": "route-intent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prompting",
+      "targetSkillId": "automated-testing",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prompting",
+      "targetSkillId": "image-caption",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prompts",
+      "targetSkillId": "computer-use",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prompts",
+      "targetSkillId": "plan-decompose",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "propose",
+      "targetSkillId": "plan-decompose",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "propose",
+      "targetSkillId": "tool-use",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "propose",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposed",
+      "targetSkillId": "parse-pdf",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposed",
+      "targetSkillId": "plan-decompose",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposed",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposer",
+      "targetSkillId": "plan-decompose",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposer",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposer",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposes",
+      "targetSkillId": "parse-json",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposes",
+      "targetSkillId": "plan-decompose",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposes",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prosody",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prosody",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "provisional",
+      "targetSkillId": "parse-json",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "provisional",
+      "targetSkillId": "conversational-agent",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pull",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pure",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pure",
+      "targetSkillId": "summarize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pure",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "python",
+      "targetSkillId": "math-reason",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "python-shell",
+      "targetSkillId": "tool-select",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "python-shell",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "python-shell-5",
+      "targetSkillId": "tool-select",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "python-version",
+      "targetSkillId": "conversational-agent",
+      "score": 0.529,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "python-version",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.514,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "python-version",
+      "targetSkillId": "content-moderation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "quantitative",
+      "targetSkillId": "extract-entities",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "quantitative",
+      "targetSkillId": "document-digitization",
+      "score": 0.485,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "quantitative",
+      "targetSkillId": "translate",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "queries",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "queries",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "queryable",
+      "targetSkillId": "memory-manage",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "question-answering",
+      "targetSkillId": "question-answer",
+      "score": 0.909,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "question-answering",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "question-answering",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.474,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "questions",
+      "targetSkillId": "question-answer",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "questions",
+      "targetSkillId": "automated-testing",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "questions",
+      "targetSkillId": "image-caption",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rag",
+      "targetSkillId": "rank",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "raise",
+      "targetSkillId": "translate",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "raise",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "raise",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "raises",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "raises",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "raises",
+      "targetSkillId": "extract-entities",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "range",
+      "targetSkillId": "rank",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "range",
+      "targetSkillId": "translate",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "range",
+      "targetSkillId": "memory-manage",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ranking",
+      "targetSkillId": "rank",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ranking",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ranks",
+      "targetSkillId": "rank",
+      "score": 0.889,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ranks",
+      "targetSkillId": "translate",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rare",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rare",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rare",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rasa",
+      "targetSkillId": "translate",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rasa",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rate",
+      "targetSkillId": "translate",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rate",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rate",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rated",
+      "targetSkillId": "translate",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rated",
+      "targetSkillId": "generate-sql",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rated",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ratio",
+      "targetSkillId": "code-generation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ratio",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ratio",
+      "targetSkillId": "registry-curation",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "raw",
+      "targetSkillId": "rank",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "re-derived",
+      "targetSkillId": "retrieve",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "re-derived",
+      "targetSkillId": "score-relevance",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "re-exports",
+      "targetSkillId": "write-report",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "re-exports",
+      "targetSkillId": "generate-text",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "re-exports",
+      "targetSkillId": "embed-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reach",
+      "targetSkillId": "research",
+      "score": 0.769,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reach",
+      "targetSkillId": "web-search",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reachable",
+      "targetSkillId": "research",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reachable",
+      "targetSkillId": "api-call",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reachable",
+      "targetSkillId": "refactor-code",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reached",
+      "targetSkillId": "research",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reached",
+      "targetSkillId": "refactor-code",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reached",
+      "targetSkillId": "web-search",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "react-reasoning",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.968,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "react-reasoning",
+      "targetSkillId": "math-reason",
+      "score": 0.692,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "react-reasoning",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.629,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "read",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "read",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "read",
+      "targetSkillId": "refactor-code",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reading",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reading",
+      "targetSkillId": "rank",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ready",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "real",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "real",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "real-time",
+      "targetSkillId": "retrieve",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "real-time",
+      "targetSkillId": "real-time-voice-assistant",
+      "score": 0.529,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "real-time",
+      "targetSkillId": "route-intent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "real-world",
+      "targetSkillId": "refactor-code",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "realistic",
+      "targetSkillId": "research",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "realistic",
+      "targetSkillId": "registry-curation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "realistic",
+      "targetSkillId": "refactor-code",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reason",
+      "targetSkillId": "math-reason",
+      "score": 0.706,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reason",
+      "targetSkillId": "parse-json",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reason",
+      "targetSkillId": "rank",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reasoning",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reasoning",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.621,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reasoning",
+      "targetSkillId": "math-reason",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reasoning-machines",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reasoning-machines",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.474,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reasoning-machines",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.474,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "record",
+      "targetSkillId": "refactor-code",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "records",
+      "targetSkillId": "refactor-code",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "recursive",
+      "targetSkillId": "retrieve",
+      "score": 0.706,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "recursive",
+      "targetSkillId": "recursive-self-improvement",
+      "score": 0.514,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "recursive",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "redirect",
+      "targetSkillId": "route-intent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "redirect",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "redirect",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ref",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refactor",
+      "targetSkillId": "refactor-code",
+      "score": 0.762,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refactor",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refactor",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refactors",
+      "targetSkillId": "refactor-code",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refactors",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refactors",
+      "targetSkillId": "retrieve",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reference",
+      "targetSkillId": "research",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reference",
+      "targetSkillId": "score-relevance",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reference",
+      "targetSkillId": "logical-inference",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "references",
+      "targetSkillId": "score-relevance",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "references",
+      "targetSkillId": "research",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "references",
+      "targetSkillId": "generate-test",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refines",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refines",
+      "targetSkillId": "route-intent",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refines",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "regex",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "regex",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "register",
+      "targetSkillId": "research",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "register",
+      "targetSkillId": "registry-curation",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "register",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registries",
+      "targetSkillId": "retrieve",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registries",
+      "targetSkillId": "ghostwrite",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registries",
+      "targetSkillId": "registry-curation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registry",
+      "targetSkillId": "registry-curation",
+      "score": 0.64,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registry",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registry",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registry-ref",
+      "targetSkillId": "registry-curation",
+      "score": 0.69,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registry-ref",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registry-ref",
+      "targetSkillId": "ghostwrite",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reject",
+      "targetSkillId": "research",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reject",
+      "targetSkillId": "tool-select",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rel",
+      "targetSkillId": "parse-html",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relations",
+      "targetSkillId": "image-caption",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relations",
+      "targetSkillId": "registry-curation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relations",
+      "targetSkillId": "browser-automation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relationships",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relationships",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relationships",
+      "targetSkillId": "registry-curation",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relative",
+      "targetSkillId": "retrieve",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relative",
+      "targetSkillId": "translate",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relative",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relevance",
+      "targetSkillId": "score-relevance",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relevance",
+      "targetSkillId": "retrieve",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relevance",
+      "targetSkillId": "research",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relevant",
+      "targetSkillId": "score-relevance",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relevant",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relevant",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relpath",
+      "targetSkillId": "research",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relpath",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "remote",
+      "targetSkillId": "retrieve",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "remote",
+      "targetSkillId": "embed-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "remove",
+      "targetSkillId": "retrieve",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repeat",
+      "targetSkillId": "research",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "replace",
+      "targetSkillId": "score-relevance",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "replace",
+      "targetSkillId": "research",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "replace",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repo",
+      "targetSkillId": "write-report",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repo",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "report",
+      "targetSkillId": "write-report",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reporting",
+      "targetSkillId": "write-report",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reporting",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reporting",
+      "targetSkillId": "retrieve",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reports",
+      "targetSkillId": "write-report",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repositories",
+      "targetSkillId": "retrieve",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repositories",
+      "targetSkillId": "extract-entities",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repositories",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repository",
+      "targetSkillId": "write-report",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "representation",
+      "targetSkillId": "error-interpretation",
+      "score": 0.647,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "representation",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "representation",
+      "targetSkillId": "browser-automation",
+      "score": 0.562,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "representations",
+      "targetSkillId": "error-interpretation",
+      "score": 0.629,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "representations",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "representations",
+      "targetSkillId": "browser-automation",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "representing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "representing",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "representing",
+      "targetSkillId": "error-interpretation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reproducible",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reproducible",
+      "targetSkillId": "refactor-code",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "request",
+      "targetSkillId": "generate-test",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "request",
+      "targetSkillId": "question-answer",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "requests",
+      "targetSkillId": "question-answer",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "requests",
+      "targetSkillId": "generate-test",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "required",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "requires",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "requiring",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "requiring",
+      "targetSkillId": "retrieve",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rerank",
+      "targetSkillId": "rank",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rerank",
+      "targetSkillId": "score-relevance",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rerank",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reranking",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reranking",
+      "targetSkillId": "rank",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reranking",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "res",
+      "targetSkillId": "research",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "res",
+      "targetSkillId": "parse-json",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "research-backed",
+      "targetSkillId": "research",
+      "score": 0.696,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "research-backed",
+      "targetSkillId": "web-search",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "research-backed",
+      "targetSkillId": "autonomous-research-agent",
+      "score": 0.55,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolution",
+      "targetSkillId": "registry-curation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolution",
+      "targetSkillId": "route-intent",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolution",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolve",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolve",
+      "targetSkillId": "research",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolve",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolved",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolved",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolver",
+      "targetSkillId": "research",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolver",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolves",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolves",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resp",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resp",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "responses",
+      "targetSkillId": "parse-json",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "responses",
+      "targetSkillId": "question-answer",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "responses",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rest",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rest",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rest",
+      "targetSkillId": "generate-test",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retrieval",
+      "targetSkillId": "retrieve",
+      "score": 0.824,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retrieval",
+      "targetSkillId": "score-relevance",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retrieval",
+      "targetSkillId": "refactor-code",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retrieval-augmented",
+      "targetSkillId": "retrieve",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retrieval-augmented",
+      "targetSkillId": "conversational-agent",
+      "score": 0.564,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retrieval-augmented",
+      "targetSkillId": "extract-entities",
+      "score": 0.514,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retrieves",
+      "targetSkillId": "retrieve",
+      "score": 0.941,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retrieves",
+      "targetSkillId": "score-relevance",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retrieves",
+      "targetSkillId": "extract-entities",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retry",
+      "targetSkillId": "retrieve",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retry",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retry",
+      "targetSkillId": "registry-curation",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "return",
+      "targetSkillId": "retrieve",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "return",
+      "targetSkillId": "registry-curation",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "return",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "returncode",
+      "targetSkillId": "refactor-code",
+      "score": 0.696,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "returncode",
+      "targetSkillId": "retrieve",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "returncode",
+      "targetSkillId": "audience-model",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "returned",
+      "targetSkillId": "retrieve",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "returned",
+      "targetSkillId": "structured-output",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "returned",
+      "targetSkillId": "registry-curation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "returns",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "returns",
+      "targetSkillId": "registry-curation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "returns",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reversal",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reversal",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reversal",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reverse",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reverse",
+      "targetSkillId": "research",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "review",
+      "targetSkillId": "retrieve",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "review",
+      "targetSkillId": "code-review-pipeline",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reviewed",
+      "targetSkillId": "retrieve",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reviewed",
+      "targetSkillId": "code-review-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reviews",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rigorous",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "roots",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "round",
+      "targetSkillId": "route-intent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "routes",
+      "targetSkillId": "route-intent",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "routes",
+      "targetSkillId": "computer-use",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "routing",
+      "targetSkillId": "route-intent",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "routing",
+      "targetSkillId": "browser-automation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "routing",
+      "targetSkillId": "code-execution",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rule-based",
+      "targetSkillId": "execute-bash",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rule-based",
+      "targetSkillId": "route-intent",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rules",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "run",
+      "targetSkillId": "rank",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "runner",
+      "targetSkillId": "question-answer",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "running",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "runs",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "runs",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "runs-on",
+      "targetSkillId": "parse-json",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "runs-on",
+      "targetSkillId": "chunk-document",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "runtime",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "runtime",
+      "targetSkillId": "route-intent",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "runtime",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "safe",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "safe",
+      "targetSkillId": "summarize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "same",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "same",
+      "targetSkillId": "summarize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scalars",
+      "targetSkillId": "classify",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scale",
+      "targetSkillId": "web-scrape",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scale",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scan",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scanned",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scanned",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scanner",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scanner",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scanner",
+      "targetSkillId": "question-answer",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "schema-dir",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "schema-valid",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "schema-valid",
+      "targetSkillId": "data-visualize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "science",
+      "targetSkillId": "score-relevance",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "science",
+      "targetSkillId": "cite-sources",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "science",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scientific",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scientific",
+      "targetSkillId": "extract-entities",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "score",
+      "targetSkillId": "web-scrape",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "score",
+      "targetSkillId": "score-relevance",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "score",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scored",
+      "targetSkillId": "web-scrape",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scored",
+      "targetSkillId": "score-relevance",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scores",
+      "targetSkillId": "web-scrape",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scores",
+      "targetSkillId": "score-relevance",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scoring",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scoring",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scoring",
+      "targetSkillId": "code-generation",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scraper",
+      "targetSkillId": "web-scrape",
+      "score": 0.706,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scraper",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scraping",
+      "targetSkillId": "web-scrape",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scraping",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scraping",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "screenshot",
+      "targetSkillId": "speech-to-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "screenshot",
+      "targetSkillId": "score-relevance",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "screenshot",
+      "targetSkillId": "voice-agent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "screenshot-based",
+      "targetSkillId": "speech-to-text",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "screenshot-based",
+      "targetSkillId": "score-relevance",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "screenshots",
+      "targetSkillId": "speech-to-text",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "screenshots",
+      "targetSkillId": "score-relevance",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "screenshots",
+      "targetSkillId": "voice-agent",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "script",
+      "targetSkillId": "self-critique",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "script",
+      "targetSkillId": "web-scrape",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "script",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scripts",
+      "targetSkillId": "self-critique",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scripts",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scripts",
+      "targetSkillId": "ghostwrite",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "search",
+      "targetSkillId": "research",
+      "score": 0.857,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "search",
+      "targetSkillId": "web-search",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "searchable",
+      "targetSkillId": "research",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "searchable",
+      "targetSkillId": "web-search",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "searchable",
+      "targetSkillId": "autonomous-research-agent",
+      "score": 0.457,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "searching",
+      "targetSkillId": "research",
+      "score": 0.706,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "searching",
+      "targetSkillId": "web-search",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "searching",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "second",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "seconds",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "secrets",
+      "targetSkillId": "self-critique",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "secrets",
+      "targetSkillId": "speech-to-text",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "secrets",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "security",
+      "targetSkillId": "self-critique",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "security",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "seed",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "segment",
+      "targetSkillId": "voice-agent",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "segment",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "segment",
+      "targetSkillId": "image-generate",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "segments",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "segments",
+      "targetSkillId": "voice-agent",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "segments",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "selecting",
+      "targetSkillId": "tool-select",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "selecting",
+      "targetSkillId": "self-critique",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "selecting",
+      "targetSkillId": "code-execution",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "selection",
+      "targetSkillId": "code-execution",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "selection",
+      "targetSkillId": "tool-select",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "selection",
+      "targetSkillId": "self-critique",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "selects",
+      "targetSkillId": "tool-select",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "selects",
+      "targetSkillId": "execute-bash",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "selects",
+      "targetSkillId": "speech-to-text",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-evidence",
+      "targetSkillId": "score-relevance",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-evidence",
+      "targetSkillId": "code-review-pipeline",
+      "score": 0.485,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-evidence",
+      "targetSkillId": "self-critique",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-feedback",
+      "targetSkillId": "self-critique",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-generated",
+      "targetSkillId": "image-generate",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-generated",
+      "targetSkillId": "code-generation",
+      "score": 0.621,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-generated",
+      "targetSkillId": "generate-sql",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-hosted",
+      "targetSkillId": "self-critique",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-hosted",
+      "targetSkillId": "speech-to-text",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-hosted",
+      "targetSkillId": "parse-html",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-refine",
+      "targetSkillId": "self-critique",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-refine",
+      "targetSkillId": "score-relevance",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-refine",
+      "targetSkillId": "code-review-pipeline",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "self-supervised",
+      "targetSkillId": "self-critique",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "semantic",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "semantic",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "semantic",
+      "targetSkillId": "browser-automation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "semantically",
+      "targetSkillId": "api-call",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "semantically",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sensemaking",
+      "targetSkillId": "code-generation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sentence-similarity",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.486,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sentence-similarity",
+      "targetSkillId": "real-time-voice-assistant",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sentence-similarity",
+      "targetSkillId": "generate-sql",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sentence-transformers",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.564,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sentence-transformers",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.514,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sentence-transformers",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.488,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sentiment",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sentiment",
+      "targetSkillId": "tokenize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sentiment",
+      "targetSkillId": "retrieve",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "separated",
+      "targetSkillId": "parse-pdf",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "separated",
+      "targetSkillId": "generate-sql",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "separated",
+      "targetSkillId": "research",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "separately",
+      "targetSkillId": "generate-sql",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "separately",
+      "targetSkillId": "parse-html",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sequence",
+      "targetSkillId": "score-relevance",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sequence",
+      "targetSkillId": "self-critique",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sequence",
+      "targetSkillId": "speech-to-text",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sequences",
+      "targetSkillId": "score-relevance",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sequences",
+      "targetSkillId": "cite-sources",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sequences",
+      "targetSkillId": "self-critique",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "server",
+      "targetSkillId": "retrieve",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "server",
+      "targetSkillId": "score-relevance",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "servers",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "servers",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "session",
+      "targetSkillId": "parse-json",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "session",
+      "targetSkillId": "question-answer",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sessions",
+      "targetSkillId": "parse-json",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sessions",
+      "targetSkillId": "question-answer",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "set",
+      "targetSkillId": "parse-html",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "setup-python",
+      "targetSkillId": "parse-json",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "several",
+      "targetSkillId": "generate-sql",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "shape",
+      "targetSkillId": "web-scrape",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "short",
+      "targetSkillId": "ghostwrite",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "shorter",
+      "targetSkillId": "ghostwrite",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "shorter",
+      "targetSkillId": "speech-to-text",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "shorter",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "showing",
+      "targetSkillId": "ghostwrite",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "showing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "shutil",
+      "targetSkillId": "parse-html",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "signals",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "signals",
+      "targetSkillId": "question-answer",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "signatures",
+      "targetSkillId": "generate-sql",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "signatures",
+      "targetSkillId": "generate-test",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "signatures",
+      "targetSkillId": "image-generate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "silent",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "silent",
+      "targetSkillId": "tool-select",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "silent",
+      "targetSkillId": "conversational-agent",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "similar",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "similarity",
+      "targetSkillId": "summarize",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "simulation",
+      "targetSkillId": "image-caption",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "simulation",
+      "targetSkillId": "registry-curation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "simulation",
+      "targetSkillId": "browser-automation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "size",
+      "targetSkillId": "summarize",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "size",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill-batches",
+      "targetSkillId": "translate",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "slashes",
+      "targetSkillId": "classify",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "slashes",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "smithery",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "software",
+      "targetSkillId": "ghostwrite",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "software",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "some",
+      "targetSkillId": "summarize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sorted",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "source",
+      "targetSkillId": "cite-sources",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "source",
+      "targetSkillId": "summarize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "source",
+      "targetSkillId": "score-relevance",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sources",
+      "targetSkillId": "cite-sources",
+      "score": 0.737,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sources",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sources",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "space",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "spaces",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "spatial",
+      "targetSkillId": "api-call",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "spatial",
+      "targetSkillId": "data-visualize",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "spatial",
+      "targetSkillId": "parse-html",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "spec",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specialized",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specialized",
+      "targetSkillId": "self-critique",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specialized",
+      "targetSkillId": "data-visualize",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specific",
+      "targetSkillId": "self-critique",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specification",
+      "targetSkillId": "image-caption",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specification",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.485,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specification",
+      "targetSkillId": "document-digitization",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specifications",
+      "targetSkillId": "image-caption",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specifications",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specifications",
+      "targetSkillId": "document-digitization",
+      "score": 0.457,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specified",
+      "targetSkillId": "self-critique",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "speech",
+      "targetSkillId": "text-to-speech",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "speech",
+      "targetSkillId": "speech-to-text",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "speech",
+      "targetSkillId": "research",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "splitlines",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "splitlines",
+      "targetSkillId": "self-critique",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "splitlines",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "splitter",
+      "targetSkillId": "self-critique",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "splitter",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "splitter",
+      "targetSkillId": "speech-to-text",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "spoken",
+      "targetSkillId": "tokenize",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "src",
+      "targetSkillId": "research",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "src",
+      "targetSkillId": "web-search",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stack",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "standard",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stars",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "start",
+      "targetSkillId": "ghostwrite",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "start",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "startswith",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "state",
+      "targetSkillId": "translate",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "state",
+      "targetSkillId": "ghostwrite",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "statistical",
+      "targetSkillId": "api-call",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "statistical",
+      "targetSkillId": "data-visualize",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "statistics",
+      "targetSkillId": "extract-entities",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stdout",
+      "targetSkillId": "structured-output",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stem",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "step-by-step",
+      "targetSkillId": "text-to-speech",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "step-by-step",
+      "targetSkillId": "web-search",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "step-by-step",
+      "targetSkillId": "web-scrape",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "still",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "store",
+      "targetSkillId": "ghostwrite",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "store",
+      "targetSkillId": "cite-sources",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "store",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "str",
+      "targetSkillId": "ghostwrite",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strategies",
+      "targetSkillId": "extract-entities",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strategies",
+      "targetSkillId": "translate",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strategies",
+      "targetSkillId": "generate-test",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strftime",
+      "targetSkillId": "ghostwrite",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strftime",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strftime",
+      "targetSkillId": "self-critique",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strict",
+      "targetSkillId": "ghostwrite",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "string",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stringify",
+      "targetSkillId": "classify",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strings",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strings",
+      "targetSkillId": "ghostwrite",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strip",
+      "targetSkillId": "ghostwrite",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "strip",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stripped",
+      "targetSkillId": "ghostwrite",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stripped",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stripped",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stripping",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "structure",
+      "targetSkillId": "structured-output",
+      "score": 0.692,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "structure",
+      "targetSkillId": "ghostwrite",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "structure",
+      "targetSkillId": "registry-curation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "structured",
+      "targetSkillId": "structured-output",
+      "score": 0.741,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "structured",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "structures",
+      "targetSkillId": "structured-output",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "structures",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "structures",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stylized",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stylized",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stylized",
+      "targetSkillId": "data-visualize",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sub-agent",
+      "targetSkillId": "voice-agent",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sub-agent",
+      "targetSkillId": "conversational-agent",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sub-agent",
+      "targetSkillId": "route-intent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "submits",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "subparsers",
+      "targetSkillId": "parse-json",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "subparsers",
+      "targetSkillId": "summarize",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "subparsers",
+      "targetSkillId": "parse-pdf",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "subprocess",
+      "targetSkillId": "cite-sources",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "success",
+      "targetSkillId": "cite-sources",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "such",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "suggestions",
+      "targetSkillId": "question-answer",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "suggestions",
+      "targetSkillId": "image-caption",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "suggestions",
+      "targetSkillId": "parse-json",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "suitable",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "suite",
+      "targetSkillId": "summarize",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "suite",
+      "targetSkillId": "ghostwrite",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "suites",
+      "targetSkillId": "summarize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "suites",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sum",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summaries",
+      "targetSkillId": "summarize",
+      "score": 0.889,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summaries",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summaries",
+      "targetSkillId": "cite-sources",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summarization",
+      "targetSkillId": "summarize",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summarization",
+      "targetSkillId": "image-caption",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summarization",
+      "targetSkillId": "registry-curation",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summarizer",
+      "targetSkillId": "summarize",
+      "score": 0.947,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summarizer",
+      "targetSkillId": "data-visualize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summarizes",
+      "targetSkillId": "summarize",
+      "score": 0.947,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summarizes",
+      "targetSkillId": "data-visualize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summarizes",
+      "targetSkillId": "math-reason",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summary",
+      "targetSkillId": "summarize",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "supervision",
+      "targetSkillId": "parse-json",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sure",
+      "targetSkillId": "summarize",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sure",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "surpasses",
+      "targetSkillId": "parse-json",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "surpasses",
+      "targetSkillId": "cite-sources",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "survey",
+      "targetSkillId": "summarize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "syntactically",
+      "targetSkillId": "api-call",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "syntactically",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "synthesis",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "synthesis",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "synthesising",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "synthesising",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "synthesizes",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "synthesizes",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tables",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tags",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tail",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tail",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tarball",
+      "targetSkillId": "api-call",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "target",
+      "targetSkillId": "parse-html",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "target",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "task",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "task",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tasks",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "taxonomy",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "teaching",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "teaching",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "template",
+      "targetSkillId": "translate",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "terminal",
+      "targetSkillId": "memory-manage",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "terminal",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "test",
+      "targetSkillId": "generate-test",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "testable",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "testing",
+      "targetSkillId": "automated-testing",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "testing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "testing",
+      "targetSkillId": "question-answer",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tests",
+      "targetSkillId": "cite-sources",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text",
+      "targetSkillId": "embed-text",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text",
+      "targetSkillId": "generate-text",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-based",
+      "targetSkillId": "text-to-speech",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-based",
+      "targetSkillId": "execute-bash",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-based",
+      "targetSkillId": "text-to-sql-pipeline",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-classification",
+      "targetSkillId": "classify",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-classification",
+      "targetSkillId": "image-caption",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-classification",
+      "targetSkillId": "document-digitization",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-generation",
+      "targetSkillId": "code-generation",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-generation",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-generation",
+      "targetSkillId": "content-moderation",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-to",
+      "targetSkillId": "text-to-speech",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-to",
+      "targetSkillId": "text-to-sql-pipeline",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text-to",
+      "targetSkillId": "content-moderation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text2text-generation",
+      "targetSkillId": "code-generation",
+      "score": 0.686,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text2text-generation",
+      "targetSkillId": "hypothesis-generate",
+      "score": 0.585,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "text2text-generation",
+      "targetSkillId": "structured-output",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "texts",
+      "targetSkillId": "embed-text",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "texts",
+      "targetSkillId": "text-to-speech",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "than",
+      "targetSkillId": "math-reason",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "than",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "than",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "then",
+      "targetSkillId": "math-reason",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "then",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "these",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "these",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "these",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "threshold",
+      "targetSkillId": "math-reason",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "threshold",
+      "targetSkillId": "research",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "thresholds",
+      "targetSkillId": "math-reason",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "through",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "throughput",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "throughput",
+      "targetSkillId": "format-output",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "throughput",
+      "targetSkillId": "structured-output",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "throw",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tier",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tier",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "time",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "time",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "timed",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "timed",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "timeout",
+      "targetSkillId": "evaluate-output",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "timezone",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "timezone",
+      "targetSkillId": "memory-manage",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "timezone",
+      "targetSkillId": "image-generate",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "title",
+      "targetSkillId": "ghostwrite",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "title",
+      "targetSkillId": "route-intent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "title",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "to-end",
+      "targetSkillId": "tool-use",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "to-end",
+      "targetSkillId": "tokenize",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "to-end",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "to-markdown",
+      "targetSkillId": "math-reason",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "token",
+      "targetSkillId": "tokenize",
+      "score": 0.769,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "token",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "token-classification",
+      "targetSkillId": "document-digitization",
+      "score": 0.537,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "token-classification",
+      "targetSkillId": "classify",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "token-classification",
+      "targetSkillId": "image-caption",
+      "score": 0.485,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tokenization",
+      "targetSkillId": "tokenize",
+      "score": 0.7,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tokenization",
+      "targetSkillId": "document-digitization",
+      "score": 0.606,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tokenization",
+      "targetSkillId": "code-generation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tokenizer",
+      "targetSkillId": "tokenize",
+      "score": 0.941,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tokens",
+      "targetSkillId": "tokenize",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tolist",
+      "targetSkillId": "tool-select",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tolist",
+      "targetSkillId": "tool-use",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tone",
+      "targetSkillId": "tokenize",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tone",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tone",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tool",
+      "targetSkillId": "tool-use",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tool",
+      "targetSkillId": "tool-select",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tools",
+      "targetSkillId": "tool-use",
+      "score": 0.769,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tools",
+      "targetSkillId": "tool-select",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "top-k",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "top-k",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "top-level",
+      "targetSkillId": "tool-select",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "top-level",
+      "targetSkillId": "score-relevance",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "top-level",
+      "targetSkillId": "tool-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "topic",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "topic",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "total",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "traces",
+      "targetSkillId": "cite-sources",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "traces",
+      "targetSkillId": "extract-entities",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "traces",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "training",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "training",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "training",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "transcribes",
+      "targetSkillId": "translate",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "transcribes",
+      "targetSkillId": "extract-entities",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "transcribes",
+      "targetSkillId": "data-analysis",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "transformer",
+      "targetSkillId": "translate",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "transformer",
+      "targetSkillId": "question-answer",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "transformer",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "translation",
+      "targetSkillId": "translate",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "translation",
+      "targetSkillId": "translation-pipeline",
+      "score": 0.71,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "translation",
+      "targetSkillId": "registry-curation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "treat",
+      "targetSkillId": "translate",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "treat",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "treat",
+      "targetSkillId": "write-report",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tree",
+      "targetSkillId": "retrieve",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tree",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tree",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "trees",
+      "targetSkillId": "retrieve",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "trees",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "trees",
+      "targetSkillId": "extract-entities",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "trim",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "true",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "true",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "true",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tsserver",
+      "targetSkillId": "write-report",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tsserver",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tuple",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "turns",
+      "targetSkillId": "translate",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "turns",
+      "targetSkillId": "cite-sources",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "turns",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "two-pass",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "two-pass",
+      "targetSkillId": "data-analysis",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "typescript",
+      "targetSkillId": "web-scrape",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "typescript-5",
+      "targetSkillId": "web-scrape",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ubuntu-latest",
+      "targetSkillId": "generate-test",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ubuntu-latest",
+      "targetSkillId": "document-analyst",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ubuntu-latest",
+      "targetSkillId": "automated-testing",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "unanswerable",
+      "targetSkillId": "question-answer",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "unanswerable",
+      "targetSkillId": "web-scrape",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "unbounded",
+      "targetSkillId": "autonomous-debug",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "uncommon",
+      "targetSkillId": "plan-decompose",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "uncommon",
+      "targetSkillId": "chunk-document",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "uncommon",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "undici-types",
+      "targetSkillId": "audience-model",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "uninstall",
+      "targetSkillId": "api-call",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "unlocked",
+      "targetSkillId": "chunk-document",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "unstructured",
+      "targetSkillId": "structured-output",
+      "score": 0.69,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "unstructured",
+      "targetSkillId": "ghostwrite",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "update-tree",
+      "targetSkillId": "retrieve",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "update-tree",
+      "targetSkillId": "route-intent",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "update-tree",
+      "targetSkillId": "generate-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "updates",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "uppercase",
+      "targetSkillId": "computer-use",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "usage",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "use",
+      "targetSkillId": "tool-use",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "used",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "used",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "user",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "user",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "username",
+      "targetSkillId": "memory-manage",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "username",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "users",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "users",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "uses",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "using",
+      "targetSkillId": "automated-testing",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "utilities",
+      "targetSkillId": "extract-entities",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "utilities",
+      "targetSkillId": "route-intent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "utilities",
+      "targetSkillId": "self-critique",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "valence",
+      "targetSkillId": "logical-inference",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "valence",
+      "targetSkillId": "audience-model",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "valence",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validate",
+      "targetSkillId": "translate",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validate",
+      "targetSkillId": "evaluate-output",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validate",
+      "targetSkillId": "data-visualize",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validated",
+      "targetSkillId": "translate",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validated",
+      "targetSkillId": "evaluate-output",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validates",
+      "targetSkillId": "translate",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validates",
+      "targetSkillId": "evaluate-output",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validation",
+      "targetSkillId": "image-caption",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validation",
+      "targetSkillId": "evaluate-output",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validation",
+      "targetSkillId": "code-generation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "value",
+      "targetSkillId": "evaluate-output",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "value",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "values",
+      "targetSkillId": "evaluate-output",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "variables",
+      "targetSkillId": "api-call",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "vector",
+      "targetSkillId": "refactor-code",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "vectors",
+      "targetSkillId": "refactor-code",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "verified",
+      "targetSkillId": "self-critique",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "verifying",
+      "targetSkillId": "memory-manage",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "version",
+      "targetSkillId": "conversational-agent",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "version",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "version",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "versions",
+      "targetSkillId": "question-answer",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "versions",
+      "targetSkillId": "conversational-agent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "virtual",
+      "targetSkillId": "data-visualize",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "vision-language",
+      "targetSkillId": "question-answer",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "vision-language",
+      "targetSkillId": "conversational-agent",
+      "score": 0.514,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "vision-language",
+      "targetSkillId": "memory-manage",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "visual",
+      "targetSkillId": "data-visualize",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "visualization",
+      "targetSkillId": "data-visualize",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "visualization",
+      "targetSkillId": "image-caption",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "visualization",
+      "targetSkillId": "registry-curation",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "visualizations",
+      "targetSkillId": "data-visualize",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "visualizations",
+      "targetSkillId": "image-caption",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "visualizations",
+      "targetSkillId": "registry-curation",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "visualstudio",
+      "targetSkillId": "data-visualize",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "visualstudio",
+      "targetSkillId": "registry-curation",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "voice",
+      "targetSkillId": "voice-agent",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "voice",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "vscode-marketplace",
+      "targetSkillId": "code-review-pipeline",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "vscode-marketplace",
+      "targetSkillId": "score-relevance",
+      "score": 0.485,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "vscode-marketplace",
+      "targetSkillId": "voice-agent",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "walk",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "want",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "want",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "warnings",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "weak",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "web",
+      "targetSkillId": "web-search",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "web",
+      "targetSkillId": "web-scrape",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "web-arena-x",
+      "targetSkillId": "web-search",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "web-arena-x",
+      "targetSkillId": "web-scrape",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "web-arena-x",
+      "targetSkillId": "embed-text",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "webarena",
+      "targetSkillId": "web-search",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "webarena",
+      "targetSkillId": "web-scrape",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "webp",
+      "targetSkillId": "web-scrape",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "websites",
+      "targetSkillId": "web-search",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "websites",
+      "targetSkillId": "web-scrape",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "well-formed",
+      "targetSkillId": "web-scrape",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "wet-lab",
+      "targetSkillId": "web-search",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "wet-lab",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "whenever",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "where",
+      "targetSkillId": "web-scrape",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "where",
+      "targetSkillId": "write-report",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "whisper",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "will",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "without",
+      "targetSkillId": "write-report",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "without",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "wrapper",
+      "targetSkillId": "web-scrape",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "wrapper",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "write",
+      "targetSkillId": "ghostwrite",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "write",
+      "targetSkillId": "write-report",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "write",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "writes",
+      "targetSkillId": "ghostwrite",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "writes",
+      "targetSkillId": "write-report",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "writes",
+      "targetSkillId": "extract-entities",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "writing",
+      "targetSkillId": "ghostwrite",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "writing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "written",
+      "targetSkillId": "ghostwrite",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "written",
+      "targetSkillId": "write-report",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "written",
+      "targetSkillId": "route-intent",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "zero-config",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "zero-shot",
+      "targetSkillId": "generate-test",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "zero-shot-classification",
+      "targetSkillId": "error-interpretation",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    }
+  ]
+}

--- a/skills/atomic/chain-of-thought.md
+++ b/skills/atomic/chain-of-thought.md
@@ -11,7 +11,7 @@
 Produces explicit intermediate reasoning steps before arriving at a final answer, dramatically improving accuracy on multi-step problems.
 
 ## Prerequisites
-_None._
+- [Logical Inference](../atomic/logical-inference.md)
 
 ## Unlocks
 - [ReAct Reasoning](../composite/re-act-reasoning.md)

--- a/skills/atomic/classify.md
+++ b/skills/atomic/classify.md
@@ -14,8 +14,8 @@ Assigns one or more categorical labels to an input based on learned or rule-base
 _None._
 
 ## Unlocks
-- [Route Intent](../atomic/route-intent.md)
 - [Content Moderation](../composite/content-moderation.md)
+- [Route Intent](../atomic/route-intent.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/skills/atomic/code-execution.md
+++ b/skills/atomic/code-execution.md
@@ -11,12 +11,13 @@
 Writes and executes code in a sandboxed environment, uses the runtime output to verify correctness, and iterates until the result is correct.
 
 ## Prerequisites
-_None._
+- [Code Generation](../atomic/code-generation.md)
+- [Execute Bash](../atomic/execute-bash.md)
 
 ## Unlocks
+- [Automated Testing](../composite/automated-testing.md)
 - [Autonomous Debug](../composite/autonomous-debug.md)
 - [Code Review Pipeline](../composite/code-review-pipeline.md)
-- [Automated Testing](../composite/automated-testing.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/skills/atomic/embed-text.md
+++ b/skills/atomic/embed-text.md
@@ -14,8 +14,8 @@ Converts text into dense vector representations suitable for similarity search a
 _None._
 
 ## Unlocks
-- [RAG Pipeline](../composite/rag-pipeline.md)
 - [Knowledge Harvest](../composite/knowledge-harvest.md)
+- [RAG Pipeline](../composite/rag-pipeline.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/skills/atomic/error-interpretation.md
+++ b/skills/atomic/error-interpretation.md
@@ -14,8 +14,8 @@ Diagnoses error messages, stack traces, and failure modes to identify root cause
 _None._
 
 ## Unlocks
-- [Autonomous Debug](../composite/autonomous-debug.md)
 - [Automated Testing](../composite/automated-testing.md)
+- [Autonomous Debug](../composite/autonomous-debug.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/skills/atomic/evaluate-output.md
+++ b/skills/atomic/evaluate-output.md
@@ -15,6 +15,7 @@ _None._
 
 ## Unlocks
 - [Code Review Pipeline](../composite/code-review-pipeline.md)
+- [True Sage: Recursive Self-Improvement](../legendary/recursive-self-improvement.md)
 - [Self-Critique](../atomic/self-critique.md)
 
 ## Evidence

--- a/skills/atomic/generate-sql.md
+++ b/skills/atomic/generate-sql.md
@@ -14,8 +14,8 @@ Translates natural-language data questions into syntactically correct, executabl
 _None._
 
 ## Unlocks
-- [Text-to-SQL Pipeline](../composite/text-to-sql-pipeline.md)
 - [Data Analysis](../composite/data-analysis.md)
+- [Text-to-SQL Pipeline](../composite/text-to-sql-pipeline.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/skills/atomic/hypothesis-generate.md
+++ b/skills/atomic/hypothesis-generate.md
@@ -11,7 +11,7 @@
 Formulates novel, testable scientific hypotheses by synthesising existing literature, identifying knowledge gaps, and proposing mechanistic explanations.
 
 ## Prerequisites
-_None._
+- [Research](../composite/research.md)
 
 ## Unlocks
 - [True Dragon: Autonomous Scientific Discovery](../legendary/scientific-discovery.md)

--- a/skills/atomic/question-answer.md
+++ b/skills/atomic/question-answer.md
@@ -15,8 +15,8 @@ _None._
 
 ## Unlocks
 - [Conversational Agent](../composite/conversational-agent.md)
-- [Voice Agent](../composite/voice-agent.md)
 - [Multimodal Reasoning](../composite/multimodal-reasoning.md)
+- [Voice Agent](../composite/voice-agent.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/skills/atomic/route-intent.md
+++ b/skills/atomic/route-intent.md
@@ -11,11 +11,12 @@
 Classifies user intent and directs execution to the appropriate handler, tool, or sub-agent.
 
 ## Prerequisites
-_None._
+- [Classify](../atomic/classify.md)
 
 ## Unlocks
-- [Plan and Execute](../composite/plan-and-execute.md)
 - [Conversational Agent](../composite/conversational-agent.md)
+- [Grand Conductor: Multi-Agent Orchestration](../legendary/multi-agent-orchestration-v.md)
+- [Plan and Execute](../composite/plan-and-execute.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/skills/atomic/self-critique.md
+++ b/skills/atomic/self-critique.md
@@ -11,7 +11,7 @@
 Iteratively evaluates and refines its own outputs using self-generated feedback, improving quality without external supervision.
 
 ## Prerequisites
-_None._
+- [Evaluate Output](../atomic/evaluate-output.md)
 
 ## Unlocks
 - [True Sage: Recursive Self-Improvement](../legendary/recursive-self-improvement.md)

--- a/skills/atomic/structured-output.md
+++ b/skills/atomic/structured-output.md
@@ -11,7 +11,7 @@
 Generates output guaranteed to conform to a given schema (JSON, YAML, Pydantic model, etc.) using constrained decoding or grammar-guided generation.
 
 ## Prerequisites
-_None._
+- [Format Output](../atomic/format-output.md)
 
 ## Unlocks
 - [RAG Pipeline](../composite/rag-pipeline.md)

--- a/skills/atomic/summarize.md
+++ b/skills/atomic/summarize.md
@@ -14,9 +14,9 @@ Condenses longer input into a shorter representation that preserves key informat
 _None._
 
 ## Unlocks
-- [Research](../composite/research.md)
-- [Document Analyst](../composite/document-analyst.md)
 - [Data Analysis](../composite/data-analysis.md)
+- [Document Analyst](../composite/document-analyst.md)
+- [Research](../composite/research.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/skills/atomic/tool-select.md
+++ b/skills/atomic/tool-select.md
@@ -14,6 +14,7 @@ Chooses the most appropriate tool or API from a set of available options given a
 _None._
 
 ## Unlocks
+- [Grand Conductor: Multi-Agent Orchestration](../legendary/multi-agent-orchestration-v.md)
 - [Plan and Execute](../composite/plan-and-execute.md)
 - [ReAct Reasoning](../composite/re-act-reasoning.md)
 - [Tool Use](../atomic/tool-use.md)

--- a/skills/atomic/tool-use.md
+++ b/skills/atomic/tool-use.md
@@ -11,7 +11,7 @@
 Invokes external functions or APIs by generating well-formed call signatures, parsing results, and incorporating them into reasoning.
 
 ## Prerequisites
-_None._
+- [Tool Select](../atomic/tool-select.md)
 
 ## Unlocks
 - [ReAct Reasoning](../composite/re-act-reasoning.md)

--- a/skills/composite/automated-testing.md
+++ b/skills/composite/automated-testing.md
@@ -11,9 +11,10 @@
 Generates test suites, executes them in a sandbox, interprets failures, and iterates until the target pass rate is reached.
 
 ## Prerequisites
-- [Generate Test](../atomic/generate-test.md)
-- [Execute Bash](../atomic/execute-bash.md)
+- [Code Execution](../atomic/code-execution.md)
 - [Error Interpretation](../atomic/error-interpretation.md)
+- [Execute Bash](../atomic/execute-bash.md)
+- [Generate Test](../atomic/generate-test.md)
 
 ## Unlocks
 - [True Craftsman: Full-Stack Developer](../legendary/full-stack-developer.md)

--- a/skills/composite/autonomous-debug.md
+++ b/skills/composite/autonomous-debug.md
@@ -11,12 +11,13 @@
 Independently identifies, diagnoses, and fixes software bugs through code generation and execution.
 
 ## Prerequisites
+- [Code Execution](../atomic/code-execution.md)
 - [Code Generation](../atomic/code-generation.md)
-- [Execute Bash](../atomic/execute-bash.md)
 - [Error Interpretation](../atomic/error-interpretation.md)
+- [Execute Bash](../atomic/execute-bash.md)
 
 ## Unlocks
-_None._
+- [True Sage: Recursive Self-Improvement](../legendary/recursive-self-improvement.md)
 
 ## Fusion Condition
 _None specified._

--- a/skills/composite/browser-automation.md
+++ b/skills/composite/browser-automation.md
@@ -11,8 +11,9 @@
 Navigates web pages, fills forms, clicks elements, and extracts information by combining web search with screenshot-based GUI control to complete multi-step web tasks.
 
 ## Prerequisites
-- [Web Search](../atomic/web-search.md)
 - [Computer Use](../atomic/computer-use.md)
+- [Web Scrape](../composite/web-scrape.md)
+- [Web Search](../atomic/web-search.md)
 
 ## Unlocks
 - [Wisdom King: Autonomous Research Agent](../legendary/autonomous-research-agent.md)

--- a/skills/composite/code-review-pipeline.md
+++ b/skills/composite/code-review-pipeline.md
@@ -11,6 +11,7 @@
 Performs automated code review by generating, diffing, and evaluating code changes for correctness, style, security, and maintainability.
 
 ## Prerequisites
+- [Code Execution](../atomic/code-execution.md)
 - [Code Generation](../atomic/code-generation.md)
 - [Diff Content](../atomic/diff-content.md)
 - [Evaluate Output](../atomic/evaluate-output.md)

--- a/skills/composite/content-moderation.md
+++ b/skills/composite/content-moderation.md
@@ -12,8 +12,8 @@ Detects policy-violating content by combining intent classification, sentiment s
 
 ## Prerequisites
 - [Classify](../atomic/classify.md)
-- [Sentiment Analysis](../atomic/sentiment-analysis.md)
 - [Extract Entities](../atomic/extract-entities.md)
+- [Sentiment Analysis](../atomic/sentiment-analysis.md)
 
 ## Unlocks
 _None._

--- a/skills/composite/conversational-agent.md
+++ b/skills/composite/conversational-agent.md
@@ -11,8 +11,8 @@
 Manages coherent multi-turn dialogue by routing intent, maintaining memory across turns, and generating contextually appropriate responses.
 
 ## Prerequisites
-- [Question Answer](../atomic/question-answer.md)
 - [Memory Manage](../atomic/memory-manage.md)
+- [Question Answer](../atomic/question-answer.md)
 - [Route Intent](../atomic/route-intent.md)
 
 ## Unlocks

--- a/skills/composite/data-analysis.md
+++ b/skills/composite/data-analysis.md
@@ -11,8 +11,8 @@
 Conducts end-to-end quantitative analysis: queries data via SQL, computes statistics, generates visualizations, and summarizes findings.
 
 ## Prerequisites
-- [Generate SQL](../atomic/generate-sql.md)
 - [Data Visualize](../atomic/data-visualize.md)
+- [Generate SQL](../atomic/generate-sql.md)
 - [Summarize](../atomic/summarize.md)
 
 ## Unlocks

--- a/skills/composite/document-analyst.md
+++ b/skills/composite/document-analyst.md
@@ -11,10 +11,10 @@
 Parses, extracts entities from, summarizes, and formats structured documents.
 
 ## Prerequisites
-- [Parse JSON](../atomic/parse-json.md)
 - [Extract Entities](../atomic/extract-entities.md)
-- [Summarize](../atomic/summarize.md)
 - [Format Output](../atomic/format-output.md)
+- [Parse JSON](../atomic/parse-json.md)
+- [Summarize](../atomic/summarize.md)
 
 ## Unlocks
 _None._

--- a/skills/composite/document-digitization.md
+++ b/skills/composite/document-digitization.md
@@ -11,9 +11,9 @@
 Converts scanned or PDF documents into structured, machine-readable output by parsing layout, extracting entities, and formatting results.
 
 ## Prerequisites
-- [Parse PDF](../atomic/parse-pdf.md)
 - [Extract Entities](../atomic/extract-entities.md)
 - [Format Output](../atomic/format-output.md)
+- [Parse PDF](../atomic/parse-pdf.md)
 
 ## Unlocks
 _None._

--- a/skills/composite/ghostwrite.md
+++ b/skills/composite/ghostwrite.md
@@ -11,12 +11,13 @@
 Produces audience-tailored, research-backed long-form written content.
 
 ## Prerequisites
+- [Audience Model](../atomic/audience-model.md)
+- [Generate Text](../atomic/generate-text.md)
 - [Research](../composite/research.md)
 - [Write Report](../atomic/write-report.md)
-- [Audience Model](../atomic/audience-model.md)
 
 ## Unlocks
-_None._
+- [Wisdom King: Autonomous Research Agent](../legendary/autonomous-research-agent.md)
 
 ## Fusion Condition
 Requires research output as input context.

--- a/skills/composite/knowledge-graph-build.md
+++ b/skills/composite/knowledge-graph-build.md
@@ -15,8 +15,8 @@ Extracts entities and relations from unstructured text, resolves co-references, 
 - [Logical Inference](../atomic/logical-inference.md)
 
 ## Unlocks
-- [RAG Pipeline](../composite/rag-pipeline.md)
 - [Wisdom King: Autonomous Research Agent](../legendary/autonomous-research-agent.md)
+- [RAG Pipeline](../composite/rag-pipeline.md)
 
 ## Fusion Condition
 _None specified._

--- a/skills/composite/knowledge-harvest.md
+++ b/skills/composite/knowledge-harvest.md
@@ -11,12 +11,12 @@
 Extracts, structures, and embeds knowledge from web sources into a searchable corpus.
 
 ## Prerequisites
-- [Web Scrape](../composite/web-scrape.md)
-- [Extract Entities](../atomic/extract-entities.md)
 - [Embed Text](../atomic/embed-text.md)
+- [Extract Entities](../atomic/extract-entities.md)
+- [Web Scrape](../composite/web-scrape.md)
 
 ## Unlocks
-_None._
+- [Wisdom King: Autonomous Research Agent](../legendary/autonomous-research-agent.md)
 
 ## Fusion Condition
 _None specified._

--- a/skills/composite/multimodal-reasoning.md
+++ b/skills/composite/multimodal-reasoning.md
@@ -12,8 +12,8 @@ Integrates information from images and text to answer questions requiring visual
 
 ## Prerequisites
 - [Image Caption](../atomic/image-caption.md)
-- [Question Answer](../atomic/question-answer.md)
 - [Logical Inference](../atomic/logical-inference.md)
+- [Question Answer](../atomic/question-answer.md)
 
 ## Unlocks
 _None._

--- a/skills/composite/plan-and-execute.md
+++ b/skills/composite/plan-and-execute.md
@@ -11,12 +11,15 @@
 Decomposes complex objectives into sub-tasks, selects tools, and orchestrates execution.
 
 ## Prerequisites
-- [Route Intent](../atomic/route-intent.md)
 - [Plan and Decompose](../atomic/plan-decompose.md)
+- [ReAct Reasoning](../composite/re-act-reasoning.md)
+- [Route Intent](../atomic/route-intent.md)
 - [Tool Select](../atomic/tool-select.md)
 
 ## Unlocks
+- [Grand Conductor: Multi-Agent Orchestration](../legendary/multi-agent-orchestration-v.md)
 - [True Herald: Real-Time Voice Assistant](../legendary/real-time-voice-assistant.md)
+- [True Sage: Recursive Self-Improvement](../legendary/recursive-self-improvement.md)
 
 ## Fusion Condition
 _None specified._

--- a/skills/composite/rag-pipeline.md
+++ b/skills/composite/rag-pipeline.md
@@ -11,10 +11,14 @@
 End-to-end retrieval-augmented generation combining document chunking, embedding, retrieval, and relevance scoring.
 
 ## Prerequisites
-- [Retrieve](../atomic/retrieve.md)
 - [Chunk Document](../atomic/chunk-document.md)
 - [Embed Text](../atomic/embed-text.md)
+- [Knowledge Graph Construction](../composite/knowledge-graph-build.md)
+- [Rank](../atomic/rank.md)
+- [Retrieve](../atomic/retrieve.md)
 - [Score Relevance](../atomic/score-relevance.md)
+- [Structured Output Generation](../atomic/structured-output.md)
+- [Tokenize](../atomic/tokenize.md)
 
 ## Unlocks
 _None._

--- a/skills/composite/re-act-reasoning.md
+++ b/skills/composite/re-act-reasoning.md
@@ -11,12 +11,14 @@
 Interleaves free-form reasoning traces with discrete tool actions in a single loop, enabling agents to plan, act, observe, and update beliefs step-by-step.
 
 ## Prerequisites
+- [Chain-of-Thought Reasoning](../atomic/chain-of-thought.md)
 - [Plan and Decompose](../atomic/plan-decompose.md)
+- [Tool Select](../atomic/tool-select.md)
 - [Tool Use](../atomic/tool-use.md)
 
 ## Unlocks
-- [Plan and Execute](../composite/plan-and-execute.md)
 - [Wisdom King: Autonomous Research Agent](../legendary/autonomous-research-agent.md)
+- [Plan and Execute](../composite/plan-and-execute.md)
 
 ## Fusion Condition
 _None specified._

--- a/skills/composite/registry-curation.md
+++ b/skills/composite/registry-curation.md
@@ -11,9 +11,9 @@
 Systematically discovers, evaluates, and ingests new skill definitions into a structured skill registry: researching capabilities, sourcing reproducible evidence, scripting graph updates, validating schema and DAG integrity, and publishing via pull request.
 
 ## Prerequisites
-- [Research](../composite/research.md)
 - [Code Generation](../atomic/code-generation.md)
 - [Execute Bash](../atomic/execute-bash.md)
+- [Research](../composite/research.md)
 
 ## Unlocks
 _None._

--- a/skills/composite/research.md
+++ b/skills/composite/research.md
@@ -11,12 +11,13 @@
 Conducts multi-source information gathering, synthesis, and citation for a given topic.
 
 ## Prerequisites
-- [Web Search](../atomic/web-search.md)
-- [Summarize](../atomic/summarize.md)
 - [Cite Sources](../atomic/cite-sources.md)
+- [Summarize](../atomic/summarize.md)
+- [Web Search](../atomic/web-search.md)
 
 ## Unlocks
 - [True Oracle: Autonomous Data Scientist](../legendary/autonomous-data-scientist.md)
+- [Wisdom King: Autonomous Research Agent](../legendary/autonomous-research-agent.md)
 - [Ghostwrite](../composite/ghostwrite.md)
 - [Hypothesis Generation](../atomic/hypothesis-generate.md)
 - [Registry Curation](../composite/registry-curation.md)

--- a/skills/composite/text-to-sql-pipeline.md
+++ b/skills/composite/text-to-sql-pipeline.md
@@ -11,9 +11,10 @@
 Converts natural-language queries into validated, executable SQL against a target schema and returns formatted result sets.
 
 ## Prerequisites
+- [Format Output](../atomic/format-output.md)
 - [Generate SQL](../atomic/generate-sql.md)
 - [Parse JSON](../atomic/parse-json.md)
-- [Format Output](../atomic/format-output.md)
+- [Structured Output Generation](../atomic/structured-output.md)
 
 ## Unlocks
 _None._

--- a/skills/composite/translation-pipeline.md
+++ b/skills/composite/translation-pipeline.md
@@ -11,9 +11,9 @@
 Translates content end-to-end while preserving sentiment and adapting tone and register for the target audience.
 
 ## Prerequisites
-- [Translate](../atomic/translate.md)
-- [Sentiment Analysis](../atomic/sentiment-analysis.md)
 - [Audience Model](../atomic/audience-model.md)
+- [Sentiment Analysis](../atomic/sentiment-analysis.md)
+- [Translate](../atomic/translate.md)
 
 ## Unlocks
 _None._

--- a/skills/composite/voice-agent.md
+++ b/skills/composite/voice-agent.md
@@ -11,8 +11,8 @@
 Handles spoken interactions end-to-end: transcribes audio input, produces language responses, and synthesizes speech output.
 
 ## Prerequisites
-- [Speech to Text](../atomic/speech-to-text.md)
 - [Question Answer](../atomic/question-answer.md)
+- [Speech to Text](../atomic/speech-to-text.md)
 - [Text to Speech](../atomic/text-to-speech.md)
 
 ## Unlocks

--- a/skills/composite/web-scrape.md
+++ b/skills/composite/web-scrape.md
@@ -11,9 +11,9 @@
 Retrieves and structures data from web pages into usable entities.
 
 ## Prerequisites
-- [Web Search](../atomic/web-search.md)
-- [Parse HTML](../atomic/parse-html.md)
 - [Extract Entities](../atomic/extract-entities.md)
+- [Parse HTML](../atomic/parse-html.md)
+- [Web Search](../atomic/web-search.md)
 
 ## Unlocks
 - [Browser Automation](../composite/browser-automation.md)

--- a/skills/legendary/autonomous-research-agent.md
+++ b/skills/legendary/autonomous-research-agent.md
@@ -11,9 +11,12 @@
 Independently conducts end-to-end research cycles including hypothesis generation, evidence gathering, synthesis, and reporting.
 
 ## Prerequisites
-- [Research](../composite/research.md)
-- [Knowledge Harvest](../composite/knowledge-harvest.md)
+- [Browser Automation](../composite/browser-automation.md)
 - [Ghostwrite](../composite/ghostwrite.md)
+- [Knowledge Graph Construction](../composite/knowledge-graph-build.md)
+- [Knowledge Harvest](../composite/knowledge-harvest.md)
+- [ReAct Reasoning](../composite/re-act-reasoning.md)
+- [Research](../composite/research.md)
 
 ## Unlocks
 _None._

--- a/skills/legendary/full-stack-developer.md
+++ b/skills/legendary/full-stack-developer.md
@@ -11,8 +11,8 @@
 Autonomously implements, reviews, tests, and refactors complete software features across the full development lifecycle from specification to merged PR.
 
 ## Prerequisites
-- [Code Review Pipeline](../composite/code-review-pipeline.md)
 - [Automated Testing](../composite/automated-testing.md)
+- [Code Review Pipeline](../composite/code-review-pipeline.md)
 - [Refactor Code](../atomic/refactor-code.md)
 
 ## Unlocks

--- a/skills/legendary/real-time-voice-assistant.md
+++ b/skills/legendary/real-time-voice-assistant.md
@@ -11,9 +11,9 @@
 Provides low-latency spoken interactions combining real-time speech I/O, persistent memory, and goal-directed task execution across multi-session conversations.
 
 ## Prerequisites
-- [Voice Agent](../composite/voice-agent.md)
 - [Memory Manage](../atomic/memory-manage.md)
 - [Plan and Execute](../composite/plan-and-execute.md)
+- [Voice Agent](../composite/voice-agent.md)
 
 ## Unlocks
 _None._

--- a/skills/legendary/recursive-self-improvement.md
+++ b/skills/legendary/recursive-self-improvement.md
@@ -14,6 +14,7 @@ Agent iteratively refines its own prompts, tools, or strategies based on perform
 - [Autonomous Debug](../composite/autonomous-debug.md)
 - [Evaluate Output](../atomic/evaluate-output.md)
 - [Plan and Execute](../composite/plan-and-execute.md)
+- [Self-Critique](../atomic/self-critique.md)
 
 ## Unlocks
 _None._

--- a/skills/legendary/scientific-discovery.md
+++ b/skills/legendary/scientific-discovery.md
@@ -11,9 +11,10 @@
 Autonomously generates novel scientific hypotheses, designs and executes experiments, analyses results, and produces a written report — completing a full research cycle without human intervention.
 
 ## Prerequisites
+- [Chain-of-Thought Reasoning](../atomic/chain-of-thought.md)
 - [Hypothesis Generation](../atomic/hypothesis-generate.md)
-- [Research](../composite/research.md)
 - [Math Reason](../atomic/math-reason.md)
+- [Research](../composite/research.md)
 
 ## Unlocks
 _None._

--- a/tree.md
+++ b/tree.md
@@ -7,89 +7,140 @@ Upgrade paths — each legendary shows its full prerequisite chain.
 Shared prerequisites marked (↑ see above) on second occurrence.
 ══════════════════════════════════════════════════════════════════════
 
-◆ Wisdom King: Autonomous Research Agent  [VI · Transcendent ★]  ← Research · Knowledge Harvest · Ghostwrite
+◆ Wisdom King: Autonomous Research Agent  [VI · Transcendent ★]  ← Browser Automation · Ghostwrite · Knowledge Graph Construction · Knowledge Harvest · ReAct Reasoning · Research
 ─────────────────────────────────────────────────────────────────
-  ├─ ◇ Research  [III · Evolved]  ← Web Search · Summarize · Cite Sources
-  │  ├─ ○ Web Search  [I · Awakened]
-  │  ├─ ○ Summarize  [I · Awakened]
-  │  └─ ○ Cite Sources  [I · Awakened]
-  ├─ ◇ Knowledge Harvest  [IV · Transcendent]  ← Web Scrape · Extract Entities · Embed Text
-  │  ├─ ◇ Web Scrape  [III · Evolved]  ← Web Search · Parse HTML · Extract Entities
-  │  │  ├─ ○ Web Search  [I · Awakened]  (↑ see above)
+  ├─ ◇ Browser Automation  [III · Evolved]  ← Computer Use · Web Scrape · Web Search
+  │  ├─ ○ Computer Use  [II · Named]
+  │  ├─ ◇ Web Scrape  [III · Evolved]  ← Extract Entities · Parse HTML · Web Search
+  │  │  ├─ ○ Extract Entities  [I · Awakened]
   │  │  ├─ ○ Parse HTML  [I · Awakened]
-  │  │  └─ ○ Extract Entities  [I · Awakened]
+  │  │  └─ ○ Web Search  [I · Awakened]
+  │  └─ ○ Web Search  [I · Awakened]  (↑ see above)
+  ├─ ◇ Ghostwrite  [IV · Transcendent]  ← Audience Model · Generate Text · Research · Write Report
+  │  ├─ ○ Audience Model  [I · Awakened]
+  │  ├─ ○ Generate Text  [I · Awakened]
+  │  ├─ ◇ Research  [III · Evolved]  ← Cite Sources · Summarize · Web Search
+  │  │  ├─ ○ Cite Sources  [I · Awakened]
+  │  │  ├─ ○ Summarize  [I · Awakened]
+  │  │  └─ ○ Web Search  [I · Awakened]  (↑ see above)
+  │  └─ ○ Write Report  [I · Awakened]
+  ├─ ◇ Knowledge Graph Construction  [III · Evolved]  ← Extract Entities · Logical Inference
   │  ├─ ○ Extract Entities  [I · Awakened]  (↑ see above)
-  │  └─ ○ Embed Text  [I · Awakened]
-  └─ ◇ Ghostwrite  [IV · Transcendent]  ← Research · Write Report · Audience Model
-     ├─ ◇ Research  [III · Evolved]  ← Web Search · Summarize · Cite Sources  (↑ see above)
-     ├─ ○ Write Report  [I · Awakened]
-     └─ ○ Audience Model  [I · Awakened]
+  │  └─ ○ Logical Inference  [II · Named]
+  ├─ ◇ Knowledge Harvest  [IV · Transcendent]  ← Embed Text · Extract Entities · Web Scrape
+  │  ├─ ○ Embed Text  [I · Awakened]
+  │  ├─ ○ Extract Entities  [I · Awakened]  (↑ see above)
+  │  └─ ◇ Web Scrape  [III · Evolved]  ← Extract Entities · Parse HTML · Web Search  (↑ see above)
+  ├─ ◇ ReAct Reasoning  [III · Evolved]  ← Chain-of-Thought Reasoning · Plan and Decompose · Tool Select · Tool Use
+  │  ├─ ○ Chain-of-Thought Reasoning  [II · Named]
+  │  │  └─ ○ Logical Inference  [II · Named]  (↑ see above)
+  │  ├─ ○ Plan and Decompose  [I · Awakened]
+  │  ├─ ○ Tool Select  [I · Awakened]
+  │  └─ ○ Tool Use  [II · Named]
+  │     └─ ○ Tool Select  [I · Awakened]  (↑ see above)
+  └─ ◇ Research  [III · Evolved]  ← Cite Sources · Summarize · Web Search  (↑ see above)
 
 ◆ Grand Conductor: Multi-Agent Orchestration  [V · Transcendent]  ← Plan and Execute · Route Intent · Tool Select
 ─────────────────────────────────────────────────────────────────
-  ├─ ◇ Plan and Execute  [III · Evolved]  ← Route Intent · Plan and Decompose · Tool Select
-  │  ├─ ○ Route Intent  [I · Awakened]
+  ├─ ◇ Plan and Execute  [III · Evolved]  ← Plan and Decompose · ReAct Reasoning · Route Intent · Tool Select
   │  ├─ ○ Plan and Decompose  [I · Awakened]
-  │  └─ ○ Tool Select  [I · Awakened]
+  │  ├─ ◇ ReAct Reasoning  [III · Evolved]  ← Chain-of-Thought Reasoning · Plan and Decompose · Tool Select · Tool Use
+  │  │  ├─ ○ Chain-of-Thought Reasoning  [II · Named]
+  │  │  │  └─ ○ Logical Inference  [II · Named]
+  │  │  ├─ ○ Plan and Decompose  [I · Awakened]  (↑ see above)
+  │  │  ├─ ○ Tool Select  [I · Awakened]
+  │  │  └─ ○ Tool Use  [II · Named]
+  │  │     └─ ○ Tool Select  [I · Awakened]  (↑ see above)
+  │  ├─ ○ Route Intent  [I · Awakened]
+  │  │  └─ ○ Classify  [I · Awakened]
+  │  └─ ○ Tool Select  [I · Awakened]  (↑ see above)
   ├─ ○ Route Intent  [I · Awakened]  (↑ see above)
   └─ ○ Tool Select  [I · Awakened]  (↑ see above)
 
-◆ True Craftsman: Full-Stack Developer  [V · Transcendent]  ← Code Review Pipeline · Automated Testing · Refactor Code
+◆ True Craftsman: Full-Stack Developer  [V · Transcendent]  ← Automated Testing · Code Review Pipeline · Refactor Code
 ─────────────────────────────────────────────────────────────────
-  ├─ ◇ Code Review Pipeline  [III · Evolved]  ← Code Generation · Diff Content · Evaluate Output
-  │  ├─ ○ Code Generation  [I · Awakened]
+  ├─ ◇ Automated Testing  [III · Evolved]  ← Code Execution · Error Interpretation · Execute Bash · Generate Test
+  │  ├─ ○ Code Execution  [II · Named]
+  │  │  ├─ ○ Code Generation  [I · Awakened]
+  │  │  └─ ○ Execute Bash  [I · Awakened]
+  │  ├─ ○ Error Interpretation  [I · Awakened]
+  │  ├─ ○ Execute Bash  [I · Awakened]  (↑ see above)
+  │  └─ ○ Generate Test  [II · Named]
+  ├─ ◇ Code Review Pipeline  [III · Evolved]  ← Code Execution · Code Generation · Diff Content · Evaluate Output
+  │  ├─ ○ Code Execution  [II · Named]  (↑ see above)
+  │  ├─ ○ Code Generation  [I · Awakened]  (↑ see above)
   │  ├─ ○ Diff Content  [I · Awakened]
   │  └─ ○ Evaluate Output  [I · Awakened]
-  ├─ ◇ Automated Testing  [III · Evolved]  ← Generate Test · Execute Bash · Error Interpretation
-  │  ├─ ○ Generate Test  [II · Named]
-  │  ├─ ○ Execute Bash  [I · Awakened]
-  │  └─ ○ Error Interpretation  [I · Awakened]
   └─ ○ Refactor Code  [II · Named]
 
-◆ True Dragon: Autonomous Scientific Discovery  [V · Transcendent]  ← Hypothesis Generation · Research · Math Reason
+◆ True Dragon: Autonomous Scientific Discovery  [V · Transcendent]  ← Chain-of-Thought Reasoning · Hypothesis Generation · Math Reason · Research
 ─────────────────────────────────────────────────────────────────
+  ├─ ○ Chain-of-Thought Reasoning  [II · Named]
+  │  └─ ○ Logical Inference  [II · Named]
   ├─ ○ Hypothesis Generation  [II · Named]
-  ├─ ◇ Research  [III · Evolved]  ← Web Search · Summarize · Cite Sources
-  │  ├─ ○ Web Search  [I · Awakened]
-  │  ├─ ○ Summarize  [I · Awakened]
-  │  └─ ○ Cite Sources  [I · Awakened]
-  └─ ○ Math Reason  [II · Named]
+  │  └─ ◇ Research  [III · Evolved]  ← Cite Sources · Summarize · Web Search
+  │     ├─ ○ Cite Sources  [I · Awakened]
+  │     ├─ ○ Summarize  [I · Awakened]
+  │     └─ ○ Web Search  [I · Awakened]
+  ├─ ○ Math Reason  [II · Named]
+  └─ ◇ Research  [III · Evolved]  ← Cite Sources · Summarize · Web Search  (↑ see above)
 
-◆ True Herald: Real-Time Voice Assistant  [V · Transcendent]  ← Voice Agent · Memory Manage · Plan and Execute
+◆ True Herald: Real-Time Voice Assistant  [V · Transcendent]  ← Memory Manage · Plan and Execute · Voice Agent
 ─────────────────────────────────────────────────────────────────
-  ├─ ◇ Voice Agent  [III · Evolved]  ← Speech to Text · Question Answer · Text to Speech
-  │  ├─ ○ Speech to Text  [II · Named]
-  │  ├─ ○ Question Answer  [II · Named]
-  │  └─ ○ Text to Speech  [II · Named]
   ├─ ○ Memory Manage  [II · Named]
-  └─ ◇ Plan and Execute  [III · Evolved]  ← Route Intent · Plan and Decompose · Tool Select
-     ├─ ○ Route Intent  [I · Awakened]
-     ├─ ○ Plan and Decompose  [I · Awakened]
-     └─ ○ Tool Select  [I · Awakened]
+  ├─ ◇ Plan and Execute  [III · Evolved]  ← Plan and Decompose · ReAct Reasoning · Route Intent · Tool Select
+  │  ├─ ○ Plan and Decompose  [I · Awakened]
+  │  ├─ ◇ ReAct Reasoning  [III · Evolved]  ← Chain-of-Thought Reasoning · Plan and Decompose · Tool Select · Tool Use
+  │  │  ├─ ○ Chain-of-Thought Reasoning  [II · Named]
+  │  │  │  └─ ○ Logical Inference  [II · Named]
+  │  │  ├─ ○ Plan and Decompose  [I · Awakened]  (↑ see above)
+  │  │  ├─ ○ Tool Select  [I · Awakened]
+  │  │  └─ ○ Tool Use  [II · Named]
+  │  │     └─ ○ Tool Select  [I · Awakened]  (↑ see above)
+  │  ├─ ○ Route Intent  [I · Awakened]
+  │  │  └─ ○ Classify  [I · Awakened]
+  │  └─ ○ Tool Select  [I · Awakened]  (↑ see above)
+  └─ ◇ Voice Agent  [III · Evolved]  ← Question Answer · Speech to Text · Text to Speech
+     ├─ ○ Question Answer  [II · Named]
+     ├─ ○ Speech to Text  [II · Named]
+     └─ ○ Text to Speech  [II · Named]
 
 ◆ True Oracle: Autonomous Data Scientist  [V · Transcendent]  ← Data Analysis · Math Reason · Research
 ─────────────────────────────────────────────────────────────────
-  ├─ ◇ Data Analysis  [III · Evolved]  ← Generate SQL · Data Visualize · Summarize
-  │  ├─ ○ Generate SQL  [II · Named]
+  ├─ ◇ Data Analysis  [III · Evolved]  ← Data Visualize · Generate SQL · Summarize
   │  ├─ ○ Data Visualize  [II · Named]
+  │  ├─ ○ Generate SQL  [II · Named]
   │  └─ ○ Summarize  [I · Awakened]
   ├─ ○ Math Reason  [II · Named]
-  └─ ◇ Research  [III · Evolved]  ← Web Search · Summarize · Cite Sources
-     ├─ ○ Web Search  [I · Awakened]
+  └─ ◇ Research  [III · Evolved]  ← Cite Sources · Summarize · Web Search
+     ├─ ○ Cite Sources  [I · Awakened]
      ├─ ○ Summarize  [I · Awakened]  (↑ see above)
-     └─ ○ Cite Sources  [I · Awakened]
+     └─ ○ Web Search  [I · Awakened]
 
-◆ True Sage: Recursive Self-Improvement  [V · Transcendent]  ← Autonomous Debug · Evaluate Output · Plan and Execute
+◆ True Sage: Recursive Self-Improvement  [V · Transcendent]  ← Autonomous Debug · Evaluate Output · Plan and Execute · Self-Critique
 ─────────────────────────────────────────────────────────────────
-  ├─ ◇ Autonomous Debug  [III · Evolved]  ← Code Generation · Execute Bash · Error Interpretation
-  │  ├─ ○ Code Generation  [I · Awakened]
-  │  ├─ ○ Execute Bash  [I · Awakened]
-  │  └─ ○ Error Interpretation  [I · Awakened]
+  ├─ ◇ Autonomous Debug  [III · Evolved]  ← Code Execution · Code Generation · Error Interpretation · Execute Bash
+  │  ├─ ○ Code Execution  [II · Named]
+  │  │  ├─ ○ Code Generation  [I · Awakened]
+  │  │  └─ ○ Execute Bash  [I · Awakened]
+  │  ├─ ○ Code Generation  [I · Awakened]  (↑ see above)
+  │  ├─ ○ Error Interpretation  [I · Awakened]
+  │  └─ ○ Execute Bash  [I · Awakened]  (↑ see above)
   ├─ ○ Evaluate Output  [I · Awakened]
-  └─ ◇ Plan and Execute  [III · Evolved]  ← Route Intent · Plan and Decompose · Tool Select
-     ├─ ○ Route Intent  [I · Awakened]
-     ├─ ○ Plan and Decompose  [I · Awakened]
-     └─ ○ Tool Select  [I · Awakened]
+  ├─ ◇ Plan and Execute  [III · Evolved]  ← Plan and Decompose · ReAct Reasoning · Route Intent · Tool Select
+  │  ├─ ○ Plan and Decompose  [I · Awakened]
+  │  ├─ ◇ ReAct Reasoning  [III · Evolved]  ← Chain-of-Thought Reasoning · Plan and Decompose · Tool Select · Tool Use
+  │  │  ├─ ○ Chain-of-Thought Reasoning  [II · Named]
+  │  │  │  └─ ○ Logical Inference  [II · Named]
+  │  │  ├─ ○ Plan and Decompose  [I · Awakened]  (↑ see above)
+  │  │  ├─ ○ Tool Select  [I · Awakened]
+  │  │  └─ ○ Tool Use  [II · Named]
+  │  │     └─ ○ Tool Select  [I · Awakened]  (↑ see above)
+  │  ├─ ○ Route Intent  [I · Awakened]
+  │  │  └─ ○ Classify  [I · Awakened]
+  │  └─ ○ Tool Select  [I · Awakened]  (↑ see above)
+  └─ ○ Self-Critique  [II · Named]
+     └─ ○ Evaluate Output  [I · Awakened]  (↑ see above)
 
 ```
 

--- a/users/gaiabot/skill-tree.md
+++ b/users/gaiabot/skill-tree.md
@@ -20,82 +20,133 @@
 ## Upgrade Path
 
 ```
-· ◆ Wisdom King: Autonomous Research Agent  [VI · Transcendent ★]  ← Research · Knowledge Harvest · Ghostwrite
-  ├─ · ◇ Research  [III · Evolved]  ← Web Search · Summarize · Cite Sources
-  │  ├─ · ○ Web Search  [I · Awakened]
-  │  ├─ · ○ Summarize  [I · Awakened]
-  │  └─ · ○ Cite Sources  [I · Awakened]
-  ├─ · ◇ Knowledge Harvest  [IV · Transcendent]  ← Web Scrape · Extract Entities · Embed Text
-  │  ├─ · ◇ Web Scrape  [III · Evolved]  ← Web Search · Parse HTML · Extract Entities
-  │  │  ├─ · ○ Web Search  [I · Awakened]  (↑ see above)
+· ◆ Wisdom King: Autonomous Research Agent  [VI · Transcendent ★]  ← Browser Automation · Ghostwrite · Knowledge Graph Construction · Knowledge Harvest · ReAct Reasoning · Research
+  ├─ · ◇ Browser Automation  [III · Evolved]  ← Computer Use · Web Scrape · Web Search
+  │  ├─ · ○ Computer Use  [II · Named]
+  │  ├─ · ◇ Web Scrape  [III · Evolved]  ← Extract Entities · Parse HTML · Web Search
+  │  │  ├─ · ○ Extract Entities  [I · Awakened]
   │  │  ├─ · ○ Parse HTML  [I · Awakened]
-  │  │  └─ · ○ Extract Entities  [I · Awakened]
+  │  │  └─ · ○ Web Search  [I · Awakened]
+  │  └─ · ○ Web Search  [I · Awakened]  (↑ see above)
+  ├─ · ◇ Ghostwrite  [IV · Transcendent]  ← Audience Model · Generate Text · Research · Write Report
+  │  ├─ · ○ Audience Model  [I · Awakened]
+  │  ├─ · ○ Generate Text  [I · Awakened]
+  │  ├─ · ◇ Research  [III · Evolved]  ← Cite Sources · Summarize · Web Search
+  │  │  ├─ · ○ Cite Sources  [I · Awakened]
+  │  │  ├─ · ○ Summarize  [I · Awakened]
+  │  │  └─ · ○ Web Search  [I · Awakened]  (↑ see above)
+  │  └─ · ○ Write Report  [I · Awakened]
+  ├─ · ◇ Knowledge Graph Construction  [III · Evolved]  ← Extract Entities · Logical Inference
   │  ├─ · ○ Extract Entities  [I · Awakened]  (↑ see above)
-  │  └─ · ○ Embed Text  [I · Awakened]
-  └─ · ◇ Ghostwrite  [IV · Transcendent]  ← Research · Write Report · Audience Model
-     ├─ · ◇ Research  [III · Evolved]  ← Web Search · Summarize · Cite Sources  (↑ see above)
-     ├─ · ○ Write Report  [I · Awakened]
-     └─ · ○ Audience Model  [I · Awakened]
+  │  └─ · ○ Logical Inference  [II · Named]
+  ├─ · ◇ Knowledge Harvest  [IV · Transcendent]  ← Embed Text · Extract Entities · Web Scrape
+  │  ├─ · ○ Embed Text  [I · Awakened]
+  │  ├─ · ○ Extract Entities  [I · Awakened]  (↑ see above)
+  │  └─ · ◇ Web Scrape  [III · Evolved]  ← Extract Entities · Parse HTML · Web Search  (↑ see above)
+  ├─ · ◇ ReAct Reasoning  [III · Evolved]  ← Chain-of-Thought Reasoning · Plan and Decompose · Tool Select · Tool Use
+  │  ├─ · ○ Chain-of-Thought Reasoning  [II · Named]
+  │  │  └─ · ○ Logical Inference  [II · Named]  (↑ see above)
+  │  ├─ ✓ ○ Plan and Decompose  [I · Awakened]
+  │  ├─ ✓ ○ Tool Select  [I · Awakened]
+  │  └─ · ○ Tool Use  [II · Named]
+  │     └─ ✓ ○ Tool Select  [I · Awakened]  (↑ see above)
+  └─ · ◇ Research  [III · Evolved]  ← Cite Sources · Summarize · Web Search  (↑ see above)
 
 · ◆ Grand Conductor: Multi-Agent Orchestration  [V · Transcendent]  ← Plan and Execute · Route Intent · Tool Select
-  ├─ ✓ ◇ Plan and Execute  [III · Evolved]  ← Route Intent · Plan and Decompose · Tool Select
-  │  ├─ ✓ ○ Route Intent  [I · Awakened]
+  ├─ ✓ ◇ Plan and Execute  [III · Evolved]  ← Plan and Decompose · ReAct Reasoning · Route Intent · Tool Select
   │  ├─ ✓ ○ Plan and Decompose  [I · Awakened]
-  │  └─ ✓ ○ Tool Select  [I · Awakened]
+  │  ├─ · ◇ ReAct Reasoning  [III · Evolved]  ← Chain-of-Thought Reasoning · Plan and Decompose · Tool Select · Tool Use
+  │  │  ├─ · ○ Chain-of-Thought Reasoning  [II · Named]
+  │  │  │  └─ · ○ Logical Inference  [II · Named]
+  │  │  ├─ ✓ ○ Plan and Decompose  [I · Awakened]  (↑ see above)
+  │  │  ├─ ✓ ○ Tool Select  [I · Awakened]
+  │  │  └─ · ○ Tool Use  [II · Named]
+  │  │     └─ ✓ ○ Tool Select  [I · Awakened]  (↑ see above)
+  │  ├─ ✓ ○ Route Intent  [I · Awakened]
+  │  │  └─ · ○ Classify  [I · Awakened]
+  │  └─ ✓ ○ Tool Select  [I · Awakened]  (↑ see above)
   ├─ ✓ ○ Route Intent  [I · Awakened]  (↑ see above)
   └─ ✓ ○ Tool Select  [I · Awakened]  (↑ see above)
 
-· ◆ True Craftsman: Full-Stack Developer  [V · Transcendent]  ← Code Review Pipeline · Automated Testing · Refactor Code
-  ├─ · ◇ Code Review Pipeline  [III · Evolved]  ← Code Generation · Diff Content · Evaluate Output
-  │  ├─ · ○ Code Generation  [I · Awakened]
+· ◆ True Craftsman: Full-Stack Developer  [V · Transcendent]  ← Automated Testing · Code Review Pipeline · Refactor Code
+  ├─ · ◇ Automated Testing  [III · Evolved]  ← Code Execution · Error Interpretation · Execute Bash · Generate Test
+  │  ├─ · ○ Code Execution  [II · Named]
+  │  │  ├─ · ○ Code Generation  [I · Awakened]
+  │  │  └─ · ○ Execute Bash  [I · Awakened]
+  │  ├─ · ○ Error Interpretation  [I · Awakened]
+  │  ├─ · ○ Execute Bash  [I · Awakened]  (↑ see above)
+  │  └─ · ○ Generate Test  [II · Named]
+  ├─ · ◇ Code Review Pipeline  [III · Evolved]  ← Code Execution · Code Generation · Diff Content · Evaluate Output
+  │  ├─ · ○ Code Execution  [II · Named]  (↑ see above)
+  │  ├─ · ○ Code Generation  [I · Awakened]  (↑ see above)
   │  ├─ · ○ Diff Content  [I · Awakened]
   │  └─ · ○ Evaluate Output  [I · Awakened]
-  ├─ · ◇ Automated Testing  [III · Evolved]  ← Generate Test · Execute Bash · Error Interpretation
-  │  ├─ · ○ Generate Test  [II · Named]
-  │  ├─ · ○ Execute Bash  [I · Awakened]
-  │  └─ · ○ Error Interpretation  [I · Awakened]
   └─ · ○ Refactor Code  [II · Named]
 
-· ◆ True Dragon: Autonomous Scientific Discovery  [V · Transcendent]  ← Hypothesis Generation · Research · Math Reason
+· ◆ True Dragon: Autonomous Scientific Discovery  [V · Transcendent]  ← Chain-of-Thought Reasoning · Hypothesis Generation · Math Reason · Research
+  ├─ · ○ Chain-of-Thought Reasoning  [II · Named]
+  │  └─ · ○ Logical Inference  [II · Named]
   ├─ · ○ Hypothesis Generation  [II · Named]
-  ├─ · ◇ Research  [III · Evolved]  ← Web Search · Summarize · Cite Sources
-  │  ├─ · ○ Web Search  [I · Awakened]
-  │  ├─ · ○ Summarize  [I · Awakened]
-  │  └─ · ○ Cite Sources  [I · Awakened]
-  └─ · ○ Math Reason  [II · Named]
+  │  └─ · ◇ Research  [III · Evolved]  ← Cite Sources · Summarize · Web Search
+  │     ├─ · ○ Cite Sources  [I · Awakened]
+  │     ├─ · ○ Summarize  [I · Awakened]
+  │     └─ · ○ Web Search  [I · Awakened]
+  ├─ · ○ Math Reason  [II · Named]
+  └─ · ◇ Research  [III · Evolved]  ← Cite Sources · Summarize · Web Search  (↑ see above)
 
-· ◆ True Herald: Real-Time Voice Assistant  [V · Transcendent]  ← Voice Agent · Memory Manage · Plan and Execute
-  ├─ · ◇ Voice Agent  [III · Evolved]  ← Speech to Text · Question Answer · Text to Speech
-  │  ├─ · ○ Speech to Text  [II · Named]
-  │  ├─ · ○ Question Answer  [II · Named]
-  │  └─ · ○ Text to Speech  [II · Named]
+· ◆ True Herald: Real-Time Voice Assistant  [V · Transcendent]  ← Memory Manage · Plan and Execute · Voice Agent
   ├─ · ○ Memory Manage  [II · Named]
-  └─ ✓ ◇ Plan and Execute  [III · Evolved]  ← Route Intent · Plan and Decompose · Tool Select
-     ├─ ✓ ○ Route Intent  [I · Awakened]
-     ├─ ✓ ○ Plan and Decompose  [I · Awakened]
-     └─ ✓ ○ Tool Select  [I · Awakened]
+  ├─ ✓ ◇ Plan and Execute  [III · Evolved]  ← Plan and Decompose · ReAct Reasoning · Route Intent · Tool Select
+  │  ├─ ✓ ○ Plan and Decompose  [I · Awakened]
+  │  ├─ · ◇ ReAct Reasoning  [III · Evolved]  ← Chain-of-Thought Reasoning · Plan and Decompose · Tool Select · Tool Use
+  │  │  ├─ · ○ Chain-of-Thought Reasoning  [II · Named]
+  │  │  │  └─ · ○ Logical Inference  [II · Named]
+  │  │  ├─ ✓ ○ Plan and Decompose  [I · Awakened]  (↑ see above)
+  │  │  ├─ ✓ ○ Tool Select  [I · Awakened]
+  │  │  └─ · ○ Tool Use  [II · Named]
+  │  │     └─ ✓ ○ Tool Select  [I · Awakened]  (↑ see above)
+  │  ├─ ✓ ○ Route Intent  [I · Awakened]
+  │  │  └─ · ○ Classify  [I · Awakened]
+  │  └─ ✓ ○ Tool Select  [I · Awakened]  (↑ see above)
+  └─ · ◇ Voice Agent  [III · Evolved]  ← Question Answer · Speech to Text · Text to Speech
+     ├─ · ○ Question Answer  [II · Named]
+     ├─ · ○ Speech to Text  [II · Named]
+     └─ · ○ Text to Speech  [II · Named]
 
 · ◆ True Oracle: Autonomous Data Scientist  [V · Transcendent]  ← Data Analysis · Math Reason · Research
-  ├─ · ◇ Data Analysis  [III · Evolved]  ← Generate SQL · Data Visualize · Summarize
-  │  ├─ · ○ Generate SQL  [II · Named]
+  ├─ · ◇ Data Analysis  [III · Evolved]  ← Data Visualize · Generate SQL · Summarize
   │  ├─ · ○ Data Visualize  [II · Named]
+  │  ├─ · ○ Generate SQL  [II · Named]
   │  └─ · ○ Summarize  [I · Awakened]
   ├─ · ○ Math Reason  [II · Named]
-  └─ · ◇ Research  [III · Evolved]  ← Web Search · Summarize · Cite Sources
-     ├─ · ○ Web Search  [I · Awakened]
+  └─ · ◇ Research  [III · Evolved]  ← Cite Sources · Summarize · Web Search
+     ├─ · ○ Cite Sources  [I · Awakened]
      ├─ · ○ Summarize  [I · Awakened]  (↑ see above)
-     └─ · ○ Cite Sources  [I · Awakened]
+     └─ · ○ Web Search  [I · Awakened]
 
-· ◆ True Sage: Recursive Self-Improvement  [V · Transcendent]  ← Autonomous Debug · Evaluate Output · Plan and Execute
-  ├─ · ◇ Autonomous Debug  [III · Evolved]  ← Code Generation · Execute Bash · Error Interpretation
-  │  ├─ · ○ Code Generation  [I · Awakened]
-  │  ├─ · ○ Execute Bash  [I · Awakened]
-  │  └─ · ○ Error Interpretation  [I · Awakened]
+· ◆ True Sage: Recursive Self-Improvement  [V · Transcendent]  ← Autonomous Debug · Evaluate Output · Plan and Execute · Self-Critique
+  ├─ · ◇ Autonomous Debug  [III · Evolved]  ← Code Execution · Code Generation · Error Interpretation · Execute Bash
+  │  ├─ · ○ Code Execution  [II · Named]
+  │  │  ├─ · ○ Code Generation  [I · Awakened]
+  │  │  └─ · ○ Execute Bash  [I · Awakened]
+  │  ├─ · ○ Code Generation  [I · Awakened]  (↑ see above)
+  │  ├─ · ○ Error Interpretation  [I · Awakened]
+  │  └─ · ○ Execute Bash  [I · Awakened]  (↑ see above)
   ├─ · ○ Evaluate Output  [I · Awakened]
-  └─ ✓ ◇ Plan and Execute  [III · Evolved]  ← Route Intent · Plan and Decompose · Tool Select
-     ├─ ✓ ○ Route Intent  [I · Awakened]
-     ├─ ✓ ○ Plan and Decompose  [I · Awakened]
-     └─ ✓ ○ Tool Select  [I · Awakened]
+  ├─ ✓ ◇ Plan and Execute  [III · Evolved]  ← Plan and Decompose · ReAct Reasoning · Route Intent · Tool Select
+  │  ├─ ✓ ○ Plan and Decompose  [I · Awakened]
+  │  ├─ · ◇ ReAct Reasoning  [III · Evolved]  ← Chain-of-Thought Reasoning · Plan and Decompose · Tool Select · Tool Use
+  │  │  ├─ · ○ Chain-of-Thought Reasoning  [II · Named]
+  │  │  │  └─ · ○ Logical Inference  [II · Named]
+  │  │  ├─ ✓ ○ Plan and Decompose  [I · Awakened]  (↑ see above)
+  │  │  ├─ ✓ ○ Tool Select  [I · Awakened]
+  │  │  └─ · ○ Tool Use  [II · Named]
+  │  │     └─ ✓ ○ Tool Select  [I · Awakened]  (↑ see above)
+  │  ├─ ✓ ○ Route Intent  [I · Awakened]
+  │  │  └─ · ○ Classify  [I · Awakened]
+  │  └─ ✓ ○ Tool Select  [I · Awakened]  (↑ see above)
+  └─ · ○ Self-Critique  [II · Named]
+     └─ · ○ Evaluate Output  [I · Awakened]  (↑ see above)
 
 ```
 

--- a/users/mbtiongson1/skill-tree.md
+++ b/users/mbtiongson1/skill-tree.md
@@ -23,82 +23,133 @@
 ## Upgrade Path
 
 ```
-· ◆ Wisdom King: Autonomous Research Agent  [VI · Transcendent ★]  ← Research · Knowledge Harvest · Ghostwrite
-  ├─ ✓ ◇ Research  [III · Evolved]  ← Web Search · Summarize · Cite Sources
-  │  ├─ ✓ ○ Web Search  [I · Awakened]
-  │  ├─ ✓ ○ Summarize  [I · Awakened]
-  │  └─ ✓ ○ Cite Sources  [I · Awakened]
-  ├─ · ◇ Knowledge Harvest  [IV · Transcendent]  ← Web Scrape · Extract Entities · Embed Text
-  │  ├─ ✓ ◇ Web Scrape  [III · Evolved]  ← Web Search · Parse HTML · Extract Entities
-  │  │  ├─ ✓ ○ Web Search  [I · Awakened]  (↑ see above)
+· ◆ Wisdom King: Autonomous Research Agent  [VI · Transcendent ★]  ← Browser Automation · Ghostwrite · Knowledge Graph Construction · Knowledge Harvest · ReAct Reasoning · Research
+  ├─ · ◇ Browser Automation  [III · Evolved]  ← Computer Use · Web Scrape · Web Search
+  │  ├─ · ○ Computer Use  [II · Named]
+  │  ├─ ✓ ◇ Web Scrape  [III · Evolved]  ← Extract Entities · Parse HTML · Web Search
+  │  │  ├─ ✓ ○ Extract Entities  [I · Awakened]
   │  │  ├─ ✓ ○ Parse HTML  [I · Awakened]
-  │  │  └─ ✓ ○ Extract Entities  [I · Awakened]
+  │  │  └─ ✓ ○ Web Search  [I · Awakened]
+  │  └─ ✓ ○ Web Search  [I · Awakened]  (↑ see above)
+  ├─ · ◇ Ghostwrite  [IV · Transcendent]  ← Audience Model · Generate Text · Research · Write Report
+  │  ├─ · ○ Audience Model  [I · Awakened]
+  │  ├─ · ○ Generate Text  [I · Awakened]
+  │  ├─ ✓ ◇ Research  [III · Evolved]  ← Cite Sources · Summarize · Web Search
+  │  │  ├─ ✓ ○ Cite Sources  [I · Awakened]
+  │  │  ├─ ✓ ○ Summarize  [I · Awakened]
+  │  │  └─ ✓ ○ Web Search  [I · Awakened]  (↑ see above)
+  │  └─ · ○ Write Report  [I · Awakened]
+  ├─ · ◇ Knowledge Graph Construction  [III · Evolved]  ← Extract Entities · Logical Inference
   │  ├─ ✓ ○ Extract Entities  [I · Awakened]  (↑ see above)
-  │  └─ · ○ Embed Text  [I · Awakened]
-  └─ · ◇ Ghostwrite  [IV · Transcendent]  ← Research · Write Report · Audience Model
-     ├─ ✓ ◇ Research  [III · Evolved]  ← Web Search · Summarize · Cite Sources  (↑ see above)
-     ├─ · ○ Write Report  [I · Awakened]
-     └─ · ○ Audience Model  [I · Awakened]
+  │  └─ · ○ Logical Inference  [II · Named]
+  ├─ · ◇ Knowledge Harvest  [IV · Transcendent]  ← Embed Text · Extract Entities · Web Scrape
+  │  ├─ · ○ Embed Text  [I · Awakened]
+  │  ├─ ✓ ○ Extract Entities  [I · Awakened]  (↑ see above)
+  │  └─ ✓ ◇ Web Scrape  [III · Evolved]  ← Extract Entities · Parse HTML · Web Search  (↑ see above)
+  ├─ · ◇ ReAct Reasoning  [III · Evolved]  ← Chain-of-Thought Reasoning · Plan and Decompose · Tool Select · Tool Use
+  │  ├─ · ○ Chain-of-Thought Reasoning  [II · Named]
+  │  │  └─ · ○ Logical Inference  [II · Named]  (↑ see above)
+  │  ├─ · ○ Plan and Decompose  [I · Awakened]
+  │  ├─ · ○ Tool Select  [I · Awakened]
+  │  └─ · ○ Tool Use  [II · Named]
+  │     └─ · ○ Tool Select  [I · Awakened]  (↑ see above)
+  └─ ✓ ◇ Research  [III · Evolved]  ← Cite Sources · Summarize · Web Search  (↑ see above)
 
 · ◆ Grand Conductor: Multi-Agent Orchestration  [V · Transcendent]  ← Plan and Execute · Route Intent · Tool Select
-  ├─ · ◇ Plan and Execute  [III · Evolved]  ← Route Intent · Plan and Decompose · Tool Select
-  │  ├─ · ○ Route Intent  [I · Awakened]
+  ├─ · ◇ Plan and Execute  [III · Evolved]  ← Plan and Decompose · ReAct Reasoning · Route Intent · Tool Select
   │  ├─ · ○ Plan and Decompose  [I · Awakened]
-  │  └─ · ○ Tool Select  [I · Awakened]
+  │  ├─ · ◇ ReAct Reasoning  [III · Evolved]  ← Chain-of-Thought Reasoning · Plan and Decompose · Tool Select · Tool Use
+  │  │  ├─ · ○ Chain-of-Thought Reasoning  [II · Named]
+  │  │  │  └─ · ○ Logical Inference  [II · Named]
+  │  │  ├─ · ○ Plan and Decompose  [I · Awakened]  (↑ see above)
+  │  │  ├─ · ○ Tool Select  [I · Awakened]
+  │  │  └─ · ○ Tool Use  [II · Named]
+  │  │     └─ · ○ Tool Select  [I · Awakened]  (↑ see above)
+  │  ├─ · ○ Route Intent  [I · Awakened]
+  │  │  └─ · ○ Classify  [I · Awakened]
+  │  └─ · ○ Tool Select  [I · Awakened]  (↑ see above)
   ├─ · ○ Route Intent  [I · Awakened]  (↑ see above)
   └─ · ○ Tool Select  [I · Awakened]  (↑ see above)
 
-· ◆ True Craftsman: Full-Stack Developer  [V · Transcendent]  ← Code Review Pipeline · Automated Testing · Refactor Code
-  ├─ · ◇ Code Review Pipeline  [III · Evolved]  ← Code Generation · Diff Content · Evaluate Output
-  │  ├─ · ○ Code Generation  [I · Awakened]
+· ◆ True Craftsman: Full-Stack Developer  [V · Transcendent]  ← Automated Testing · Code Review Pipeline · Refactor Code
+  ├─ · ◇ Automated Testing  [III · Evolved]  ← Code Execution · Error Interpretation · Execute Bash · Generate Test
+  │  ├─ · ○ Code Execution  [II · Named]
+  │  │  ├─ · ○ Code Generation  [I · Awakened]
+  │  │  └─ · ○ Execute Bash  [I · Awakened]
+  │  ├─ · ○ Error Interpretation  [I · Awakened]
+  │  ├─ · ○ Execute Bash  [I · Awakened]  (↑ see above)
+  │  └─ · ○ Generate Test  [II · Named]
+  ├─ · ◇ Code Review Pipeline  [III · Evolved]  ← Code Execution · Code Generation · Diff Content · Evaluate Output
+  │  ├─ · ○ Code Execution  [II · Named]  (↑ see above)
+  │  ├─ · ○ Code Generation  [I · Awakened]  (↑ see above)
   │  ├─ · ○ Diff Content  [I · Awakened]
   │  └─ · ○ Evaluate Output  [I · Awakened]
-  ├─ · ◇ Automated Testing  [III · Evolved]  ← Generate Test · Execute Bash · Error Interpretation
-  │  ├─ · ○ Generate Test  [II · Named]
-  │  ├─ · ○ Execute Bash  [I · Awakened]
-  │  └─ · ○ Error Interpretation  [I · Awakened]
   └─ · ○ Refactor Code  [II · Named]
 
-· ◆ True Dragon: Autonomous Scientific Discovery  [V · Transcendent]  ← Hypothesis Generation · Research · Math Reason
+· ◆ True Dragon: Autonomous Scientific Discovery  [V · Transcendent]  ← Chain-of-Thought Reasoning · Hypothesis Generation · Math Reason · Research
+  ├─ · ○ Chain-of-Thought Reasoning  [II · Named]
+  │  └─ · ○ Logical Inference  [II · Named]
   ├─ · ○ Hypothesis Generation  [II · Named]
-  ├─ ✓ ◇ Research  [III · Evolved]  ← Web Search · Summarize · Cite Sources
-  │  ├─ ✓ ○ Web Search  [I · Awakened]
-  │  ├─ ✓ ○ Summarize  [I · Awakened]
-  │  └─ ✓ ○ Cite Sources  [I · Awakened]
-  └─ · ○ Math Reason  [II · Named]
+  │  └─ ✓ ◇ Research  [III · Evolved]  ← Cite Sources · Summarize · Web Search
+  │     ├─ ✓ ○ Cite Sources  [I · Awakened]
+  │     ├─ ✓ ○ Summarize  [I · Awakened]
+  │     └─ ✓ ○ Web Search  [I · Awakened]
+  ├─ · ○ Math Reason  [II · Named]
+  └─ ✓ ◇ Research  [III · Evolved]  ← Cite Sources · Summarize · Web Search  (↑ see above)
 
-· ◆ True Herald: Real-Time Voice Assistant  [V · Transcendent]  ← Voice Agent · Memory Manage · Plan and Execute
-  ├─ · ◇ Voice Agent  [III · Evolved]  ← Speech to Text · Question Answer · Text to Speech
-  │  ├─ · ○ Speech to Text  [II · Named]
-  │  ├─ · ○ Question Answer  [II · Named]
-  │  └─ · ○ Text to Speech  [II · Named]
+· ◆ True Herald: Real-Time Voice Assistant  [V · Transcendent]  ← Memory Manage · Plan and Execute · Voice Agent
   ├─ · ○ Memory Manage  [II · Named]
-  └─ · ◇ Plan and Execute  [III · Evolved]  ← Route Intent · Plan and Decompose · Tool Select
-     ├─ · ○ Route Intent  [I · Awakened]
-     ├─ · ○ Plan and Decompose  [I · Awakened]
-     └─ · ○ Tool Select  [I · Awakened]
+  ├─ · ◇ Plan and Execute  [III · Evolved]  ← Plan and Decompose · ReAct Reasoning · Route Intent · Tool Select
+  │  ├─ · ○ Plan and Decompose  [I · Awakened]
+  │  ├─ · ◇ ReAct Reasoning  [III · Evolved]  ← Chain-of-Thought Reasoning · Plan and Decompose · Tool Select · Tool Use
+  │  │  ├─ · ○ Chain-of-Thought Reasoning  [II · Named]
+  │  │  │  └─ · ○ Logical Inference  [II · Named]
+  │  │  ├─ · ○ Plan and Decompose  [I · Awakened]  (↑ see above)
+  │  │  ├─ · ○ Tool Select  [I · Awakened]
+  │  │  └─ · ○ Tool Use  [II · Named]
+  │  │     └─ · ○ Tool Select  [I · Awakened]  (↑ see above)
+  │  ├─ · ○ Route Intent  [I · Awakened]
+  │  │  └─ · ○ Classify  [I · Awakened]
+  │  └─ · ○ Tool Select  [I · Awakened]  (↑ see above)
+  └─ · ◇ Voice Agent  [III · Evolved]  ← Question Answer · Speech to Text · Text to Speech
+     ├─ · ○ Question Answer  [II · Named]
+     ├─ · ○ Speech to Text  [II · Named]
+     └─ · ○ Text to Speech  [II · Named]
 
 · ◆ True Oracle: Autonomous Data Scientist  [V · Transcendent]  ← Data Analysis · Math Reason · Research
-  ├─ · ◇ Data Analysis  [III · Evolved]  ← Generate SQL · Data Visualize · Summarize
-  │  ├─ · ○ Generate SQL  [II · Named]
+  ├─ · ◇ Data Analysis  [III · Evolved]  ← Data Visualize · Generate SQL · Summarize
   │  ├─ · ○ Data Visualize  [II · Named]
+  │  ├─ · ○ Generate SQL  [II · Named]
   │  └─ ✓ ○ Summarize  [I · Awakened]
   ├─ · ○ Math Reason  [II · Named]
-  └─ ✓ ◇ Research  [III · Evolved]  ← Web Search · Summarize · Cite Sources
-     ├─ ✓ ○ Web Search  [I · Awakened]
+  └─ ✓ ◇ Research  [III · Evolved]  ← Cite Sources · Summarize · Web Search
+     ├─ ✓ ○ Cite Sources  [I · Awakened]
      ├─ ✓ ○ Summarize  [I · Awakened]  (↑ see above)
-     └─ ✓ ○ Cite Sources  [I · Awakened]
+     └─ ✓ ○ Web Search  [I · Awakened]
 
-· ◆ True Sage: Recursive Self-Improvement  [V · Transcendent]  ← Autonomous Debug · Evaluate Output · Plan and Execute
-  ├─ · ◇ Autonomous Debug  [III · Evolved]  ← Code Generation · Execute Bash · Error Interpretation
-  │  ├─ · ○ Code Generation  [I · Awakened]
-  │  ├─ · ○ Execute Bash  [I · Awakened]
-  │  └─ · ○ Error Interpretation  [I · Awakened]
+· ◆ True Sage: Recursive Self-Improvement  [V · Transcendent]  ← Autonomous Debug · Evaluate Output · Plan and Execute · Self-Critique
+  ├─ · ◇ Autonomous Debug  [III · Evolved]  ← Code Execution · Code Generation · Error Interpretation · Execute Bash
+  │  ├─ · ○ Code Execution  [II · Named]
+  │  │  ├─ · ○ Code Generation  [I · Awakened]
+  │  │  └─ · ○ Execute Bash  [I · Awakened]
+  │  ├─ · ○ Code Generation  [I · Awakened]  (↑ see above)
+  │  ├─ · ○ Error Interpretation  [I · Awakened]
+  │  └─ · ○ Execute Bash  [I · Awakened]  (↑ see above)
   ├─ · ○ Evaluate Output  [I · Awakened]
-  └─ · ◇ Plan and Execute  [III · Evolved]  ← Route Intent · Plan and Decompose · Tool Select
-     ├─ · ○ Route Intent  [I · Awakened]
-     ├─ · ○ Plan and Decompose  [I · Awakened]
-     └─ · ○ Tool Select  [I · Awakened]
+  ├─ · ◇ Plan and Execute  [III · Evolved]  ← Plan and Decompose · ReAct Reasoning · Route Intent · Tool Select
+  │  ├─ · ○ Plan and Decompose  [I · Awakened]
+  │  ├─ · ◇ ReAct Reasoning  [III · Evolved]  ← Chain-of-Thought Reasoning · Plan and Decompose · Tool Select · Tool Use
+  │  │  ├─ · ○ Chain-of-Thought Reasoning  [II · Named]
+  │  │  │  └─ · ○ Logical Inference  [II · Named]
+  │  │  ├─ · ○ Plan and Decompose  [I · Awakened]  (↑ see above)
+  │  │  ├─ · ○ Tool Select  [I · Awakened]
+  │  │  └─ · ○ Tool Use  [II · Named]
+  │  │     └─ · ○ Tool Select  [I · Awakened]  (↑ see above)
+  │  ├─ · ○ Route Intent  [I · Awakened]
+  │  │  └─ · ○ Classify  [I · Awakened]
+  │  └─ · ○ Tool Select  [I · Awakened]  (↑ see above)
+  └─ · ○ Self-Critique  [II · Named]
+     └─ · ○ Evaluate Output  [I · Awakened]  (↑ see above)
 
 ```
 


### PR DESCRIPTION
## Gaia Draft Skill Intake

This PR submits a draft intake batch for human review.
The canonical intake artifact is the JSON file in `intake/skill-batches/`.
Accepted skills must be promoted separately into `graph/gaia.json`.

### Batch Summary
- User: `gaiabot`
- Source repo: `mbtiongson1/gaia-skill-tree`
- Generated at: `2026-04-29T13:51:45Z`
- Known skills: `51`
- Proposed skills: `1709`

See the JSON file in the commit for the full list of proposed skills, as the list was truncated to fit the PR body limit.

### Reviewer Checklist
- [ ] Reviewed each proposed skill for clarity and non-overlap.
- [ ] Marked each candidate as: accept, rename, duplicate, needs evidence, or reject.
- [ ] Verified similarity hints are directionally useful (not authoritative).
- [ ] Noted any evidence gaps or requests for follow-up.

### Maintainer Promotion Checklist
- [ ] Convert accepted draft skills into canonical `graph/gaia.json` edits in a follow-up PR.
- [ ] Run `python3 scripts/validate.py` and `python3 scripts/validate_intake.py` on promotion PR.
- [ ] Close or link back this intake PR from the promotion PR.

Automatically generated by `gaia push`.
