### PR TITLE
feat(docs): embed named map + index inline — Named Skills works without a server

### DIFF
--- a/.claude/skills/gaia-curate/skill.md
+++ b/.claude/skills/gaia-curate/skill.md
@@ -1,7 +1,7 @@
 ---
 name: gaia-curate
 description: Expand the Gaia skill registry with new popular AI agent skills, fully evidenced and validated, then push a PR. Use this skill when the user asks to "update the tree", "add new skills to Gaia", "curate the registry", "expand the skill graph", or explicitly types /gaia-curate.
-version: 1.4.0
+version: 1.5.0
 ---
 
 # gaia-curate
@@ -19,7 +19,32 @@ Expand the Gaia skill registry (`graph/gaia.json`) with new popular AI agent ski
    gh search repos --topic="<skill-topic>" --sort=stars --limit=20
    gh search repos "<skill-name> agent" --sort=stars --limit=10
    ```
-   Qualify repos: stars > 50, last commit < 1 year, has README + license. Use the repo URL as Class B evidence. Prefer repos with CI, tests, and clear documentation.
+   Qualify repos: stars > 50, last commit < 1 year, has README + license. Prefer repos with CI, tests, and clear documentation.
+
+   **2a-ii. Inspect repos for individual skill files — do not use a repo URL as evidence until you confirm what is inside it.**
+
+   A repo is often a *collection* of many skills, not a single skill. After finding a qualifying repo, check the common skill directory layouts:
+   ```bash
+   # Check each layout — only the first match that returns results matters
+   gh api repos/{owner}/{repo}/contents/skills --jq '.[].name'
+   gh api repos/{owner}/{repo}/contents/.claude/skills --jq '.[].name'
+   gh api repos/{owner}/{repo}/contents/codex/skills --jq '.[].name'
+   gh api repos/{owner}/{repo}/contents/.codex/skills --jq '.[].name'
+   gh api repos/{owner}/{repo}/contents/cursor/skills --jq '.[].name'
+   ```
+   If a skills directory exists, it will return a list of subdirectory names — each is a distinct skill.
+
+   **For each skill subdirectory found:**
+   1. Verify it contains a `SKILL.md` (or `skill.md`) file:
+      ```bash
+      gh api repos/{owner}/{repo}/contents/<skills-dir>/<skill-name>/SKILL.md --jq '.download_url'
+      ```
+   2. Fetch the SKILL.md content to read its description.
+   3. Map it to an existing or new Gaia skill ID.
+   4. Use the **raw file URL** (e.g., `https://github.com/{owner}/{repo}/blob/main/<skills-dir>/<skill-name>/SKILL.md`) as the Class B evidence `source` — never the repo root URL.
+   5. Treat each discovered skill as a **separate candidate** to evaluate independently (accept/rename/duplicate/reject it on its own merits).
+
+   If no skills directory is found, the repo itself is the evidence source and its URL may be used directly.
 
    **2b. SkillsMP search (10% — Class C evidence):**
    Query the SkillsMP public API for related community skills:

--- a/.claude/skills/gaia-draft-curate/skill.md
+++ b/.claude/skills/gaia-draft-curate/skill.md
@@ -1,7 +1,7 @@
 ---
 name: gaia-draft-curate
 description: Review pending Gaia draft skill intake batches and open draft PRs. Classifies each proposed skill (accept/rename/duplicate/needs-evidence/reject) without touching graph/gaia.json. Optionally triggers a promotion PR for accepted skills. Use when the user asks to "check drafts", "review intake batches", "triage pending skills", or explicitly types /gaia-draft-curate.
-version: 1.1.0
+version: 1.2.0
 ---
 
 # gaia-draft-curate
