### PR TITLE
docs: update README + DESIGN.md for new tree display format

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,58 +19,58 @@ back through its full prerequisite chain.
 GAIA SKILL TREE  v1.0.0
 ═════════════════════════════════════════════════════════════════
 
-◆ Wisdom King: Autonomous Research Agent  [VI · Transcendent ★]  ← Research · Knowledge Harvest · Ghostwrite
+◆ karpathy/autoresearch - Wisdom King: Autonomous Research Agent  [VI]
 ─────────────────────────────────────────────────────────────────
-  ├─ ◇ Research  [III · Evolved]  ← Web Search · Summarize · Cite Sources
-  │  ├─ ○ Web Search  [I · Awakened]
-  │  ├─ ○ Summarize  [0 · Basic]
-  │  └─ ○ Cite Sources  [I · Awakened]
-  ├─ ◇ Knowledge Harvest  [IV · Hardened]  ← Web Scrape · Extract Entities · Embed Text
-  │  ├─ ◇ Web Scrape  [III · Evolved]  ← Web Search · Parse HTML · Extract Entities
-  │  │  ├─ ○ Web Search  [I · Awakened]  (↑ see above)
-  │  │  ├─ ○ Parse HTML  [I · Awakened]
-  │  │  └─ ○ Extract Entities  [I · Awakened]
-  │  ├─ ○ Extract Entities  [I · Awakened]  (↑ see above)
-  │  └─ ○ Embed Text  [I · Awakened]
-  └─ ◇ Ghostwrite  [IV · Hardened]  ← Research · Write Report · Audience Model
-     ├─ ◇ Research  [III · Evolved]  ← Web Search · Summarize · Cite Sources  (↑ see above)
-     ├─ ○ Write Report  [I · Awakened]
-     └─ ○ Audience Model  [I · Awakened]
+  ├─ ◇ /research  [III]
+  │  ├─ ○ /web-search  [I]
+  │  ├─ ○ /summarize  [0]
+  │  └─ ○ /cite-sources  [I]
+  ├─ ◇ /knowledge-harvest  [IV]
+  │  ├─ ◇ /web-scrape  [III]
+  │  │  ├─ ○ /web-search  [I]  (↑ see above)
+  │  │  ├─ ○ /parse-html  [I]
+  │  │  └─ ○ /extract-entities  [I]
+  │  ├─ ○ /extract-entities  [I]  (↑ see above)
+  │  └─ ○ /embed-text  [I]
+  └─ ◇ /ghostwrite  [IV]
+     ├─ ◇ /research  [III]  (↑ see above)
+     ├─ ○ glincker/readme-generator - Write Report  [I]
+     └─ ○ /audience-model  [I]
 
-◆ Grand Conductor: Multi-Agent Orchestration  [V · Transcendent]  ← Plan and Execute · Route Intent · Tool Select
+◆ ruvnet/flow-nexus-swarm - Grand Conductor: Multi-Agent Orchestration  [V]
 ─────────────────────────────────────────────────────────────────
-  ├─ ◇ Plan and Execute  [IV · Hardened]  ← Route Intent · Plan and Decompose · Tool Select
-  │  ├─ ○ Route Intent  [I · Awakened]
-  │  ├─ ○ Plan and Decompose  [I · Awakened]
-  │  └─ ○ Tool Select  [I · Awakened]
-  ├─ ○ Route Intent  [I · Awakened]  (↑ see above)
-  └─ ○ Tool Select  [I · Awakened]  (↑ see above)
+  ├─ ◇ /plan-and-execute  [IV]
+  │  ├─ ○ /route-intent  [I]
+  │  ├─ ○ /plan-decompose  [I]
+  │  └─ ○ /tool-select  [I]
+  ├─ ○ /route-intent  [I]  (↑ see above)
+  └─ ○ /tool-select  [I]  (↑ see above)
 
 ...
 
