### PR TITLE
[feat] Batch 3 — add 5 new AI agent skills

### DIFF
--- a/combinations.md
+++ b/combinations.md
@@ -20,6 +20,7 @@
 | ◆ Grand Conductor: Multi-Agent Orchestration | Ultimate Skill | Plan and Execute, Route Intent, Tool Select | V · Transcendent | Requires extensive multi-system validation before level advancement. |
 | ◇ Multimodal Reasoning | Extra Skill | Image Caption, Question Answer, Logical Inference | III · Evolved | Requires vision-language model capability. |
 | ◇ Plan and Execute | Extra Skill | Route Intent, Plan and Decompose, Tool Select | III · Evolved |  |
+| ◇ Prompt Optimization | Extra Skill | Evaluate Output, Generate Text | IV · Transcendent |  |
 | ◇ RAG Pipeline | Extra Skill | Retrieve, Chunk Document, Embed Text, Score Relevance | III · Evolved |  |
 | ◇ ReAct Reasoning | Extra Skill | Plan and Decompose, Tool Use | III · Evolved |  |
 | ◆ True Herald: Real-Time Voice Assistant | Ultimate Skill | Voice Agent, Memory Manage, Plan and Execute | V · Transcendent | Requires real-time audio pipeline, <500ms end-to-end latency target, and persistent session store. Minimum 3 Class A/B evidence sources. |
@@ -28,7 +29,9 @@
 | ◇ Research | Extra Skill | Web Search, Summarize, Cite Sources | III · Evolved |  |
 | ◆ True Dragon: Autonomous Scientific Discovery | Ultimate Skill | Hypothesis Generation, Research, Math Reason | V · Transcendent | Requires laboratory tool access or simulation environment. Minimum 3 Class A/B evidence sources. |
 | ◇ Text-to-SQL Pipeline | Extra Skill | Generate SQL, Parse JSON, Format Output | III · Evolved | Requires schema context in prompt. |
+| ◇ Tool Creation | Extra Skill | Code Generation, Tool Use | IV · Transcendent |  |
 | ◇ Translation Pipeline | Extra Skill | Translate, Sentiment Analysis, Audience Model | III · Evolved |  |
+| ◇ Tree of Thought | Extra Skill | Chain-of-Thought Reasoning, Plan and Decompose | IV · Transcendent |  |
 | ◇ Voice Agent | Extra Skill | Speech to Text, Question Answer, Text to Speech | III · Evolved | Requires real-time audio I/O or audio file access. |
 | ◇ Web Scrape | Extra Skill | Web Search, Parse HTML, Extract Entities | III · Evolved | Structured output mode required. |
 

--- a/graph/gaia.gexf
+++ b/graph/gaia.gexf
@@ -236,6 +236,14 @@
           <attvalue for="type" value="atomic" />
         </attvalues>
       </node>
+      <node id="few-shot-learning" label="Few-Shot Learning">
+        <attvalues>
+          <attvalue for="level" value="IV" />
+          <attvalue for="rarity" value="common" />
+          <attvalue for="status" value="provisional" />
+          <attvalue for="type" value="atomic" />
+        </attvalues>
+      </node>
       <node id="format-output" label="Format Output">
         <attvalues>
           <attvalue for="level" value="I" />
@@ -404,6 +412,14 @@
           <attvalue for="type" value="atomic" />
         </attvalues>
       </node>
+      <node id="prompt-optimization" label="Prompt Optimization">
+        <attvalues>
+          <attvalue for="level" value="IV" />
+          <attvalue for="rarity" value="uncommon" />
+          <attvalue for="status" value="provisional" />
+          <attvalue for="type" value="composite" />
+        </attvalues>
+      </node>
       <node id="question-answer" label="Question Answer">
         <attvalues>
           <attvalue for="level" value="II" />
@@ -508,6 +524,14 @@
           <attvalue for="type" value="atomic" />
         </attvalues>
       </node>
+      <node id="self-consistency" label="Self-Consistency">
+        <attvalues>
+          <attvalue for="level" value="IV" />
+          <attvalue for="rarity" value="rare" />
+          <attvalue for="status" value="provisional" />
+          <attvalue for="type" value="atomic" />
+        </attvalues>
+      </node>
       <node id="self-critique" label="Self-Critique">
         <attvalues>
           <attvalue for="level" value="II" />
@@ -572,6 +596,14 @@
           <attvalue for="type" value="atomic" />
         </attvalues>
       </node>
+      <node id="tool-creation" label="Tool Creation">
+        <attvalues>
+          <attvalue for="level" value="IV" />
+          <attvalue for="rarity" value="rare" />
+          <attvalue for="status" value="provisional" />
+          <attvalue for="type" value="composite" />
+        </attvalues>
+      </node>
       <node id="tool-select" label="Tool Select">
         <attvalues>
           <attvalue for="level" value="I" />
@@ -600,6 +632,14 @@
         <attvalues>
           <attvalue for="level" value="III" />
           <attvalue for="rarity" value="uncommon" />
+          <attvalue for="status" value="provisional" />
+          <attvalue for="type" value="composite" />
+        </attvalues>
+      </node>
+      <node id="tree-of-thought" label="Tree of Thought">
+        <attvalues>
+          <attvalue for="level" value="IV" />
+          <attvalue for="rarity" value="rare" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="composite" />
         </attvalues>
@@ -691,39 +731,45 @@
       <edge id="e50" source="route-intent" target="plan-and-execute" />
       <edge id="e51" source="plan-decompose" target="plan-and-execute" />
       <edge id="e52" source="tool-select" target="plan-and-execute" />
-      <edge id="e53" source="retrieve" target="rag-pipeline" />
-      <edge id="e54" source="chunk-document" target="rag-pipeline" />
-      <edge id="e55" source="embed-text" target="rag-pipeline" />
-      <edge id="e56" source="score-relevance" target="rag-pipeline" />
-      <edge id="e57" source="plan-decompose" target="re-act-reasoning" />
-      <edge id="e58" source="tool-use" target="re-act-reasoning" />
-      <edge id="e59" source="voice-agent" target="real-time-voice-assistant" />
-      <edge id="e60" source="memory-manage" target="real-time-voice-assistant" />
-      <edge id="e61" source="plan-and-execute" target="real-time-voice-assistant" />
-      <edge id="e62" source="autonomous-debug" target="recursive-self-improvement" />
-      <edge id="e63" source="evaluate-output" target="recursive-self-improvement" />
-      <edge id="e64" source="plan-and-execute" target="recursive-self-improvement" />
-      <edge id="e65" source="research" target="registry-curation" />
-      <edge id="e66" source="code-generation" target="registry-curation" />
-      <edge id="e67" source="execute-bash" target="registry-curation" />
-      <edge id="e68" source="web-search" target="research" />
-      <edge id="e69" source="summarize" target="research" />
-      <edge id="e70" source="cite-sources" target="research" />
-      <edge id="e71" source="hypothesis-generate" target="scientific-discovery" />
-      <edge id="e72" source="research" target="scientific-discovery" />
-      <edge id="e73" source="math-reason" target="scientific-discovery" />
-      <edge id="e74" source="generate-sql" target="text-to-sql-pipeline" />
-      <edge id="e75" source="parse-json" target="text-to-sql-pipeline" />
-      <edge id="e76" source="format-output" target="text-to-sql-pipeline" />
-      <edge id="e77" source="translate" target="translation-pipeline" />
-      <edge id="e78" source="sentiment-analysis" target="translation-pipeline" />
-      <edge id="e79" source="audience-model" target="translation-pipeline" />
-      <edge id="e80" source="speech-to-text" target="voice-agent" />
-      <edge id="e81" source="question-answer" target="voice-agent" />
-      <edge id="e82" source="text-to-speech" target="voice-agent" />
-      <edge id="e83" source="web-search" target="web-scrape" />
-      <edge id="e84" source="parse-html" target="web-scrape" />
-      <edge id="e85" source="extract-entities" target="web-scrape" />
+      <edge id="e53" source="evaluate-output" target="prompt-optimization" />
+      <edge id="e54" source="generate-text" target="prompt-optimization" />
+      <edge id="e55" source="retrieve" target="rag-pipeline" />
+      <edge id="e56" source="chunk-document" target="rag-pipeline" />
+      <edge id="e57" source="embed-text" target="rag-pipeline" />
+      <edge id="e58" source="score-relevance" target="rag-pipeline" />
+      <edge id="e59" source="plan-decompose" target="re-act-reasoning" />
+      <edge id="e60" source="tool-use" target="re-act-reasoning" />
+      <edge id="e61" source="voice-agent" target="real-time-voice-assistant" />
+      <edge id="e62" source="memory-manage" target="real-time-voice-assistant" />
+      <edge id="e63" source="plan-and-execute" target="real-time-voice-assistant" />
+      <edge id="e64" source="autonomous-debug" target="recursive-self-improvement" />
+      <edge id="e65" source="evaluate-output" target="recursive-self-improvement" />
+      <edge id="e66" source="plan-and-execute" target="recursive-self-improvement" />
+      <edge id="e67" source="research" target="registry-curation" />
+      <edge id="e68" source="code-generation" target="registry-curation" />
+      <edge id="e69" source="execute-bash" target="registry-curation" />
+      <edge id="e70" source="web-search" target="research" />
+      <edge id="e71" source="summarize" target="research" />
+      <edge id="e72" source="cite-sources" target="research" />
+      <edge id="e73" source="hypothesis-generate" target="scientific-discovery" />
+      <edge id="e74" source="research" target="scientific-discovery" />
+      <edge id="e75" source="math-reason" target="scientific-discovery" />
+      <edge id="e76" source="generate-sql" target="text-to-sql-pipeline" />
+      <edge id="e77" source="parse-json" target="text-to-sql-pipeline" />
+      <edge id="e78" source="format-output" target="text-to-sql-pipeline" />
+      <edge id="e79" source="code-generation" target="tool-creation" />
+      <edge id="e80" source="tool-use" target="tool-creation" />
+      <edge id="e81" source="translate" target="translation-pipeline" />
+      <edge id="e82" source="sentiment-analysis" target="translation-pipeline" />
+      <edge id="e83" source="audience-model" target="translation-pipeline" />
+      <edge id="e84" source="chain-of-thought" target="tree-of-thought" />
+      <edge id="e85" source="plan-decompose" target="tree-of-thought" />
+      <edge id="e86" source="speech-to-text" target="voice-agent" />
+      <edge id="e87" source="question-answer" target="voice-agent" />
+      <edge id="e88" source="text-to-speech" target="voice-agent" />
+      <edge id="e89" source="web-search" target="web-scrape" />
+      <edge id="e90" source="parse-html" target="web-scrape" />
+      <edge id="e91" source="extract-entities" target="web-scrape" />
     </edges>
   </graph>
 </gexf>

