### PR TITLE
[composite] function-calling — schema-driven tool invocation

### DIFF
--- a/combinations.md
+++ b/combinations.md
@@ -14,6 +14,7 @@
 | ◇ Document Analyst | Extra Skill | Parse JSON, Extract Entities, Summarize, Format Output | III · Evolved |  |
 | ◇ Document Digitization | Extra Skill | Parse PDF, Extract Entities, Format Output | III · Evolved |  |
 | ◆ True Craftsman: Full-Stack Developer | Ultimate Skill | Code Review Pipeline, Automated Testing, Refactor Code | V · Transcendent | Requires access to repository, execution environment, and test runner. Minimum 3 Class A/B evidence sources. |
+| ◇ Function Calling | Extra Skill | Structured Output Generation, API Call, Tool Select | III · Evolved | Requires an available function or tool catalog with machine-readable argument schemas and result contracts. |
 | ◇ Ghostwrite | Extra Skill | Research, Write Report, Audience Model | IV · Transcendent | Requires research output as input context. |
 | ◇ Knowledge Graph Construction | Extra Skill | Extract Entities, Logical Inference | III · Evolved |  |
 | ◇ Knowledge Harvest | Extra Skill | Web Scrape, Extract Entities, Embed Text | IV · Transcendent |  |

--- a/graph/gaia.gexf
+++ b/graph/gaia.gexf
@@ -260,6 +260,14 @@
           <attvalue for="type" value="legendary" />
         </attvalues>
       </node>
+      <node id="function-calling" label="Function Calling">
+        <attvalues>
+          <attvalue for="level" value="III" />
+          <attvalue for="rarity" value="uncommon" />
+          <attvalue for="status" value="provisional" />
+          <attvalue for="type" value="composite" />
+        </attvalues>
+      </node>
       <node id="generate-sql" label="Generate SQL">
         <attvalues>
           <attvalue for="level" value="II" />
@@ -714,62 +722,65 @@
       <edge id="e33" source="code-review-pipeline" target="full-stack-developer" />
       <edge id="e34" source="automated-testing" target="full-stack-developer" />
       <edge id="e35" source="refactor-code" target="full-stack-developer" />
-      <edge id="e36" source="research" target="ghostwrite" />
-      <edge id="e37" source="write-report" target="ghostwrite" />
-      <edge id="e38" source="audience-model" target="ghostwrite" />
-      <edge id="e39" source="extract-entities" target="knowledge-graph-build" />
-      <edge id="e40" source="logical-inference" target="knowledge-graph-build" />
-      <edge id="e41" source="web-scrape" target="knowledge-harvest" />
-      <edge id="e42" source="extract-entities" target="knowledge-harvest" />
-      <edge id="e43" source="embed-text" target="knowledge-harvest" />
-      <edge id="e44" source="plan-and-execute" target="multi-agent-orchestration-v" />
-      <edge id="e45" source="route-intent" target="multi-agent-orchestration-v" />
-      <edge id="e46" source="tool-select" target="multi-agent-orchestration-v" />
-      <edge id="e47" source="image-caption" target="multimodal-reasoning" />
-      <edge id="e48" source="question-answer" target="multimodal-reasoning" />
-      <edge id="e49" source="logical-inference" target="multimodal-reasoning" />
-      <edge id="e50" source="route-intent" target="plan-and-execute" />
-      <edge id="e51" source="plan-decompose" target="plan-and-execute" />
-      <edge id="e52" source="tool-select" target="plan-and-execute" />
-      <edge id="e53" source="evaluate-output" target="prompt-optimization" />
-      <edge id="e54" source="generate-text" target="prompt-optimization" />
-      <edge id="e55" source="retrieve" target="rag-pipeline" />
-      <edge id="e56" source="chunk-document" target="rag-pipeline" />
-      <edge id="e57" source="embed-text" target="rag-pipeline" />
-      <edge id="e58" source="score-relevance" target="rag-pipeline" />
-      <edge id="e59" source="plan-decompose" target="re-act-reasoning" />
-      <edge id="e60" source="tool-use" target="re-act-reasoning" />
-      <edge id="e61" source="voice-agent" target="real-time-voice-assistant" />
-      <edge id="e62" source="memory-manage" target="real-time-voice-assistant" />
-      <edge id="e63" source="plan-and-execute" target="real-time-voice-assistant" />
-      <edge id="e64" source="autonomous-debug" target="recursive-self-improvement" />
-      <edge id="e65" source="evaluate-output" target="recursive-self-improvement" />
-      <edge id="e66" source="plan-and-execute" target="recursive-self-improvement" />
-      <edge id="e67" source="research" target="registry-curation" />
-      <edge id="e68" source="code-generation" target="registry-curation" />
-      <edge id="e69" source="execute-bash" target="registry-curation" />
-      <edge id="e70" source="web-search" target="research" />
-      <edge id="e71" source="summarize" target="research" />
-      <edge id="e72" source="cite-sources" target="research" />
-      <edge id="e73" source="hypothesis-generate" target="scientific-discovery" />
-      <edge id="e74" source="research" target="scientific-discovery" />
-      <edge id="e75" source="math-reason" target="scientific-discovery" />
-      <edge id="e76" source="generate-sql" target="text-to-sql-pipeline" />
-      <edge id="e77" source="parse-json" target="text-to-sql-pipeline" />
-      <edge id="e78" source="format-output" target="text-to-sql-pipeline" />
-      <edge id="e79" source="code-generation" target="tool-creation" />
-      <edge id="e80" source="tool-use" target="tool-creation" />
-      <edge id="e81" source="translate" target="translation-pipeline" />
-      <edge id="e82" source="sentiment-analysis" target="translation-pipeline" />
-      <edge id="e83" source="audience-model" target="translation-pipeline" />
-      <edge id="e84" source="chain-of-thought" target="tree-of-thought" />
-      <edge id="e85" source="plan-decompose" target="tree-of-thought" />
-      <edge id="e86" source="speech-to-text" target="voice-agent" />
-      <edge id="e87" source="question-answer" target="voice-agent" />
-      <edge id="e88" source="text-to-speech" target="voice-agent" />
-      <edge id="e89" source="web-search" target="web-scrape" />
-      <edge id="e90" source="parse-html" target="web-scrape" />
-      <edge id="e91" source="extract-entities" target="web-scrape" />
+      <edge id="e36" source="structured-output" target="function-calling" />
+      <edge id="e37" source="api-call" target="function-calling" />
+      <edge id="e38" source="tool-select" target="function-calling" />
+      <edge id="e39" source="research" target="ghostwrite" />
+      <edge id="e40" source="write-report" target="ghostwrite" />
+      <edge id="e41" source="audience-model" target="ghostwrite" />
+      <edge id="e42" source="extract-entities" target="knowledge-graph-build" />
+      <edge id="e43" source="logical-inference" target="knowledge-graph-build" />
+      <edge id="e44" source="web-scrape" target="knowledge-harvest" />
+      <edge id="e45" source="extract-entities" target="knowledge-harvest" />
+      <edge id="e46" source="embed-text" target="knowledge-harvest" />
+      <edge id="e47" source="plan-and-execute" target="multi-agent-orchestration-v" />
+      <edge id="e48" source="route-intent" target="multi-agent-orchestration-v" />
+      <edge id="e49" source="tool-select" target="multi-agent-orchestration-v" />
+      <edge id="e50" source="image-caption" target="multimodal-reasoning" />
+      <edge id="e51" source="question-answer" target="multimodal-reasoning" />
+      <edge id="e52" source="logical-inference" target="multimodal-reasoning" />
+      <edge id="e53" source="route-intent" target="plan-and-execute" />
+      <edge id="e54" source="plan-decompose" target="plan-and-execute" />
+      <edge id="e55" source="tool-select" target="plan-and-execute" />
+      <edge id="e56" source="evaluate-output" target="prompt-optimization" />
+      <edge id="e57" source="generate-text" target="prompt-optimization" />
+      <edge id="e58" source="retrieve" target="rag-pipeline" />
+      <edge id="e59" source="chunk-document" target="rag-pipeline" />
+      <edge id="e60" source="embed-text" target="rag-pipeline" />
+      <edge id="e61" source="score-relevance" target="rag-pipeline" />
+      <edge id="e62" source="plan-decompose" target="re-act-reasoning" />
+      <edge id="e63" source="tool-use" target="re-act-reasoning" />
+      <edge id="e64" source="voice-agent" target="real-time-voice-assistant" />
+      <edge id="e65" source="memory-manage" target="real-time-voice-assistant" />
+      <edge id="e66" source="plan-and-execute" target="real-time-voice-assistant" />
+      <edge id="e67" source="autonomous-debug" target="recursive-self-improvement" />
+      <edge id="e68" source="evaluate-output" target="recursive-self-improvement" />
+      <edge id="e69" source="plan-and-execute" target="recursive-self-improvement" />
+      <edge id="e70" source="research" target="registry-curation" />
+      <edge id="e71" source="code-generation" target="registry-curation" />
+      <edge id="e72" source="execute-bash" target="registry-curation" />
+      <edge id="e73" source="web-search" target="research" />
+      <edge id="e74" source="summarize" target="research" />
+      <edge id="e75" source="cite-sources" target="research" />
+      <edge id="e76" source="hypothesis-generate" target="scientific-discovery" />
+      <edge id="e77" source="research" target="scientific-discovery" />
+      <edge id="e78" source="math-reason" target="scientific-discovery" />
+      <edge id="e79" source="generate-sql" target="text-to-sql-pipeline" />
+      <edge id="e80" source="parse-json" target="text-to-sql-pipeline" />
+      <edge id="e81" source="format-output" target="text-to-sql-pipeline" />
+      <edge id="e82" source="code-generation" target="tool-creation" />
+      <edge id="e83" source="tool-use" target="tool-creation" />
+      <edge id="e84" source="translate" target="translation-pipeline" />
+      <edge id="e85" source="sentiment-analysis" target="translation-pipeline" />
+      <edge id="e86" source="audience-model" target="translation-pipeline" />
+      <edge id="e87" source="chain-of-thought" target="tree-of-thought" />
+      <edge id="e88" source="plan-decompose" target="tree-of-thought" />
+      <edge id="e89" source="speech-to-text" target="voice-agent" />
+      <edge id="e90" source="question-answer" target="voice-agent" />
+      <edge id="e91" source="text-to-speech" target="voice-agent" />
+      <edge id="e92" source="web-search" target="web-scrape" />
+      <edge id="e93" source="parse-html" target="web-scrape" />
+      <edge id="e94" source="extract-entities" target="web-scrape" />
     </edges>
   </graph>
 </gexf>