-◆ True Oracle: Autonomous Data Scientist  [V · Transcendent]  ← Data Analysis · Math Reason · Research
+◆ /autonomous-data-scientist  [V]
 ─────────────────────────────────────────────────────────────────
-  ├─ ◇ Data Analysis  [III · Evolved]  ← Generate SQL · Data Visualize · Summarize
-  │  ├─ ○ Generate SQL  [II · Named]
-  │  ├─ ○ Data Visualize  [II · Named]
-  │  └─ ○ Summarize  [0 · Basic]
-  ├─ ○ Math Reason  [II · Named]
-  └─ ◇ Research  [III · Evolved]  ← Web Search · Summarize · Cite Sources
-     ├─ ○ Web Search  [I · Awakened]
-     ├─ ○ Summarize  [0 · Basic]  (↑ see above)
-     └─ ○ Cite Sources  [I · Awakened]
+  ├─ ◇ /data-analysis  [III]
+  │  ├─ ○ /generate-sql  [II]
+  │  ├─ ○ /data-visualize  [II]
+  │  └─ ○ /summarize  [0]
+  ├─ ○ /math-reason  [II]
+  └─ ◇ /research  [III]
+     ├─ ○ /web-search  [I]
+     ├─ ○ /summarize  [0]  (↑ see above)
+     └─ ○ /cite-sources  [I]
 
-◆ True Sage: Recursive Self-Improvement  [V · Transcendent]  ← Autonomous Debug · Evaluate Output · Plan and Execute
+◆ /recursive-self-improvement  [V]
 ─────────────────────────────────────────────────────────────────
-  ├─ ◇ Autonomous Debug  [IV · Hardened]  ← Code Generation · Execute Bash · Error Interpretation
-  │  ├─ ○ Code Generation  [I · Awakened]
-  │  ├─ ○ Execute Bash  [I · Awakened]
-  │  └─ ○ Error Interpretation  [I · Awakened]
-  ├─ ○ Evaluate Output  [I · Awakened]
-  └─ ◇ Plan and Execute  [IV · Hardened]  ← Route Intent · Plan and Decompose · Tool Select
-     ├─ ○ Route Intent  [I · Awakened]
-     ├─ ○ Plan and Decompose  [I · Awakened]
-     └─ ○ Tool Select  [I · Awakened]
+  ├─ ◇ /autonomous-debug  [IV]
+  │  ├─ ○ /code-generation  [I]
+  │  ├─ ○ /execute-bash  [I]
+  │  └─ ○ /error-interpretation  [I]
+  ├─ ○ /evaluate-output  [I]
+  └─ ◇ /plan-and-execute  [IV]
+     ├─ ○ /route-intent  [I]
+     ├─ ○ /plan-decompose  [I]
+     └─ ○ /tool-select  [I]
 
 
 → Full graph: tree.md
