### PR TITLE
feat: Batch 3 skills + CI fork-PR fix + schema test coverage

### DIFF
--- a/tests/fixtures/atomic_with_prereqs.json
+++ b/tests/fixtures/atomic_with_prereqs.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "../../schema/skill.schema.json",
+  "version": "0.1.0",
+  "generatedAt": "2026-04-26T00:00:00Z",
+  "skills": [
+    {
+      "id": "skill-a",
+      "name": "Skill A",
+      "type": "atomic",
+      "level": "II",
+      "rarity": "common",
+      "description": "Atomic skill that incorrectly declares prerequisites.",
+      "prerequisites": ["skill-b"],
+      "derivatives": [],
+      "evidence": [
+        {
+          "class": "C",
+          "source": "http://example.com",
+          "evaluator": "test",
+          "date": "2026-04-26"
+        }
+      ],
+      "knownAgents": [],
+      "status": "provisional",
+      "createdAt": "2026-04-26",
+      "updatedAt": "2026-04-26",
+      "version": "0.1.0"
+    },
+    {
+      "id": "skill-b",
+      "name": "Skill B",
+      "type": "atomic",
+      "level": "II",
+      "rarity": "common",
+      "description": "Valid atomic skill.",
+      "prerequisites": [],
+      "derivatives": ["skill-a"],
+      "evidence": [
+        {
+          "class": "C",
+          "source": "http://example.com",
+          "evaluator": "test",
+          "date": "2026-04-26"
+        }
+      ],
+      "knownAgents": [],
+      "status": "provisional",
+      "createdAt": "2026-04-26",
+      "updatedAt": "2026-04-26",
+      "version": "0.1.0"
+    }
+  ]
+}

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -62,6 +62,12 @@ class TestValidate(unittest.TestCase):
         self.assertIn("Validated legendary", out)
         self.assertIn("needs ≥3 Class A/B evidence", out)
 
+    def test_atomic_with_prerequisites(self):
+        """Ensure an atomic skill that declares prerequisites is rejected."""
+        code, out = run_validate(os.path.join(FIXTURES_DIR, "atomic_with_prereqs.json"))
+        self.assertEqual(code, 1, "Expected atomic-with-prereqs to fail validation.")
+        self.assertIn("must have 0 prerequisites", out)
+
 class TestNamedSkillValidation(unittest.TestCase):
     """Tests that verify named skill files pass validate_and_group rules."""
 

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -12,6 +12,13 @@ class TestWorkflowConfig(unittest.TestCase):
             content = f.read()
         self.assertIn('- "intake/**"', content)
 
+    def test_auto_triage_uses_pull_request_target(self):
+        """Regression: pull_request gives read-only token on fork PRs, breaking label writes."""
+        with open(AUTO_TRIAGE_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        self.assertIn("pull_request_target", content)
+        self.assertNotIn("on:\n  pull_request:\n", content)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Adds 5 new Level IV skills: `self-consistency`, `few-shot-learning`, `tree-of-thought`, `prompt-optimization`, `tool-creation`
- Fixes `route-review` CI failure on fork PRs (PRs #35, #36) by switching `auto-triage.yml` trigger from `pull_request` to `pull_request_target`
- Adds regression test + new schema validation test to prevent both issues from silently regressing

## Changes

### Skills (Batch 3)
| ID | Type | Level | Rarity |
|---|---|---|---|
| `self-consistency` | atomic | IV | rare |
| `few-shot-learning` | atomic | IV | common |
| `tree-of-thought` | composite | IV | rare |
| `prompt-optimization` | composite | IV | uncommon |
| `tool-creation` | composite | IV | rare |

### CI Fix
`pull_request` events from forks get a read-only `GITHUB_TOKEN` — `gh pr edit --add-label` fails with `GraphQL: Resource not accessible by integration (addLabelsToLabelable)`. Switching to `pull_request_target` runs with the base-repo token. Removed `checkout + python validate` steps from triage jobs (already covered by `validate.yml`) so no PR code runs under elevated permissions.

### Tests
- `test_auto_triage_uses_pull_request_target` — regression guard for the CI fix
- `test_atomic_with_prerequisites` + `fixtures/atomic_with_prereqs.json` — covers the previously untested validate.py path that rejects atomic skills with prerequisites

## Test plan
- [x] `pytest tests/test_validate.py tests/test_workflows.py` — 14 passed
- [ ] Verify `route-review` passes on next fork PR after merge