### PR TITLE
[reclassify] rag-pipeline — strengthen Named evidence

### DIFF
--- a/graph/gaia.json
+++ b/graph/gaia.json
@@ -14,7 +14,7 @@
       "III": "Evolved",
       "IV": "Transcendent",
       "V": "Transcendent",
-      "VI": "Transcendent ★"
+      "VI": "Transcendent \u2605"
     },
     "rarityLabels": {
       "legendary": "Divine"
@@ -932,18 +932,25 @@
       "conditions": "",
       "evidence": [
         {
+          "class": "A",
+          "source": "https://aclanthology.org/2024.eacl-demo.16/",
+          "evaluator": "rico-favor",
+          "date": "2026-04-29",
+          "notes": "RAGAS peer-reviewed demo paper defines reproducible metrics for retrieval-augmented generation, including context relevance, faithfulness, and answer relevance; these directly evaluate known RAG failure modes such as irrelevant retrieval and unfaithful generation."
+        },
+        {
           "class": "B",
-          "source": "https://github.com/gaia-registry/gaia/blob/main/docs/evidence/ragPipeline.md",
-          "evaluator": "mbtiongson1",
-          "date": "2026-04-26",
-          "notes": "Seed evidence for RAG Pipeline."
+          "source": "https://github.com/vibrantlabsai/ragas",
+          "evaluator": "rico-favor",
+          "date": "2026-04-29",
+          "notes": "RAGAS open-source implementation provides a reproducible evaluation toolkit for RAG pipelines. Notes: RAG pipelines can fail when retrieval misses relevant chunks, ambiguous queries retrieve misleading context, or generated answers drift from retrieved evidence."
         }
       ],
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-26",
-      "updatedAt": "2026-04-26",
-      "version": "0.1.0"
+      "updatedAt": "2026-04-29",
+      "version": "0.2.0"
     },
     {
       "id": "document-analyst",
@@ -995,7 +1002,7 @@
           "source": "https://github.com/gaia-registry/gaia/blob/main/docs/evidence/seed.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Seed evidence — structural validation placeholder."
+          "notes": "Seed evidence \u2014 structural validation placeholder."
         }
       ],
       "knownAgents": [],
@@ -1024,7 +1031,7 @@
           "source": "https://github.com/gaia-registry/gaia/blob/main/docs/evidence/seed.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Seed evidence — structural validation placeholder."
+          "notes": "Seed evidence \u2014 structural validation placeholder."
         }
       ],
       "knownAgents": [],
@@ -1053,7 +1060,7 @@
           "source": "https://github.com/gaia-registry/gaia/blob/main/docs/evidence/seed.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Seed evidence — apex tier structural validation placeholder."
+          "notes": "Seed evidence \u2014 apex tier structural validation placeholder."
         }
       ],
       "knownAgents": [],
@@ -1080,7 +1087,7 @@
           "source": "https://arxiv.org/abs/2207.04672",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "NLLB (No Language Left Behind) — Meta AI paper demonstrating 200-language translation at human-level quality on FLORES-200 benchmark."
+          "notes": "NLLB (No Language Left Behind) \u2014 Meta AI paper demonstrating 200-language translation at human-level quality on FLORES-200 benchmark."
         }
       ],
       "knownAgents": [],
@@ -1108,7 +1115,7 @@
           "source": "https://arxiv.org/abs/1810.04805",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "BERT paper — achieves SOTA on SST-2 sentiment benchmark (93.5% accuracy), foundational evidence for LLM-based sentiment analysis."
+          "notes": "BERT paper \u2014 achieves SOTA on SST-2 sentiment benchmark (93.5% accuracy), foundational evidence for LLM-based sentiment analysis."
         }
       ],
       "knownAgents": [],
@@ -1135,7 +1142,7 @@
           "source": "https://arxiv.org/abs/2301.12597",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "BLIP-2 — bootstrapped language-image pre-training achieving SOTA on COCO Captions (CIDEr 145.8) and NoCaps benchmarks."
+          "notes": "BLIP-2 \u2014 bootstrapped language-image pre-training achieving SOTA on COCO Captions (CIDEr 145.8) and NoCaps benchmarks."
         }
       ],
       "knownAgents": [],
@@ -1162,7 +1169,7 @@
           "source": "https://arxiv.org/abs/2212.04356",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Whisper (OpenAI) — large-scale weak supervision across 680K hours of audio achieves near-human WER on LibriSpeech and multilingual benchmarks."
+          "notes": "Whisper (OpenAI) \u2014 large-scale weak supervision across 680K hours of audio achieves near-human WER on LibriSpeech and multilingual benchmarks."
         }
       ],
       "knownAgents": [],
@@ -1189,7 +1196,7 @@
           "source": "https://arxiv.org/abs/2301.02111",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "VALL-E (Microsoft) — neural codec language model achieving SOTA speech synthesis with 3-second voice cloning on LibriSpeech."
