### PR TITLE
[docs] Add GitHub Pages skill browser MVP

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,27 @@
+# Gaia Skill Registry
+
+Gaia maps AI agent capabilities as a composable skill tree: intrinsic skills, extra skills, and ultimate skills connected by prerequisite relationships.
+
+This page is a lightweight, read-only entrypoint for browsing the registry from GitHub Pages.
+
+## Browse the registry
+
+- [Skill Registry](../registry.md) — canonical generated list of skills, levels, rarity, and evidence links.
+- [Skill Tree](../tree.md) — hierarchy-oriented view of the graph.
+- [Fusion Recipes](../combinations.md) — prerequisite combinations that produce composite skills.
+
+## Contribute
+
+- [Contributing Guide](../CONTRIBUTING.md) — contribution types, naming rules, evidence requirements, and PR workflow.
+- [Skill Source Contributions](./skill_source_contributions.md) — source research notes for broader skill discovery.
+
+## Source of truth
+
+The canonical graph lives in [`graph/gaia.json`](../graph/gaia.json). Files such as `registry.md`, `tree.md`, `combinations.md`, and generated skill pages are projections from that graph.
+
+For graph changes, edit `graph/gaia.json` and run:
+
+```bash
+python3 scripts/validate.py
+python3 scripts/generateProjections.py
+```


### PR DESCRIPTION
## Summary

Adds a minimal GitHub Pages-ready landing page under `docs/` so visitors have a friendly read-only entrypoint into the Gaia skill registry.

## Changes

- Add `docs/index.md` as the Pages landing page.
- Link to the canonical generated registry files:
  - `registry.md`
  - `tree.md`
  - `combinations.md`
- Link to contributor docs and source research notes.
- Keep the MVP framework-free and static.

## Why

The current registry is browsable from GitHub, but a `docs/` entrypoint makes it easier to expose via GitHub Pages and gives non-developer visitors a simpler starting point.

## Existing PRs / related work

Searched open/closed PRs for related Pages / skill browser work. The closest prior work is #32, which added the tutorial link to the README. `origin/main` does not currently include `docs/index.md`, `CNAME`, or a Pages workflow/source file.

## Validation

- Markdown-only change.
- `git diff --check HEAD~1..HEAD`
- No generated files edited.
- No schema or graph changes.

Closes #12