--- a/graph/gaia.json
+++ b/graph/gaia.json
@@ -14,7 +14,7 @@
       "III": "Evolved",
       "IV": "Transcendent",
       "V": "Transcendent",
-      "VI": "Transcendent \u2605"
+      "VI": "Transcendent ★"
     },
     "rarityLabels": {
       "legendary": "Divine"
@@ -57,8 +57,9 @@
       "description": "Assigns one or more categorical labels to an input based on learned or rule-based criteria.",
       "prerequisites": [],
       "derivatives": [
-        "route-intent",
-        "content-moderation"
+        "content-moderation",
+        "few-shot-learning",
+        "route-intent"
       ],
       "conditions": "",
       "evidence": [
@@ -73,7 +74,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-26",
-      "updatedAt": "2026-04-26",
+      "updatedAt": "2026-04-29",
       "version": "0.1.0"
     },
     {
@@ -224,7 +225,9 @@
       "description": "Produces coherent natural language output given a prompt, instruction, or context window.",
       "prerequisites": [],
       "derivatives": [
-        "ghostwrite"
+        "few-shot-learning",
+        "ghostwrite",
+        "prompt-optimization"
       ],
       "conditions": "",
       "evidence": [
@@ -239,7 +242,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-26",
-      "updatedAt": "2026-04-26",
+      "updatedAt": "2026-04-29",
       "version": "0.1.0"
     },
     {
@@ -368,6 +371,7 @@
       "prerequisites": [],
       "derivatives": [
         "code-review-pipeline",
+        "prompt-optimization",
         "self-critique"
       ],
       "conditions": "",
@@ -383,7 +387,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-26",
-      "updatedAt": "2026-04-28",
+      "updatedAt": "2026-04-29",
       "version": "0.1.0"
     },
     {
@@ -451,7 +455,8 @@
       "prerequisites": [],
       "derivatives": [
         "plan-and-execute",
-        "re-act-reasoning"
+        "re-act-reasoning",
+        "tree-of-thought"
       ],
       "conditions": "",
       "evidence": [
@@ -466,7 +471,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-26",
-      "updatedAt": "2026-04-28",
+      "updatedAt": "2026-04-29",
       "version": "0.1.0"
     },
     {
@@ -593,7 +598,8 @@
         "autonomous-debug",
         "code-execution",
         "code-review-pipeline",
-        "registry-curation"
+        "registry-curation",
+        "tool-creation"
       ],
       "conditions": "",
       "evidence": [
@@ -608,7 +614,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-26",
-      "updatedAt": "2026-04-28",
+      "updatedAt": "2026-04-29",
       "version": "0.1.0"
     },
     {
@@ -989,7 +995,7 @@
           "source": "https://github.com/gaia-registry/gaia/blob/main/docs/evidence/seed.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Seed evidence \u2014 structural validation placeholder."
+          "notes": "Seed evidence — structural validation placeholder."
         }
       ],
       "knownAgents": [],
@@ -1018,7 +1024,7 @@
           "source": "https://github.com/gaia-registry/gaia/blob/main/docs/evidence/seed.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Seed evidence \u2014 structural validation placeholder."
+          "notes": "Seed evidence — structural validation placeholder."
         }
       ],
       "knownAgents": [],
@@ -1047,7 +1053,7 @@
           "source": "https://github.com/gaia-registry/gaia/blob/main/docs/evidence/seed.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Seed evidence \u2014 apex tier structural validation placeholder."
+          "notes": "Seed evidence — apex tier structural validation placeholder."
         }
       ],
       "knownAgents": [],
@@ -1074,7 +1080,7 @@
           "source": "https://arxiv.org/abs/2207.04672",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "NLLB (No Language Left Behind) \u2014 Meta AI paper demonstrating 200-language translation at human-level quality on FLORES-200 benchmark."
+          "notes": "NLLB (No Language Left Behind) — Meta AI paper demonstrating 200-language translation at human-level quality on FLORES-200 benchmark."
         }
       ],
       "knownAgents": [],
@@ -1102,7 +1108,7 @@
           "source": "https://arxiv.org/abs/1810.04805",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "BERT paper \u2014 achieves SOTA on SST-2 sentiment benchmark (93.5% accuracy), foundational evidence for LLM-based sentiment analysis."
+          "notes": "BERT paper — achieves SOTA on SST-2 sentiment benchmark (93.5% accuracy), foundational evidence for LLM-based sentiment analysis."
         }
       ],
       "knownAgents": [],
@@ -1129,7 +1135,7 @@
           "source": "https://arxiv.org/abs/2301.12597",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "BLIP-2 \u2014 bootstrapped language-image pre-training achieving SOTA on COCO Captions (CIDEr 145.8) and NoCaps benchmarks."
+          "notes": "BLIP-2 — bootstrapped language-image pre-training achieving SOTA on COCO Captions (CIDEr 145.8) and NoCaps benchmarks."
         }
       ],
       "knownAgents": [],
@@ -1156,7 +1162,7 @@
           "source": "https://arxiv.org/abs/2212.04356",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Whisper (OpenAI) \u2014 large-scale weak supervision across 680K hours of audio achieves near-human WER on LibriSpeech and multilingual benchmarks."
+          "notes": "Whisper (OpenAI) — large-scale weak supervision across 680K hours of audio achieves near-human WER on LibriSpeech and multilingual benchmarks."
         }
       ],
       "knownAgents": [],
@@ -1183,7 +1189,7 @@
           "source": "https://arxiv.org/abs/2301.02111",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "VALL-E (Microsoft) \u2014 neural codec language model achieving SOTA speech synthesis with 3-second voice cloning on LibriSpeech."
+          "notes": "VALL-E (Microsoft) — neural codec language model achieving SOTA speech synthesis with 3-second voice cloning on LibriSpeech."
         }
       ],
       "knownAgents": [],
@@ -1211,7 +1217,7 @@
           "source": "https://arxiv.org/abs/1809.08887",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Spider benchmark \u2014 cross-domain text-to-SQL dataset; LLM baselines reach >85% exact match, establishing reproducible evaluation methodology."
+          "notes": "Spider benchmark — cross-domain text-to-SQL dataset; LLM baselines reach >85% exact match, establishing reproducible evaluation methodology."
         }
       ],
       "knownAgents": [],
@@ -1230,8 +1236,9 @@
       "prerequisites": [],
       "derivatives": [
         "conversational-agent",
-        "voice-agent",
-        "multimodal-reasoning"
+        "few-shot-learning",
+        "multimodal-reasoning",
+        "voice-agent"
       ],
       "conditions": "",
       "evidence": [
@@ -1240,13 +1247,13 @@
           "source": "https://arxiv.org/abs/1806.03822",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SQuAD 2.0 \u2014 reading comprehension benchmark with 150K questions; modern LLMs exceed human F1 (90.9), providing rigorous reproducible evaluation."
+          "notes": "SQuAD 2.0 — reading comprehension benchmark with 150K questions; modern LLMs exceed human F1 (90.9), providing rigorous reproducible evaluation."
         }
       ],
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-28",
-      "updatedAt": "2026-04-28",
+      "updatedAt": "2026-04-29",
       "version": "0.2.0"
     },
     {
@@ -1265,7 +1272,7 @@
           "source": "https://arxiv.org/abs/2112.10752",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Latent Diffusion Models (Rombach et al.) \u2014 foundational paper for Stable Diffusion; achieves FID 5.11 on LSUN-Beds at 200\u00d7 less compute than pixel-space diffusion."
+          "notes": "Latent Diffusion Models (Rombach et al.) — foundational paper for Stable Diffusion; achieves FID 5.11 on LSUN-Beds at 200× less compute than pixel-space diffusion."
         }
       ],
       "knownAgents": [],
@@ -1293,7 +1300,7 @@
           "source": "https://arxiv.org/abs/2206.14858",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Minerva (Google) \u2014 50.3% on MATH and 78.5% on MMLU-STEM benchmarks using chain-of-thought over scientific literature."
+          "notes": "Minerva (Google) — 50.3% on MATH and 78.5% on MMLU-STEM benchmarks using chain-of-thought over scientific literature."
         }
       ],
       "knownAgents": [],
@@ -1322,7 +1329,7 @@
           "source": "https://arxiv.org/abs/2201.11903",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Chain-of-Thought prompting (Wei et al.) \u2014 few-shot CoT elicits multi-step reasoning; +18% on GSM8K and +15% on SVAMP over standard prompting."
+          "notes": "Chain-of-Thought prompting (Wei et al.) — few-shot CoT elicits multi-step reasoning; +18% on GSM8K and +15% on SVAMP over standard prompting."
         }
       ],
       "knownAgents": [],
@@ -1350,7 +1357,7 @@
           "source": "https://arxiv.org/abs/2310.08560",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "MemGPT \u2014 virtual context management system enabling LLMs to handle unbounded memory; benchmarked on multi-session dialogue and document QA."
+          "notes": "MemGPT — virtual context management system enabling LLMs to handle unbounded memory; benchmarked on multi-session dialogue and document QA."
         }
       ],
       "knownAgents": [],
@@ -1375,7 +1382,7 @@
           "source": "https://arxiv.org/abs/2305.15334",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Gorilla (Patil et al.) \u2014 LLM that generates accurate API calls across TorchHub, TensorFlow Hub, and HuggingFace; 20.43% AST accuracy improvement over GPT-4."
+          "notes": "Gorilla (Patil et al.) — LLM that generates accurate API calls across TorchHub, TensorFlow Hub, and HuggingFace; 20.43% AST accuracy improvement over GPT-4."
         }
       ],
       "knownAgents": [],