+          "notes": "VALL-E (Microsoft) \u2014 neural codec language model achieving SOTA speech synthesis with 3-second voice cloning on LibriSpeech."
         }
       ],
       "knownAgents": [],
@@ -1217,7 +1224,7 @@
           "source": "https://arxiv.org/abs/1809.08887",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Spider benchmark — cross-domain text-to-SQL dataset; LLM baselines reach >85% exact match, establishing reproducible evaluation methodology."
+          "notes": "Spider benchmark \u2014 cross-domain text-to-SQL dataset; LLM baselines reach >85% exact match, establishing reproducible evaluation methodology."
         }
       ],
       "knownAgents": [],
@@ -1247,7 +1254,7 @@
           "source": "https://arxiv.org/abs/1806.03822",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SQuAD 2.0 — reading comprehension benchmark with 150K questions; modern LLMs exceed human F1 (90.9), providing rigorous reproducible evaluation."
+          "notes": "SQuAD 2.0 \u2014 reading comprehension benchmark with 150K questions; modern LLMs exceed human F1 (90.9), providing rigorous reproducible evaluation."
         }
       ],
       "knownAgents": [],
@@ -1272,7 +1279,7 @@
           "source": "https://arxiv.org/abs/2112.10752",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Latent Diffusion Models (Rombach et al.) — foundational paper for Stable Diffusion; achieves FID 5.11 on LSUN-Beds at 200× less compute than pixel-space diffusion."
+          "notes": "Latent Diffusion Models (Rombach et al.) \u2014 foundational paper for Stable Diffusion; achieves FID 5.11 on LSUN-Beds at 200\u00d7 less compute than pixel-space diffusion."
         }
       ],
       "knownAgents": [],
@@ -1300,7 +1307,7 @@
           "source": "https://arxiv.org/abs/2206.14858",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Minerva (Google) — 50.3% on MATH and 78.5% on MMLU-STEM benchmarks using chain-of-thought over scientific literature."
+          "notes": "Minerva (Google) \u2014 50.3% on MATH and 78.5% on MMLU-STEM benchmarks using chain-of-thought over scientific literature."
         }
       ],
       "knownAgents": [],
@@ -1329,7 +1336,7 @@
           "source": "https://arxiv.org/abs/2201.11903",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Chain-of-Thought prompting (Wei et al.) — few-shot CoT elicits multi-step reasoning; +18% on GSM8K and +15% on SVAMP over standard prompting."
+          "notes": "Chain-of-Thought prompting (Wei et al.) \u2014 few-shot CoT elicits multi-step reasoning; +18% on GSM8K and +15% on SVAMP over standard prompting."
         }
       ],
       "knownAgents": [],
@@ -1357,7 +1364,7 @@
           "source": "https://arxiv.org/abs/2310.08560",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "MemGPT — virtual context management system enabling LLMs to handle unbounded memory; benchmarked on multi-session dialogue and document QA."
+          "notes": "MemGPT \u2014 virtual context management system enabling LLMs to handle unbounded memory; benchmarked on multi-session dialogue and document QA."
         }
       ],
       "knownAgents": [],
@@ -1382,7 +1389,7 @@
           "source": "https://arxiv.org/abs/2305.15334",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Gorilla (Patil et al.) — LLM that generates accurate API calls across TorchHub, TensorFlow Hub, and HuggingFace; 20.43% AST accuracy improvement over GPT-4."
+          "notes": "Gorilla (Patil et al.) \u2014 LLM that generates accurate API calls across TorchHub, TensorFlow Hub, and HuggingFace; 20.43% AST accuracy improvement over GPT-4."
         }
       ],
       "knownAgents": [],
@@ -1409,7 +1416,7 @@
           "source": "https://arxiv.org/abs/2310.06770",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SWE-bench — 2294 real GitHub issues benchmark; agents that resolve issues must safely refactor code while passing existing test suites."
+          "notes": "SWE-bench \u2014 2294 real GitHub issues benchmark; agents that resolve issues must safely refactor code while passing existing test suites."
         }
       ],
       "knownAgents": [],
@@ -1436,7 +1443,7 @@
           "source": "https://arxiv.org/abs/2107.03374",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Codex/HumanEval (Chen et al.) — evaluates LLMs on writing Python functions that pass hand-crafted unit tests; pass@1 72.0% for GPT-4."
+          "notes": "Codex/HumanEval (Chen et al.) \u2014 evaluates LLMs on writing Python functions that pass hand-crafted unit tests; pass@1 72.0% for GPT-4."
         }
       ],
       "knownAgents": [],