@@ -27,15 +27,33 @@ Review pending Gaia draft skill intake batches and open draft PRs. This skill is
    gh search repos "<proposed-skill-name>" --sort=stars --limit=5
    gh search repos --topic="<proposed-skill-id>" --sort=stars --limit=5
    ```
-   b. If repos with >50 stars found, note as "Class B evidence available" with the repo URL.
+   b. **Inspect each qualifying repo for individual skill files.** A repo is often a *collection*, not a single skill. After finding a repo with >50 stars, check the common skill directory layouts:
+   ```bash
+   gh api repos/{owner}/{repo}/contents/skills --jq '.[].name'
+   gh api repos/{owner}/{repo}/contents/.claude/skills --jq '.[].name'
+   gh api repos/{owner}/{repo}/contents/codex/skills --jq '.[].name'
+   gh api repos/{owner}/{repo}/contents/.codex/skills --jq '.[].name'
+   gh api repos/{owner}/{repo}/contents/cursor/skills --jq '.[].name'
+   ```
+   If skill subdirectories exist, for each subdirectory that matches the proposed skill name (fuzzy-match OK):
+   ```bash
+   gh api repos/{owner}/{repo}/contents/<skills-dir>/<skill-name>/SKILL.md --jq '.download_url'
+   ```
+   Fetch the SKILL.md to read its description. **Use the specific file URL** (`https://github.com/{owner}/{repo}/blob/main/<skills-dir>/<skill-name>/SKILL.md`) as the Class B evidence source — never the repo root URL.
 
-   c. Query SkillsMP for matching community skills:
+   If the repo has *multiple* skill subdirectories and several map to proposed skills in the current batch (or to unproposed skills worth adding), note each one separately in the review table — they each get their own row and decision.
+
+   If no skills directory is found, the repo URL itself is acceptable as Class B evidence.
+
+   c. If a repo-level URL was previously recorded as evidence for this skill (e.g., the `sourceRepo` in the intake batch), **re-resolve it to a specific SKILL.md path** using the steps above before accepting. Flag repo-root URLs as `needs-specific-url` if no SKILL.md can be found.
+
+   d. Query SkillsMP for matching community skills:
    ```
    WebFetch: https://skillsmp.com/api/v1/skills/search?q=<skill-name>
    ```
-   d. Note any SkillsMP matches as "Class C evidence available".
+   Note any SkillsMP matches as "Class C evidence available".
 
-   This enrichment helps reviewers make informed accept/reject decisions. Skills with readily available Class B/A evidence should be favored for acceptance.
+   This enrichment helps reviewers make informed accept/reject decisions. Skills with readily available Class B/A evidence and a verified SKILL.md should be favored for acceptance.
 
 5. **Display review table** — for each batch, show:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -757,6 +757,22 @@
     { id:'autonomous-debug', type:'composite', name:'Autonomous Debug', prerequisites:['code-generation','execute-bash','tool-select'] },
     { id:'autonomous-research-agent', type:'legendary', name:'Autonomous Research Agent', prerequisites:['research','rag-pipeline'] },
   ];