--- a/graph/gaia.json
+++ b/graph/gaia.json
@@ -14,7 +14,7 @@
       "III": "Evolved",
       "IV": "Transcendent",
       "V": "Transcendent",
-      "VI": "Transcendent ★"
+      "VI": "Transcendent \u2605"
     },
     "rarityLabels": {
       "legendary": "Divine"
@@ -540,7 +540,8 @@
       "derivatives": [
         "plan-and-execute",
         "re-act-reasoning",
-        "tool-use"
+        "tool-use",
+        "function-calling"
       ],
       "conditions": "",
       "evidence": [
@@ -995,7 +996,7 @@
           "source": "https://github.com/gaia-registry/gaia/blob/main/docs/evidence/seed.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Seed evidence — structural validation placeholder."
+          "notes": "Seed evidence \u2014 structural validation placeholder."
         }
       ],
       "knownAgents": [],
@@ -1024,7 +1025,7 @@
           "source": "https://github.com/gaia-registry/gaia/blob/main/docs/evidence/seed.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Seed evidence — structural validation placeholder."
+          "notes": "Seed evidence \u2014 structural validation placeholder."
         }
       ],
       "knownAgents": [],
@@ -1053,7 +1054,7 @@
           "source": "https://github.com/gaia-registry/gaia/blob/main/docs/evidence/seed.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Seed evidence — apex tier structural validation placeholder."
+          "notes": "Seed evidence \u2014 apex tier structural validation placeholder."
         }
       ],
       "knownAgents": [],
@@ -1080,7 +1081,7 @@
           "source": "https://arxiv.org/abs/2207.04672",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "NLLB (No Language Left Behind) — Meta AI paper demonstrating 200-language translation at human-level quality on FLORES-200 benchmark."
+          "notes": "NLLB (No Language Left Behind) \u2014 Meta AI paper demonstrating 200-language translation at human-level quality on FLORES-200 benchmark."
         }
       ],
       "knownAgents": [],
@@ -1108,7 +1109,7 @@
           "source": "https://arxiv.org/abs/1810.04805",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "BERT paper — achieves SOTA on SST-2 sentiment benchmark (93.5% accuracy), foundational evidence for LLM-based sentiment analysis."
+          "notes": "BERT paper \u2014 achieves SOTA on SST-2 sentiment benchmark (93.5% accuracy), foundational evidence for LLM-based sentiment analysis."
         }
       ],
       "knownAgents": [],
@@ -1135,7 +1136,7 @@
           "source": "https://arxiv.org/abs/2301.12597",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "BLIP-2 — bootstrapped language-image pre-training achieving SOTA on COCO Captions (CIDEr 145.8) and NoCaps benchmarks."