@@ -1463,7 +1470,7 @@
           "source": "https://arxiv.org/abs/2308.13418",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Nougat (Meta AI) — visual transformer for scientific PDF parsing; 7.6% edit distance on arXiv papers, handling LaTeX, tables, and equations."
+          "notes": "Nougat (Meta AI) \u2014 visual transformer for scientific PDF parsing; 7.6% edit distance on arXiv papers, handling LaTeX, tables, and equations."
         }
       ],
       "knownAgents": [],
@@ -1488,7 +1495,7 @@
           "source": "https://arxiv.org/abs/2007.02500",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Deep Learning for Anomaly Detection survey (Pang et al., ACM CSUR) — comprehensive benchmark of 30+ methods across fraud, intrusion, and medical anomaly detection."
+          "notes": "Deep Learning for Anomaly Detection survey (Pang et al., ACM CSUR) \u2014 comprehensive benchmark of 30+ methods across fraud, intrusion, and medical anomaly detection."
         }
       ],
       "knownAgents": [],
@@ -1515,7 +1522,7 @@
           "source": "https://github.com/microsoft/lida",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "LIDA (Microsoft) — open-source LLM-based data visualization tool with reproducible generation pipeline; evaluated on diverse real-world datasets."
+          "notes": "LIDA (Microsoft) \u2014 open-source LLM-based data visualization tool with reproducible generation pipeline; evaluated on diverse real-world datasets."
         }
       ],
       "knownAgents": [],
@@ -1544,7 +1551,7 @@
           "source": "https://github.com/langchain-ai/langchain/tree/master/libs/langchain/langchain/chains/conversation",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "LangChain ConversationChain — reproducible open-source multi-turn conversational agent with buffer and summary memory backends."
+          "notes": "LangChain ConversationChain \u2014 reproducible open-source multi-turn conversational agent with buffer and summary memory backends."
         }
       ],
       "knownAgents": [],
@@ -1573,7 +1580,7 @@
           "source": "https://arxiv.org/abs/2304.11015",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "DIN-SQL — decomposed in-context learning for text-to-SQL; 82.8% execution accuracy on Spider dev, demonstrating end-to-end pipeline."
+          "notes": "DIN-SQL \u2014 decomposed in-context learning for text-to-SQL; 82.8% execution accuracy on Spider dev, demonstrating end-to-end pipeline."
         }
       ],
       "knownAgents": [],
@@ -1604,7 +1611,7 @@
           "source": "https://arxiv.org/abs/2203.09095",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "CodeReviewer (Microsoft) — pre-trained model for code review tasks; 28.7% BLEU improvement on comment generation and change quality prediction."
+          "notes": "CodeReviewer (Microsoft) \u2014 pre-trained model for code review tasks; 28.7% BLEU improvement on comment generation and change quality prediction."
         }
       ],
       "knownAgents": [],
@@ -1635,7 +1642,7 @@
           "source": "https://github.com/Sinaptik-AI/pandas-ai",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "pandas-ai — open-source agent for natural-language data analysis over pandas DataFrames; reproducible demos with logging and output artifacts."
+          "notes": "pandas-ai \u2014 open-source agent for natural-language data analysis over pandas DataFrames; reproducible demos with logging and output artifacts."
         }
       ],
       "knownAgents": [],
@@ -1666,7 +1673,7 @@
           "source": "https://github.com/rasa/rasa",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Rasa Open Source — production voice agent framework with ASR/TTS integrations; reproducible pipeline with test suite and documented benchmarks."
+          "notes": "Rasa Open Source \u2014 production voice agent framework with ASR/TTS integrations; reproducible pipeline with test suite and documented benchmarks."
         }
       ],
       "knownAgents": [],
@@ -1697,7 +1704,7 @@
           "source": "https://github.com/princeton-nlp/SWE-bench",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SWE-bench Verified — open-source evaluation harness where agents fix GitHub issues by generating and passing test suites; full execution logs archived."
+          "notes": "SWE-bench Verified \u2014 open-source evaluation harness where agents fix GitHub issues by generating and passing test suites; full execution logs archived."
         }
       ],
       "knownAgents": [],
@@ -1726,7 +1733,7 @@
           "source": "https://platform.openai.com/docs/guides/moderation",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "OpenAI Moderation API — publicly documented multi-category content classifier with reproducible API calls, category scores, and evaluation methodology."
+          "notes": "OpenAI Moderation API \u2014 publicly documented multi-category content classifier with reproducible API calls, category scores, and evaluation methodology."
         }
       ],
       "knownAgents": [],
@@ -1755,7 +1762,7 @@
           "source": "https://arxiv.org/abs/2304.08485",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "LLaVA — large language and vision assistant; 85.1% on ScienceQA and 64.3% on TextVQA, establishing reproducible multimodal reasoning benchmark."
