### PR TITLE
docs: named skills browser, curation v1.5.0/v1.2.0, reviewer URL requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ If you have [Claude Code](https://claude.ai/code) installed, this repository shi
 
 Runs the complete curation pipeline end-to-end:
 1. Reads the current graph to avoid duplicates.
-2. Researches candidate skills with Class A/B evidence.
+2. Researches candidate skills with Class A/B evidence. For each qualifying repo found on GitHub, checks common skill directory layouts (`skills/`, `.claude/skills/`, `codex/skills/`, etc.) to find individual SKILL.md files inside — each discovered skill is treated as a separate candidate with a specific file URL as evidence, not the repo root.
 3. Presents a draft review table — you classify each candidate as `accept`, `rename`, `duplicate`, `needs-evidence`, or `reject` before any file is touched.
 4. Writes and runs the generation script, validates the DAG, regenerates derived files, and opens a PR.
 
@@ -53,8 +53,9 @@ Runs the complete curation pipeline end-to-end:
 A lighter, read-only triage command for reviewing skill batches submitted via `gaia push`:
 1. Pulls latest and scans `intake/skill-batches/*.json`.
 2. Checks GitHub for open `draft-skills` PRs.
-3. Presents each proposed skill for classification: `accept`, `rename`, `duplicate`, `needs-evidence`, or `reject`.
-4. Optionally hands off to `/gaia-curate` to promote accepted skills into `graph/gaia.json`.
+3. For each proposed skill, searches GitHub for evidence and inspects qualifying repos for individual SKILL.md files inside common skill directories — resolves any repo-root evidence URLs to specific file paths before accepting.
+4. Presents each proposed skill for classification: `accept`, `rename`, `duplicate`, `needs-evidence`, or `reject`.
+5. Optionally hands off to `/gaia-curate` to promote accepted skills into `graph/gaia.json`.
 
 ```
 /gaia-draft-curate
@@ -208,7 +209,8 @@ After a named skill is merged as `awakened`, a reviewer checks whether it matche
 1. Open a classification PR using the `named_skill_classification.md` template.
 2. Add `title` (reviewer-assigned RPG epithet) and optionally `catalogRef` (back-link to `graph/real_skill_catalog.json`).
 3. Change `status: awakened` → `status: named`.
-4. If no catalog entry exists yet, add one to `graph/real_skill_catalog.json` with `promotedNamedSkillId` pointing back.
+4. Set `links.github` to the **specific SKILL.md file URL** inside the source repo (e.g., `https://github.com/owner/repo/blob/main/.claude/skills/skill-name/SKILL.md`), not the repo root or a directory listing. If no SKILL.md exists, a repo URL is acceptable but flag it as `needs-specific-url` in the classification PR.
+5. If no catalog entry exists yet, add one to `graph/real_skill_catalog.json` with `promotedNamedSkillId` pointing back.
 
 Only `status: named` skills surface as `realVariants` on abstract skill nodes and in the real-skills catalog. `awakened` skills remain in `graph/named/index.json` under `awaitingClassification` until classified.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 - **Track your agent's capabilities** — every skill your agent demonstrates gets logged to your personal skill tree, tied to your GitHub identity, portable across every repo you own.
 - **Unlock combinations** — when your agent has the prerequisites, a new composite or ultimate skill becomes available to fuse. The CLI detects it automatically.
-- **Name and share skills** — contribute named implementations of generic skills (e.g., `karpathy/autoresearch`), attributed to your GitHub identity and installable by anyone via `gaia install`. Submit with `status: awakened`; a reviewer promotes to `status: named` after confirming the real-world identity.
+- **Name and share skills** — contribute named implementations of generic skills (e.g., `karpathy/autoresearch`), attributed to your GitHub identity and installable by anyone via `gaia install`. Submit with `status: awakened`; a reviewer promotes to `status: named` after confirming the real-world identity. Browse all named skills at [`docs/index.html`](docs/index.html) or the live tutorial site.
 - **Contribute to the canon** — review draft skills, submit evidence, or create new skills from strong reviews. The graph grows with the field.
 
 ---
@@ -67,6 +67,16 @@ gaia --registry . scan
 # 4. Regenerate all skill pages, registry, tree, and user trees
 python3 scripts/generateProjections.py
 ```
+
+## Named Skills Browser
+
+The registry ships an interactive Named Skills browser at [`docs/index.html`](docs/index.html):
+
+- **Level-filtered tabs** — browse by Named (II), Evolved (III), Hardened (IV), or all levels.
+- **Expandable cards** — each card shows the contributor, title, description, `genericSkillRef`, tags, and a direct link to the upstream SKILL.md.
+- **Graph canvas toggle** — the **Named Skills** button in the graph explorer dims all non-named nodes and highlights named implementations with contributor attribution and a distinct glow.
+
+Serve locally with `python -m http.server 8080` from the repo root, then open `http://localhost:8080/docs/`.
 
 ## Real Skill Catalog
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -577,7 +577,18 @@ Storage:
 - **Repo reference**: `.gaia/named-skills/{contributor}/{skill-name}.md` (symlink on Unix, copy on Windows)
 - **Manifest**: `.gaia/install-manifest.json` (tracks id, installedAt, sourceRef, sha256)
 
-### 13.5 Semantic Search
+### 13.6 Named Skills Graph Canvas Toggle
+
+The skill graph explorer in `docs/index.html` includes a **Named Skills** highlight button overlaid on the graph canvas. When activated:
+
+- All non-named nodes are dimmed to 7 % opacity so named implementations stand out.
+- Named skill nodes receive a coloured ring glow.
+- Node labels switch from the generic skill name to `contributor/skill-name` attribution.
+- The button state is local to the page session — it does not persist across reloads.
+
+This toggle is implemented in `createSkillGraph()` as `state.redPillActive` (toggled by the `.graph-redpill` button). It reads `state.namedMap`, a lookup built from the `buckets` section of `graph/named/index.json` that maps each `genericSkillRef` to its named implementations.
+
+The Named Skills browser section below the graph provides the same data in a paginated card layout with level-filtered tabs, expandable detail cards (dependencies, derivatives, variants, tags, upstream SKILL.md link), and does not require the graph canvas.
 
 Skills are embedded using `sentence-transformers` (model: `all-MiniLM-L6-v2`, 384 dimensions). The embedding input is `"{name}: {description}"` for each skill.
 


### PR DESCRIPTION
## Summary

- **README.md** — adds a Named Skills Browser section documenting the interactive `docs/index.html` page (level-filtered tabs, expandable cards, graph canvas highlight toggle); updates the "Name and share skills" bullet to reference it
- **CONTRIBUTING.md** — updates `/gaia-curate` (v1.5.0) and `/gaia-draft-curate` (v1.2.0) descriptions to reflect repo-inspection behaviour (checking inside repos for individual SKILL.md files); adds reviewer rule requiring `links.github` to point to a specific SKILL.md file URL, not a repo root
- **docs/DESIGN.md** — adds section 13.6 documenting the Named Skills graph canvas toggle (`state.redPillActive`, 7 % opacity dimming, contributor attribution labels, `namedMap` lookup)

## Test plan

- [ ] Verify README renders correctly on GitHub (Named Skills Browser section, repo structure, What This Means for You bullet)
- [ ] Verify CONTRIBUTING.md section 2 slash command descriptions match `.claude/skills/` behaviour
- [ ] Verify CONTRIBUTING.md section 6 reviewer steps include the SKILL.md URL requirement
- [ ] Verify DESIGN.md section 13.6 is coherent and references correct source identifiers