+          "notes": "BLIP-2 \u2014 bootstrapped language-image pre-training achieving SOTA on COCO Captions (CIDEr 145.8) and NoCaps benchmarks."
         }
       ],
       "knownAgents": [],
@@ -1162,7 +1163,7 @@
           "source": "https://arxiv.org/abs/2212.04356",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Whisper (OpenAI) — large-scale weak supervision across 680K hours of audio achieves near-human WER on LibriSpeech and multilingual benchmarks."
+          "notes": "Whisper (OpenAI) \u2014 large-scale weak supervision across 680K hours of audio achieves near-human WER on LibriSpeech and multilingual benchmarks."
         }
       ],
       "knownAgents": [],
@@ -1189,7 +1190,7 @@
           "source": "https://arxiv.org/abs/2301.02111",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "VALL-E (Microsoft) — neural codec language model achieving SOTA speech synthesis with 3-second voice cloning on LibriSpeech."
+          "notes": "VALL-E (Microsoft) \u2014 neural codec language model achieving SOTA speech synthesis with 3-second voice cloning on LibriSpeech."
         }
       ],
       "knownAgents": [],
@@ -1217,7 +1218,7 @@
           "source": "https://arxiv.org/abs/1809.08887",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Spider benchmark — cross-domain text-to-SQL dataset; LLM baselines reach >85% exact match, establishing reproducible evaluation methodology."
+          "notes": "Spider benchmark \u2014 cross-domain text-to-SQL dataset; LLM baselines reach >85% exact match, establishing reproducible evaluation methodology."
         }
       ],
       "knownAgents": [],
@@ -1247,7 +1248,7 @@
           "source": "https://arxiv.org/abs/1806.03822",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SQuAD 2.0 — reading comprehension benchmark with 150K questions; modern LLMs exceed human F1 (90.9), providing rigorous reproducible evaluation."
+          "notes": "SQuAD 2.0 \u2014 reading comprehension benchmark with 150K questions; modern LLMs exceed human F1 (90.9), providing rigorous reproducible evaluation."
         }
       ],
       "knownAgents": [],
@@ -1272,7 +1273,7 @@
           "source": "https://arxiv.org/abs/2112.10752",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Latent Diffusion Models (Rombach et al.) — foundational paper for Stable Diffusion; achieves FID 5.11 on LSUN-Beds at 200× less compute than pixel-space diffusion."
+          "notes": "Latent Diffusion Models (Rombach et al.) \u2014 foundational paper for Stable Diffusion; achieves FID 5.11 on LSUN-Beds at 200\u00d7 less compute than pixel-space diffusion."
         }
       ],
       "knownAgents": [],
@@ -1300,7 +1301,7 @@
           "source": "https://arxiv.org/abs/2206.14858",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Minerva (Google) — 50.3% on MATH and 78.5% on MMLU-STEM benchmarks using chain-of-thought over scientific literature."
+          "notes": "Minerva (Google) \u2014 50.3% on MATH and 78.5% on MMLU-STEM benchmarks using chain-of-thought over scientific literature."
         }
       ],
       "knownAgents": [],
@@ -1329,7 +1330,7 @@
           "source": "https://arxiv.org/abs/2201.11903",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Chain-of-Thought prompting (Wei et al.) — few-shot CoT elicits multi-step reasoning; +18% on GSM8K and +15% on SVAMP over standard prompting."
+          "notes": "Chain-of-Thought prompting (Wei et al.) \u2014 few-shot CoT elicits multi-step reasoning; +18% on GSM8K and +15% on SVAMP over standard prompting."
         }
       ],
       "knownAgents": [],
@@ -1357,7 +1358,7 @@
           "source": "https://arxiv.org/abs/2310.08560",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "MemGPT — virtual context management system enabling LLMs to handle unbounded memory; benchmarked on multi-session dialogue and document QA."
+          "notes": "MemGPT \u2014 virtual context management system enabling LLMs to handle unbounded memory; benchmarked on multi-session dialogue and document QA."
         }
       ],
       "knownAgents": [],
@@ -1374,7 +1375,9 @@
       "rarity": "common",
       "description": "Constructs, executes, and handles responses from HTTP APIs by interpreting documentation and selecting appropriate endpoints and parameters.",
       "prerequisites": [],
-      "derivatives": [],
+      "derivatives": [
+        "function-calling"
+      ],
       "conditions": "",
       "evidence": [
         {
@@ -1382,7 +1385,7 @@
           "source": "https://arxiv.org/abs/2305.15334",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Gorilla (Patil et al.) — LLM that generates accurate API calls across TorchHub, TensorFlow Hub, and HuggingFace; 20.43% AST accuracy improvement over GPT-4."
+          "notes": "Gorilla (Patil et al.) \u2014 LLM that generates accurate API calls across TorchHub, TensorFlow Hub, and HuggingFace; 20.43% AST accuracy improvement over GPT-4."
         }
       ],
       "knownAgents": [],
@@ -1409,7 +1412,7 @@
           "source": "https://arxiv.org/abs/2310.06770",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SWE-bench — 2294 real GitHub issues benchmark; agents that resolve issues must safely refactor code while passing existing test suites."
+          "notes": "SWE-bench \u2014 2294 real GitHub issues benchmark; agents that resolve issues must safely refactor code while passing existing test suites."
         }
       ],
       "knownAgents": [],
@@ -1436,7 +1439,7 @@
           "source": "https://arxiv.org/abs/2107.03374",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Codex/HumanEval (Chen et al.) — evaluates LLMs on writing Python functions that pass hand-crafted unit tests; pass@1 72.0% for GPT-4."
+          "notes": "Codex/HumanEval (Chen et al.) \u2014 evaluates LLMs on writing Python functions that pass hand-crafted unit tests; pass@1 72.0% for GPT-4."
         }
       ],
       "knownAgents": [],
@@ -1463,7 +1466,7 @@
           "source": "https://arxiv.org/abs/2308.13418",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Nougat (Meta AI) — visual transformer for scientific PDF parsing; 7.6% edit distance on arXiv papers, handling LaTeX, tables, and equations."
+          "notes": "Nougat (Meta AI) \u2014 visual transformer for scientific PDF parsing; 7.6% edit distance on arXiv papers, handling LaTeX, tables, and equations."
         }
       ],
       "knownAgents": [],
@@ -1488,7 +1491,7 @@
           "source": "https://arxiv.org/abs/2007.02500",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Deep Learning for Anomaly Detection survey (Pang et al., ACM CSUR) — comprehensive benchmark of 30+ methods across fraud, intrusion, and medical anomaly detection."
+          "notes": "Deep Learning for Anomaly Detection survey (Pang et al., ACM CSUR) \u2014 comprehensive benchmark of 30+ methods across fraud, intrusion, and medical anomaly detection."
         }
       ],
       "knownAgents": [],