@@ -1402,7 +1409,7 @@
           "source": "https://arxiv.org/abs/2310.06770",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SWE-bench \u2014 2294 real GitHub issues benchmark; agents that resolve issues must safely refactor code while passing existing test suites."
+          "notes": "SWE-bench — 2294 real GitHub issues benchmark; agents that resolve issues must safely refactor code while passing existing test suites."
         }
       ],
       "knownAgents": [],
@@ -1429,7 +1436,7 @@
           "source": "https://arxiv.org/abs/2107.03374",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Codex/HumanEval (Chen et al.) \u2014 evaluates LLMs on writing Python functions that pass hand-crafted unit tests; pass@1 72.0% for GPT-4."
+          "notes": "Codex/HumanEval (Chen et al.) — evaluates LLMs on writing Python functions that pass hand-crafted unit tests; pass@1 72.0% for GPT-4."
         }
       ],
       "knownAgents": [],
@@ -1456,7 +1463,7 @@
           "source": "https://arxiv.org/abs/2308.13418",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Nougat (Meta AI) \u2014 visual transformer for scientific PDF parsing; 7.6% edit distance on arXiv papers, handling LaTeX, tables, and equations."
+          "notes": "Nougat (Meta AI) — visual transformer for scientific PDF parsing; 7.6% edit distance on arXiv papers, handling LaTeX, tables, and equations."
         }
       ],
       "knownAgents": [],
@@ -1481,7 +1488,7 @@
           "source": "https://arxiv.org/abs/2007.02500",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Deep Learning for Anomaly Detection survey (Pang et al., ACM CSUR) \u2014 comprehensive benchmark of 30+ methods across fraud, intrusion, and medical anomaly detection."
+          "notes": "Deep Learning for Anomaly Detection survey (Pang et al., ACM CSUR) — comprehensive benchmark of 30+ methods across fraud, intrusion, and medical anomaly detection."
         }
       ],
       "knownAgents": [],
@@ -1508,7 +1515,7 @@
           "source": "https://github.com/microsoft/lida",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "LIDA (Microsoft) \u2014 open-source LLM-based data visualization tool with reproducible generation pipeline; evaluated on diverse real-world datasets."
+          "notes": "LIDA (Microsoft) — open-source LLM-based data visualization tool with reproducible generation pipeline; evaluated on diverse real-world datasets."
         }
       ],
       "knownAgents": [],
@@ -1537,7 +1544,7 @@
           "source": "https://github.com/langchain-ai/langchain/tree/master/libs/langchain/langchain/chains/conversation",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "LangChain ConversationChain \u2014 reproducible open-source multi-turn conversational agent with buffer and summary memory backends."
+          "notes": "LangChain ConversationChain — reproducible open-source multi-turn conversational agent with buffer and summary memory backends."
         }
       ],
       "knownAgents": [],
@@ -1566,7 +1573,7 @@
           "source": "https://arxiv.org/abs/2304.11015",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "DIN-SQL \u2014 decomposed in-context learning for text-to-SQL; 82.8% execution accuracy on Spider dev, demonstrating end-to-end pipeline."
+          "notes": "DIN-SQL — decomposed in-context learning for text-to-SQL; 82.8% execution accuracy on Spider dev, demonstrating end-to-end pipeline."
         }
       ],
       "knownAgents": [],
@@ -1597,7 +1604,7 @@
           "source": "https://arxiv.org/abs/2203.09095",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "CodeReviewer (Microsoft) \u2014 pre-trained model for code review tasks; 28.7% BLEU improvement on comment generation and change quality prediction."
+          "notes": "CodeReviewer (Microsoft) — pre-trained model for code review tasks; 28.7% BLEU improvement on comment generation and change quality prediction."
         }
       ],
       "knownAgents": [],
@@ -1628,7 +1635,7 @@
           "source": "https://github.com/Sinaptik-AI/pandas-ai",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "pandas-ai \u2014 open-source agent for natural-language data analysis over pandas DataFrames; reproducible demos with logging and output artifacts."
+          "notes": "pandas-ai — open-source agent for natural-language data analysis over pandas DataFrames; reproducible demos with logging and output artifacts."
         }
       ],
       "knownAgents": [],
@@ -1659,7 +1666,7 @@
           "source": "https://github.com/rasa/rasa",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Rasa Open Source \u2014 production voice agent framework with ASR/TTS integrations; reproducible pipeline with test suite and documented benchmarks."
+          "notes": "Rasa Open Source — production voice agent framework with ASR/TTS integrations; reproducible pipeline with test suite and documented benchmarks."
         }
       ],
       "knownAgents": [],
@@ -1690,7 +1697,7 @@
           "source": "https://github.com/princeton-nlp/SWE-bench",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SWE-bench Verified \u2014 open-source evaluation harness where agents fix GitHub issues by generating and passing test suites; full execution logs archived."
+          "notes": "SWE-bench Verified — open-source evaluation harness where agents fix GitHub issues by generating and passing test suites; full execution logs archived."
         }
       ],
       "knownAgents": [],
@@ -1719,7 +1726,7 @@
           "source": "https://platform.openai.com/docs/guides/moderation",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "OpenAI Moderation API \u2014 publicly documented multi-category content classifier with reproducible API calls, category scores, and evaluation methodology."
+          "notes": "OpenAI Moderation API — publicly documented multi-category content classifier with reproducible API calls, category scores, and evaluation methodology."
         }
       ],
       "knownAgents": [],
@@ -1748,7 +1755,7 @@
           "source": "https://arxiv.org/abs/2304.08485",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "LLaVA \u2014 large language and vision assistant; 85.1% on ScienceQA and 64.3% on TextVQA, establishing reproducible multimodal reasoning benchmark."
+          "notes": "LLaVA — large language and vision assistant; 85.1% on ScienceQA and 64.3% on TextVQA, establishing reproducible multimodal reasoning benchmark."
         }
       ],
       "knownAgents": [],
@@ -1777,7 +1784,7 @@
           "source": "https://arxiv.org/abs/2308.11596",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SeamlessM4T (Meta AI) \u2014 unified speech and text translation model with tone and register control; BLEU +3.3 over NLLB on FLORES-200."
+          "notes": "SeamlessM4T (Meta AI) — unified speech and text translation model with tone and register control; BLEU +3.3 over NLLB on FLORES-200."
         }
       ],
       "knownAgents": [],
@@ -1806,7 +1813,7 @@
           "source": "https://github.com/VikParuchuri/marker",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Marker \u2014 open-source PDF-to-markdown pipeline with reproducible benchmarks; outperforms Nougat on edit distance across 1000+ arXiv PDFs."
+          "notes": "Marker — open-source PDF-to-markdown pipeline with reproducible benchmarks; outperforms Nougat on edit distance across 1000+ arXiv PDFs."
         }
       ],
       "knownAgents": [],
@@ -1835,21 +1842,21 @@
           "source": "https://arxiv.org/abs/2310.06770",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SWE-bench \u2014 2294 real GitHub issues; Claude 3.5 Sonnet (Cognition) resolves 49% on Verified, demonstrating full-cycle autonomous development."
+          "notes": "SWE-bench — 2294 real GitHub issues; Claude 3.5 Sonnet (Cognition) resolves 49% on Verified, demonstrating full-cycle autonomous development."
         },
         {
           "class": "B",
           "source": "https://github.com/princeton-nlp/SWE-agent",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SWE-agent \u2014 open-source agent with AgentComputer Interface; reproducible harness achieving 12.5% on SWE-bench full with logs and eval scripts."
+          "notes": "SWE-agent — open-source agent with AgentComputer Interface; reproducible harness achieving 12.5% on SWE-bench full with logs and eval scripts."
         },
         {
           "class": "A",
           "source": "https://arxiv.org/abs/2402.01030",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "CodeAct \u2014 executable code action space for LLM agents; +20% task completion vs JSON/text-based actions across 17 programming benchmarks."
+          "notes": "CodeAct — executable code action space for LLM agents; +20% task completion vs JSON/text-based actions across 17 programming benchmarks."
         }
       ],
       "knownAgents": [],
@@ -1878,21 +1885,21 @@
           "source": "https://arxiv.org/abs/2210.12641",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "DS-1000 \u2014 benchmark of 1000 data science problems across NumPy/Pandas/Scikit-learn; GPT-4 achieves 43.3% pass@1, establishing reproducible DS evaluation."
+          "notes": "DS-1000 — benchmark of 1000 data science problems across NumPy/Pandas/Scikit-learn; GPT-4 achieves 43.3% pass@1, establishing reproducible DS evaluation."
         },
         {
           "class": "A",
           "source": "https://arxiv.org/abs/2208.01756",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "AutoML Survey (He et al., ACM CSUR) \u2014 systematic review of autonomous ML pipeline search; demonstrates automated feature engineering, model selection, and HPO."
+          "notes": "AutoML Survey (He et al., ACM CSUR) — systematic review of autonomous ML pipeline search; demonstrates automated feature engineering, model selection, and HPO."
         },
         {
           "class": "B",
           "source": "https://github.com/microsoft/autogen",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "AutoGen (Microsoft) \u2014 multi-agent framework with reproducible data science notebooks; science agent achieves 44.3% on DS-1000 with full execution logs."
+          "notes": "AutoGen (Microsoft) — multi-agent framework with reproducible data science notebooks; science agent achieves 44.3% on DS-1000 with full execution logs."
         }
       ],
       "knownAgents": [],
@@ -1921,21 +1928,21 @@
           "source": "https://arxiv.org/abs/2312.11805",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "AudioPaLM (Google) \u2014 unified audio language model supporting real-time spoken dialogue; SOTA on ASR and speech translation, demonstrating end-to-end voice assistant capability."
+          "notes": "AudioPaLM (Google) — unified audio language model supporting real-time spoken dialogue; SOTA on ASR and speech translation, demonstrating end-to-end voice assistant capability."
         },
         {
           "class": "A",
           "source": "https://arxiv.org/abs/2305.11206",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "VoiceBox (Meta AI) \u2014 generative speech model with zero-shot TTS; enables real-time voice assistants with <100ms synthesis latency benchmarked on VCTK."
+          "notes": "VoiceBox (Meta AI) — generative speech model with zero-shot TTS; enables real-time voice assistants with <100ms synthesis latency benchmarked on VCTK."
         },
         {
           "class": "B",
           "source": "https://github.com/openai/whisper",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Whisper + LLM integration demos \u2014 open-source real-time voice assistant pipelines combining Whisper STT, LLM reasoning, and TTS with documented latency benchmarks."
+          "notes": "Whisper + LLM integration demos — open-source real-time voice assistant pipelines combining Whisper STT, LLM reasoning, and TTS with documented latency benchmarks."
         }
       ],
       "knownAgents": [],
