### PR TITLE
fix(docs): Named Skills mode keyed on namedMap catalogue, not gaia.json level field

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -940,7 +940,7 @@
       ctx.fillStyle = `rgba(255,255,255,${(alpha * 0.85).toFixed(2)})`; ctx.fill();
     }
     function shouldLabel(skill) {
-      if (state.redPillActive && NAMED_LEVELS.has(skill.level)) return true;
+      if (state.redPillActive && state.namedMap[skill.id]) return true;
       if (state.labelMode === 'none') return false;
       if (state.labelMode === 'all') return true;
       if (state.labelMode === 'modal') return skill.type !== 'atomic' || stableHash(skill.id) % 7 === 0;
@@ -998,7 +998,7 @@
         } else {
           targetVis = 1.0;
         }
-        if (state.redPillActive && !NAMED_LEVELS.has(skill.level)) targetVis = Math.min(targetVis, 0.07);
+        if (state.redPillActive && !state.namedMap[skill.id]) targetVis = Math.min(targetVis, 0.07);
         if (state.nodeAlphas[skill.id] === undefined) state.nodeAlphas[skill.id] = targetVis;
         state.nodeAlphas[skill.id] += (targetVis - state.nodeAlphas[skill.id]) * 0.15;
       });
@@ -1046,7 +1046,7 @@
         const vis = state.nodeAlphas[skill.id] !== undefined ? state.nodeAlphas[skill.id] : 1.0;
         if (skill.level === 'VI') {
           drawNodeVI(pr.sx, pr.sy, baseR * state.scale * pr.scale * pulse, depthAlpha * vis, state.t, p);
-        } else if (state.redPillActive && NAMED_LEVELS.has(skill.level)) {
+        } else if (state.redPillActive && state.namedMap[skill.id]) {
           drawNodeNamed(pr.sx, pr.sy, baseR * state.scale * pr.scale * pulse, depthAlpha * vis);
         } else {
           drawNode(pr.sx, pr.sy, baseR * state.scale * pr.scale * pulse, col, depthAlpha * vis);
@@ -1061,7 +1061,7 @@
         const vis = state.nodeAlphas[skill.id] !== undefined ? state.nodeAlphas[skill.id] : 1.0;
         const labelAlpha = highlighted ? 1.0 : depthAlpha * Math.max(0.22, vis) * 0.9;
         if (labelAlpha < 0.04) return;
-        const col = (state.redPillActive && NAMED_LEVELS.has(skill.level))
+        const col = (state.redPillActive && state.namedMap[skill.id])
           ? { rgb:'239,68,68' }
           : (PALETTE[skill.type] || PALETTE.atomic);
         const size = skill.type === 'legendary' ? 13 : skill.type === 'composite' ? 10 : 8;


### PR DESCRIPTION
## Summary

- **Named Skills graph toggle**: `FALLBACK_NAMED_MAP` constant initialises `state.namedMap` at startup — the toggle works immediately on `file://` or any static host, no server required. Live fetch still runs and overrides when available.
- **Named Skills browser**: `FALLBACK_NAMED_INDEX` embedded inline; both `fetch()` calls now use individual `.catch()` fallbacks so the card grid always renders.

## Root cause

Both features relied on `fetch('graph/named/index.json')` which fails on `file://` protocol. The fix mirrors the existing `FALLBACK_SKILLS` pattern already used for the graph.

## Test plan

- [ ] Open `docs/index.html` directly as a local file (`file://`) — no server
- [ ] Named Skills toggle in graph dialog highlights 14 contributor nodes with red glow + `contributor/skill-name` labels
- [ ] Named Skills browser section renders all 14 cards
- [ ] When served normally, live fetch overrides the fallback seamlessly