@@ -1515,7 +1518,7 @@
           "source": "https://github.com/microsoft/lida",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "LIDA (Microsoft) — open-source LLM-based data visualization tool with reproducible generation pipeline; evaluated on diverse real-world datasets."
+          "notes": "LIDA (Microsoft) \u2014 open-source LLM-based data visualization tool with reproducible generation pipeline; evaluated on diverse real-world datasets."
         }
       ],
       "knownAgents": [],
@@ -1544,7 +1547,7 @@
           "source": "https://github.com/langchain-ai/langchain/tree/master/libs/langchain/langchain/chains/conversation",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "LangChain ConversationChain — reproducible open-source multi-turn conversational agent with buffer and summary memory backends."
+          "notes": "LangChain ConversationChain \u2014 reproducible open-source multi-turn conversational agent with buffer and summary memory backends."
         }
       ],
       "knownAgents": [],
@@ -1573,7 +1576,7 @@
           "source": "https://arxiv.org/abs/2304.11015",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "DIN-SQL — decomposed in-context learning for text-to-SQL; 82.8% execution accuracy on Spider dev, demonstrating end-to-end pipeline."
+          "notes": "DIN-SQL \u2014 decomposed in-context learning for text-to-SQL; 82.8% execution accuracy on Spider dev, demonstrating end-to-end pipeline."
         }
       ],
       "knownAgents": [],
@@ -1604,7 +1607,7 @@
           "source": "https://arxiv.org/abs/2203.09095",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "CodeReviewer (Microsoft) — pre-trained model for code review tasks; 28.7% BLEU improvement on comment generation and change quality prediction."
+          "notes": "CodeReviewer (Microsoft) \u2014 pre-trained model for code review tasks; 28.7% BLEU improvement on comment generation and change quality prediction."
         }
       ],
       "knownAgents": [],
@@ -1635,7 +1638,7 @@
           "source": "https://github.com/Sinaptik-AI/pandas-ai",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "pandas-ai — open-source agent for natural-language data analysis over pandas DataFrames; reproducible demos with logging and output artifacts."
+          "notes": "pandas-ai \u2014 open-source agent for natural-language data analysis over pandas DataFrames; reproducible demos with logging and output artifacts."
         }
       ],
       "knownAgents": [],
@@ -1666,7 +1669,7 @@
           "source": "https://github.com/rasa/rasa",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Rasa Open Source — production voice agent framework with ASR/TTS integrations; reproducible pipeline with test suite and documented benchmarks."
+          "notes": "Rasa Open Source \u2014 production voice agent framework with ASR/TTS integrations; reproducible pipeline with test suite and documented benchmarks."
         }
       ],
       "knownAgents": [],
@@ -1697,7 +1700,7 @@
           "source": "https://github.com/princeton-nlp/SWE-bench",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SWE-bench Verified — open-source evaluation harness where agents fix GitHub issues by generating and passing test suites; full execution logs archived."
+          "notes": "SWE-bench Verified \u2014 open-source evaluation harness where agents fix GitHub issues by generating and passing test suites; full execution logs archived."
         }
       ],
       "knownAgents": [],
@@ -1726,7 +1729,7 @@
           "source": "https://platform.openai.com/docs/guides/moderation",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "OpenAI Moderation API — publicly documented multi-category content classifier with reproducible API calls, category scores, and evaluation methodology."
+          "notes": "OpenAI Moderation API \u2014 publicly documented multi-category content classifier with reproducible API calls, category scores, and evaluation methodology."
         }
       ],
       "knownAgents": [],
@@ -1755,7 +1758,7 @@
           "source": "https://arxiv.org/abs/2304.08485",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "LLaVA — large language and vision assistant; 85.1% on ScienceQA and 64.3% on TextVQA, establishing reproducible multimodal reasoning benchmark."
+          "notes": "LLaVA \u2014 large language and vision assistant; 85.1% on ScienceQA and 64.3% on TextVQA, establishing reproducible multimodal reasoning benchmark."
         }
       ],
       "knownAgents": [],
@@ -1784,7 +1787,7 @@
           "source": "https://arxiv.org/abs/2308.11596",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SeamlessM4T (Meta AI) — unified speech and text translation model with tone and register control; BLEU +3.3 over NLLB on FLORES-200."
+          "notes": "SeamlessM4T (Meta AI) \u2014 unified speech and text translation model with tone and register control; BLEU +3.3 over NLLB on FLORES-200."
         }
       ],
       "knownAgents": [],
@@ -1813,7 +1816,7 @@
           "source": "https://github.com/VikParuchuri/marker",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Marker — open-source PDF-to-markdown pipeline with reproducible benchmarks; outperforms Nougat on edit distance across 1000+ arXiv PDFs."
+          "notes": "Marker \u2014 open-source PDF-to-markdown pipeline with reproducible benchmarks; outperforms Nougat on edit distance across 1000+ arXiv PDFs."
         }
       ],
       "knownAgents": [],
@@ -1842,21 +1845,21 @@
           "source": "https://arxiv.org/abs/2310.06770",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SWE-bench — 2294 real GitHub issues; Claude 3.5 Sonnet (Cognition) resolves 49% on Verified, demonstrating full-cycle autonomous development."
+          "notes": "SWE-bench \u2014 2294 real GitHub issues; Claude 3.5 Sonnet (Cognition) resolves 49% on Verified, demonstrating full-cycle autonomous development."
         },
         {
           "class": "B",
           "source": "https://github.com/princeton-nlp/SWE-agent",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SWE-agent — open-source agent with AgentComputer Interface; reproducible harness achieving 12.5% on SWE-bench full with logs and eval scripts."
+          "notes": "SWE-agent \u2014 open-source agent with AgentComputer Interface; reproducible harness achieving 12.5% on SWE-bench full with logs and eval scripts."
         },
         {
           "class": "A",
           "source": "https://arxiv.org/abs/2402.01030",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "CodeAct — executable code action space for LLM agents; +20% task completion vs JSON/text-based actions across 17 programming benchmarks."
+          "notes": "CodeAct \u2014 executable code action space for LLM agents; +20% task completion vs JSON/text-based actions across 17 programming benchmarks."
         }
       ],
       "knownAgents": [],
@@ -1885,21 +1888,21 @@
           "source": "https://arxiv.org/abs/2210.12641",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "DS-1000 — benchmark of 1000 data science problems across NumPy/Pandas/Scikit-learn; GPT-4 achieves 43.3% pass@1, establishing reproducible DS evaluation."