@@ -144,7 +144,7 @@ The registry ships an interactive Named Skills browser at [`docs/index.html`](do
 
 - **Level-filtered tabs** — browse by Named (II), Evolved (III), Hardened (IV), or all levels.
 - **Expandable cards** — each card shows the contributor, title, description, `genericSkillRef`, tags, and a direct link to the upstream SKILL.md.
-- **Graph canvas toggle** — the **Named Skills** button in the graph explorer dims all non-named nodes and highlights named implementations with contributor attribution and a distinct glow.
+- **Graph canvas** — node labels show `contributor/skill-name` for named implementations (e.g. `karpathy/autoresearch`) and `/slug` for anonymous skills by default. The **Named Skills** button dims all non-named nodes and adds a coloured ring glow to highlight named implementations.
 
 Serve locally with `python -m http.server 8080` from the repo root, then open `http://localhost:8080/docs/`.
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -577,16 +577,26 @@ Storage:
 - **Repo reference**: `.gaia/named-skills/{contributor}/{skill-name}.md` (symlink on Unix, copy on Windows)
 - **Manifest**: `.gaia/install-manifest.json` (tracks id, installedAt, sourceRef, sha256)
 
-### 13.6 Named Skills Graph Canvas Toggle
+### 13.6 Named Skills Graph Canvas
 
-The skill graph explorer in `docs/index.html` includes a **Named Skills** highlight button overlaid on the graph canvas. When activated:
+The skill graph explorer in `docs/index.html` renders node labels using the following default logic:
 
-- All non-named nodes are dimmed to 7 % opacity so named implementations stand out.
-- Named skill nodes receive a coloured ring glow.
-- Node labels switch from the generic skill name to `contributor/skill-name` attribution.
+- Named implementations (those with an entry in `state.namedMap`) always display their `contributor/skill-name` ID (e.g. `karpathy/autoresearch`).
+- Anonymous skills display their canonical slug prefixed with `/` (e.g. `/web-search`).
+- The **Named Skills** button (`state.redPillActive`) is an overlay toggle — it dims all non-named nodes to 7 % opacity and adds a coloured ring glow to named nodes; it does not affect label text.
 - The button state is local to the page session — it does not persist across reloads.
 
-This toggle is implemented in `createSkillGraph()` as `state.redPillActive` (toggled by the `.graph-redpill` button). It reads `state.namedMap`, a lookup built from the `buckets` section of `graph/named/index.json` that maps each `genericSkillRef` to its named implementations.
+The label logic is implemented in `createSkillGraph()`:
+
+```js
+const labelText = (state.namedMap && state.namedMap[skill.id])
+  ? state.namedMap[skill.id]
+  : '/' + skill.id;
+```
+
+`state.namedMap` is a lookup built from the `buckets` section of `graph/named/index.json`, mapping each `genericSkillRef` to the origin named implementation's ID.
+
+The tooltip rank pill shows the level numeral only (e.g. `VI`) — rank names (Awakened, Evolved, …) are not displayed in the UI but remain defined in `RANK_META` for colour-coding.
 
 The Named Skills browser section below the graph provides the same data in a paginated card layout with level-filtered tabs, expandable detail cards (dependencies, derivatives, variants, tags, upstream SKILL.md link), and does not require the graph canvas.
 


### PR DESCRIPTION
## Summary

Syncs documentation with the tree display overhaul merged in PR #73.

- **README.md — tree example**: refreshed code block shows numeric-only level labels (`[VI]`, `[III]`, `[I]`), named-skill identifiers (`karpathy/autoresearch - Wisdom King`), and `/slug` format for anonymous skills; removed the old `← prerequisites` inline and rank names
- **README.md — Named Skills Browser**: updated "Graph canvas" bullet to reflect that labels now always show `contributor/skill-name` or `/slug` by default without requiring the Named Skills toggle; clarified the toggle controls dimming/glow only
- **docs/DESIGN.md §13.6**: rewrote "Named Skills Graph Canvas Toggle" section to document the unconditional label logic, include the JS snippet, and note that rank names are not displayed in the UI (while still defined in `RANK_META` for colour-coding)

## Files modified

| File | Section | Change |
|---|---|---|
| `README.md` | Hero tree example | New format with named/slug identifiers |
| `README.md` | Named Skills Browser | Canvas label behavior, toggle clarification |
| `docs/DESIGN.md` | §13.6 | Rewritten to match actual label logic |

## Files reviewed — no update needed

| File | Reason |
|---|---|
| `DESIGN.md` | Rank color table (`Awakened`, `Evolved`, …) is design-language, not display text — still accurate |
| `CONTRIBUTING.md`, `mcp-server/README.md`, `plugin/README.md` | No public surface affected |

## Test plan

- [x] README.md tree example matches current `tree.md` output
- [x] Named Skills Browser description is accurate for `docs/index.html` behavior
- [x] `docs/DESIGN.md` §13.6 JS snippet matches `docs/index.html` label logic