+          "notes": "LLaVA \u2014 large language and vision assistant; 85.1% on ScienceQA and 64.3% on TextVQA, establishing reproducible multimodal reasoning benchmark."
         }
       ],
       "knownAgents": [],
@@ -1784,7 +1791,7 @@
           "source": "https://arxiv.org/abs/2308.11596",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SeamlessM4T (Meta AI) — unified speech and text translation model with tone and register control; BLEU +3.3 over NLLB on FLORES-200."
+          "notes": "SeamlessM4T (Meta AI) \u2014 unified speech and text translation model with tone and register control; BLEU +3.3 over NLLB on FLORES-200."
         }
       ],
       "knownAgents": [],
@@ -1813,7 +1820,7 @@
           "source": "https://github.com/VikParuchuri/marker",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Marker — open-source PDF-to-markdown pipeline with reproducible benchmarks; outperforms Nougat on edit distance across 1000+ arXiv PDFs."
+          "notes": "Marker \u2014 open-source PDF-to-markdown pipeline with reproducible benchmarks; outperforms Nougat on edit distance across 1000+ arXiv PDFs."
         }
       ],
       "knownAgents": [],
@@ -1842,21 +1849,21 @@
           "source": "https://arxiv.org/abs/2310.06770",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SWE-bench — 2294 real GitHub issues; Claude 3.5 Sonnet (Cognition) resolves 49% on Verified, demonstrating full-cycle autonomous development."
+          "notes": "SWE-bench \u2014 2294 real GitHub issues; Claude 3.5 Sonnet (Cognition) resolves 49% on Verified, demonstrating full-cycle autonomous development."
         },
         {
           "class": "B",
           "source": "https://github.com/princeton-nlp/SWE-agent",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SWE-agent — open-source agent with AgentComputer Interface; reproducible harness achieving 12.5% on SWE-bench full with logs and eval scripts."
+          "notes": "SWE-agent \u2014 open-source agent with AgentComputer Interface; reproducible harness achieving 12.5% on SWE-bench full with logs and eval scripts."
         },
         {
           "class": "A",
           "source": "https://arxiv.org/abs/2402.01030",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "CodeAct — executable code action space for LLM agents; +20% task completion vs JSON/text-based actions across 17 programming benchmarks."
+          "notes": "CodeAct \u2014 executable code action space for LLM agents; +20% task completion vs JSON/text-based actions across 17 programming benchmarks."
         }
       ],
       "knownAgents": [],
@@ -1885,21 +1892,21 @@
           "source": "https://arxiv.org/abs/2210.12641",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "DS-1000 — benchmark of 1000 data science problems across NumPy/Pandas/Scikit-learn; GPT-4 achieves 43.3% pass@1, establishing reproducible DS evaluation."
+          "notes": "DS-1000 \u2014 benchmark of 1000 data science problems across NumPy/Pandas/Scikit-learn; GPT-4 achieves 43.3% pass@1, establishing reproducible DS evaluation."
         },
         {
           "class": "A",
           "source": "https://arxiv.org/abs/2208.01756",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "AutoML Survey (He et al., ACM CSUR) — systematic review of autonomous ML pipeline search; demonstrates automated feature engineering, model selection, and HPO."
+          "notes": "AutoML Survey (He et al., ACM CSUR) \u2014 systematic review of autonomous ML pipeline search; demonstrates automated feature engineering, model selection, and HPO."
         },
         {
           "class": "B",
           "source": "https://github.com/microsoft/autogen",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "AutoGen (Microsoft) — multi-agent framework with reproducible data science notebooks; science agent achieves 44.3% on DS-1000 with full execution logs."
+          "notes": "AutoGen (Microsoft) \u2014 multi-agent framework with reproducible data science notebooks; science agent achieves 44.3% on DS-1000 with full execution logs."
         }
       ],
       "knownAgents": [],
@@ -1928,21 +1935,21 @@
           "source": "https://arxiv.org/abs/2312.11805",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "AudioPaLM (Google) — unified audio language model supporting real-time spoken dialogue; SOTA on ASR and speech translation, demonstrating end-to-end voice assistant capability."
+          "notes": "AudioPaLM (Google) \u2014 unified audio language model supporting real-time spoken dialogue; SOTA on ASR and speech translation, demonstrating end-to-end voice assistant capability."
         },
         {
           "class": "A",
           "source": "https://arxiv.org/abs/2305.11206",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "VoiceBox (Meta AI) — generative speech model with zero-shot TTS; enables real-time voice assistants with <100ms synthesis latency benchmarked on VCTK."
+          "notes": "VoiceBox (Meta AI) \u2014 generative speech model with zero-shot TTS; enables real-time voice assistants with <100ms synthesis latency benchmarked on VCTK."
         },
         {
           "class": "B",
           "source": "https://github.com/openai/whisper",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Whisper + LLM integration demos — open-source real-time voice assistant pipelines combining Whisper STT, LLM reasoning, and TTS with documented latency benchmarks."
+          "notes": "Whisper + LLM integration demos \u2014 open-source real-time voice assistant pipelines combining Whisper STT, LLM reasoning, and TTS with documented latency benchmarks."
         }
       ],
       "knownAgents": [],
