### PR TITLE
docs: update README, CONTRIBUTING, and DESIGN.md for real-skills pipeline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,9 @@ Thank you for helping map the frontier of AI agent capability. This guide covers
 3. [Naming Conventions](#naming-conventions)
 4. [Evidence Requirements](#evidence-requirements)
 5. [How to Submit a PR](#how-to-submit-a-pr)
-6. [Reviewer Rubric](#reviewer-rubric)
-7. [Why a PR Gets Rejected](#why-a-pr-gets-rejected)
+6. [Named Skills](#named-skills)
+7. [Reviewer Rubric](#reviewer-rubric)
+8. [Why a PR Gets Rejected](#why-a-pr-gets-rejected)
 
 ---
 
@@ -26,6 +27,8 @@ Thank you for helping map the frontier of AI agent capability. This guide covers
 | Reclassification | `reclassification.md` | Changing level or rarity of an existing skill |
 | New user tree | `new_user_tree.md` | Registering your first skill tree in `users/` |
 | Batch skill intake | `gaia push` / `/gaia-draft-curate` | Submitting known and proposed skills detected from agent usage |
+| New named skill | `new_named_skill.md` | Adding a real-world implementation to `graph/named/` |
+| Named skill classification | `named_skill_classification.md` | Reviewer-only: promoting an `awakened` named skill to `named` status |
 
 ---
 
@@ -173,6 +176,43 @@ Examples:
 - `[atomic] parse-csv — adds CSV parsing as a primitive Intrinsic Skill`
 - `[composite] autonomous-debug — combines code-generation + execute-bash + error-interpretation`
 - `[reclassify] web-scrape — upgrade from Awakened (II) to Named (III) with new evidence`
+
+---
+
+## Named Skills
+
+Named skills are real-world implementations of abstract Gaia skills, attributed to a specific contributor. They live at `graph/named/{contributor}/{skill-name}.md`.
+
+### Contributor: submitting a named skill
+
+Always submit with `status: awakened`. Never set `title`, `catalogRef`, or `status: named` — these fields are reviewer-only. CI will fail if you attempt to set them.
+
+Use the `new_named_skill.md` PR template, which contains the full contributor and reviewer checklists.
+
+```bash
+# Example named skill frontmatter (contributor submits this)
+id: karpathy/autoresearch
+name: AutoResearch
+contributor: karpathy
+genericSkillRef: autonomous-research-agent
+status: awakened          # <-- always awakened at submission
+level: II
+origin: true
+description: "..."
+```
+
+### Reviewer: classifying a named skill
+
+After a named skill is merged as `awakened`, a reviewer checks whether it matches a real-world published implementation (a SKILL.md, open-source repo, or documented tool). If yes:
+
+1. Open a classification PR using the `named_skill_classification.md` template.
+2. Add `title` (reviewer-assigned RPG epithet) and optionally `catalogRef` (back-link to `graph/real_skill_catalog.json`).
+3. Change `status: awakened` → `status: named`.
+4. If no catalog entry exists yet, add one to `graph/real_skill_catalog.json` with `promotedNamedSkillId` pointing back.
+
+Only `status: named` skills surface as `realVariants` on abstract skill nodes and in the real-skills catalog. `awakened` skills remain in `graph/named/index.json` under `awaitingClassification` until classified.
+
+**Key rule:** Contributors declare skills. Reviewers classify identity.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ GAIA SKILL TREE  v1.0.0
 
 - **Track your agent's capabilities** — every skill your agent demonstrates gets logged to your personal skill tree, tied to your GitHub identity, portable across every repo you own.
 - **Unlock combinations** — when your agent has the prerequisites, a new composite or ultimate skill becomes available to fuse. The CLI detects it automatically.
-- **Name and share skills** — contribute named implementations of generic skills (e.g., `karpathy/autoresearch`), attributed to your GitHub identity and installable by anyone via `gaia install`.
+- **Name and share skills** — contribute named implementations of generic skills (e.g., `karpathy/autoresearch`), attributed to your GitHub identity and installable by anyone via `gaia install`. Submit with `status: awakened`; a reviewer promotes to `status: named` after confirming the real-world identity.
 - **Contribute to the canon** — review draft skills, submit evidence, or create new skills from strong reviews. The graph grows with the field.
 
 ---
@@ -110,27 +110,53 @@ Gaia also keeps a curated catalog of real-world named `SKILL.md` entries before 
 
 Use this catalog to bucket popular named skills from sources such as VoltAgent's Awesome Agent Skills, AgentSkills.me, official skill pages, and Superpowers. The canonical DAG still lives in `graph/gaia.json`; the real skill catalog is a review surface for source-backed names and Gaia mappings.
 
-## Install the Plugin (per-repo)
+## CLI Usage
 
-Write the SVG somewhere specific:
-
-```bash
-gaia graph -o graph/gaia.svg --no-open
-```
-
-Generate browser-friendly layout JSON instead of SVG:
+Install once from the repo root:
 
 ```bash
-gaia graph --format json -o graph/render/latest.json --no-open
+pip install -e .
 ```
 
-For graph tools such as Gephi or Cytoscape, regenerate the GEXF export:
+Then `gaia` works from any directory — no path prefix needed.
+
+### Project setup
 
 ```bash
-python3 scripts/exportGexf.py
+gaia init --user your-github-username --scan AGENTS.md --scan scripts
 ```
 
-The public Pages experience also mirrors downloadable graph artifacts under `docs/graph/` so the site can offer JSON, GEXF, and SVG downloads.
+### Commands
+
+| Command | What it does |
+|---|---|
+| `gaia init` | Creates `.gaia/config.json` in the current project. Supports `--user`, `--registry-ref`, and repeated `--scan` flags. |
+| `gaia doctor` | Checks CLI/config/registry health and reports missing setup pieces. |
+| `gaia scan` | Scans configured paths and reports detected canonical skills and possible fusions. |
+| `gaia push --dry-run` | Prints the batch intake JSON without writing files. |
+| `gaia push` | Writes a batch intake record under `intake/skill-batches/` in the registry checkout. |
+| `gaia push --no-pr` | Writes a batch intake record without trying to open a PR. |
+| `gaia name <batch> <index> <contributor/skill>` | Promotes an awakened skill from intake to a named skill in `graph/named/`. |
+| `gaia install <contributor/skill>` | Downloads a named skill into the repo (global cache + repo reference). |
+| `gaia install --list` | Lists all installed named skills. |
+| `gaia sync` | Updates installed named skills from their registry origin. |
+| `gaia uninstall <contributor/skill>` | Removes an installed named skill. |
+| `gaia embed` | Pre-computes embeddings for all skills. Run once after `pip install -e ".[embeddings]"`, re-run when the graph changes. |
+| `gaia search <query>` | Semantic search across generic and named skills (requires embeddings). |
+| `gaia graph` | Generates `graph/gaia.svg` from the canonical registry and opens it in your browser. |
+| `gaia graph -o /tmp/gaia.svg --no-open` | Writes a graph image to a custom path without opening it. |
+| `gaia status` | Shows the configured user's registered skill-tree summary. |
+| `gaia tree` | Lists unlocked skills for the configured user. |
+| `gaia fuse <skillId>` | Adds a pending fusion candidate to the user's skill tree. |
+
+### View the skill graph
+
+```bash
+gaia graph                                              # generate and open SVG
+gaia graph -o graph/gaia.svg --no-open                 # write to specific path
+gaia graph --format json -o graph/render/latest.json   # browser-friendly JSON
+python3 scripts/exportGexf.py                          # Gephi/Cytoscape GEXF
+```
 
 ### Typical workflow
 
@@ -197,23 +223,29 @@ See [`mcp-server/`](mcp-server/) for full documentation.
 
 ```
 gaia-skill-tree/
-├── graph/gaia.json          ← CANONICAL source (the only file humans edit)
-├── graph/real_skill_catalog.json ← Curated real-world named skills
-├── mcp-server/              ← TypeScript MCP server (agent-native integration)
-├── schema/                  ← JSON Schema definitions
-├── skills/                  ← GENERATED skill pages (atomic, composite, legendary)
-├── users/                   ← Personal skill trees by GitHub username
-├── scripts/                 ← Validation, projection, and analysis scripts
-├── scripts/crawlers/        ← Bot crawlers (MCP registries, npm, VS Code, HuggingFace)
-├── src/gaia_cli/            ← Python package source for the gaia CLI (pip-installable)
-├── plugin/                  ← TypeScript CLI wrapper + GitHub Action for per-repo integration
-├── pyproject.toml           ← Package metadata and optional dependencies (e.g. [embeddings])
-├── registry.md              ← GENERATED flat index of all skills
-├── combinations.md          ← GENERATED fusion recipe matrix
-├── tree.md                  ← GENERATED full ASCII skill graph
-├── real-skills.html         ← GENERATED linked catalog of real named skills
-├── CONTRIBUTING.md          ← How to contribute
-└── docs/                    ← Governance, design spec, examples
+├── graph/gaia.json               ← CANONICAL source (the only file humans edit)
+├── graph/named/                  ← Named skill implementations ({contributor}/{skill-name}.md)
+├── graph/named/index.json        ← GENERATED bucket index (named + awaitingClassification + byContributor)
+├── graph/real_skill_catalog.json ← Upstream catalog of real-world named skills
+├── graph/embeddings.json         ← GENERATED skill embeddings (sentence-transformers)
+├── graph/similarity.json         ← GENERATED pairwise similarity scores
+├── intake/                       ← Batch skill proposals submitted by gaia push
+├── mcp-server/                   ← TypeScript MCP server (agent-native integration)
+├── schema/                       ← JSON Schema definitions
+├── schema/realSkillCatalog.schema.json ← Schema for graph/real_skill_catalog.json
+├── skills/                       ← GENERATED skill pages (atomic, composite, legendary)
+├── users/                        ← Personal skill trees by GitHub username
+├── scripts/                      ← Validation, projection, and analysis scripts
+├── scripts/crawlers/             ← Bot crawlers (MCP registries, npm, VS Code, HuggingFace)
+├── src/gaia_cli/                 ← Python package source for the gaia CLI (pip-installable)
+├── plugin/                       ← TypeScript CLI wrapper + GitHub Action for per-repo integration
+├── pyproject.toml                ← Package metadata and optional dependencies (e.g. [embeddings])
+├── registry.md                   ← GENERATED flat index of all skills
+├── combinations.md               ← GENERATED fusion recipe matrix
+├── tree.md                       ← GENERATED full ASCII skill graph
+├── real-skills.html              ← GENERATED linked catalog of real named skills
+├── CONTRIBUTING.md               ← How to contribute
+└── docs/                         ← Governance, design spec, examples
 ```
 
 ---

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -180,6 +180,10 @@ gaia/
 ├── graph/
 │   ├── gaia.json                    ← CANONICAL. The only file humans edit directly.
 │   ├── gaia.gexf                    ← Generated Gephi export
+│   ├── named/                       ← Named skill implementations
+│   │   ├── {contributor}/{skill}.md ← Frontmatter + body per named skill
+│   │   └── index.json               ← GENERATED: buckets, awaitingClassification, byContributor
+│   ├── real_skill_catalog.json      ← Upstream catalog of real-world skill implementations
 │   └── render/                      ← Versioned static graph snapshots
 │       ├── v0.1.0.json
 │       └── v0.1.0.png
@@ -207,8 +211,10 @@ gaia/
 ├── combinations.md                  ← GENERATED. Fusion recipe matrix.
 │
 ├── schema/
-│   ├── skill.schema.json            ← Validates skill nodes
+│   ├── skill.schema.json            ← Validates skill nodes (includes optional realVariants array)
 │   ├── combination.schema.json      ← Validates fusion recipes / edges
+│   ├── namedSkill.schema.json       ← Validates graph/named/*.md frontmatter
+│   ├── realSkillCatalog.schema.json ← Validates graph/real_skill_catalog.json
 │   ├── skillTree.schema.json        ← Validates user skill trees
 │   └── pluginConfig.schema.json     ← Validates .gaia/config.json
 │
@@ -518,14 +524,42 @@ The generated `graph/named/index.json` provides fast lookup of all named impleme
 
 ### 13.3 Lifecycle
 
+Contributors always submit named skills with `status: awakened`. Reviewer classification is a separate, subsequent step.
+
 ```
-gaia push → intake/skill-batches/ (lifecycle: "pending")
-         → reviewer accepts (lifecycle: "awakened")
-         → gaia name <batch> <index> <contributor/skill-name>
-         → graph/named/{contributor}/{skill-name}.md (lifecycle: "named")
+Contributor opens PR (graph/named/{contributor}/{skill}.md)
+     status: awakened  ←  always. title/catalogRef: absent.
+            │
+            ▼ CI: schema valid, genericSkillRef resolves, level ≥ II
+            │
+            ▼ Reviewer: checks correctness, evidence, level
+            │
+         MERGE as status: awakened
+            │
+            │ Reviewer asks: does this match a real-world SKILL.md?
+            │
+    YES ────┤                              NO
+            ▼                              ▼
+ Reviewer opens classification PR    Skill sits as awakened
+ Adds: title (RPG epithet)           Visible in awaitingClassification
+ Adds: catalogRef (optional)         Not surfaced as realVariant
+ Sets: status: named
+ CI enforces: named requires
+   title OR catalogRef
+            │
+            ▼
+ MERGE → generateNamedIndex.py
+ populates realVariants on abstract node
 ```
 
-Level 0 (Basic) and Level I (Awakened) skills are generic-only. A skill only becomes "named" in the sense of Level II once a contributor claims it via `gaia name`. Basic skills (Level 0) are universal LLM primitives and do not accept named implementations.
+**Rule:** Contributors declare skills. Reviewers classify identity.
+
+The `graph/named/index.json` file produced by `generateNamedIndex.py` has three keys:
+- `buckets` — skills with `status: named`, grouped by `genericSkillRef` (feeds `realVariants` on abstract nodes)
+- `awaitingClassification` — skills with `status: awakened`, pending reviewer action
+- `byContributor` — secondary index mapping contributor username → list of named skill IDs
+
+Level 0 (Basic) and Level I (Awakened) skills are generic-only and do not accept named implementations.
 
 ### 13.4 Install & Sync
 


### PR DESCRIPTION
## Summary

- **README.md** — restored the missing CLI commands table (lost in a prior merge); fixed the orphaned `## Install the Plugin` heading (replaced with `### View the skill graph`); updated the named-skill bullet to describe the `awakened`-first + reviewer-classification workflow; expanded the repo structure block with `graph/named/`, `graph/named/index.json`, and `schema/realSkillCatalog.schema.json`.
- **CONTRIBUTING.md** — added `new_named_skill` and `named_skill_classification` PR types to the contribution table; added a new **Named Skills** section documenting the contributor (always submit `awakened`) and reviewer (classify + promote to `named`) roles; updated the Table of Contents.
- **docs/DESIGN.md** — Section 4 repo structure: added `graph/named/` tree and `real_skill_catalog.json`; Section 4 schemas: added `realSkillCatalog.schema.json` and `namedSkill.schema.json`; Section 13.3 lifecycle: replaced the old single-pass diagram with the two-step contributor/reviewer flow, and documented the `awaitingClassification` and `byContributor` keys in `index.json`.

## Test plan

- [ ] README renders correctly on GitHub — CLI table visible, repo structure accurate
- [ ] CONTRIBUTING Named Skills section reads clearly for both contributors and reviewers
- [ ] docs/DESIGN.md Section 13.3 lifecycle diagram matches actual code behaviour in `validate.py` and `generateNamedIndex.py`