@@ -1964,7 +1971,7 @@
           "source": "https://github.com/mbtiongson1/gaia-skill-tree/pull/2",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Reproducible demonstration: Claude Code agent researched 30 popular AI skills, sourced 22 peer-reviewed papers, generated gaia.json via script, passed all 6 validator checks, and submitted PR \u2014 full inputs/outputs archived in the PR diff."
+          "notes": "Reproducible demonstration: Claude Code agent researched 30 popular AI skills, sourced 22 peer-reviewed papers, generated gaia.json via script, passed all 6 validator checks, and submitted PR — full inputs/outputs archived in the PR diff."
         },
         {
           "class": "B",
@@ -1972,12 +1979,19 @@
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
           "notes": "Batch 2 curation: 11 skills added (7 atomic, 3 composite, 1 legendary) with verified Class A/B evidence."
+        },
+        {
+          "class": "B",
+          "source": "https://github.com/mbtiongson1/gaia-skill-tree",
+          "evaluator": "mbtiongson1",
+          "date": "2026-04-29",
+          "notes": "Batch 3 curation: 5 skills added (2 atomic, 3 composite) — self-consistency, few-shot-learning, tree-of-thought, prompt-optimization, tool-creation."
         }
       ],
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-28",
-      "updatedAt": "2026-04-28",
+      "updatedAt": "2026-04-29",
       "version": "0.2.0"
     },
     {
@@ -1989,7 +2003,8 @@
       "description": "Invokes external functions or APIs by generating well-formed call signatures, parsing results, and incorporating them into reasoning.",
       "prerequisites": [],
       "derivatives": [
-        "re-act-reasoning"
+        "re-act-reasoning",
+        "tool-creation"
       ],
       "conditions": "",
       "evidence": [
@@ -1998,20 +2013,20 @@
           "source": "https://arxiv.org/abs/2302.04761",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Toolformer (Schick et al., 2023) \u2014 self-supervised method teaching LLMs to call APIs; zero-shot tool use surpasses GPT-3 175B on several benchmarks."
+          "notes": "Toolformer (Schick et al., 2023) — self-supervised method teaching LLMs to call APIs; zero-shot tool use surpasses GPT-3 175B on several benchmarks."
         },
         {
           "class": "B",
           "source": "https://github.com/OpenBMB/ToolBench",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "ToolBench \u2014 open benchmark with 16,000+ real-world APIs; end-to-end tool-use training and evaluation harness."
+          "notes": "ToolBench — open benchmark with 16,000+ real-world APIs; end-to-end tool-use training and evaluation harness."
         }
       ],
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-28",
-      "updatedAt": "2026-04-28",
+      "updatedAt": "2026-04-29",
       "version": "0.2.0"
     },
     {
@@ -2024,7 +2039,9 @@
       "prerequisites": [],
       "derivatives": [
         "re-act-reasoning",
-        "scientific-discovery"
+        "scientific-discovery",
+        "self-consistency",
+        "tree-of-thought"
       ],
       "conditions": "",
       "evidence": [
@@ -2033,20 +2050,20 @@
           "source": "https://arxiv.org/abs/2201.11903",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Wei et al. (2022) \u2014 Chain-of-Thought Prompting; +18% on GSM8K and +14% on MATH with PaLM 540B vs standard prompting."
+          "notes": "Wei et al. (2022) — Chain-of-Thought Prompting; +18% on GSM8K and +14% on MATH with PaLM 540B vs standard prompting."
         },
         {
           "class": "B",
           "source": "https://github.com/princeton-nlp/chain-of-thought-hub",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Chain-of-Thought Hub \u2014 reproducible evaluation suite covering 10+ reasoning benchmarks with CoT prompts and baselines."
+          "notes": "Chain-of-Thought Hub — reproducible evaluation suite covering 10+ reasoning benchmarks with CoT prompts and baselines."
         }
       ],
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-28",
-      "updatedAt": "2026-04-28",
+      "updatedAt": "2026-04-29",
       "version": "0.2.0"
     },
     {
@@ -2067,14 +2084,14 @@
           "source": "https://arxiv.org/abs/2303.17651",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Self-Refine (Madaan et al., 2023) \u2014 iterative self-feedback loop; +20% on code generation and +13% on math reasoning vs single-pass generation."
+          "notes": "Self-Refine (Madaan et al., 2023) — iterative self-feedback loop; +20% on code generation and +13% on math reasoning vs single-pass generation."
         },
         {
           "class": "B",
           "source": "https://github.com/madaan/self-refine",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Self-Refine repo \u2014 reproducible demos across 7 tasks (code, math, dialogue, sentiment reversal) with evaluation scripts."
+          "notes": "Self-Refine repo — reproducible demos across 7 tasks (code, math, dialogue, sentiment reversal) with evaluation scripts."
         }
       ],
       "knownAgents": [],
@@ -2102,14 +2119,14 @@
           "source": "https://arxiv.org/abs/2307.09702",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Willard & Louf (2023) \u2014 Efficient Guided Generation for LLMs; finite-state machine approach guarantees schema-valid output with <1% throughput overhead."
+          "notes": "Willard & Louf (2023) — Efficient Guided Generation for LLMs; finite-state machine approach guarantees schema-valid output with <1% throughput overhead."
         },
         {
           "class": "B",
           "source": "https://github.com/outlines-dev/outlines",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Outlines library \u2014 production-grade constrained decoding supporting JSON Schema, regex, and CFG grammars; 2k+ GitHub stars."
+          "notes": "Outlines library — production-grade constrained decoding supporting JSON Schema, regex, and CFG grammars; 2k+ GitHub stars."
         }
       ],
       "knownAgents": [],
@@ -2138,14 +2155,14 @@
           "source": "https://arxiv.org/abs/2211.10435",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "PAL (Gao et al., 2023) \u2014 Program-Aided Language Models; delegates computation to Python interpreter, achieving +7% on GSM8K over direct CoT."
+          "notes": "PAL (Gao et al., 2023) — Program-Aided Language Models; delegates computation to Python interpreter, achieving +7% on GSM8K over direct CoT."
         },
         {
           "class": "B",
           "source": "https://github.com/reasoning-machines/pal",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "PAL repo \u2014 reproducible harness across 13 reasoning benchmarks; evaluation scripts and baseline comparisons included."
+          "notes": "PAL repo — reproducible harness across 13 reasoning benchmarks; evaluation scripts and baseline comparisons included."
         }
       ],
       "knownAgents": [],
@@ -2172,14 +2189,14 @@
           "source": "https://arxiv.org/abs/2307.13854",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "WebArena (Zhou et al., 2023) \u2014 realistic 812-task benchmark for autonomous web agents; establishes controlled eval for GUI-based computer use."
+          "notes": "WebArena (Zhou et al., 2023) — realistic 812-task benchmark for autonomous web agents; establishes controlled eval for GUI-based computer use."
         },
         {
           "class": "B",
           "source": "https://github.com/xlang-ai/OSWorld",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "OSWorld \u2014 369 computer tasks across real OS environments (Windows, macOS, Ubuntu); reproducible VM-based evaluation harness."
+          "notes": "OSWorld — 369 computer tasks across real OS environments (Windows, macOS, Ubuntu); reproducible VM-based evaluation harness."
         }
       ],
       "knownAgents": [],
@@ -2206,21 +2223,21 @@
           "source": "https://arxiv.org/abs/2304.05376",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "ChemCrow (Bran et al., 2023) \u2014 LLM augmented with 18 chemistry tools autonomously proposes and validates synthesis routes; GPT-4 outperforms on Chem. benchmark."
+          "notes": "ChemCrow (Bran et al., 2023) — LLM augmented with 18 chemistry tools autonomously proposes and validates synthesis routes; GPT-4 outperforms on Chem. benchmark."
         },
         {
           "class": "A",
           "source": "https://arxiv.org/abs/2304.05332",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Coscientist (Boiko et al., 2023) \u2014 autonomous LLM system designs and executes chemistry experiments; independently re-derived Suzuki coupling conditions."
+          "notes": "Coscientist (Boiko et al., 2023) — autonomous LLM system designs and executes chemistry experiments; independently re-derived Suzuki coupling conditions."
         },
         {
           "class": "B",
           "source": "https://github.com/SakanaAI/AI-Scientist",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "The AI Scientist (Sakana AI) \u2014 end-to-end pipeline generating ideas, running experiments, and writing ML papers; 50+ auto-generated manuscripts reviewed."
+          "notes": "The AI Scientist (Sakana AI) — end-to-end pipeline generating ideas, running experiments, and writing ML papers; 50+ auto-generated manuscripts reviewed."
         }
       ],
       "knownAgents": [],
@@ -2251,14 +2268,14 @@
           "source": "https://arxiv.org/abs/2210.03629",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "ReAct (Yao et al., 2023) \u2014 reasoning+acting paradigm; +34% on HotpotQA and +10% on ALFWorld vs chain-of-thought-only baselines."
+          "notes": "ReAct (Yao et al., 2023) — reasoning+acting paradigm; +34% on HotpotQA and +10% on ALFWorld vs chain-of-thought-only baselines."
         },
         {
           "class": "B",
           "source": "https://github.com/ysymyth/ReAct",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "ReAct repo \u2014 reproducible prompts and evaluation harness for HotpotQA, FEVER, ALFWorld, and WebShop benchmarks."
+          "notes": "ReAct repo — reproducible prompts and evaluation harness for HotpotQA, FEVER, ALFWorld, and WebShop benchmarks."
         }
       ],
       "knownAgents": [],
@@ -2288,14 +2305,14 @@
           "source": "https://arxiv.org/abs/2401.13919",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "WebVoyager (He et al., 2024) \u2014 end-to-end web agent with GPT-4V; 59.1% task success on real-world web tasks across 15 popular websites."