+          "notes": "DS-1000 \u2014 benchmark of 1000 data science problems across NumPy/Pandas/Scikit-learn; GPT-4 achieves 43.3% pass@1, establishing reproducible DS evaluation."
         },
         {
           "class": "A",
           "source": "https://arxiv.org/abs/2208.01756",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "AutoML Survey (He et al., ACM CSUR) — systematic review of autonomous ML pipeline search; demonstrates automated feature engineering, model selection, and HPO."
+          "notes": "AutoML Survey (He et al., ACM CSUR) \u2014 systematic review of autonomous ML pipeline search; demonstrates automated feature engineering, model selection, and HPO."
         },
         {
           "class": "B",
           "source": "https://github.com/microsoft/autogen",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "AutoGen (Microsoft) — multi-agent framework with reproducible data science notebooks; science agent achieves 44.3% on DS-1000 with full execution logs."
+          "notes": "AutoGen (Microsoft) \u2014 multi-agent framework with reproducible data science notebooks; science agent achieves 44.3% on DS-1000 with full execution logs."
         }
       ],
       "knownAgents": [],
@@ -1928,21 +1931,21 @@
           "source": "https://arxiv.org/abs/2312.11805",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "AudioPaLM (Google) — unified audio language model supporting real-time spoken dialogue; SOTA on ASR and speech translation, demonstrating end-to-end voice assistant capability."
+          "notes": "AudioPaLM (Google) \u2014 unified audio language model supporting real-time spoken dialogue; SOTA on ASR and speech translation, demonstrating end-to-end voice assistant capability."
         },
         {
           "class": "A",
           "source": "https://arxiv.org/abs/2305.11206",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "VoiceBox (Meta AI) — generative speech model with zero-shot TTS; enables real-time voice assistants with <100ms synthesis latency benchmarked on VCTK."
+          "notes": "VoiceBox (Meta AI) \u2014 generative speech model with zero-shot TTS; enables real-time voice assistants with <100ms synthesis latency benchmarked on VCTK."
         },
         {
           "class": "B",
           "source": "https://github.com/openai/whisper",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Whisper + LLM integration demos — open-source real-time voice assistant pipelines combining Whisper STT, LLM reasoning, and TTS with documented latency benchmarks."
+          "notes": "Whisper + LLM integration demos \u2014 open-source real-time voice assistant pipelines combining Whisper STT, LLM reasoning, and TTS with documented latency benchmarks."
         }
       ],
       "knownAgents": [],
@@ -1971,7 +1974,7 @@
           "source": "https://github.com/mbtiongson1/gaia-skill-tree/pull/2",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Reproducible demonstration: Claude Code agent researched 30 popular AI skills, sourced 22 peer-reviewed papers, generated gaia.json via script, passed all 6 validator checks, and submitted PR — full inputs/outputs archived in the PR diff."
+          "notes": "Reproducible demonstration: Claude Code agent researched 30 popular AI skills, sourced 22 peer-reviewed papers, generated gaia.json via script, passed all 6 validator checks, and submitted PR \u2014 full inputs/outputs archived in the PR diff."
         },
         {
           "class": "B",
@@ -1985,7 +1988,7 @@
           "source": "https://github.com/mbtiongson1/gaia-skill-tree",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Batch 3 curation: 5 skills added (2 atomic, 3 composite) — self-consistency, few-shot-learning, tree-of-thought, prompt-optimization, tool-creation."
+          "notes": "Batch 3 curation: 5 skills added (2 atomic, 3 composite) \u2014 self-consistency, few-shot-learning, tree-of-thought, prompt-optimization, tool-creation."
         }
       ],
       "knownAgents": [],
@@ -2013,14 +2016,14 @@
           "source": "https://arxiv.org/abs/2302.04761",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Toolformer (Schick et al., 2023) — self-supervised method teaching LLMs to call APIs; zero-shot tool use surpasses GPT-3 175B on several benchmarks."
+          "notes": "Toolformer (Schick et al., 2023) \u2014 self-supervised method teaching LLMs to call APIs; zero-shot tool use surpasses GPT-3 175B on several benchmarks."
         },
         {
           "class": "B",
           "source": "https://github.com/OpenBMB/ToolBench",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "ToolBench — open benchmark with 16,000+ real-world APIs; end-to-end tool-use training and evaluation harness."
+          "notes": "ToolBench \u2014 open benchmark with 16,000+ real-world APIs; end-to-end tool-use training and evaluation harness."
         }
       ],
       "knownAgents": [],
@@ -2028,6 +2031,42 @@
       "createdAt": "2026-04-28",
       "updatedAt": "2026-04-29",
       "version": "0.2.0"
+    },
+    {
+      "id": "function-calling",
+      "name": "Function Calling",
+      "type": "composite",
+      "level": "III",
+      "rarity": "uncommon",
+      "description": "Selects an external callable, emits schema-valid arguments, invokes the function or API, and integrates the returned result into the agent loop.",
+      "prerequisites": [
+        "structured-output",
+        "api-call",
+        "tool-select"
+      ],
+      "derivatives": [],
+      "conditions": "Requires an available function or tool catalog with machine-readable argument schemas and result contracts.",
+      "evidence": [
+        {
+          "class": "A",
+          "source": "https://arxiv.org/abs/2307.16789",
+          "evaluator": "rico-favor",
+          "date": "2026-04-29",
+          "notes": "ToolLLM / ToolBench demonstrates LLM tool invocation over 16,000+ real-world APIs with documented evaluation tasks and failure analysis, supporting function calling as a schema-driven tool-use pattern."
+        },
+        {
+          "class": "A",
+          "source": "https://arxiv.org/abs/2305.15334",
+          "evaluator": "rico-favor",
+          "date": "2026-04-29",
+          "notes": "Gorilla / APIBench evaluates model generation of API calls across large API collections, including accurate endpoint and argument selection."
+        }
+      ],
+      "knownAgents": [],
+      "status": "provisional",
+      "createdAt": "2026-04-29",
+      "updatedAt": "2026-04-29",
+      "version": "0.1.0"
     },
     {
       "id": "chain-of-thought",
@@ -2050,14 +2089,14 @@
           "source": "https://arxiv.org/abs/2201.11903",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Wei et al. (2022) — Chain-of-Thought Prompting; +18% on GSM8K and +14% on MATH with PaLM 540B vs standard prompting."
+          "notes": "Wei et al. (2022) \u2014 Chain-of-Thought Prompting; +18% on GSM8K and +14% on MATH with PaLM 540B vs standard prompting."
         },
         {
           "class": "B",
           "source": "https://github.com/princeton-nlp/chain-of-thought-hub",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Chain-of-Thought Hub — reproducible evaluation suite covering 10+ reasoning benchmarks with CoT prompts and baselines."
+          "notes": "Chain-of-Thought Hub \u2014 reproducible evaluation suite covering 10+ reasoning benchmarks with CoT prompts and baselines."
         }
       ],
       "knownAgents": [],