@@ -1971,7 +1978,7 @@
           "source": "https://github.com/mbtiongson1/gaia-skill-tree/pull/2",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Reproducible demonstration: Claude Code agent researched 30 popular AI skills, sourced 22 peer-reviewed papers, generated gaia.json via script, passed all 6 validator checks, and submitted PR — full inputs/outputs archived in the PR diff."
+          "notes": "Reproducible demonstration: Claude Code agent researched 30 popular AI skills, sourced 22 peer-reviewed papers, generated gaia.json via script, passed all 6 validator checks, and submitted PR \u2014 full inputs/outputs archived in the PR diff."
         },
         {
           "class": "B",
@@ -1985,7 +1992,7 @@
           "source": "https://github.com/mbtiongson1/gaia-skill-tree",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Batch 3 curation: 5 skills added (2 atomic, 3 composite) — self-consistency, few-shot-learning, tree-of-thought, prompt-optimization, tool-creation."
+          "notes": "Batch 3 curation: 5 skills added (2 atomic, 3 composite) \u2014 self-consistency, few-shot-learning, tree-of-thought, prompt-optimization, tool-creation."
         }
       ],
       "knownAgents": [],
@@ -2013,14 +2020,14 @@
           "source": "https://arxiv.org/abs/2302.04761",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Toolformer (Schick et al., 2023) — self-supervised method teaching LLMs to call APIs; zero-shot tool use surpasses GPT-3 175B on several benchmarks."
+          "notes": "Toolformer (Schick et al., 2023) \u2014 self-supervised method teaching LLMs to call APIs; zero-shot tool use surpasses GPT-3 175B on several benchmarks."
         },
         {
           "class": "B",
           "source": "https://github.com/OpenBMB/ToolBench",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "ToolBench — open benchmark with 16,000+ real-world APIs; end-to-end tool-use training and evaluation harness."
+          "notes": "ToolBench \u2014 open benchmark with 16,000+ real-world APIs; end-to-end tool-use training and evaluation harness."
         }
       ],
       "knownAgents": [],
@@ -2050,14 +2057,14 @@
           "source": "https://arxiv.org/abs/2201.11903",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Wei et al. (2022) — Chain-of-Thought Prompting; +18% on GSM8K and +14% on MATH with PaLM 540B vs standard prompting."
+          "notes": "Wei et al. (2022) \u2014 Chain-of-Thought Prompting; +18% on GSM8K and +14% on MATH with PaLM 540B vs standard prompting."
         },
         {
           "class": "B",
           "source": "https://github.com/princeton-nlp/chain-of-thought-hub",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Chain-of-Thought Hub — reproducible evaluation suite covering 10+ reasoning benchmarks with CoT prompts and baselines."
+          "notes": "Chain-of-Thought Hub \u2014 reproducible evaluation suite covering 10+ reasoning benchmarks with CoT prompts and baselines."
         }
       ],
       "knownAgents": [],
@@ -2084,14 +2091,14 @@
           "source": "https://arxiv.org/abs/2303.17651",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Self-Refine (Madaan et al., 2023) — iterative self-feedback loop; +20% on code generation and +13% on math reasoning vs single-pass generation."
+          "notes": "Self-Refine (Madaan et al., 2023) \u2014 iterative self-feedback loop; +20% on code generation and +13% on math reasoning vs single-pass generation."
         },
         {
           "class": "B",
           "source": "https://github.com/madaan/self-refine",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Self-Refine repo — reproducible demos across 7 tasks (code, math, dialogue, sentiment reversal) with evaluation scripts."
+          "notes": "Self-Refine repo \u2014 reproducible demos across 7 tasks (code, math, dialogue, sentiment reversal) with evaluation scripts."
         }
       ],
       "knownAgents": [],
@@ -2119,14 +2126,14 @@
           "source": "https://arxiv.org/abs/2307.09702",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Willard & Louf (2023) — Efficient Guided Generation for LLMs; finite-state machine approach guarantees schema-valid output with <1% throughput overhead."
+          "notes": "Willard & Louf (2023) \u2014 Efficient Guided Generation for LLMs; finite-state machine approach guarantees schema-valid output with <1% throughput overhead."
         },
         {
           "class": "B",
           "source": "https://github.com/outlines-dev/outlines",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Outlines library — production-grade constrained decoding supporting JSON Schema, regex, and CFG grammars; 2k+ GitHub stars."
+          "notes": "Outlines library \u2014 production-grade constrained decoding supporting JSON Schema, regex, and CFG grammars; 2k+ GitHub stars."
         }
       ],
       "knownAgents": [],