+  const FALLBACK_NAMED_MAP = {
+    'automated-testing':           '0xdarkmatter/pytest-patterns',
+    'test-driven-development':     'addy-osmani/test-driven-development',
+    'document-editing':            'anthropic/pptx',
+    'tool-creation':               'anthropic/skill-creator',
+    'autonomous-debug':            'devin-ai/autonomous-swe',
+    'write-report':                'glincker/readme-generator',
+    'browser-automation':          'gooseworks/notte-browser',
+    'autonomous-research-agent':   'karpathy/autoresearch',
+    'framework-upgrade':           'laravel/upgrade-laravel-v13',
+    'ux-audit':                    'martin-stepanoski/nielsen-heuristics-audit',
+    'multi-agent-orchestration-v': 'ruvnet/flow-nexus-swarm',
+    'generate-test':               'upsonic/unittest-generator',
+    'skill-discovery':             'vercel/find-skills',
+    'rag-pipeline':                'yonatangross/orchestkit-rag',
+  };
 
   function normalizeSkills(graph) {
     const skills = (graph && graph.skills) ? graph.skills : FALLBACK_SKILLS;
@@ -844,7 +860,7 @@
       legendEl: null,
       showSlugs: false,
       redPillActive: false,
-      namedMap: {},
+      namedMap: FALLBACK_NAMED_MAP,
     };
 
     function resize() {
@@ -1423,9 +1439,27 @@ document.querySelectorAll('.reveal').forEach(el => obs.observe(el));
     var tabsEl = document.getElementById('nsLevelTabs');
     if (!grid) return;
 
+    var FALLBACK_NAMED_INDEX = { buckets: {
+      'automated-testing':           [{ id:'0xdarkmatter/pytest-patterns',            name:'Pytest Patterns',               contributor:'0xdarkmatter',       origin:true,  genericSkillRef:'automated-testing',           status:'named', level:'III', description:'Comprehensive pytest skill covering modern patterns for Python test automation including fixtures, parametrize, async testing, mocking, coverage strategies, integration tests, and conftest organisation for pytest 7.0+ projects.',            title:'The Quality Guardian',           tags:['pytest','python','test-automation','fixtures','async-testing','coverage','mocking'],                   links:{ github:'https://github.com/aiskillstore/marketplace' } }],
+      'test-driven-development':     [{ id:'addy-osmani/test-driven-development',     name:'Test-Driven Development',       contributor:'addy-osmani',        origin:true,  genericSkillRef:'test-driven-development',     status:'named', level:'II',  description:'Forces the AI agent to follow a strict red-green-refactor TDD workflow — writing failing tests before any implementation code, blocking code generation that skips the test step, and enforcing coverage thresholds before completing a task.', title:'The Red-Green Oath',             tags:['tdd','testing','red-green-refactor','workflow-enforcement','software-quality'],              links:{ github:'https://github.com/addyosmani/agent-skills' } }],
+      'document-editing':            [{ id:'anthropic/pptx',                           name:'PPTX Editor',                   contributor:'anthropic',          origin:true,  genericSkillRef:'document-editing',            status:'named', level:'II',  description:'Extracts slide content from PowerPoint (.pptx) files using markitdown, applies edits or design principles in-place, and repacks the file — enabling agents to read, modify, and write structured presentation files without a GUI.',            title:'The Slide Artisan',              tags:['pptx','powerpoint','document-editing','markitdown','presentations'],                          links:{ github:'https://github.com/anthropics/skills/blob/main/skills/pptx/SKILL.md' } }],
+      'tool-creation':               [{ id:'anthropic/skill-creator',                 name:'Skill Creator',                 contributor:'anthropic',          origin:true,  genericSkillRef:'tool-creation',               status:'named', level:'II',  description:'Interviews the user through a structured dialogue to elicit the skill\'s purpose, trigger conditions, and step-by-step instructions, then programmatically writes a new SKILL.md file ready for use in a Claude Code or Codex CLI skills directory.', title:'The Skill Forger\'s Art',        tags:['skill-authoring','meta-agent','claude-code','tool-creation'],                                links:{ github:'https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md' } }],
+      'autonomous-debug':            [{ id:'devin-ai/autonomous-swe',                 name:'Autonomous SWE',                contributor:'devin-ai',           origin:true,  genericSkillRef:'autonomous-debug',            status:'named', level:'III', description:'Autonomous software engineering agent capable of end-to-end debugging, code generation, and self-correction across complex multi-file codebases.',                                                                                               title:'The Codebreaker\'s Will',        tags:['software-engineering','autonomous','debugging','code-generation','self-correction'],         links:{ github:'https://github.com/cognition-labs/devin' } }],
+      'write-report':                [{ id:'glincker/readme-generator',               name:'README Generator',              contributor:'glincker',           origin:true,  genericSkillRef:'write-report',                status:'named', level:'II',  description:'Analyzes a project\'s directory structure, dependency manifests, and configuration files to generate a professional README.md covering installation, usage, API reference, and contributing guidelines.',                                          title:'The Document Weaver',            tags:['documentation','readme','code-analysis','project-structure'],                                links:{ github:'https://github.com/GLINCKER/claude-code-marketplace/blob/main/skills/documentation/readme-generator/SKILL.md' } },
+                                      { id:'spring-ai/readme-generate',               name:'REST API README Generator',     contributor:'spring-ai',          origin:false, genericSkillRef:'write-report',                status:'named', level:'II',  description:'Scans a Java Spring project for controller annotations, extracts REST API endpoint definitions, and automatically generates structured API documentation in README format.',                                                                      title:'The Endpoint Scribe',            tags:['java','spring','rest-api','documentation','readme'],                                         links:{ github:'https://github.com/spring-ai-alibaba/examples/tree/main/.claude/skills' } }],
+      'browser-automation':          [{ id:'gooseworks/notte-browser',                name:'Notte Browser',                 contributor:'gooseworks',         origin:true,  genericSkillRef:'browser-automation',          status:'named', level:'III', description:'AI-first browser automation using the Notte Browser API to control browser sessions, scrape pages, fill forms, take screenshots, and run autonomous web agents with managed credential handling.',                                              title:'The Digital Navigator',          tags:['browser','automation','web-agent','scraping','notte'],                                       links:{ github:'https://github.com/gooseworks-ai/goose-skills' } }],
+      'autonomous-research-agent':   [{ id:'karpathy/autoresearch',                   name:'AutoResearch',                  contributor:'karpathy',           origin:true,  genericSkillRef:'autonomous-research-agent',   status:'named', level:'II',  description:'Autonomous research agent that iteratively searches, reads, and synthesizes academic papers into structured summaries.',                                                                                                                           title:'The Scholar\'s Compass',         tags:['research','autonomous','paper-synthesis'],                                                   links:{ github:'https://github.com/karpathy/autoresearch' } }],
+      'framework-upgrade':           [{ id:'laravel/upgrade-laravel-v13',             name:'Upgrade Laravel v13',           contributor:'laravel',            origin:true,  genericSkillRef:'framework-upgrade',           status:'named', level:'II',  description:'Guides an AI agent through upgrading a Laravel 12 application to Laravel 13 safely, covering breaking changes, dependency updates, config migrations, and post-upgrade test validation.',                                                       title:'The Versionist\'s Trial',        tags:['laravel','php','framework-upgrade','migration'],                                             links:{ github:'https://github.com/laravel/boost/issues/698' } }],
+      'ux-audit':                    [{ id:'martin-stepanoski/nielsen-heuristics-audit',name:'Nielsen Heuristics Audit',    contributor:'martin-stepanoski',  origin:true,  genericSkillRef:'ux-audit',                    status:'named', level:'II',  description:'Audits a UI interface against Jakob Nielsen\'s 10 usability heuristics step-by-step, scoring each heuristic, surfacing violations, and producing a prioritized remediation report.',                                                             title:'The Ten Laws of Sight',          tags:['ux','usability','nielsen','heuristics','accessibility'],                                     links:{ npm:'https://classic.yarnpkg.com/en/package/@mastepanoski/claude-skills' } }],
+      'multi-agent-orchestration-v': [{ id:'ruvnet/flow-nexus-swarm',                 name:'Flow Nexus Swarm',              contributor:'ruvnet',             origin:true,  genericSkillRef:'multi-agent-orchestration-v', status:'named', level:'III', description:'Cloud-based AI swarm orchestration platform supporting hierarchical, mesh, ring, and star topologies with event-driven workflows, message queue processing, and intelligent agent assignment.',                                                  title:'The Grand Conductor\'s Blueprint',tags:['multi-agent','swarm','orchestration','event-driven','workflow'],                             links:{ github:'https://github.com/ruvnet/ruflo' } }],
+      'generate-test':               [{ id:'upsonic/unittest-generator',              name:'Unittest Generator',            contributor:'upsonic',            origin:true,  genericSkillRef:'generate-test',               status:'named', level:'II',  description:'Autonomous Claude agent that generates comprehensive unittest.TestCase suites from source code, organising tests into concept-based subfolders under a tests/ directory with proper imports, fixtures, and edge-case coverage.',                 title:'The Test Weaver',                tags:['unit-testing','unittest','test-generation','python','autonomous-agent'],                      links:{ github:'https://github.com/Upsonic/Upsonic' } }],
+      'skill-discovery':             [{ id:'vercel/find-skills',                      name:'Find Skills',                   contributor:'vercel',             origin:true,  genericSkillRef:'skill-discovery',             status:'named', level:'II',  description:'Searches the skills.sh registry by keyword or category, queries install counts to surface popular skills, and auto-installs the selected skill into the current project\'s skills directory.',                                                   title:'The Registry Scout',             tags:['skill-registry','discovery','skills-sh','auto-install'],                                     links:{ github:'https://github.com/vercel-labs/skills/blob/main/skills/find-skills/SKILL.md' } }],
+      'rag-pipeline':                [{ id:'yonatangross/orchestkit-rag',             name:'OrchestrKit RAG',               contributor:'yonatangross',       origin:true,  genericSkillRef:'rag-pipeline',                status:'named', level:'III', description:'Production-grade RAG retrieval skill covering 30+ patterns including core pipeline composition, HyDE query expansion, pgvector hybrid search, cross-encoder reranking, multimodal chunking, and agentic self-RAG and corrective-RAG loops.', title:'The Knowledge Architect',        tags:['rag','retrieval','hybrid-search','hyde','pgvector','reranking','agentic-rag'],               links:{ github:'https://github.com/yonatangross/orchestkit' } }],
+    }};
+
     Promise.all([
-      fetch('graph/named/index.json').then(function(r){ if (!r.ok) throw r; return r.json(); }),
-      fetch('graph/gaia.json').then(function(r){ if (!r.ok) throw r; return r.json(); }),
+      fetch('graph/named/index.json').then(function(r){ if (!r.ok) throw r; return r.json(); }).catch(function(){ return FALLBACK_NAMED_INDEX; }),
+      fetch('graph/gaia.json').then(function(r){ if (!r.ok) throw r; return r.json(); }).catch(function(){ return { skills: [] }; }),
     ]).then(function(results) {
       var indexData = results[0], fullGraph = results[1];
       var skillMap = {};
@@ -1466,7 +1500,7 @@ document.querySelectorAll('.reveal').forEach(el => obs.observe(el));
         if (head) head.closest('.ns-card').classList.toggle('open');
       });
     }).catch(function() {
-      grid.innerHTML = '<div class="ns-empty">Named skills unavailable. Serve from a local server: <code>python -m http.server 8080</code> in repo root, then open <code>/docs/</code></div>';
+      grid.innerHTML = '<div class="ns-empty">Unable to render named skills.</div>';
     });
   }
 