@@ -2084,14 +2123,14 @@
           "source": "https://arxiv.org/abs/2303.17651",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Self-Refine (Madaan et al., 2023) — iterative self-feedback loop; +20% on code generation and +13% on math reasoning vs single-pass generation."
+          "notes": "Self-Refine (Madaan et al., 2023) \u2014 iterative self-feedback loop; +20% on code generation and +13% on math reasoning vs single-pass generation."
         },
         {
           "class": "B",
           "source": "https://github.com/madaan/self-refine",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Self-Refine repo — reproducible demos across 7 tasks (code, math, dialogue, sentiment reversal) with evaluation scripts."
+          "notes": "Self-Refine repo \u2014 reproducible demos across 7 tasks (code, math, dialogue, sentiment reversal) with evaluation scripts."
         }
       ],
       "knownAgents": [],
@@ -2110,7 +2149,8 @@
       "prerequisites": [],
       "derivatives": [
         "rag-pipeline",
-        "text-to-sql-pipeline"
+        "text-to-sql-pipeline",
+        "function-calling"
       ],
       "conditions": "",
       "evidence": [
@@ -2119,14 +2159,14 @@
           "source": "https://arxiv.org/abs/2307.09702",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Willard & Louf (2023) — Efficient Guided Generation for LLMs; finite-state machine approach guarantees schema-valid output with <1% throughput overhead."
+          "notes": "Willard & Louf (2023) \u2014 Efficient Guided Generation for LLMs; finite-state machine approach guarantees schema-valid output with <1% throughput overhead."
         },
         {
           "class": "B",
           "source": "https://github.com/outlines-dev/outlines",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Outlines library — production-grade constrained decoding supporting JSON Schema, regex, and CFG grammars; 2k+ GitHub stars."
+          "notes": "Outlines library \u2014 production-grade constrained decoding supporting JSON Schema, regex, and CFG grammars; 2k+ GitHub stars."
         }
       ],
       "knownAgents": [],
@@ -2155,14 +2195,14 @@
           "source": "https://arxiv.org/abs/2211.10435",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "PAL (Gao et al., 2023) — Program-Aided Language Models; delegates computation to Python interpreter, achieving +7% on GSM8K over direct CoT."
+          "notes": "PAL (Gao et al., 2023) \u2014 Program-Aided Language Models; delegates computation to Python interpreter, achieving +7% on GSM8K over direct CoT."
         },
         {
           "class": "B",
           "source": "https://github.com/reasoning-machines/pal",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "PAL repo — reproducible harness across 13 reasoning benchmarks; evaluation scripts and baseline comparisons included."
+          "notes": "PAL repo \u2014 reproducible harness across 13 reasoning benchmarks; evaluation scripts and baseline comparisons included."
         }
       ],
       "knownAgents": [],
@@ -2189,14 +2229,14 @@
           "source": "https://arxiv.org/abs/2307.13854",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "WebArena (Zhou et al., 2023) — realistic 812-task benchmark for autonomous web agents; establishes controlled eval for GUI-based computer use."
+          "notes": "WebArena (Zhou et al., 2023) \u2014 realistic 812-task benchmark for autonomous web agents; establishes controlled eval for GUI-based computer use."
         },
         {
           "class": "B",
           "source": "https://github.com/xlang-ai/OSWorld",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "OSWorld — 369 computer tasks across real OS environments (Windows, macOS, Ubuntu); reproducible VM-based evaluation harness."
+          "notes": "OSWorld \u2014 369 computer tasks across real OS environments (Windows, macOS, Ubuntu); reproducible VM-based evaluation harness."
         }
       ],
       "knownAgents": [],
@@ -2223,21 +2263,21 @@
           "source": "https://arxiv.org/abs/2304.05376",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "ChemCrow (Bran et al., 2023) — LLM augmented with 18 chemistry tools autonomously proposes and validates synthesis routes; GPT-4 outperforms on Chem. benchmark."
+          "notes": "ChemCrow (Bran et al., 2023) \u2014 LLM augmented with 18 chemistry tools autonomously proposes and validates synthesis routes; GPT-4 outperforms on Chem. benchmark."
         },
         {
           "class": "A",
           "source": "https://arxiv.org/abs/2304.05332",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Coscientist (Boiko et al., 2023) — autonomous LLM system designs and executes chemistry experiments; independently re-derived Suzuki coupling conditions."
+          "notes": "Coscientist (Boiko et al., 2023) \u2014 autonomous LLM system designs and executes chemistry experiments; independently re-derived Suzuki coupling conditions."
         },
         {
           "class": "B",
           "source": "https://github.com/SakanaAI/AI-Scientist",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "The AI Scientist (Sakana AI) — end-to-end pipeline generating ideas, running experiments, and writing ML papers; 50+ auto-generated manuscripts reviewed."
+          "notes": "The AI Scientist (Sakana AI) \u2014 end-to-end pipeline generating ideas, running experiments, and writing ML papers; 50+ auto-generated manuscripts reviewed."
         }
       ],
       "knownAgents": [],
@@ -2268,14 +2308,14 @@
           "source": "https://arxiv.org/abs/2210.03629",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "ReAct (Yao et al., 2023) — reasoning+acting paradigm; +34% on HotpotQA and +10% on ALFWorld vs chain-of-thought-only baselines."
+          "notes": "ReAct (Yao et al., 2023) \u2014 reasoning+acting paradigm; +34% on HotpotQA and +10% on ALFWorld vs chain-of-thought-only baselines."
         },
         {
           "class": "B",
           "source": "https://github.com/ysymyth/ReAct",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "ReAct repo — reproducible prompts and evaluation harness for HotpotQA, FEVER, ALFWorld, and WebShop benchmarks."
+          "notes": "ReAct repo \u2014 reproducible prompts and evaluation harness for HotpotQA, FEVER, ALFWorld, and WebShop benchmarks."
         }
       ],
       "knownAgents": [],
@@ -2305,14 +2345,14 @@
           "source": "https://arxiv.org/abs/2401.13919",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "WebVoyager (He et al., 2024) — end-to-end web agent with GPT-4V; 59.1% task success on real-world web tasks across 15 popular websites."
+          "notes": "WebVoyager (He et al., 2024) \u2014 end-to-end web agent with GPT-4V; 59.1% task success on real-world web tasks across 15 popular websites."
         },
         {
           "class": "B",
           "source": "https://github.com/web-arena-x/webarena",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "WebArena — self-hosted web environment with 812 realistic tasks; reproducible benchmark with ground-truth evaluation scripts."
+          "notes": "WebArena \u2014 self-hosted web environment with 812 realistic tasks; reproducible benchmark with ground-truth evaluation scripts."
         }
       ],
       "knownAgents": [],