@@ -2155,14 +2162,14 @@
           "source": "https://arxiv.org/abs/2211.10435",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "PAL (Gao et al., 2023) — Program-Aided Language Models; delegates computation to Python interpreter, achieving +7% on GSM8K over direct CoT."
+          "notes": "PAL (Gao et al., 2023) \u2014 Program-Aided Language Models; delegates computation to Python interpreter, achieving +7% on GSM8K over direct CoT."
         },
         {
           "class": "B",
           "source": "https://github.com/reasoning-machines/pal",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "PAL repo — reproducible harness across 13 reasoning benchmarks; evaluation scripts and baseline comparisons included."
+          "notes": "PAL repo \u2014 reproducible harness across 13 reasoning benchmarks; evaluation scripts and baseline comparisons included."
         }
       ],
       "knownAgents": [],
@@ -2189,14 +2196,14 @@
           "source": "https://arxiv.org/abs/2307.13854",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "WebArena (Zhou et al., 2023) — realistic 812-task benchmark for autonomous web agents; establishes controlled eval for GUI-based computer use."
+          "notes": "WebArena (Zhou et al., 2023) \u2014 realistic 812-task benchmark for autonomous web agents; establishes controlled eval for GUI-based computer use."
         },
         {
           "class": "B",
           "source": "https://github.com/xlang-ai/OSWorld",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "OSWorld — 369 computer tasks across real OS environments (Windows, macOS, Ubuntu); reproducible VM-based evaluation harness."
+          "notes": "OSWorld \u2014 369 computer tasks across real OS environments (Windows, macOS, Ubuntu); reproducible VM-based evaluation harness."
         }
       ],
       "knownAgents": [],
@@ -2223,21 +2230,21 @@
           "source": "https://arxiv.org/abs/2304.05376",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "ChemCrow (Bran et al., 2023) — LLM augmented with 18 chemistry tools autonomously proposes and validates synthesis routes; GPT-4 outperforms on Chem. benchmark."
+          "notes": "ChemCrow (Bran et al., 2023) \u2014 LLM augmented with 18 chemistry tools autonomously proposes and validates synthesis routes; GPT-4 outperforms on Chem. benchmark."
         },
         {
           "class": "A",
           "source": "https://arxiv.org/abs/2304.05332",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Coscientist (Boiko et al., 2023) — autonomous LLM system designs and executes chemistry experiments; independently re-derived Suzuki coupling conditions."
+          "notes": "Coscientist (Boiko et al., 2023) \u2014 autonomous LLM system designs and executes chemistry experiments; independently re-derived Suzuki coupling conditions."
         },
         {
           "class": "B",
           "source": "https://github.com/SakanaAI/AI-Scientist",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "The AI Scientist (Sakana AI) — end-to-end pipeline generating ideas, running experiments, and writing ML papers; 50+ auto-generated manuscripts reviewed."
+          "notes": "The AI Scientist (Sakana AI) \u2014 end-to-end pipeline generating ideas, running experiments, and writing ML papers; 50+ auto-generated manuscripts reviewed."
         }
       ],
       "knownAgents": [],
@@ -2268,14 +2275,14 @@
           "source": "https://arxiv.org/abs/2210.03629",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "ReAct (Yao et al., 2023) — reasoning+acting paradigm; +34% on HotpotQA and +10% on ALFWorld vs chain-of-thought-only baselines."
+          "notes": "ReAct (Yao et al., 2023) \u2014 reasoning+acting paradigm; +34% on HotpotQA and +10% on ALFWorld vs chain-of-thought-only baselines."
         },
         {
           "class": "B",
           "source": "https://github.com/ysymyth/ReAct",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "ReAct repo — reproducible prompts and evaluation harness for HotpotQA, FEVER, ALFWorld, and WebShop benchmarks."
+          "notes": "ReAct repo \u2014 reproducible prompts and evaluation harness for HotpotQA, FEVER, ALFWorld, and WebShop benchmarks."
         }
       ],
       "knownAgents": [],
@@ -2305,14 +2312,14 @@
           "source": "https://arxiv.org/abs/2401.13919",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "WebVoyager (He et al., 2024) — end-to-end web agent with GPT-4V; 59.1% task success on real-world web tasks across 15 popular websites."
+          "notes": "WebVoyager (He et al., 2024) \u2014 end-to-end web agent with GPT-4V; 59.1% task success on real-world web tasks across 15 popular websites."
         },
         {
           "class": "B",
           "source": "https://github.com/web-arena-x/webarena",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "WebArena — self-hosted web environment with 812 realistic tasks; reproducible benchmark with ground-truth evaluation scripts."
+          "notes": "WebArena \u2014 self-hosted web environment with 812 realistic tasks; reproducible benchmark with ground-truth evaluation scripts."
         }
       ],
       "knownAgents": [],