--- a/graph/gaia.json
+++ b/graph/gaia.json
@@ -3142,7 +3142,7 @@
       "evidence": [
         {
           "class": "B",
-          "source": "https://github.com/addyosmani/agent-skills",
+          "source": "https://github.com/addyosmani/agent-skills/blob/main/skills/test-driven-development/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
           "notes": "Addy Osmani /test-driven-development slash command -- forces strict TDD workflow, stopping agents from skipping tests."
@@ -3167,7 +3167,7 @@
       "evidence": [
         {
           "class": "B",
-          "source": "https://classic.yarnpkg.com/en/package/@mastepanoski/claude-skills",
+          "source": "https://github.com/mastepanoski/claude-skills/blob/main/skills/nielsen-heuristics-audit/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
           "notes": "Martin Stepanoski @mastepanoski/claude-skills -- /nielsen-heuristics-audit audits UI against Nielsen 10 usability heuristics step-by-step."

--- a/graph/named/addy-osmani/test-driven-development.md
+++ b/graph/named/addy-osmani/test-driven-development.md
@@ -10,7 +10,7 @@ catalogRef: addy-osmani-test-driven-development
 level: II
 description: Forces the AI agent to follow a strict red-green-refactor TDD workflow — writing failing tests before any implementation code, blocking code generation that skips the test step, and enforcing coverage thresholds before completing a task.
 links:
-  github: https://github.com/addyosmani/agent-skills
+  github: https://github.com/addyosmani/agent-skills/blob/main/skills/test-driven-development/SKILL.md
 tags:
   - tdd
   - testing

--- a/graph/named/martin-stepanoski/nielsen-heuristics-audit.md
+++ b/graph/named/martin-stepanoski/nielsen-heuristics-audit.md
@@ -10,7 +10,7 @@ catalogRef: martin-stepanoski-nielsen-heuristics-audit
 level: II
 description: Audits a UI interface against Jakob Nielsen's 10 usability heuristics step-by-step, scoring each heuristic, surfacing violations, and producing a prioritized remediation report.
 links:
-  npm: https://classic.yarnpkg.com/en/package/@mastepanoski/claude-skills
+  github: https://github.com/mastepanoski/claude-skills/blob/main/skills/nielsen-heuristics-audit/SKILL.md
 tags:
   - ux
   - usability

--- a/graph/named/spring-ai/readme-generate.md
+++ b/graph/named/spring-ai/readme-generate.md
@@ -10,7 +10,7 @@ catalogRef: spring-ai-readme-generate
 level: II
 description: Scans a Java Spring project for controller annotations, extracts REST API endpoint definitions, and automatically generates structured API documentation in README format.
 links:
-  github: https://github.com/spring-ai-alibaba/examples/tree/main/.claude/skills
+  github: https://github.com/spring-ai-alibaba/examples/blob/main/.claude/skills/readme-generate/SKILL.md
 tags:
   - java
   - spring

--- a/graph/real_skill_catalog.json
+++ b/graph/real_skill_catalog.json
@@ -221,7 +221,7 @@
       "title": "The Red-Green Oath",
       "description": "Forces a strict red-green-refactor TDD workflow, blocking code generation that skips the test step and enforcing coverage thresholds.",
       "sourceRepo": "addyosmani/agent-skills",
-      "url": "https://github.com/addyosmani/agent-skills",
+      "url": "https://github.com/addyosmani/agent-skills/blob/main/skills/test-driven-development/SKILL.md",
       "mapsToGaia": [
         "test-driven-development"
       ],
@@ -242,7 +242,7 @@
       "title": "The Ten Laws of Sight",
       "description": "Audits a UI against Jakob Nielsen's 10 usability heuristics, scores each, and produces a prioritized remediation report.",
       "sourceRepo": "mastepanoski/claude-skills",
-      "url": "https://classic.yarnpkg.com/en/package/@mastepanoski/claude-skills",
+      "url": "https://github.com/mastepanoski/claude-skills/blob/main/skills/nielsen-heuristics-audit/SKILL.md",
       "mapsToGaia": [
         "ux-audit"
       ],
@@ -368,7 +368,7 @@
       "title": "The Endpoint Scribe",
       "description": "Scans a Java Spring project for controller annotations, extracts REST API endpoint definitions, and generates structured API documentation in README format.",
       "sourceRepo": "spring-ai-alibaba/examples",
-      "url": "https://github.com/spring-ai-alibaba/examples/tree/main/.claude/skills",
+      "url": "https://github.com/spring-ai-alibaba/examples/blob/main/.claude/skills/readme-generate/SKILL.md",
       "mapsToGaia": [
         "write-report"
       ],

--- a/scripts/dry_run_agent_skills.py
+++ b/scripts/dry_run_agent_skills.py
@@ -4,34 +4,37 @@ Dry-run report: parse a markdown table of agent slash commands,
 classify real vs procedural entries, and show what would be proposed
 for the Gaia skill tree. No files are written.
 """
-import json
 import re
 import sys
+from collections import Counter
 from difflib import SequenceMatcher
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+from gaia_cli.resolver import load_canonical_skills
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
-GAIA_JSON = REPO_ROOT / "graph" / "gaia.json"
 NAMED_INDEX = REPO_ROOT / "graph" / "named" / "index.json"
 
 # Procedural URL pattern — auto-generated entries all share this shape
 PROCEDURAL_URL = re.compile(
     r"https?://github\.com/[a-z]+/agent-skills/tree/main/skills/[^/]+/SKILL\.md"
 )
+MATCH_THRESHOLD = 0.55
 
 
-def load_gaia_skills():
-    with open(GAIA_JSON) as f:
-        graph = json.load(f)
-    return {s["id"] for s in graph["skills"]}
-
-
-def load_named_index():
+def load_named_ids() -> set[str]:
+    """Return the set of all known named skill IDs (contributor/skill-name)."""
+    import json
     if not NAMED_INDEX.exists():
-        return {}
+        return set()
     with open(NAMED_INDEX) as f:
         data = json.load(f)
-    return data.get("buckets", {})
+    return {
+        e["id"]
+        for entries in data.get("buckets", {}).values()
+        for e in entries
+    }
 
 
 def parse_rows(md_path: str):
@@ -57,57 +60,46 @@ def is_real(url: str) -> bool:
     return bool(url) and not PROCEDURAL_URL.match(url)
 
 
-def similarity(a: str, b: str) -> float:
-    return SequenceMatcher(None, a, b).ratio()
-
-
-def find_best_match(cmd_id: str, gaia_ids: set[str]):
-    """Return (best_id, score) for the closest existing skill, or (None, 0)."""
+def find_best_match(cmd_id: str, gaia_ids: set[str]) -> tuple[str | None, float]:
     best_id, best_score = None, 0.0
     for gid in gaia_ids:
-        s = similarity(cmd_id, gid)
+        s = SequenceMatcher(None, cmd_id, gid).ratio()
         if s > best_score:
             best_id, best_score = gid, s
     return best_id, best_score
 
 
 def contributor_slug(owner: str) -> str:
-    """Normalize owner name to a filesystem-safe slug."""
-    slug = owner.lower()
-    slug = re.sub(r"[^a-z0-9]+", "-", slug)
-    return slug.strip("-")
+    return re.sub(r"[^a-z0-9]+", "-", owner.lower()).strip("-")
 
 
 def skill_name(cmd: str) -> str:
-    """Strip leading slash."""
     return cmd.lstrip("/")
 
 
 def main():
     if len(sys.argv) < 2:
-        print("Usage: python dry_run_agent_skills.py <path/to/10000_Agent_Slash_Skills.md>")
+        print("Usage: python dry_run_agent_skills.py <path/to/skills.md>")
         sys.exit(1)
 
     md_path = sys.argv[1]
-    gaia_ids = load_gaia_skills()
-    named_buckets = load_named_index()
+    gaia_ids = load_canonical_skills(str(REPO_ROOT / "graph" / "gaia.json"))
+    named_ids = load_named_ids()
 
     rows = parse_rows(md_path)
     real = [r for r in rows if is_real(r["url"])]
-    procedural_count = len(rows) - len(real)
 
     print("=" * 60)
     print("DRY RUN: Agent Skills Intake")
     print("=" * 60)
     print(f"Total rows parsed:      {len(rows):,}")
     print(f"Real entries found:     {len(real)}")
-    print(f"Procedural (skipped):   {procedural_count:,}")
+    print(f"Procedural (skipped):   {len(rows) - len(real):,}")
     print()
 
-    seen_generics: dict[str, str] = {}  # skill_id → first cmd that proposed it
+    first_cmd_for_generic: dict[str, str] = {}  # generic_id -> first cmd that claimed it
     new_generics: list[str] = []
     named_proposals: list[dict] = []
-    MATCH_THRESHOLD = 0.55
 
     print("-" * 60)
     print("REAL SKILL PROPOSALS")
@@ -117,12 +109,8 @@ def main():
         cmd_id = skill_name(r["cmd"])
         contrib = contributor_slug(r["owner"])
         named_path = f"graph/named/{contrib}/{cmd_id}.md"
-        already_named = contrib in named_buckets and any(
-            e.get("id") == f"{contrib}/{cmd_id}"
-            for e in named_buckets.get(contrib, [])
-        )
+        already_named = f"{contrib}/{cmd_id}" in named_ids
 
-        # Check exact match first
         if cmd_id in gaia_ids:
             generic_id = cmd_id
             generic_status = "EXISTS (exact match)"
@@ -131,33 +119,31 @@ def main():
             best_id, score = find_best_match(cmd_id, gaia_ids)
             if score >= MATCH_THRESHOLD:
                 generic_id = best_id
-                generic_status = "EXISTS -> maps to '{}' (score {:.2f})".format(best_id, score)
+                generic_status = f"EXISTS -> maps to '{best_id}' (score {score:.2f})"
                 is_new = False
             else:
                 generic_id = cmd_id
-                generic_status = "NEW -- not in gaia.json (closest: '{}' score {:.2f})".format(best_id, score)
+                generic_status = f"NEW -- not in gaia.json (closest: '{best_id}' score {score:.2f})"
                 is_new = True
 
-        if is_new and generic_id not in seen_generics:
-            new_generics.append(generic_id)
-        is_dup = generic_id in seen_generics
+        is_dup = generic_id in first_cmd_for_generic
         if not is_dup:
-            seen_generics[generic_id] = r["cmd"]
+            first_cmd_for_generic[generic_id] = r["cmd"]
+            if is_new:
+                new_generics.append(generic_id)
 
         named_status = "ALREADY EXISTS" if already_named else "WOULD CREATE"
-        dup_suffix = "  ** DUPE: '{}' already maps here".format(seen_generics[generic_id]) if is_dup else ""
+        dup_suffix = f"  ** DUPE of {first_cmd_for_generic[generic_id]}" if is_dup else ""
 
-        print("\n{}. {}  ({})".format(i, r["cmd"], r["owner"]))
-        print("   Source : {}".format(r["url"]))
-        print("   Desc   : {}".format(r["desc"][:90]))
-        print("   Generic: {}  [{}]".format(generic_id, generic_status))
-        print("   Named  : {}  [{}]{}".format(named_path, named_status, dup_suffix))
+        print(f"\n{i}. {r['cmd']}  ({r['owner']})")
+        print(f"   Source : {r['url']}")
+        print(f"   Desc   : {r['desc'][:90]}")
+        print(f"   Generic: {generic_id}  [{generic_status}]")
+        print(f"   Named  : {named_path}  [{named_status}]{dup_suffix}")
 
         named_proposals.append({
             "cmd": r["cmd"],
-            "cmd_id": cmd_id,
             "owner": r["owner"],
-            "contrib": contrib,
             "url": r["url"],
             "desc": r["desc"],
             "generic_id": generic_id,
@@ -166,6 +152,8 @@ def main():
             "already_named": already_named,
         })
 
+    generic_counts = Counter(p["generic_id"] for p in named_proposals)
+
     print()
     print("-" * 60)
     print("SUMMARY")
@@ -173,16 +161,14 @@ def main():
     print(f"Named skill files to create : {sum(1 for p in named_proposals if not p['already_named'])}")
     print(f"Named skills already exist  : {sum(1 for p in named_proposals if p['already_named'])}")
     print(f"New generic skills needed   : {len(new_generics)}")
-    if new_generics:
-        for ng in new_generics:
-            print(f"  + {ng}")
+    for ng in new_generics:
+        print(f"  + {ng}")
     print(f"Existing generics reused    : {len(named_proposals) - len(new_generics)}")
-    dupes = [p for p in named_proposals if p["generic_id"] in seen_generics and
-             seen_generics[p["generic_id"]] != p["cmd"]]
+    dupes = [p for p in named_proposals if generic_counts[p["generic_id"]] > 1]
     if dupes:
         print(f"Duplicate generic mappings  : {len(dupes)}")
         for d in dupes:
-            print("  {} -> same generic as another entry".format(d["cmd"]))
+            print(f"  {d['cmd']} -> generic '{d['generic_id']}' claimed by multiple entries")
     print()
     print("No files were written. Approve the above to proceed.")
 


### PR DESCRIPTION
## Summary

- **Named Skills graph toggle**: `FALLBACK_NAMED_MAP` constant initialises `state.namedMap` at startup — the toggle works immediately on `file://` or any static host, no server required. Live fetch still runs and overrides when available.
- **Named Skills browser**: `FALLBACK_NAMED_INDEX` embedded inline; both `fetch()` calls now use individual `.catch()` fallbacks so the card grid always renders.

## Root cause

Both features relied on `fetch('graph/named/index.json')` which fails on `file://` protocol. The fix mirrors the existing `FALLBACK_SKILLS` pattern already used for the graph.

## Test plan

- [ ] Open `docs/index.html` directly as a local file (`file://`) — no server
- [ ] Named Skills toggle in graph dialog highlights 14 contributor nodes with red glow + `contributor/skill-name` labels
- [ ] Named Skills browser section renders all 14 cards
- [ ] When served normally, live fetch overrides the fallback seamlessly