+          "notes": "WebVoyager (He et al., 2024) — end-to-end web agent with GPT-4V; 59.1% task success on real-world web tasks across 15 popular websites."
         },
         {
           "class": "B",
           "source": "https://github.com/web-arena-x/webarena",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "WebArena \u2014 self-hosted web environment with 812 realistic tasks; reproducible benchmark with ground-truth evaluation scripts."
+          "notes": "WebArena — self-hosted web environment with 812 realistic tasks; reproducible benchmark with ground-truth evaluation scripts."
         }
       ],
       "knownAgents": [],
@@ -2326,14 +2343,14 @@
           "source": "https://arxiv.org/abs/2306.08302",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Pan et al. (2024) \u2014 Unifying Large Language Models and Knowledge Graphs: A Roadmap; comprehensive survey showing LLM-KG synergy improves downstream tasks by 5-15%."
+          "notes": "Pan et al. (2024) — Unifying Large Language Models and Knowledge Graphs: A Roadmap; comprehensive survey showing LLM-KG synergy improves downstream tasks by 5-15%."
         },
         {
           "class": "B",
           "source": "https://github.com/microsoft/graphrag",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Microsoft GraphRAG \u2014 production KG construction pipeline; extracts community summaries and entity graphs from corpora, enabling global sensemaking queries."
+          "notes": "Microsoft GraphRAG — production KG construction pipeline; extracts community summaries and entity graphs from corpora, enabling global sensemaking queries."
         }
       ],
       "knownAgents": [],
@@ -2348,7 +2365,7 @@
       "type": "legendary",
       "level": "V",
       "rarity": "legendary",
-      "description": "Autonomously generates novel scientific hypotheses, designs and executes experiments, analyses results, and produces a written report \u2014 completing a full research cycle without human intervention.",
+      "description": "Autonomously generates novel scientific hypotheses, designs and executes experiments, analyses results, and produces a written report — completing a full research cycle without human intervention.",
       "prerequisites": [
         "hypothesis-generate",
         "research",
@@ -2362,27 +2379,195 @@
           "source": "https://arxiv.org/abs/2304.05376",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "ChemCrow (Bran et al., 2023) \u2014 autonomous chemistry agent completes synthesis planning and molecular design tasks rated expert-level by human chemists."
+          "notes": "ChemCrow (Bran et al., 2023) — autonomous chemistry agent completes synthesis planning and molecular design tasks rated expert-level by human chemists."
         },
         {
           "class": "A",
           "source": "https://arxiv.org/abs/2304.05332",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Coscientist (Boiko et al., 2023) \u2014 autonomously planned and executed real wet-lab chemistry experiments, confirmed by GC-MS analysis."
+          "notes": "Coscientist (Boiko et al., 2023) — autonomously planned and executed real wet-lab chemistry experiments, confirmed by GC-MS analysis."
         },
         {
           "class": "B",
           "source": "https://github.com/SakanaAI/AI-Scientist",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "AI Scientist (Lu et al., 2024) \u2014 generates idea, writes code, runs experiments, and produces a full NeurIPS-style paper; 50+ manuscripts auto-generated."
+          "notes": "AI Scientist (Lu et al., 2024) — generates idea, writes code, runs experiments, and produces a full NeurIPS-style paper; 50+ manuscripts auto-generated."
         }
       ],
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-28",
       "updatedAt": "2026-04-28",
+      "version": "0.2.0"
+    },
+    {
+      "id": "self-consistency",
+      "name": "Self-Consistency",
+      "type": "atomic",
+      "level": "IV",
+      "rarity": "rare",
+      "description": "Samples multiple independent reasoning paths for the same problem and selects the answer by majority vote, improving robustness without any additional training.",
+      "prerequisites": [],
+      "derivatives": [
+        "tree-of-thought",
+        "re-act-reasoning"
+      ],
+      "conditions": "",
+      "evidence": [
+        {
+          "class": "A",
+          "source": "https://arxiv.org/abs/2203.11171",
+          "evaluator": "mbtiongson1",
+          "date": "2026-04-29",
+          "notes": "Wang et al. (2022) — Self-Consistency Improves Chain of Thought Reasoning in Language Models; +17.9% on GSM8K and +11.0% on MATH over greedy CoT decoding."
+        }
+      ],
+      "knownAgents": [],
+      "status": "provisional",
+      "createdAt": "2026-04-29",
+      "updatedAt": "2026-04-29",
+      "version": "0.2.0"
+    },
+    {
+      "id": "few-shot-learning",
+      "name": "Few-Shot Learning",
+      "type": "atomic",
+      "level": "IV",
+      "rarity": "common",
+      "description": "Conditions a language model on a small number of input-output demonstrations within the prompt, enabling task adaptation without weight updates.",
+      "prerequisites": [],
+      "derivatives": [
+        "chain-of-thought",
+        "conversational-agent"
+      ],
+      "conditions": "",
+      "evidence": [
+        {
+          "class": "A",
+          "source": "https://arxiv.org/abs/2005.14165",
+          "evaluator": "mbtiongson1",
+          "date": "2026-04-29",
+          "notes": "Brown et al. (2020) — Language Models are Few-Shot Learners (GPT-3); in-context learning from 1-100 examples achieves near-SOTA on SuperGLUE, translation, and QA benchmarks."
+        }
+      ],
+      "knownAgents": [],
+      "status": "provisional",
+      "createdAt": "2026-04-29",
+      "updatedAt": "2026-04-29",
+      "version": "0.2.0"
+    },
+    {
+      "id": "tree-of-thought",
+      "name": "Tree of Thought",
+      "type": "composite",
+      "level": "IV",
+      "rarity": "rare",
+      "description": "Frames problem solving as a search over a tree of partial solutions, using LLM-generated evaluations to prune unpromising branches and backtrack, dramatically improving success on complex reasoning tasks.",
+      "prerequisites": [
+        "chain-of-thought",
+        "plan-decompose"
+      ],
+      "derivatives": [
+        "scientific-discovery"
+      ],
+      "conditions": "",
+      "evidence": [
+        {
+          "class": "A",
+          "source": "https://arxiv.org/abs/2305.10601",
+          "evaluator": "mbtiongson1",
+          "date": "2026-04-29",
+          "notes": "Yao et al. (2023) — Tree of Thoughts: Deliberate Problem Solving with LLMs; +74% on Game of 24 and +4% on Creative Writing vs chain-of-thought baseline."
+        },
+        {
+          "class": "B",
+          "source": "https://github.com/princeton-nlp/tree-of-thought-llm",
+          "evaluator": "mbtiongson1",
+          "date": "2026-04-29",
+          "notes": "Princeton-NLP ToT repo — reproducible breadth-first and depth-first tree search implementations with evaluation scripts for Game of 24 and Mini Crosswords."
+        }
+      ],
+      "knownAgents": [],
+      "status": "provisional",
+      "createdAt": "2026-04-29",
+      "updatedAt": "2026-04-29",
+      "version": "0.2.0"
+    },
+    {
+      "id": "prompt-optimization",
+      "name": "Prompt Optimization",
+      "type": "composite",
+      "level": "IV",
+      "rarity": "uncommon",
+      "description": "Automatically improves prompt instructions through iterative compilation, treating prompts as programs that can be optimized against a metric using LLM-driven feedback loops.",
+      "prerequisites": [
+        "evaluate-output",
+        "generate-text"
+      ],
+      "derivatives": [
+        "registry-curation"
+      ],
+      "conditions": "",
+      "evidence": [
+        {
+          "class": "A",
+          "source": "https://arxiv.org/abs/2310.03714",
+          "evaluator": "mbtiongson1",
+          "date": "2026-04-29",
+          "notes": "Khattab et al. (2023) — DSPy: Compiling Declarative Language Model Calls into Self-Improving Pipelines; automated prompt tuning matches or exceeds hand-crafted prompts on GSM8K, HotPotQA, and FEVER."
+        },
+        {
+          "class": "B",
+          "source": "https://github.com/stanfordnlp/dspy",
+          "evaluator": "mbtiongson1",
+          "date": "2026-04-29",
+          "notes": "DSPy — Stanford NLP library for programmable LM pipelines; 18k+ GitHub stars, supports multiple optimizers (BootstrapFewShot, MIPRO, COPRO) across any LM."
+        }
+      ],
+      "knownAgents": [],
+      "status": "provisional",
+      "createdAt": "2026-04-29",
+      "updatedAt": "2026-04-29",
+      "version": "0.2.0"
+    },
+    {
+      "id": "tool-creation",
+      "name": "Tool Creation",
+      "type": "composite",
+      "level": "IV",
+      "rarity": "rare",
+      "description": "Dynamically generates reusable tool functions (code) at runtime to solve novel sub-tasks, then invokes those tools to complete the overall objective without human-written APIs.",
+      "prerequisites": [
+        "code-generation",
+        "tool-use"
+      ],
+      "derivatives": [
+        "full-stack-developer",
+        "autonomous-research-agent"
+      ],
+      "conditions": "",
+      "evidence": [
+        {
+          "class": "A",
+          "source": "https://arxiv.org/abs/2305.17126",
+          "evaluator": "mbtiongson1",
+          "date": "2026-04-29",
+          "notes": "Cai et al. (2023) — Large Language Models as Tool Makers (LATM); LLM-generated tools reused across problem instances achieve +8.7% on BigBench Hard vs per-instance CoT."
+        },
+        {
+          "class": "B",
+          "source": "https://github.com/ctlllll/LLM-ToolMaker",
+          "evaluator": "mbtiongson1",
+          "date": "2026-04-29",
+          "notes": "LATM repo — reproducible tool-maker/tool-user pipeline with evaluation on BigBench Hard tasks and tool reuse across problem batches."
+        }
+      ],
+      "knownAgents": [],
+      "status": "provisional",
+      "createdAt": "2026-04-29",
+      "updatedAt": "2026-04-29",
       "version": "0.2.0"
     }
   ],
@@ -3311,6 +3496,118 @@
       "sourceSkillId": "math-reason",
       "targetSkillId": "scientific-discovery",
       "edgeType": "prerequisite",