@@ -2343,14 +2383,14 @@
           "source": "https://arxiv.org/abs/2306.08302",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Pan et al. (2024) — Unifying Large Language Models and Knowledge Graphs: A Roadmap; comprehensive survey showing LLM-KG synergy improves downstream tasks by 5-15%."
+          "notes": "Pan et al. (2024) \u2014 Unifying Large Language Models and Knowledge Graphs: A Roadmap; comprehensive survey showing LLM-KG synergy improves downstream tasks by 5-15%."
         },
         {
           "class": "B",
           "source": "https://github.com/microsoft/graphrag",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Microsoft GraphRAG — production KG construction pipeline; extracts community summaries and entity graphs from corpora, enabling global sensemaking queries."
+          "notes": "Microsoft GraphRAG \u2014 production KG construction pipeline; extracts community summaries and entity graphs from corpora, enabling global sensemaking queries."
         }
       ],
       "knownAgents": [],
@@ -2365,7 +2405,7 @@
       "type": "legendary",
       "level": "V",
       "rarity": "legendary",
-      "description": "Autonomously generates novel scientific hypotheses, designs and executes experiments, analyses results, and produces a written report — completing a full research cycle without human intervention.",
+      "description": "Autonomously generates novel scientific hypotheses, designs and executes experiments, analyses results, and produces a written report \u2014 completing a full research cycle without human intervention.",
       "prerequisites": [
         "hypothesis-generate",
         "research",
@@ -2379,21 +2419,21 @@
           "source": "https://arxiv.org/abs/2304.05376",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "ChemCrow (Bran et al., 2023) — autonomous chemistry agent completes synthesis planning and molecular design tasks rated expert-level by human chemists."
+          "notes": "ChemCrow (Bran et al., 2023) \u2014 autonomous chemistry agent completes synthesis planning and molecular design tasks rated expert-level by human chemists."
         },
         {
           "class": "A",
           "source": "https://arxiv.org/abs/2304.05332",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Coscientist (Boiko et al., 2023) — autonomously planned and executed real wet-lab chemistry experiments, confirmed by GC-MS analysis."
+          "notes": "Coscientist (Boiko et al., 2023) \u2014 autonomously planned and executed real wet-lab chemistry experiments, confirmed by GC-MS analysis."
         },
         {
           "class": "B",
           "source": "https://github.com/SakanaAI/AI-Scientist",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "AI Scientist (Lu et al., 2024) — generates idea, writes code, runs experiments, and produces a full NeurIPS-style paper; 50+ manuscripts auto-generated."
+          "notes": "AI Scientist (Lu et al., 2024) \u2014 generates idea, writes code, runs experiments, and produces a full NeurIPS-style paper; 50+ manuscripts auto-generated."
         }
       ],
       "knownAgents": [],
@@ -2421,7 +2461,7 @@
           "source": "https://arxiv.org/abs/2203.11171",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Wang et al. (2022) — Self-Consistency Improves Chain of Thought Reasoning in Language Models; +17.9% on GSM8K and +11.0% on MATH over greedy CoT decoding."
+          "notes": "Wang et al. (2022) \u2014 Self-Consistency Improves Chain of Thought Reasoning in Language Models; +17.9% on GSM8K and +11.0% on MATH over greedy CoT decoding."
         }
       ],
       "knownAgents": [],
@@ -2449,7 +2489,7 @@
           "source": "https://arxiv.org/abs/2005.14165",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Brown et al. (2020) — Language Models are Few-Shot Learners (GPT-3); in-context learning from 1-100 examples achieves near-SOTA on SuperGLUE, translation, and QA benchmarks."
+          "notes": "Brown et al. (2020) \u2014 Language Models are Few-Shot Learners (GPT-3); in-context learning from 1-100 examples achieves near-SOTA on SuperGLUE, translation, and QA benchmarks."
         }
       ],
       "knownAgents": [],
@@ -2479,14 +2519,14 @@
           "source": "https://arxiv.org/abs/2305.10601",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Yao et al. (2023) — Tree of Thoughts: Deliberate Problem Solving with LLMs; +74% on Game of 24 and +4% on Creative Writing vs chain-of-thought baseline."
+          "notes": "Yao et al. (2023) \u2014 Tree of Thoughts: Deliberate Problem Solving with LLMs; +74% on Game of 24 and +4% on Creative Writing vs chain-of-thought baseline."
         },
         {
           "class": "B",
           "source": "https://github.com/princeton-nlp/tree-of-thought-llm",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Princeton-NLP ToT repo — reproducible breadth-first and depth-first tree search implementations with evaluation scripts for Game of 24 and Mini Crosswords."
+          "notes": "Princeton-NLP ToT repo \u2014 reproducible breadth-first and depth-first tree search implementations with evaluation scripts for Game of 24 and Mini Crosswords."
         }
       ],
       "knownAgents": [],
@@ -2516,14 +2556,14 @@
           "source": "https://arxiv.org/abs/2310.03714",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Khattab et al. (2023) — DSPy: Compiling Declarative Language Model Calls into Self-Improving Pipelines; automated prompt tuning matches or exceeds hand-crafted prompts on GSM8K, HotPotQA, and FEVER."
+          "notes": "Khattab et al. (2023) \u2014 DSPy: Compiling Declarative Language Model Calls into Self-Improving Pipelines; automated prompt tuning matches or exceeds hand-crafted prompts on GSM8K, HotPotQA, and FEVER."
         },
         {
           "class": "B",
           "source": "https://github.com/stanfordnlp/dspy",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "DSPy — Stanford NLP library for programmable LM pipelines; 18k+ GitHub stars, supports multiple optimizers (BootstrapFewShot, MIPRO, COPRO) across any LM."
+          "notes": "DSPy \u2014 Stanford NLP library for programmable LM pipelines; 18k+ GitHub stars, supports multiple optimizers (BootstrapFewShot, MIPRO, COPRO) across any LM."
         }
       ],
       "knownAgents": [],
@@ -2554,14 +2594,14 @@
           "source": "https://arxiv.org/abs/2305.17126",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Cai et al. (2023) — Large Language Models as Tool Makers (LATM); LLM-generated tools reused across problem instances achieve +8.7% on BigBench Hard vs per-instance CoT."
+          "notes": "Cai et al. (2023) \u2014 Large Language Models as Tool Makers (LATM); LLM-generated tools reused across problem instances achieve +8.7% on BigBench Hard vs per-instance CoT."
         },
         {
           "class": "B",
           "source": "https://github.com/ctlllll/LLM-ToolMaker",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "LATM repo — reproducible tool-maker/tool-user pipeline with evaluation on BigBench Hard tasks and tool reuse across problem batches."
+          "notes": "LATM repo \u2014 reproducible tool-maker/tool-user pipeline with evaluation on BigBench Hard tasks and tool reuse across problem batches."
         }
       ],
       "knownAgents": [],