@@ -2343,14 +2350,14 @@
           "source": "https://arxiv.org/abs/2306.08302",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Pan et al. (2024) — Unifying Large Language Models and Knowledge Graphs: A Roadmap; comprehensive survey showing LLM-KG synergy improves downstream tasks by 5-15%."
+          "notes": "Pan et al. (2024) \u2014 Unifying Large Language Models and Knowledge Graphs: A Roadmap; comprehensive survey showing LLM-KG synergy improves downstream tasks by 5-15%."
         },
         {
           "class": "B",
           "source": "https://github.com/microsoft/graphrag",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Microsoft GraphRAG — production KG construction pipeline; extracts community summaries and entity graphs from corpora, enabling global sensemaking queries."
+          "notes": "Microsoft GraphRAG \u2014 production KG construction pipeline; extracts community summaries and entity graphs from corpora, enabling global sensemaking queries."
         }
       ],
       "knownAgents": [],
@@ -2365,7 +2372,7 @@
       "type": "legendary",
       "level": "V",
       "rarity": "legendary",
-      "description": "Autonomously generates novel scientific hypotheses, designs and executes experiments, analyses results, and produces a written report — completing a full research cycle without human intervention.",
+      "description": "Autonomously generates novel scientific hypotheses, designs and executes experiments, analyses results, and produces a written report \u2014 completing a full research cycle without human intervention.",
       "prerequisites": [
         "hypothesis-generate",
         "research",
@@ -2379,21 +2386,21 @@
           "source": "https://arxiv.org/abs/2304.05376",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "ChemCrow (Bran et al., 2023) — autonomous chemistry agent completes synthesis planning and molecular design tasks rated expert-level by human chemists."
+          "notes": "ChemCrow (Bran et al., 2023) \u2014 autonomous chemistry agent completes synthesis planning and molecular design tasks rated expert-level by human chemists."
         },
         {
           "class": "A",
           "source": "https://arxiv.org/abs/2304.05332",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Coscientist (Boiko et al., 2023) — autonomously planned and executed real wet-lab chemistry experiments, confirmed by GC-MS analysis."
+          "notes": "Coscientist (Boiko et al., 2023) \u2014 autonomously planned and executed real wet-lab chemistry experiments, confirmed by GC-MS analysis."
         },
         {
           "class": "B",
           "source": "https://github.com/SakanaAI/AI-Scientist",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "AI Scientist (Lu et al., 2024) — generates idea, writes code, runs experiments, and produces a full NeurIPS-style paper; 50+ manuscripts auto-generated."
+          "notes": "AI Scientist (Lu et al., 2024) \u2014 generates idea, writes code, runs experiments, and produces a full NeurIPS-style paper; 50+ manuscripts auto-generated."
         }
       ],
       "knownAgents": [],
@@ -2421,7 +2428,7 @@
           "source": "https://arxiv.org/abs/2203.11171",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Wang et al. (2022) — Self-Consistency Improves Chain of Thought Reasoning in Language Models; +17.9% on GSM8K and +11.0% on MATH over greedy CoT decoding."
+          "notes": "Wang et al. (2022) \u2014 Self-Consistency Improves Chain of Thought Reasoning in Language Models; +17.9% on GSM8K and +11.0% on MATH over greedy CoT decoding."
         }
       ],
       "knownAgents": [],
@@ -2449,7 +2456,7 @@
           "source": "https://arxiv.org/abs/2005.14165",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Brown et al. (2020) — Language Models are Few-Shot Learners (GPT-3); in-context learning from 1-100 examples achieves near-SOTA on SuperGLUE, translation, and QA benchmarks."
+          "notes": "Brown et al. (2020) \u2014 Language Models are Few-Shot Learners (GPT-3); in-context learning from 1-100 examples achieves near-SOTA on SuperGLUE, translation, and QA benchmarks."
         }
       ],
       "knownAgents": [],
@@ -2479,14 +2486,14 @@
           "source": "https://arxiv.org/abs/2305.10601",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Yao et al. (2023) — Tree of Thoughts: Deliberate Problem Solving with LLMs; +74% on Game of 24 and +4% on Creative Writing vs chain-of-thought baseline."
+          "notes": "Yao et al. (2023) \u2014 Tree of Thoughts: Deliberate Problem Solving with LLMs; +74% on Game of 24 and +4% on Creative Writing vs chain-of-thought baseline."
         },
         {
           "class": "B",
           "source": "https://github.com/princeton-nlp/tree-of-thought-llm",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Princeton-NLP ToT repo — reproducible breadth-first and depth-first tree search implementations with evaluation scripts for Game of 24 and Mini Crosswords."
+          "notes": "Princeton-NLP ToT repo \u2014 reproducible breadth-first and depth-first tree search implementations with evaluation scripts for Game of 24 and Mini Crosswords."
         }
       ],
       "knownAgents": [],