+      "condition": "",
+      "levelFloor": "I",
+      "evidenceRefs": []
+    },
+    {
+      "sourceSkillId": "self-consistency",
+      "targetSkillId": "tree-of-thought",
+      "edgeType": "enhances",
+      "condition": "",
+      "levelFloor": "I",
+      "evidenceRefs": []
+    },
+    {
+      "sourceSkillId": "self-consistency",
+      "targetSkillId": "re-act-reasoning",
+      "edgeType": "enhances",
+      "condition": "",
+      "levelFloor": "I",
+      "evidenceRefs": []
+    },
+    {
+      "sourceSkillId": "few-shot-learning",
+      "targetSkillId": "chain-of-thought",
+      "edgeType": "enhances",
+      "condition": "",
+      "levelFloor": "I",
+      "evidenceRefs": []
+    },
+    {
+      "sourceSkillId": "few-shot-learning",
+      "targetSkillId": "conversational-agent",
+      "edgeType": "enhances",
+      "condition": "",
+      "levelFloor": "I",
+      "evidenceRefs": []
+    },
+    {
+      "sourceSkillId": "chain-of-thought",
+      "targetSkillId": "tree-of-thought",
+      "edgeType": "prerequisite",
+      "condition": "",
+      "levelFloor": "I",
+      "evidenceRefs": []
+    },
+    {
+      "sourceSkillId": "plan-decompose",
+      "targetSkillId": "tree-of-thought",
+      "edgeType": "prerequisite",
+      "condition": "",
+      "levelFloor": "I",
+      "evidenceRefs": []
+    },
+    {
+      "sourceSkillId": "tree-of-thought",
+      "targetSkillId": "scientific-discovery",
+      "edgeType": "enhances",
+      "condition": "",
+      "levelFloor": "I",
+      "evidenceRefs": []
+    },
+    {
+      "sourceSkillId": "evaluate-output",
+      "targetSkillId": "prompt-optimization",
+      "edgeType": "prerequisite",
+      "condition": "",
+      "levelFloor": "I",
+      "evidenceRefs": []
+    },
+    {
+      "sourceSkillId": "generate-text",
+      "targetSkillId": "prompt-optimization",
+      "edgeType": "prerequisite",
+      "condition": "",
+      "levelFloor": "I",
+      "evidenceRefs": []
+    },
+    {
+      "sourceSkillId": "prompt-optimization",
+      "targetSkillId": "registry-curation",
+      "edgeType": "enhances",
+      "condition": "",
+      "levelFloor": "I",
+      "evidenceRefs": []
+    },
+    {
+      "sourceSkillId": "code-generation",
+      "targetSkillId": "tool-creation",
+      "edgeType": "prerequisite",
+      "condition": "",
+      "levelFloor": "I",
+      "evidenceRefs": []
+    },
+    {
+      "sourceSkillId": "tool-use",
+      "targetSkillId": "tool-creation",
+      "edgeType": "prerequisite",
+      "condition": "",
+      "levelFloor": "I",
+      "evidenceRefs": []
+    },
+    {
+      "sourceSkillId": "tool-creation",
+      "targetSkillId": "full-stack-developer",
+      "edgeType": "enhances",
+      "condition": "",
+      "levelFloor": "I",
+      "evidenceRefs": []
+    },
+    {
+      "sourceSkillId": "tool-creation",
+      "targetSkillId": "autonomous-research-agent",
+      "edgeType": "enhances",
       "condition": "",
       "levelFloor": "I",
       "evidenceRefs": []

--- a/registry.md
+++ b/registry.md
@@ -30,6 +30,7 @@
 | ○ Evaluate Output | Intrinsic Skill | I · Awakened | Common | Provisional |
 | ○ Execute Bash | Intrinsic Skill | I · Awakened | Common | Provisional |
 | ○ Extract Entities | Intrinsic Skill | I · Awakened | Common | Provisional |
+| ○ Few-Shot Learning | Intrinsic Skill | IV · Transcendent | Common | Provisional |
 | ○ Format Output | Intrinsic Skill | I · Awakened | Common | Provisional |
 | ◆ True Craftsman: Full-Stack Developer | Ultimate Skill | V · Transcendent | Divine | Provisional |
 | ○ Generate SQL | Intrinsic Skill | II · Named | Common | Provisional |
@@ -51,6 +52,7 @@
 | ○ Parse PDF | Intrinsic Skill | II · Named | Common | Provisional |
 | ◇ Plan and Execute | Extra Skill | III · Evolved | Rare | Provisional |
 | ○ Plan and Decompose | Intrinsic Skill | I · Awakened | Common | Provisional |
+| ◇ Prompt Optimization | Extra Skill | IV · Transcendent | Uncommon | Provisional |
 | ○ Question Answer | Intrinsic Skill | II · Named | Common | Provisional |
 | ◇ RAG Pipeline | Extra Skill | III · Evolved | Uncommon | Provisional |
 | ○ Rank | Intrinsic Skill | I · Awakened | Common | Provisional |
@@ -64,6 +66,7 @@
 | ○ Route Intent | Intrinsic Skill | I · Awakened | Common | Provisional |
 | ◆ True Dragon: Autonomous Scientific Discovery | Ultimate Skill | V · Transcendent | Divine | Provisional |
 | ○ Score Relevance | Intrinsic Skill | I · Awakened | Common | Provisional |
+| ○ Self-Consistency | Intrinsic Skill | IV · Transcendent | Rare | Provisional |
 | ○ Self-Critique | Intrinsic Skill | II · Named | Uncommon | Provisional |
 | ○ Sentiment Analysis | Intrinsic Skill | II · Named | Common | Provisional |
 | ○ Speech to Text | Intrinsic Skill | II · Named | Common | Provisional |
@@ -72,10 +75,12 @@
 | ○ Text to Speech | Intrinsic Skill | II · Named | Common | Provisional |
 | ◇ Text-to-SQL Pipeline | Extra Skill | III · Evolved | Uncommon | Provisional |
 | ○ Tokenize | Intrinsic Skill | I · Awakened | Common | Provisional |
+| ◇ Tool Creation | Extra Skill | IV · Transcendent | Rare | Provisional |
 | ○ Tool Select | Intrinsic Skill | I · Awakened | Common | Provisional |
 | ○ Tool Use | Intrinsic Skill | II · Named | Uncommon | Provisional |
 | ○ Translate | Intrinsic Skill | II · Named | Common | Provisional |
 | ◇ Translation Pipeline | Extra Skill | III · Evolved | Uncommon | Provisional |
+| ◇ Tree of Thought | Extra Skill | IV · Transcendent | Rare | Provisional |
 | ◇ Voice Agent | Extra Skill | III · Evolved | Uncommon | Provisional |
 | ◇ Web Scrape | Extra Skill | III · Evolved | Uncommon | Provisional |
 | ○ Web Search | Intrinsic Skill | I · Awakened | Common | Provisional |

--- a/scripts/add_batch_3_skills.py
+++ b/scripts/add_batch_3_skills.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Batch 3 — inject 5 new skills into graph/gaia.json.
+
+New skills added:
+  Atomic  (2): self-consistency, few-shot-learning
+  Composite (3): tree-of-thought, prompt-optimization, tool-creation
+
+Run from repo root:
+    python3 scripts/add_batch_3_skills.py
+"""
+
+import json
+import os
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+GRAPH_PATH = os.path.join(REPO_ROOT, "graph", "gaia.json")
+TODAY = "2026-04-29"
+VERSION = "0.2.0"
+EVALUATOR = "mbtiongson1"
+
+
+# ---------------------------------------------------------------------------
+# New skills — Atomic
+# ---------------------------------------------------------------------------
+
+NEW_ATOMICS = [
+    {
+        "id": "self-consistency",
+        "name": "Self-Consistency",
+        "type": "atomic",
+        "level": "IV",
+        "rarity": "rare",
+        "description": "Samples multiple independent reasoning paths for the same problem and selects the answer by majority vote, improving robustness without any additional training.",
+        "prerequisites": [],
+        "derivatives": ["tree-of-thought", "re-act-reasoning"],
+        "conditions": "",
+        "evidence": [
+            {
+                "class": "A",
+                "source": "https://arxiv.org/abs/2203.11171",
+                "evaluator": EVALUATOR,
+                "date": TODAY,
+                "notes": "Wang et al. (2022) — Self-Consistency Improves Chain of Thought Reasoning in Language Models; +17.9% on GSM8K and +11.0% on MATH over greedy CoT decoding.",
+            }
+        ],
+        "knownAgents": [],
+        "status": "provisional",
+        "createdAt": TODAY,
+        "updatedAt": TODAY,
+        "version": VERSION,
+    },
+    {
+        "id": "few-shot-learning",
+        "name": "Few-Shot Learning",
+        "type": "atomic",
+        "level": "IV",
+        "rarity": "common",
+        "description": "Conditions a language model on a small number of input-output demonstrations within the prompt, enabling task adaptation without weight updates.",
+        "prerequisites": [],
+        "derivatives": ["chain-of-thought", "conversational-agent"],
+        "conditions": "",
+        "evidence": [
+            {
+                "class": "A",
+                "source": "https://arxiv.org/abs/2005.14165",
+                "evaluator": EVALUATOR,
+                "date": TODAY,
+                "notes": "Brown et al. (2020) — Language Models are Few-Shot Learners (GPT-3); in-context learning from 1-100 examples achieves near-SOTA on SuperGLUE, translation, and QA benchmarks.",
+            }
+        ],
+        "knownAgents": [],
+        "status": "provisional",
+        "createdAt": TODAY,
+        "updatedAt": TODAY,
+        "version": VERSION,
+    },
+]
+
+# ---------------------------------------------------------------------------
+# New skills — Composite
+# ---------------------------------------------------------------------------
+
+NEW_COMPOSITES = [
+    {
+        "id": "tree-of-thought",
+        "name": "Tree of Thought",
+        "type": "composite",
+        "level": "IV",
+        "rarity": "rare",
+        "description": "Frames problem solving as a search over a tree of partial solutions, using LLM-generated evaluations to prune unpromising branches and backtrack, dramatically improving success on complex reasoning tasks.",
+        "prerequisites": ["chain-of-thought", "plan-decompose"],
+        "derivatives": ["scientific-discovery"],
+        "conditions": "",
+        "evidence": [
+            {
+                "class": "A",
+                "source": "https://arxiv.org/abs/2305.10601",
+                "evaluator": EVALUATOR,
+                "date": TODAY,
+                "notes": "Yao et al. (2023) — Tree of Thoughts: Deliberate Problem Solving with LLMs; +74% on Game of 24 and +4% on Creative Writing vs chain-of-thought baseline.",
+            },
+            {
+                "class": "B",
+                "source": "https://github.com/princeton-nlp/tree-of-thought-llm",
+                "evaluator": EVALUATOR,
+                "date": TODAY,
+                "notes": "Princeton-NLP ToT repo — reproducible breadth-first and depth-first tree search implementations with evaluation scripts for Game of 24 and Mini Crosswords.",
+            },
+        ],
+        "knownAgents": [],
+        "status": "provisional",
+        "createdAt": TODAY,
+        "updatedAt": TODAY,
+        "version": VERSION,
+    },
+    {
+        "id": "prompt-optimization",
+        "name": "Prompt Optimization",
+        "type": "composite",
+        "level": "IV",
+        "rarity": "uncommon",
+        "description": "Automatically improves prompt instructions through iterative compilation, treating prompts as programs that can be optimized against a metric using LLM-driven feedback loops.",
+        "prerequisites": ["evaluate-output", "generate-text"],
+        "derivatives": ["registry-curation"],
+        "conditions": "",
+        "evidence": [
+            {
+                "class": "A",
+                "source": "https://arxiv.org/abs/2310.03714",
+                "evaluator": EVALUATOR,
+                "date": TODAY,
+                "notes": "Khattab et al. (2023) — DSPy: Compiling Declarative Language Model Calls into Self-Improving Pipelines; automated prompt tuning matches or exceeds hand-crafted prompts on GSM8K, HotPotQA, and FEVER.",
+            },
+            {
+                "class": "B",
+                "source": "https://github.com/stanfordnlp/dspy",
+                "evaluator": EVALUATOR,
+                "date": TODAY,
+                "notes": "DSPy — Stanford NLP library for programmable LM pipelines; 18k+ GitHub stars, supports multiple optimizers (BootstrapFewShot, MIPRO, COPRO) across any LM.",
+            },
+        ],
+        "knownAgents": [],
+        "status": "provisional",
+        "createdAt": TODAY,
+        "updatedAt": TODAY,
+        "version": VERSION,
+    },
+    {
+        "id": "tool-creation",
+        "name": "Tool Creation",
+        "type": "composite",
+        "level": "IV",
+        "rarity": "rare",
+        "description": "Dynamically generates reusable tool functions (code) at runtime to solve novel sub-tasks, then invokes those tools to complete the overall objective without human-written APIs.",
+        "prerequisites": ["code-generation", "tool-use"],
+        "derivatives": ["full-stack-developer", "autonomous-research-agent"],
+        "conditions": "",
+        "evidence": [
+            {
+                "class": "A",
+                "source": "https://arxiv.org/abs/2305.17126",
+                "evaluator": EVALUATOR,
+                "date": TODAY,
+                "notes": "Cai et al. (2023) — Large Language Models as Tool Makers (LATM); LLM-generated tools reused across problem instances achieve +8.7% on BigBench Hard vs per-instance CoT.",
+            },
+            {
+                "class": "B",
+                "source": "https://github.com/ctlllll/LLM-ToolMaker",
+                "evaluator": EVALUATOR,
+                "date": TODAY,
+                "notes": "LATM repo — reproducible tool-maker/tool-user pipeline with evaluation on BigBench Hard tasks and tool reuse across problem batches.",
+            },
+        ],
+        "knownAgents": [],
+        "status": "provisional",
+        "createdAt": TODAY,
+        "updatedAt": TODAY,
+        "version": VERSION,
+    },
+]
+
+# ---------------------------------------------------------------------------
+# Derivative patches — existing skill IDs → new derivative IDs to append
+# ---------------------------------------------------------------------------
+
+DERIVATIVE_PATCHES = {
+    "chain-of-thought": ["tree-of-thought", "self-consistency"],
+    "plan-decompose":   ["tree-of-thought"],
+    "evaluate-output":  ["prompt-optimization"],
+    "generate-text":    ["prompt-optimization", "few-shot-learning"],
+    "code-generation":  ["tool-creation"],
+    "tool-use":         ["tool-creation"],
+    "classify":         ["few-shot-learning"],
+    "question-answer":  ["few-shot-learning"],
+}
+
+# ---------------------------------------------------------------------------
+# Registry-curation self-evidence entry
+# ---------------------------------------------------------------------------
+
+CURATION_EVIDENCE = {
+    "class": "B",
+    "source": "https://github.com/mbtiongson1/gaia-skill-tree",
+    "evaluator": EVALUATOR,
+    "date": TODAY,
+    "notes": "Batch 3 curation: 5 skills added (2 atomic, 3 composite) — self-consistency, few-shot-learning, tree-of-thought, prompt-optimization, tool-creation.",
+}
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    with open(GRAPH_PATH, "r", encoding="utf-8") as f:
+        graph = json.load(f)
+
+    skills_list = graph["skills"]
+    skill_index = {s["id"]: s for s in skills_list}
+    existing_ids = set(skill_index.keys())
+
+    new_skills = NEW_ATOMICS + NEW_COMPOSITES
+
+    # Deduplicate — skip any IDs already present
+    added = []
+    skipped = []
+    for skill in new_skills:
+        if skill["id"] in existing_ids:
+            skipped.append(skill["id"])
+            continue
+        skills_list.append(skill)
+        existing_ids.add(skill["id"])
+        skill_index[skill["id"]] = skill
+        added.append(skill["id"])
+
+    # Apply derivative patches to existing skills
+    patched = []
+    for skill_id, new_derivatives in DERIVATIVE_PATCHES.items():
+        if skill_id not in skill_index:
+            print(f"  WARN: {skill_id} not found for derivative patch, skipping.")
+            continue
+        target = skill_index[skill_id]
+        current = set(target.get("derivatives", []))
+        to_add = [d for d in new_derivatives if d not in current and d in existing_ids]
+        if to_add:
+            target["derivatives"] = sorted(current | set(to_add))
+            target["updatedAt"] = TODAY
+            patched.append(f"{skill_id} += {to_add}")
+
+    # Add prerequisite edges for new skills
+    edge_set = {(e["sourceSkillId"], e["targetSkillId"]) for e in graph.get("edges", [])}
+    new_edges_added = 0
+    for skill in new_skills:
+        if skill["id"] not in added:
+            continue
+        for prereq in skill.get("prerequisites", []):
+            key = (prereq, skill["id"])
+            if key not in edge_set:
+                graph["edges"].append({
+                    "sourceSkillId": prereq,
+                    "targetSkillId": skill["id"],
+                    "edgeType": "prerequisite",
+                    "condition": "",
+                    "levelFloor": "I",
+                    "evidenceRefs": [],
+                })
+                edge_set.add(key)
+                new_edges_added += 1
+        for deriv in skill.get("derivatives", []):
+            key = (skill["id"], deriv)
+            if key not in edge_set and deriv in existing_ids:
+                graph["edges"].append({
+                    "sourceSkillId": skill["id"],
+                    "targetSkillId": deriv,
+                    "edgeType": "enhances",
+                    "condition": "",
+                    "levelFloor": "I",
+                    "evidenceRefs": [],
+                })
+                edge_set.add(key)
+                new_edges_added += 1
+
+    # Append curation evidence to registry-curation skill
+    if "registry-curation" in skill_index:
+        skill_index["registry-curation"]["evidence"].append(CURATION_EVIDENCE)
+        skill_index["registry-curation"]["updatedAt"] = TODAY
+
+    graph["generatedAt"] = TODAY
+
+    with open(GRAPH_PATH, "w", encoding="utf-8") as f:
+        json.dump(graph, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+
+    print(f"Added {len(added)} skills: {added}")
+    if skipped:
+        print(f"Skipped {len(skipped)} (already exist): {skipped}")
+    print(f"Patched derivatives on {len(patched)} existing skills:")
+    for p in patched:
+        print(f"   {p}")
+    print(f"New edges added: {new_edges_added}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/atomic/chain-of-thought.md
+++ b/skills/atomic/chain-of-thought.md
@@ -16,6 +16,8 @@ _None._
 ## Unlocks
 - [ReAct Reasoning](../composite/re-act-reasoning.md)
 - [True Dragon: Autonomous Scientific Discovery](../legendary/scientific-discovery.md)
+- [Self-Consistency](../atomic/self-consistency.md)
+- [Tree of Thought](../composite/tree-of-thought.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/skills/atomic/classify.md
+++ b/skills/atomic/classify.md
@@ -14,8 +14,9 @@ Assigns one or more categorical labels to an input based on learned or rule-base
 _None._
 
 ## Unlocks
-- [Route Intent](../atomic/route-intent.md)
 - [Content Moderation](../composite/content-moderation.md)
+- [Few-Shot Learning](../atomic/few-shot-learning.md)
+- [Route Intent](../atomic/route-intent.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/skills/atomic/code-generation.md
+++ b/skills/atomic/code-generation.md
@@ -18,6 +18,7 @@ _None._
 - [Code Execution](../atomic/code-execution.md)
 - [Code Review Pipeline](../composite/code-review-pipeline.md)
 - [Registry Curation](../composite/registry-curation.md)
+- [Tool Creation](../composite/tool-creation.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/skills/atomic/evaluate-output.md
+++ b/skills/atomic/evaluate-output.md
@@ -15,6 +15,7 @@ _None._
 
 ## Unlocks
 - [Code Review Pipeline](../composite/code-review-pipeline.md)
+- [Prompt Optimization](../composite/prompt-optimization.md)
 - [Self-Critique](../atomic/self-critique.md)
 
 ## Evidence

--- a/skills/atomic/few-shot-learning.md
+++ b/skills/atomic/few-shot-learning.md
@@ -1,0 +1,29 @@
+# [IV · Transcendent · Intrinsic Skill] Few-Shot Learning
+**ID:** few-shot-learning  
+**Type:** Intrinsic Skill  
+**Level:** IV · Transcendent  
+**Rarity:** Common  
+**Status:** Provisional
+
+---
+
+## Description
+Conditions a language model on a small number of input-output demonstrations within the prompt, enabling task adaptation without weight updates.
+
+## Prerequisites
+_None._
+
+## Unlocks
+- [Chain-of-Thought Reasoning](../atomic/chain-of-thought.md)
+- [Conversational Agent](../composite/conversational-agent.md)
+
+## Evidence
+| Class | Source | Evaluator | Date |
+|---|---|---|---|
+| A | https://arxiv.org/abs/2005.14165 | mbtiongson1 | 2026-04-29 |
+
+## Known Agents
+_None verified yet._
+
+---
+*Generated from gaia.json v1.0.0 on 2026-04-29. Do not edit directly.*

--- a/skills/atomic/generate-text.md
+++ b/skills/atomic/generate-text.md
@@ -14,7 +14,9 @@ Produces coherent natural language output given a prompt, instruction, or contex
 _None._
 
 ## Unlocks
+- [Few-Shot Learning](../atomic/few-shot-learning.md)
 - [Ghostwrite](../composite/ghostwrite.md)
+- [Prompt Optimization](../composite/prompt-optimization.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/skills/atomic/plan-decompose.md
+++ b/skills/atomic/plan-decompose.md
@@ -16,6 +16,7 @@ _None._
 ## Unlocks
 - [Plan and Execute](../composite/plan-and-execute.md)
 - [ReAct Reasoning](../composite/re-act-reasoning.md)
+- [Tree of Thought](../composite/tree-of-thought.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/skills/atomic/question-answer.md
+++ b/skills/atomic/question-answer.md
@@ -15,8 +15,9 @@ _None._
 
 ## Unlocks
 - [Conversational Agent](../composite/conversational-agent.md)
-- [Voice Agent](../composite/voice-agent.md)
+- [Few-Shot Learning](../atomic/few-shot-learning.md)
 - [Multimodal Reasoning](../composite/multimodal-reasoning.md)
+- [Voice Agent](../composite/voice-agent.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/skills/atomic/self-consistency.md
+++ b/skills/atomic/self-consistency.md
@@ -1,0 +1,29 @@
+# [IV · Transcendent · Intrinsic Skill] Self-Consistency
+**ID:** self-consistency  
+**Type:** Intrinsic Skill  
+**Level:** IV · Transcendent  
+**Rarity:** Rare  
+**Status:** Provisional
+
+---
+
+## Description
+Samples multiple independent reasoning paths for the same problem and selects the answer by majority vote, improving robustness without any additional training.
+
+## Prerequisites
+_None._
+
+## Unlocks
+- [Tree of Thought](../composite/tree-of-thought.md)
+- [ReAct Reasoning](../composite/re-act-reasoning.md)
+
+## Evidence
+| Class | Source | Evaluator | Date |
+|---|---|---|---|
+| A | https://arxiv.org/abs/2203.11171 | mbtiongson1 | 2026-04-29 |
+
+## Known Agents
+_None verified yet._
+
+---
+*Generated from gaia.json v1.0.0 on 2026-04-29. Do not edit directly.*

--- a/skills/atomic/tool-use.md
+++ b/skills/atomic/tool-use.md
@@ -15,6 +15,7 @@ _None._
 
 ## Unlocks
 - [ReAct Reasoning](../composite/re-act-reasoning.md)
+- [Tool Creation](../composite/tool-creation.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/skills/composite/prompt-optimization.md
+++ b/skills/composite/prompt-optimization.md
@@ -1,0 +1,33 @@
+# [IV · Transcendent · Extra Skill] Prompt Optimization
+**ID:** prompt-optimization  
+**Type:** Extra Skill  
+**Level:** IV · Transcendent  
+**Rarity:** Uncommon  
+**Status:** Provisional
+
+---
+
+## Description
+Automatically improves prompt instructions through iterative compilation, treating prompts as programs that can be optimized against a metric using LLM-driven feedback loops.
+
+## Prerequisites
+- [Evaluate Output](../atomic/evaluate-output.md)
+- [Generate Text](../atomic/generate-text.md)
+
+## Unlocks
+- [Registry Curation](../composite/registry-curation.md)
+
+## Fusion Condition
+_None specified._
+
+## Evidence
+| Class | Source | Evaluator | Date |
+|---|---|---|---|
+| A | https://arxiv.org/abs/2310.03714 | mbtiongson1 | 2026-04-29 |
+| B | https://github.com/stanfordnlp/dspy | mbtiongson1 | 2026-04-29 |
+
+## Known Agents
+_None verified yet._
+
+---
+*Generated from gaia.json v1.0.0 on 2026-04-29. Do not edit directly.*

--- a/skills/composite/registry-curation.md
+++ b/skills/composite/registry-curation.md
@@ -26,6 +26,7 @@ Requires write access to the canonical graph and a passing validation suite.
 |---|---|---|---|
 | B | https://github.com/mbtiongson1/gaia-skill-tree/pull/2 | mbtiongson1 | 2026-04-28 |
 | B | https://github.com/mbtiongson1/gaia-skill-tree | mbtiongson1 | 2026-04-28 |
+| B | https://github.com/mbtiongson1/gaia-skill-tree | mbtiongson1 | 2026-04-29 |
 
 ## Known Agents
 _None verified yet._

--- a/skills/composite/tool-creation.md
+++ b/skills/composite/tool-creation.md
@@ -1,0 +1,34 @@
+# [IV · Transcendent · Extra Skill] Tool Creation
+**ID:** tool-creation  
+**Type:** Extra Skill  
+**Level:** IV · Transcendent  
+**Rarity:** Rare  
+**Status:** Provisional
+
+---
+
+## Description
+Dynamically generates reusable tool functions (code) at runtime to solve novel sub-tasks, then invokes those tools to complete the overall objective without human-written APIs.
+
+## Prerequisites
+- [Code Generation](../atomic/code-generation.md)
+- [Tool Use](../atomic/tool-use.md)
+
+## Unlocks
+- [True Craftsman: Full-Stack Developer](../legendary/full-stack-developer.md)
+- [Wisdom King: Autonomous Research Agent](../legendary/autonomous-research-agent.md)
+
+## Fusion Condition
+_None specified._
+
+## Evidence
+| Class | Source | Evaluator | Date |
+|---|---|---|---|
+| A | https://arxiv.org/abs/2305.17126 | mbtiongson1 | 2026-04-29 |
+| B | https://github.com/ctlllll/LLM-ToolMaker | mbtiongson1 | 2026-04-29 |
+
+## Known Agents
+_None verified yet._
+
+---
+*Generated from gaia.json v1.0.0 on 2026-04-29. Do not edit directly.*

--- a/skills/composite/tree-of-thought.md
+++ b/skills/composite/tree-of-thought.md
@@ -1,0 +1,33 @@
+# [IV · Transcendent · Extra Skill] Tree of Thought
+**ID:** tree-of-thought  
+**Type:** Extra Skill  
+**Level:** IV · Transcendent  
+**Rarity:** Rare  
+**Status:** Provisional
+
+---
+
+## Description
+Frames problem solving as a search over a tree of partial solutions, using LLM-generated evaluations to prune unpromising branches and backtrack, dramatically improving success on complex reasoning tasks.
+
+## Prerequisites
+- [Chain-of-Thought Reasoning](../atomic/chain-of-thought.md)
+- [Plan and Decompose](../atomic/plan-decompose.md)
+
+## Unlocks
+- [True Dragon: Autonomous Scientific Discovery](../legendary/scientific-discovery.md)
+
+## Fusion Condition
+_None specified._
+
+## Evidence
+| Class | Source | Evaluator | Date |
+|---|---|---|---|
+| A | https://arxiv.org/abs/2305.10601 | mbtiongson1 | 2026-04-29 |
+| B | https://github.com/princeton-nlp/tree-of-thought-llm | mbtiongson1 | 2026-04-29 |
+
+## Known Agents
+_None verified yet._
+
+---
+*Generated from gaia.json v1.0.0 on 2026-04-29. Do not edit directly.*


### PR DESCRIPTION
## Summary

Adds 5 highly-evidenced AI agent skills to the registry:

| ID | Name | Type | Rarity | Evidence |
|---|---|---|---|---|
| `self-consistency` | Self-Consistency | atomic | rare | Class A — Wang et al. 2022 ([arXiv:2203.11171](https://arxiv.org/abs/2203.11171)) |
| `few-shot-learning` | Few-Shot Learning | atomic | common | Class A — Brown et al. 2020 ([arXiv:2005.14165](https://arxiv.org/abs/2005.14165)) |
| `tree-of-thought` | Tree of Thought | composite | rare | Class A — Yao et al. 2023 ([arXiv:2305.10601](https://arxiv.org/abs/2305.10601)) + Class B — [princeton-nlp/tree-of-thought-llm](https://github.com/princeton-nlp/tree-of-thought-llm) |
| `prompt-optimization` | Prompt Optimization | composite | uncommon | Class A — Khattab et al. 2023 ([arXiv:2310.03714](https://arxiv.org/abs/2310.03714)) + Class B — [stanfordnlp/dspy](https://github.com/stanfordnlp/dspy) |
| `tool-creation` | Tool Creation | composite | rare | Class A — Cai et al. 2023 ([arXiv:2305.17126](https://arxiv.org/abs/2305.17126)) + Class B — [ctlllll/LLM-ToolMaker](https://github.com/ctlllll/LLM-ToolMaker) |

## Changes

- Derivative patches applied to 8 existing skills (`chain-of-thought`, `plan-decompose`, `evaluate-output`, `generate-text`, `code-generation`, `tool-use`, `classify`, `question-answer`)
- 14 new edges added to the DAG
- All derived files regenerated (`registry.md`, `combinations.md`, `skills/**/*.md`, `graph/gaia.gexf`)

## Validation

```
Total skills: 83  (was 78)
By type: atomic 51 | composite 25 | legendary 7
Total edges: 113
Max lineage depth: 4
✅ All validation checks passed.
```

## Test plan

- [x] `python3 scripts/validate.py` exits 0
- [x] `python3 scripts/generateProjections.py` completes without error
- [x] `python3 scripts/exportGexf.py` completes without error
- [x] No cycles in DAG
- [x] All prerequisite IDs reference existing skills
- [x] All evidence sources are real, resolvable URLs (arXiv abs pages or GitHub repos)