@@ -3608,6 +3648,30 @@
       "sourceSkillId": "tool-creation",
       "targetSkillId": "autonomous-research-agent",
       "edgeType": "enhances",
+      "condition": "",
+      "levelFloor": "I",
+      "evidenceRefs": []
+    },
+    {
+      "sourceSkillId": "structured-output",
+      "targetSkillId": "function-calling",
+      "edgeType": "prerequisite",
+      "condition": "",
+      "levelFloor": "I",
+      "evidenceRefs": []
+    },
+    {
+      "sourceSkillId": "api-call",
+      "targetSkillId": "function-calling",
+      "edgeType": "prerequisite",
+      "condition": "",
+      "levelFloor": "I",
+      "evidenceRefs": []
+    },
+    {
+      "sourceSkillId": "tool-select",
+      "targetSkillId": "function-calling",
+      "edgeType": "prerequisite",
       "condition": "",
       "levelFloor": "I",
       "evidenceRefs": []

--- a/registry.md
+++ b/registry.md
@@ -33,6 +33,7 @@
 | ○ Few-Shot Learning | Intrinsic Skill | IV · Transcendent | Common | Provisional |
 | ○ Format Output | Intrinsic Skill | I · Awakened | Common | Provisional |
 | ◆ True Craftsman: Full-Stack Developer | Ultimate Skill | V · Transcendent | Divine | Provisional |
+| ◇ Function Calling | Extra Skill | III · Evolved | Uncommon | Provisional |
 | ○ Generate SQL | Intrinsic Skill | II · Named | Common | Provisional |
 | ○ Generate Test | Intrinsic Skill | II · Named | Common | Provisional |
 | ○ Generate Text | Intrinsic Skill | I · Awakened | Common | Provisional |

--- a/skills/atomic/api-call.md
+++ b/skills/atomic/api-call.md
@@ -14,7 +14,7 @@ Constructs, executes, and handles responses from HTTP APIs by interpreting docum
 _None._
 
 ## Unlocks
-_None._
+- [Function Calling](../composite/function-calling.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/skills/atomic/structured-output.md
+++ b/skills/atomic/structured-output.md
@@ -16,6 +16,7 @@ _None._
 ## Unlocks
 - [RAG Pipeline](../composite/rag-pipeline.md)
 - [Text-to-SQL Pipeline](../composite/text-to-sql-pipeline.md)
+- [Function Calling](../composite/function-calling.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/skills/atomic/tool-select.md
+++ b/skills/atomic/tool-select.md
@@ -17,6 +17,7 @@ _None._
 - [Plan and Execute](../composite/plan-and-execute.md)
 - [ReAct Reasoning](../composite/re-act-reasoning.md)
 - [Tool Use](../atomic/tool-use.md)
+- [Function Calling](../composite/function-calling.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/skills/composite/function-calling.md
+++ b/skills/composite/function-calling.md
@@ -1,0 +1,34 @@
+# [III · Evolved · Extra Skill] Function Calling
+**ID:** function-calling  
+**Type:** Extra Skill  
+**Level:** III · Evolved  
+**Rarity:** Uncommon  
+**Status:** Provisional
+
+---
+
+## Description
+Selects an external callable, emits schema-valid arguments, invokes the function or API, and integrates the returned result into the agent loop.
+
+## Prerequisites
+- [Structured Output Generation](../atomic/structured-output.md)
+- [API Call](../atomic/api-call.md)
+- [Tool Select](../atomic/tool-select.md)
+
+## Unlocks
+_None._
+
+## Fusion Condition
+Requires an available function or tool catalog with machine-readable argument schemas and result contracts.
+
+## Evidence
+| Class | Source | Evaluator | Date |
+|---|---|---|---|
+| A | https://arxiv.org/abs/2307.16789 | rico-favor | 2026-04-29 |
+| A | https://arxiv.org/abs/2305.15334 | rico-favor | 2026-04-29 |
+
+## Known Agents
+_None verified yet._
+
+---
+*Generated from gaia.json v1.0.0 on 2026-04-29. Do not edit directly.*


### PR DESCRIPTION
## New Composite Skill

### Skill Details
- **ID:** `function-calling`
- **Name:** Function Calling
- **Level:** III
- **Prerequisites:** `structured-output`, `api-call`, `tool-select`
- **Description:** Selects an external callable, emits schema-valid arguments, invokes the function or API, and integrates the returned result into the agent loop.
- **Fusion Condition:** Requires an available function or tool catalog with machine-readable argument schemas and result contracts.

### Evidence
| Class | Source | Evaluator | Date | Notes |
|---|---|---|---|---|
| A | https://arxiv.org/abs/2307.16789 | rico-favor | 2026-04-29 | ToolLLM / ToolBench demonstrates LLM tool invocation over 16,000+ real-world APIs with documented evaluation tasks and failure analysis. |
| A | https://arxiv.org/abs/2305.15334 | rico-favor | 2026-04-29 | Gorilla / APIBench evaluates model generation of API calls across large API collections, including endpoint and argument selection. |

### Rationale

The issue proposed `function-calling` as an atomic skill, but the current graph already has the primitives that make it work: `structured-output`, `api-call`, and `tool-select`. This PR models function calling as the emergent capability of combining those primitives instead of duplicating `tool-use` or `api-call`.

A model that only has `structured-output` can emit valid JSON but not necessarily choose or invoke a tool. A model that only has `api-call` can call APIs but not necessarily choose from a tool catalog or produce schema-valid function arguments. A model that only has `tool-select` can choose a tool but not necessarily execute a complete typed invocation loop. The composite captures the full function-calling loop.

### Existing PRs / related work

Searched open/closed PRs for related function-calling / tool-use work. Closest related merged work is #33, which added or updated adjacent skills including `tool-use`, `api-call`, and `structured-output`; this PR builds on those rather than adding a duplicate atomic primitive.

### Checklist

**Contributor:**
- [x] Skill ID uses `kebab-case` with no vendor references.
- [x] Description describes an emergent capability, not just "all parents at once."
- [x] At least 2 prerequisites listed, all referencing existing skill IDs in `gaia.json`.
- [x] Evidence meets the minimum threshold for the claimed level (Level III = Class B+).
- [x] Fusion condition is specified if applicable.
- [x] I have run `python scripts/validate.py` locally and it passes.
- [x] Generated projections were regenerated with `python3 scripts/generateProjections.py`.

Closes #9