@@ -2516,14 +2523,14 @@
           "source": "https://arxiv.org/abs/2310.03714",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Khattab et al. (2023) — DSPy: Compiling Declarative Language Model Calls into Self-Improving Pipelines; automated prompt tuning matches or exceeds hand-crafted prompts on GSM8K, HotPotQA, and FEVER."
+          "notes": "Khattab et al. (2023) \u2014 DSPy: Compiling Declarative Language Model Calls into Self-Improving Pipelines; automated prompt tuning matches or exceeds hand-crafted prompts on GSM8K, HotPotQA, and FEVER."
         },
         {
           "class": "B",
           "source": "https://github.com/stanfordnlp/dspy",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "DSPy — Stanford NLP library for programmable LM pipelines; 18k+ GitHub stars, supports multiple optimizers (BootstrapFewShot, MIPRO, COPRO) across any LM."
+          "notes": "DSPy \u2014 Stanford NLP library for programmable LM pipelines; 18k+ GitHub stars, supports multiple optimizers (BootstrapFewShot, MIPRO, COPRO) across any LM."
         }
       ],
       "knownAgents": [],
@@ -2554,14 +2561,14 @@
           "source": "https://arxiv.org/abs/2305.17126",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Cai et al. (2023) — Large Language Models as Tool Makers (LATM); LLM-generated tools reused across problem instances achieve +8.7% on BigBench Hard vs per-instance CoT."
+          "notes": "Cai et al. (2023) \u2014 Large Language Models as Tool Makers (LATM); LLM-generated tools reused across problem instances achieve +8.7% on BigBench Hard vs per-instance CoT."
         },
         {
           "class": "B",
           "source": "https://github.com/ctlllll/LLM-ToolMaker",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "LATM repo — reproducible tool-maker/tool-user pipeline with evaluation on BigBench Hard tasks and tool reuse across problem batches."
+          "notes": "LATM repo \u2014 reproducible tool-maker/tool-user pipeline with evaluation on BigBench Hard tasks and tool reuse across problem batches."
         }
       ],
       "knownAgents": [],

--- a/skills/composite/rag-pipeline.md
+++ b/skills/composite/rag-pipeline.md
@@ -25,7 +25,8 @@ _None specified._
 ## Evidence
 | Class | Source | Evaluator | Date |
 |---|---|---|---|
-| B | https://github.com/gaia-registry/gaia/blob/main/docs/evidence/ragPipeline.md | mbtiongson1 | 2026-04-26 |
+| A | https://aclanthology.org/2024.eacl-demo.16/ | rico-favor | 2026-04-29 |
+| B | https://github.com/vibrantlabsai/ragas | rico-favor | 2026-04-29 |
 
 ## Known Agents
 _None verified yet._


### PR DESCRIPTION
## Reclassification Request

### Target Skill
- **ID:** `rag-pipeline`
- **Current Level:** III → **Proposed Level:** III
- **Current Rarity:** uncommon → **Proposed Rarity:** uncommon

### Justification

`rag-pipeline` is already classified at Level III, but its evidence entry was a thin internal seed note. This PR keeps the classification unchanged and strengthens the public evidence supporting it with a peer-reviewed RAG evaluation demo and a reproducible open-source implementation.

The new notes also document concrete failure modes relevant to RAG pipelines:
- retrieval can miss relevant chunks;
- ambiguous queries can retrieve misleading context;
- generated answers can drift from retrieved evidence;
- retrieval quality and answer faithfulness need separate evaluation dimensions.

### New Evidence
| Class | Source | Evaluator | Date | Notes |
|---|---|---|---|---|
| A | https://aclanthology.org/2024.eacl-demo.16/ | rico-favor | 2026-04-29 | RAGAS peer-reviewed demo paper defines reproducible metrics for retrieval-augmented generation, including context relevance, faithfulness, and answer relevance. |
| B | https://github.com/vibrantlabsai/ragas | rico-favor | 2026-04-29 | RAGAS open-source implementation provides a reproducible evaluation toolkit for RAG pipelines and documents RAG evaluation workflows. |

### Existing PRs / related work

Searched open/closed PRs for related RAG evidence work. No duplicate RAG evidence PR was found. This directly addresses #10.

### Validation

```bash
python3 scripts/validate.py
python3 scripts/generateProjections.py
python3 scripts/validate.py
```

### Checklist

**Contributor:**
- [x] Justification references concrete evidence, not opinion.
- [x] New evidence meets the threshold for the target level.
- [x] Rarity is unchanged.
- [x] I have run `python scripts/validate.py` locally and it passes.

Closes #10
