### PR TITLE
[atomic|composite] Add 5 scientific-domain skills from GitHub /skills repos

### DIFF
--- a/combinations.md
+++ b/combinations.md
@@ -12,6 +12,7 @@
 | ◇ Content Moderation | Extra Skill | Classify, Sentiment Analysis, Extract Entities | III |  |
 | ◇ Conversational Agent | Extra Skill | Question Answer, Memory Manage, Route Intent | III | Requires persistent memory store across turns. |
 | ◇ Data Analysis | Extra Skill | Generate SQL, Data Visualize, Summarize | III |  |
+| ◇ Design Review | Extra Skill | Evaluate Output, Plan and Decompose | III |  |
 | ◇ Document Analyst | Extra Skill | Parse JSON, Extract Entities, Summarize, Format Output | III |  |
 | ◇ Document Digitization | Extra Skill | Parse PDF, Extract Entities, Format Output | III |  |
 | ◆ True Craftsman: Full-Stack Developer | Ultimate Skill | Code Review Pipeline, Automated Testing, Refactor Code | V | Requires access to repository, execution environment, and test runner. Minimum 3 Class A/B evidence sources. |
@@ -21,10 +22,13 @@
 | ◇ Guardrails | Extra Skill | Evaluate Output, Classify, Structured Output Generation | III | Requires a defined policy schema and an evaluation loop. |
 | ◇ Knowledge Graph Construction | Extra Skill | Extract Entities, Logical Inference | III |  |
 | ◇ Knowledge Harvest | Extra Skill | Web Scrape, Extract Entities, Embed Text | IV |  |
+| ◇ Literature Review | Extra Skill | Research, Cite Sources, Summarize | IV | Requires access to academic databases (PubMed, bioRxiv, ChEMBL, or equivalent). |
+| ◇ ML Pipeline | Extra Skill | Data Analysis, Automated Testing, Code Generation | IV | Requires access to a container orchestration environment and model registry. |
 | ◇ Multi-Agent Debate | Extra Skill | Self-Critique, Evaluate Output, Chain-of-Thought Reasoning | IV |  |
 | ◆ Grand Conductor: Multi-Agent Orchestration | Ultimate Skill | Plan and Execute, Route Intent, Tool Select | V | Requires extensive multi-system validation before level advancement. |
 | ◇ Multimodal Reasoning | Extra Skill | Image Caption, Question Answer, Logical Inference | III | Requires vision-language model capability. |
 | ◇ Plan and Execute | Extra Skill | Route Intent, Plan and Decompose, Tool Select | IV |  |
+| ◇ PRD Generation | Extra Skill | Write Report, Plan and Decompose | IV |  |
 | ◇ Prompt Optimization | Extra Skill | Evaluate Output, Generate Text | IV |  |
 | ◇ RAG Pipeline | Extra Skill | Retrieve, Chunk Document, Embed Text, Score Relevance, Tokenize, Rank | III |  |
 | ◇ ReAct Reasoning | Extra Skill | Plan and Decompose, Tool Use | III |  |
@@ -33,11 +37,13 @@
 | ◇ Registry Curation | Extra Skill | Research, Code Generation, Execute Bash | IV | Requires write access to the canonical graph and a passing validation suite. |
 | ◇ Research | Extra Skill | Web Search, Summarize, Cite Sources | III |  |
 | ◆ True Dragon: Autonomous Scientific Discovery | Ultimate Skill | Hypothesis Generation, Research, Math Reason | V | Requires laboratory tool access or simulation environment. Minimum 3 Class A/B evidence sources. |
+| ◇ Scientific Writing | Extra Skill | Write Report, Cite Sources, Scientific Visualization | III |  |
 | ◇ Text-to-SQL Pipeline | Extra Skill | Generate SQL, Parse JSON, Format Output | III | Requires schema context in prompt. |
 | ◇ Tool Chaining | Extra Skill | Tool Use, Tool Select | III | Requires at least two distinct tools whose data schemas are compatible for chaining. |
 | ◇ Tool Creation | Extra Skill | Code Generation, Tool Use | IV |  |
 | ◇ Translation Pipeline | Extra Skill | Translate, Sentiment Analysis, Audience Model | III |  |
 | ◇ Tree of Thought | Extra Skill | Chain-of-Thought Reasoning, Plan and Decompose | IV |  |
+| ◇ Vertical Slice Planning | Extra Skill | Plan and Decompose, Route Intent | III |  |
 | ◇ Voice Agent | Extra Skill | Speech to Text, Question Answer, Text to Speech | III | Requires real-time audio I/O or audio file access. |
 | ◇ Web Scrape | Extra Skill | Web Search, Parse HTML, Extract Entities | III | Structured output mode required. |
 | ◇ Workflow Automation | Extra Skill | Plan and Decompose, Tool Use, API Call | IV |  |

--- a/graph/gaia.gexf
+++ b/graph/gaia.gexf
@@ -188,6 +188,14 @@
           <attvalue for="type" value="atomic" />
         </attvalues>
       </node>
+      <node id="design-review" label="Design Review">
+        <attvalues>
+          <attvalue for="level" value="III" />
+          <attvalue for="rarity" value="rare" />
+          <attvalue for="status" value="provisional" />
+          <attvalue for="type" value="composite" />
+        </attvalues>
+      </node>
       <node id="detect-anomaly" label="Detect Anomaly">
         <attvalues>
           <attvalue for="level" value="II" />
@@ -388,6 +396,14 @@
           <attvalue for="type" value="atomic" />
         </attvalues>
       </node>
+      <node id="issue-triage" label="Issue Triage">
+        <attvalues>
+          <attvalue for="level" value="IV" />
+          <attvalue for="rarity" value="uncommon" />
+          <attvalue for="status" value="provisional" />
+          <attvalue for="type" value="atomic" />
+        </attvalues>
+      </node>
       <node id="knowledge-graph-build" label="Knowledge Graph Construction">
         <attvalues>
           <attvalue for="level" value="III" />
@@ -400,6 +416,14 @@
         <attvalues>
           <attvalue for="level" value="IV" />
           <attvalue for="rarity" value="rare" />
+          <attvalue for="status" value="provisional" />
+          <attvalue for="type" value="composite" />
+        </attvalues>
+      </node>
+      <node id="literature-review" label="Literature Review">
+        <attvalues>
+          <attvalue for="level" value="IV" />
+          <attvalue for="rarity" value="uncommon" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="composite" />
         </attvalues>
@@ -426,6 +450,14 @@
           <attvalue for="rarity" value="uncommon" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
+        </attvalues>
+      </node>
+      <node id="ml-pipeline" label="ML Pipeline">
+        <attvalues>
+          <attvalue for="level" value="IV" />
+          <attvalue for="rarity" value="rare" />
+          <attvalue for="status" value="provisional" />
+          <attvalue for="type" value="composite" />
         </attvalues>
       </node>
       <node id="multi-agent-debate" label="Multi-Agent Debate">
@@ -506,6 +538,14 @@
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
+        </attvalues>
+      </node>
+      <node id="prd-generation" label="PRD Generation">
+        <attvalues>
+          <attvalue for="level" value="IV" />
+          <attvalue for="rarity" value="uncommon" />
+          <attvalue for="status" value="provisional" />
+          <attvalue for="type" value="composite" />
         </attvalues>
       </node>
       <node id="prompt-injection-defense" label="Prompt Injection Defense">
@@ -628,6 +668,22 @@
           <attvalue for="type" value="legendary" />
         </attvalues>
       </node>
+      <node id="scientific-visualization" label="Scientific Visualization">
+        <attvalues>
+          <attvalue for="level" value="II" />
+          <attvalue for="rarity" value="uncommon" />
+          <attvalue for="status" value="provisional" />
+          <attvalue for="type" value="atomic" />
+        </attvalues>
+      </node>
+      <node id="scientific-writing" label="Scientific Writing">
+        <attvalues>
+          <attvalue for="level" value="III" />
+          <attvalue for="rarity" value="uncommon" />
+          <attvalue for="status" value="provisional" />
+          <attvalue for="type" value="composite" />
+        </attvalues>
+      </node>
       <node id="score-relevance" label="Score Relevance">
         <attvalues>
           <attvalue for="level" value="I" />
@@ -680,6 +736,14 @@
         <attvalues>
           <attvalue for="level" value="II" />
           <attvalue for="rarity" value="common" />
+          <attvalue for="status" value="provisional" />
+          <attvalue for="type" value="atomic" />
+        </attvalues>
+      </node>
+      <node id="statistical-analysis" label="Statistical Analysis">
+        <attvalues>
+          <attvalue for="level" value="III" />
+          <attvalue for="rarity" value="uncommon" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="atomic" />
         </attvalues>
@@ -796,6 +860,14 @@
           <attvalue for="type" value="atomic" />
         </attvalues>
       </node>
+      <node id="vertical-slice-planning" label="Vertical Slice Planning">
+        <attvalues>
+          <attvalue for="level" value="III" />
+          <attvalue for="rarity" value="uncommon" />
+          <attvalue for="status" value="provisional" />
+          <attvalue for="type" value="composite" />
+        </attvalues>
+      </node>
       <node id="vision-qa" label="Visual Question Answering">
         <attvalues>
           <attvalue for="level" value="III" />
@@ -874,91 +946,106 @@
       <edge id="e25" source="generate-sql" target="data-analysis" />
       <edge id="e26" source="data-visualize" target="data-analysis" />
       <edge id="e27" source="summarize" target="data-analysis" />
-      <edge id="e28" source="parse-json" target="document-analyst" />
-      <edge id="e29" source="extract-entities" target="document-analyst" />
-      <edge id="e30" source="summarize" target="document-analyst" />
-      <edge id="e31" source="format-output" target="document-analyst" />
-      <edge id="e32" source="parse-pdf" target="document-digitization" />
-      <edge id="e33" source="extract-entities" target="document-digitization" />
-      <edge id="e34" source="format-output" target="document-digitization" />
-      <edge id="e35" source="code-review-pipeline" target="full-stack-developer" />
-      <edge id="e36" source="automated-testing" target="full-stack-developer" />
-      <edge id="e37" source="refactor-code" target="full-stack-developer" />
-      <edge id="e38" source="structured-output" target="function-calling" />
-      <edge id="e39" source="api-call" target="function-calling" />
-      <edge id="e40" source="tool-select" target="function-calling" />
-      <edge id="e41" source="research" target="ghostwrite" />
-      <edge id="e42" source="write-report" target="ghostwrite" />
-      <edge id="e43" source="audience-model" target="ghostwrite" />
-      <edge id="e44" source="retrieve" target="grounding" />
-      <edge id="e45" source="cite-sources" target="grounding" />
-      <edge id="e46" source="evaluate-output" target="grounding" />
-      <edge id="e47" source="evaluate-output" target="guardrails" />
-      <edge id="e48" source="classify" target="guardrails" />
-      <edge id="e49" source="structured-output" target="guardrails" />
-      <edge id="e50" source="extract-entities" target="knowledge-graph-build" />
-      <edge id="e51" source="logical-inference" target="knowledge-graph-build" />
-      <edge id="e52" source="web-scrape" target="knowledge-harvest" />
-      <edge id="e53" source="extract-entities" target="knowledge-harvest" />
-      <edge id="e54" source="embed-text" target="knowledge-harvest" />
-      <edge id="e55" source="self-critique" target="multi-agent-debate" />
-      <edge id="e56" source="evaluate-output" target="multi-agent-debate" />
-      <edge id="e57" source="chain-of-thought" target="multi-agent-debate" />
-      <edge id="e58" source="plan-and-execute" target="multi-agent-orchestration-v" />
-      <edge id="e59" source="route-intent" target="multi-agent-orchestration-v" />
-      <edge id="e60" source="tool-select" target="multi-agent-orchestration-v" />
-      <edge id="e61" source="image-caption" target="multimodal-reasoning" />
-      <edge id="e62" source="question-answer" target="multimodal-reasoning" />
-      <edge id="e63" source="logical-inference" target="multimodal-reasoning" />
-      <edge id="e64" source="route-intent" target="plan-and-execute" />
-      <edge id="e65" source="plan-decompose" target="plan-and-execute" />
-      <edge id="e66" source="tool-select" target="plan-and-execute" />
-      <edge id="e67" source="evaluate-output" target="prompt-optimization" />
-      <edge id="e68" source="generate-text" target="prompt-optimization" />
-      <edge id="e69" source="retrieve" target="rag-pipeline" />
-      <edge id="e70" source="chunk-document" target="rag-pipeline" />
-      <edge id="e71" source="embed-text" target="rag-pipeline" />
-      <edge id="e72" source="score-relevance" target="rag-pipeline" />
-      <edge id="e73" source="tokenize" target="rag-pipeline" />
-      <edge id="e74" source="rank" target="rag-pipeline" />
-      <edge id="e75" source="plan-decompose" target="re-act-reasoning" />
-      <edge id="e76" source="tool-use" target="re-act-reasoning" />
-      <edge id="e77" source="voice-agent" target="real-time-voice-assistant" />
-      <edge id="e78" source="memory-manage" target="real-time-voice-assistant" />
-      <edge id="e79" source="plan-and-execute" target="real-time-voice-assistant" />
-      <edge id="e80" source="autonomous-debug" target="recursive-self-improvement" />
-      <edge id="e81" source="evaluate-output" target="recursive-self-improvement" />
-      <edge id="e82" source="plan-and-execute" target="recursive-self-improvement" />
-      <edge id="e83" source="research" target="registry-curation" />
-      <edge id="e84" source="code-generation" target="registry-curation" />
-      <edge id="e85" source="execute-bash" target="registry-curation" />
-      <edge id="e86" source="web-search" target="research" />
-      <edge id="e87" source="summarize" target="research" />
-      <edge id="e88" source="cite-sources" target="research" />
-      <edge id="e89" source="hypothesis-generate" target="scientific-discovery" />
-      <edge id="e90" source="research" target="scientific-discovery" />
-      <edge id="e91" source="math-reason" target="scientific-discovery" />
-      <edge id="e92" source="generate-sql" target="text-to-sql-pipeline" />
-      <edge id="e93" source="parse-json" target="text-to-sql-pipeline" />
-      <edge id="e94" source="format-output" target="text-to-sql-pipeline" />
-      <edge id="e95" source="tool-use" target="tool-chaining" />
-      <edge id="e96" source="tool-select" target="tool-chaining" />
-      <edge id="e97" source="code-generation" target="tool-creation" />
-      <edge id="e98" source="tool-use" target="tool-creation" />
-      <edge id="e99" source="translate" target="translation-pipeline" />
-      <edge id="e100" source="sentiment-analysis" target="translation-pipeline" />
-      <edge id="e101" source="audience-model" target="translation-pipeline" />
-      <edge id="e102" source="chain-of-thought" target="tree-of-thought" />
-      <edge id="e103" source="plan-decompose" target="tree-of-thought" />
-      <edge id="e104" source="speech-to-text" target="voice-agent" />
-      <edge id="e105" source="question-answer" target="voice-agent" />
-      <edge id="e106" source="text-to-speech" target="voice-agent" />
-      <edge id="e107" source="web-search" target="web-scrape" />
-      <edge id="e108" source="parse-html" target="web-scrape" />
-      <edge id="e109" source="extract-entities" target="web-scrape" />
-      <edge id="e110" source="plan-decompose" target="workflow-automation" />
-      <edge id="e111" source="tool-use" target="workflow-automation" />
-      <edge id="e112" source="api-call" target="workflow-automation" />
+      <edge id="e28" source="evaluate-output" target="design-review" />
+      <edge id="e29" source="plan-decompose" target="design-review" />
+      <edge id="e30" source="parse-json" target="document-analyst" />
+      <edge id="e31" source="extract-entities" target="document-analyst" />
+      <edge id="e32" source="summarize" target="document-analyst" />
+      <edge id="e33" source="format-output" target="document-analyst" />
+      <edge id="e34" source="parse-pdf" target="document-digitization" />
+      <edge id="e35" source="extract-entities" target="document-digitization" />
+      <edge id="e36" source="format-output" target="document-digitization" />
+      <edge id="e37" source="code-review-pipeline" target="full-stack-developer" />
+      <edge id="e38" source="automated-testing" target="full-stack-developer" />
+      <edge id="e39" source="refactor-code" target="full-stack-developer" />
+      <edge id="e40" source="structured-output" target="function-calling" />
+      <edge id="e41" source="api-call" target="function-calling" />
+      <edge id="e42" source="tool-select" target="function-calling" />
+      <edge id="e43" source="research" target="ghostwrite" />
+      <edge id="e44" source="write-report" target="ghostwrite" />
+      <edge id="e45" source="audience-model" target="ghostwrite" />
+      <edge id="e46" source="retrieve" target="grounding" />
+      <edge id="e47" source="cite-sources" target="grounding" />
+      <edge id="e48" source="evaluate-output" target="grounding" />
+      <edge id="e49" source="evaluate-output" target="guardrails" />
+      <edge id="e50" source="classify" target="guardrails" />
+      <edge id="e51" source="structured-output" target="guardrails" />
+      <edge id="e52" source="extract-entities" target="knowledge-graph-build" />
+      <edge id="e53" source="logical-inference" target="knowledge-graph-build" />
+      <edge id="e54" source="web-scrape" target="knowledge-harvest" />
+      <edge id="e55" source="extract-entities" target="knowledge-harvest" />
+      <edge id="e56" source="embed-text" target="knowledge-harvest" />
+      <edge id="e57" source="research" target="literature-review" />
+      <edge id="e58" source="cite-sources" target="literature-review" />
+      <edge id="e59" source="summarize" target="literature-review" />
+      <edge id="e60" source="data-analysis" target="ml-pipeline" />
+      <edge id="e61" source="automated-testing" target="ml-pipeline" />
+      <edge id="e62" source="code-generation" target="ml-pipeline" />
+      <edge id="e63" source="self-critique" target="multi-agent-debate" />
+      <edge id="e64" source="evaluate-output" target="multi-agent-debate" />
+      <edge id="e65" source="chain-of-thought" target="multi-agent-debate" />
+      <edge id="e66" source="plan-and-execute" target="multi-agent-orchestration-v" />
+      <edge id="e67" source="route-intent" target="multi-agent-orchestration-v" />
+      <edge id="e68" source="tool-select" target="multi-agent-orchestration-v" />
+      <edge id="e69" source="image-caption" target="multimodal-reasoning" />
+      <edge id="e70" source="question-answer" target="multimodal-reasoning" />
+      <edge id="e71" source="logical-inference" target="multimodal-reasoning" />
+      <edge id="e72" source="route-intent" target="plan-and-execute" />
+      <edge id="e73" source="plan-decompose" target="plan-and-execute" />
+      <edge id="e74" source="tool-select" target="plan-and-execute" />
+      <edge id="e75" source="write-report" target="prd-generation" />
+      <edge id="e76" source="plan-decompose" target="prd-generation" />
+      <edge id="e77" source="evaluate-output" target="prompt-optimization" />
+      <edge id="e78" source="generate-text" target="prompt-optimization" />
+      <edge id="e79" source="retrieve" target="rag-pipeline" />
+      <edge id="e80" source="chunk-document" target="rag-pipeline" />
+      <edge id="e81" source="embed-text" target="rag-pipeline" />
+      <edge id="e82" source="score-relevance" target="rag-pipeline" />
+      <edge id="e83" source="tokenize" target="rag-pipeline" />
+      <edge id="e84" source="rank" target="rag-pipeline" />
+      <edge id="e85" source="plan-decompose" target="re-act-reasoning" />
+      <edge id="e86" source="tool-use" target="re-act-reasoning" />
+      <edge id="e87" source="voice-agent" target="real-time-voice-assistant" />
+      <edge id="e88" source="memory-manage" target="real-time-voice-assistant" />
+      <edge id="e89" source="plan-and-execute" target="real-time-voice-assistant" />
+      <edge id="e90" source="autonomous-debug" target="recursive-self-improvement" />
+      <edge id="e91" source="evaluate-output" target="recursive-self-improvement" />
+      <edge id="e92" source="plan-and-execute" target="recursive-self-improvement" />
+      <edge id="e93" source="research" target="registry-curation" />
+      <edge id="e94" source="code-generation" target="registry-curation" />
+      <edge id="e95" source="execute-bash" target="registry-curation" />
+      <edge id="e96" source="web-search" target="research" />
+      <edge id="e97" source="summarize" target="research" />
+      <edge id="e98" source="cite-sources" target="research" />
+      <edge id="e99" source="hypothesis-generate" target="scientific-discovery" />
+      <edge id="e100" source="research" target="scientific-discovery" />
+      <edge id="e101" source="math-reason" target="scientific-discovery" />
+      <edge id="e102" source="write-report" target="scientific-writing" />
+      <edge id="e103" source="cite-sources" target="scientific-writing" />
+      <edge id="e104" source="scientific-visualization" target="scientific-writing" />
+      <edge id="e105" source="generate-sql" target="text-to-sql-pipeline" />
+      <edge id="e106" source="parse-json" target="text-to-sql-pipeline" />
+      <edge id="e107" source="format-output" target="text-to-sql-pipeline" />
+      <edge id="e108" source="tool-use" target="tool-chaining" />
+      <edge id="e109" source="tool-select" target="tool-chaining" />
+      <edge id="e110" source="code-generation" target="tool-creation" />
+      <edge id="e111" source="tool-use" target="tool-creation" />
+      <edge id="e112" source="translate" target="translation-pipeline" />
+      <edge id="e113" source="sentiment-analysis" target="translation-pipeline" />
+      <edge id="e114" source="audience-model" target="translation-pipeline" />
+      <edge id="e115" source="chain-of-thought" target="tree-of-thought" />
+      <edge id="e116" source="plan-decompose" target="tree-of-thought" />
+      <edge id="e117" source="plan-decompose" target="vertical-slice-planning" />
+      <edge id="e118" source="route-intent" target="vertical-slice-planning" />
+      <edge id="e119" source="speech-to-text" target="voice-agent" />
+      <edge id="e120" source="question-answer" target="voice-agent" />
+      <edge id="e121" source="text-to-speech" target="voice-agent" />
+      <edge id="e122" source="web-search" target="web-scrape" />
+      <edge id="e123" source="parse-html" target="web-scrape" />
+      <edge id="e124" source="extract-entities" target="web-scrape" />
+      <edge id="e125" source="plan-decompose" target="workflow-automation" />
+      <edge id="e126" source="tool-use" target="workflow-automation" />
+      <edge id="e127" source="api-call" target="workflow-automation" />
     </edges>
   </graph>
 </gexf>

--- a/graph/gaia.json
+++ b/graph/gaia.json
@@ -254,7 +254,8 @@
       "derivatives": [
         "research",
         "document-analyst",
-        "data-analysis"
+        "data-analysis",
+        "literature-review"
       ],
       "conditions": "",
       "evidence": [
@@ -269,7 +270,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-26",
-      "updatedAt": "2026-04-26",
+      "updatedAt": "2026-04-30",
       "version": "0.1.0"
     },
     {
@@ -282,7 +283,9 @@
       "prerequisites": [],
       "derivatives": [
         "grounding",
-        "research"
+        "research",
+        "literature-review",
+        "scientific-writing"
       ],
       "conditions": "",
       "evidence": [
@@ -342,7 +345,8 @@
       "prerequisites": [],
       "derivatives": [
         "plan-and-execute",
-        "conversational-agent"
+        "conversational-agent",
+        "vertical-slice-planning"
       ],
       "conditions": "",
       "evidence": [
@@ -374,7 +378,8 @@
         "multi-agent-debate",
         "prompt-optimization",
         "guardrails",
-        "agent-eval"
+        "agent-eval",
+        "design-review"
       ],
       "conditions": "",
       "evidence": [
@@ -459,7 +464,10 @@
         "plan-and-execute",
         "re-act-reasoning",
         "tree-of-thought",
-        "workflow-automation"
+        "workflow-automation",
+        "prd-generation",
+        "vertical-slice-planning",
+        "design-review"
       ],
       "conditions": "",
       "evidence": [
@@ -486,7 +494,9 @@
       "description": "Produces structured, multi-section written output with headings, citations, and coherent narrative.",
       "prerequisites": [],
       "derivatives": [
-        "ghostwrite"
+        "ghostwrite",
+        "prd-generation",
+        "scientific-writing"
       ],
       "conditions": "",
       "evidence": [
@@ -501,7 +511,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-26",
-      "updatedAt": "2026-04-26",
+      "updatedAt": "2026-04-30",
       "version": "0.1.0"
     },
     {
@@ -601,7 +611,8 @@
         "autonomous-debug",
         "code-review-pipeline",
         "registry-curation",
-        "tool-creation"
+        "tool-creation",
+        "ml-pipeline"
       ],
       "conditions": "",
       "evidence": [
@@ -616,7 +627,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-26",
-      "updatedAt": "2026-04-29",
+      "updatedAt": "2026-04-30",
       "version": "0.1.0"
     },
     {
@@ -779,7 +790,8 @@
         "autonomous-data-scientist",
         "ghostwrite",
         "registry-curation",
-        "scientific-discovery"
+        "scientific-discovery",
+        "literature-review"
       ],
       "conditions": "",
       "evidence": [
@@ -794,7 +806,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-26",
-      "updatedAt": "2026-04-28",
+      "updatedAt": "2026-04-30",
       "version": "0.1.0"
     },
     {
@@ -1636,7 +1648,8 @@
         "summarize"
       ],
       "derivatives": [
-        "autonomous-data-scientist"
+        "autonomous-data-scientist",
+        "ml-pipeline"
       ],
       "conditions": "",
       "evidence": [
@@ -1651,7 +1664,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-28",
-      "updatedAt": "2026-04-28",
+      "updatedAt": "2026-04-30",
       "version": "0.2.0"
     },
     {
@@ -1698,7 +1711,8 @@
         "error-interpretation"
       ],
       "derivatives": [
-        "full-stack-developer"
+        "full-stack-developer",
+        "ml-pipeline"
       ],
       "conditions": "",
       "evidence": [
@@ -1713,7 +1727,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-28",
-      "updatedAt": "2026-04-28",
+      "updatedAt": "2026-04-30",
       "version": "0.2.0"
     },
     {
@@ -2003,6 +2017,13 @@
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
           "notes": "Batch 4 curation: 6 skills added (4 atomic, 2 composite) -- ocr, object-detection, code-explain, reward-modeling, grounding, multi-agent-debate."
+        },
+        {
+          "class": "B",
+          "source": "https://github.com/mbtiongson1/gaia-skill-tree",
+          "evaluator": "mbtiongson1",
+          "date": "2026-04-30",
+          "notes": "Batch 5 curation: 5 skills added (2 atomic, 3 composite) -- statistical-analysis, scientific-visualization, literature-review, scientific-writing, ml-pipeline."
         }
       ],
       "knownAgents": [],
@@ -3307,6 +3328,310 @@
       "createdAt": "2026-04-30",
       "updatedAt": "2026-04-30",
       "version": "0.1.0"
+    },
+    {
+      "id": "issue-triage",
+      "name": "Issue Triage",
+      "type": "atomic",
+      "level": "IV",
+      "rarity": "uncommon",
+      "description": "Classifies incoming issue reports through a structured state machine, assigns triage roles (bug/enhancement, needs-info/ready-for-agent/wontfix), reproduces bugs, requests missing detail, and produces structured resolution briefs for agent or human handoff.",
+      "prerequisites": [],
+      "derivatives": [],
+      "conditions": "",
+      "evidence": [
+        {
+          "class": "B",
+          "source": "https://github.com/mattpocock/skills/blob/main/skills/engineering/triage/SKILL.md",
+          "evaluator": "mbtiongson1",
+          "date": "2026-04-30",
+          "notes": "Production triage skill with state-machine workflow, HITL/AFK routing, and structured agent-brief output."
+        },
+        {
+          "class": "A",
+          "source": "https://arxiv.org/abs/2501.18908",
+          "evaluator": "mbtiongson1",
+          "date": "2026-04-30",
+          "notes": "CASEY system: LLMs automate CWE identification (68% accuracy) and severity assessment (73.6%) for security bug triage."
+        },
+        {
+          "class": "A",
+          "source": "https://arxiv.org/abs/2504.18804",
+          "evaluator": "mbtiongson1",
+          "date": "2026-04-30",
+          "notes": "LLMs transform unstructured bug reports into high-quality structured formats; fine-tuned Qwen 2.5 achieves 77% CTQRS."
+        }
+      ],
+      "knownAgents": [],
+      "status": "provisional",
+      "createdAt": "2026-04-30",
+      "updatedAt": "2026-04-30",
+      "version": "0.1.0"
+    },
+    {
+      "id": "prd-generation",
+      "name": "PRD Generation",
+      "type": "composite",
+      "level": "IV",
+      "rarity": "uncommon",
+      "description": "Synthesizes conversation context and codebase knowledge into a structured Product Requirements Document containing a problem statement, extensive user stories, implementation decisions, module boundaries, testing decisions, and out-of-scope items.",
+      "prerequisites": [
+        "write-report",
+        "plan-decompose"
+      ],
+      "derivatives": [],
+      "conditions": "",
+      "evidence": [
+        {
+          "class": "B",
+          "source": "https://github.com/mattpocock/skills/blob/main/skills/engineering/to-prd/SKILL.md",
+          "evaluator": "mbtiongson1",
+          "date": "2026-04-30",
+          "notes": "Production skill that synthesises live conversation context into a fully-structured PRD and publishes it to the issue tracker."
+        },
+        {
+          "class": "A",
+          "source": "https://arxiv.org/abs/2507.19113",
+          "evaluator": "mbtiongson1",
+          "date": "2026-04-30",
+          "notes": "Practical study: LLMs generate Functional Design Specifications and user stories from fragmented requirement sources in an IT consulting deployment."
+        }
+      ],
+      "knownAgents": [],
+      "status": "provisional",
+      "createdAt": "2026-04-30",
+      "updatedAt": "2026-04-30",
+      "version": "0.1.0"
+    },
+    {
+      "id": "vertical-slice-planning",
+      "name": "Vertical Slice Planning",
+      "type": "composite",
+      "level": "III",
+      "rarity": "uncommon",
+      "description": "Decomposes a product plan into independently-demoable vertical slices that each cut through all integration layers end-to-end. Classifies each slice as HITL (human-in-the-loop) or AFK (autonomous), identifies dependency ordering, and publishes structured issues with acceptance criteria.",
+      "prerequisites": [
+        "plan-decompose",
+        "route-intent"
+      ],
+      "derivatives": [],
+      "conditions": "",
+      "evidence": [
+        {
+          "class": "B",
+          "source": "https://github.com/mattpocock/skills/blob/main/skills/engineering/to-issues/SKILL.md",
+          "evaluator": "mbtiongson1",
+          "date": "2026-04-30",
+          "notes": "Production skill implementing tracer-bullet vertical slicing with HITL/AFK classification and issue-tracker publication."
+        }
+      ],
+      "knownAgents": [],
+      "status": "provisional",
+      "createdAt": "2026-04-30",
+      "updatedAt": "2026-04-30",
+      "version": "0.1.0"
+    },
+    {
+      "id": "design-review",
+      "name": "Design Review",
+      "type": "composite",
+      "level": "III",
+      "rarity": "rare",
+      "description": "Stress-tests a plan or design through relentless targeted questioning, walking the decision tree branch-by-branch, resolving concept dependencies, surfacing contradictions against the existing codebase, and crystallising ubiquitous language — optionally persisting resolved decisions to CONTEXT.md and ADRs.",
+      "prerequisites": [
+        "evaluate-output",
+        "plan-decompose"
+      ],
+      "derivatives": [],
+      "conditions": "",
+      "evidence": [
+        {
+          "class": "B",
+          "source": "https://github.com/mattpocock/skills/blob/main/skills/productivity/grill-me/SKILL.md",
+          "evaluator": "mbtiongson1",
+          "date": "2026-04-30",
+          "notes": "Production interactive design-grilling skill; walks decision tree with recommended answers, one question at a time."
+        },
+        {
+          "class": "B",
+          "source": "https://github.com/mattpocock/skills/blob/main/skills/engineering/grill-with-docs/SKILL.md",
+          "evaluator": "mbtiongson1",
+          "date": "2026-04-30",
+          "notes": "Extended implementation with domain-model awareness: challenges language against CONTEXT.md, cross-references code, writes ADRs inline."
+        }
+      ],
+      "knownAgents": [],
+      "status": "provisional",
+      "createdAt": "2026-04-30",
+      "updatedAt": "2026-04-30",
+      "version": "0.1.0"
+    },
+    {
+      "id": "statistical-analysis",
+      "name": "Statistical Analysis",
+      "type": "atomic",
+      "level": "III",
+      "rarity": "uncommon",
+      "description": "Performs hypothesis testing, regression analysis, and Bayesian modelling with effect size calculation and APA-formatted statistical reporting using scipy, statsmodels, and PyMC.",
+      "prerequisites": [],
+      "derivatives": [],
+      "conditions": "",
+      "evidence": [
+        {
+          "class": "A",
+          "source": "https://arxiv.org/abs/2511.06701",
+          "evaluator": "mbtiongson1",
+          "date": "2026-04-30",
+          "notes": "Sargsyan (2025) — Structural Enforcement of Statistical Rigor in AI-Driven Discovery; monadic architecture achieves 1.1% false discovery rate vs 41% for naive LLM approaches across automated hypothesis-testing pipelines."
+        },
+        {
+          "class": "B",
+          "source": "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/scientific-skills/statistical-analysis/SKILL.md",
+          "evaluator": "mbtiongson1",
+          "date": "2026-04-30",
+          "notes": "K-Dense-AI scientific-agent-skills — reproducible statistical-analysis skill covering parametric, non-parametric, and Bayesian workflows with scipy/statsmodels/pingouin/PyMC and APA-formatted output."
+        }
+      ],
+      "knownAgents": [],
+      "status": "provisional",
+      "createdAt": "2026-04-30",
+      "updatedAt": "2026-04-30",
+      "version": "0.1.0"
+    },
+    {
+      "id": "scientific-visualization",
+      "name": "Scientific Visualization",
+      "type": "atomic",
+      "level": "II",
+      "rarity": "uncommon",
+      "description": "Creates publication-ready scientific figures with multi-panel layouts, statistical annotations, colorblind-safe palettes, and journal-specific formatting (Nature, Science, Cell) using matplotlib, seaborn, and plotly.",
+      "prerequisites": [],
+      "derivatives": [
+        "scientific-writing"
+      ],
+      "conditions": "",
+      "evidence": [
+        {
+          "class": "B",
+          "source": "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/scientific-skills/scientific-visualization/SKILL.md",
+          "evaluator": "mbtiongson1",
+          "date": "2026-04-30",
+          "notes": "K-Dense-AI scientific-agent-skills — reproducible scientific-visualization skill orchestrating matplotlib, seaborn, and plotly for journal-quality multi-panel figures with PDF/EPS/TIFF/PNG export and accessibility annotations."
+        }
+      ],
+      "knownAgents": [],
+      "status": "provisional",
+      "createdAt": "2026-04-30",
+      "updatedAt": "2026-04-30",
+      "version": "0.1.0"
+    },
+    {
+      "id": "literature-review",
+      "name": "Literature Review",
+      "type": "composite",
+      "level": "IV",
+      "rarity": "uncommon",
+      "description": "Conducts systematic multi-database academic literature searches following PRISMA/SWARM protocols, screens and synthesises findings, verifies all citations, and generates a structured review report.",
+      "prerequisites": [
+        "research",
+        "cite-sources",
+        "summarize"
+      ],
+      "derivatives": [],
+      "conditions": "Requires access to academic databases (PubMed, bioRxiv, ChEMBL, or equivalent).",
+      "evidence": [
+        {
+          "class": "A",
+          "source": "https://arxiv.org/abs/2501.05468",
+          "evaluator": "mbtiongson1",
+          "date": "2026-04-30",
+          "notes": "Rouzrokh et al. (2025) — LatteReview: multi-agent framework for systematic review automation; modular agents for title/abstract screening, relevance scoring, and structured data extraction with RAG and multimodal support."
+        },
+        {
+          "class": "B",
+          "source": "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/scientific-skills/literature-review/SKILL.md",
+          "evaluator": "mbtiongson1",
+          "date": "2026-04-30",
+          "notes": "K-Dense-AI scientific-agent-skills — reproducible literature-review skill: seven-phase workflow from research-question planning through multi-database search, screening, extraction, synthesis, citation verification to final PDF output."
+        }
+      ],
+      "knownAgents": [],
+      "status": "provisional",
+      "createdAt": "2026-04-30",
+      "updatedAt": "2026-04-30",
+      "version": "0.1.0"
+    },
+    {
+      "id": "scientific-writing",
+      "name": "Scientific Writing",
+      "type": "composite",
+      "level": "III",
+      "rarity": "uncommon",
+      "description": "Composes research manuscripts in IMRAD structure with reporting-guideline compliance (CONSORT, STROBE, PRISMA), citation management, publication-quality figures, and LaTeX/PDF formatting.",
+      "prerequisites": [
+        "write-report",
+        "cite-sources",
+        "scientific-visualization"
+      ],
+      "derivatives": [],
+      "conditions": "",
+      "evidence": [
+        {
+          "class": "A",
+          "source": "https://arxiv.org/abs/2405.20477",
+          "evaluator": "mbtiongson1",
+          "date": "2026-04-30",
+          "notes": "Chamoun et al. (ACL 2024 Findings) — SWIFT: automated focused feedback for scientific writing; multi-component LLM system (planner, investigator, reviewer, controller) rated more specific and helpful than human reviewers on 300 peer-reviewed manuscripts."
+        },
+        {
+          "class": "B",
+          "source": "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/scientific-skills/scientific-writing/SKILL.md",
+          "evaluator": "mbtiongson1",
+          "date": "2026-04-30",
+          "notes": "K-Dense-AI scientific-agent-skills — reproducible scientific-writing skill: two-stage outline-to-prose pipeline with IMRAD structure, multi-style citation management, and reporting-guideline validation (CONSORT, STROBE, PRISMA, STARD, TRIPOD)."
+        }
+      ],
+      "knownAgents": [],
+      "status": "provisional",
+      "createdAt": "2026-04-30",
+      "updatedAt": "2026-04-30",
+      "version": "0.1.0"
+    },
+    {
+      "id": "ml-pipeline",
+      "name": "ML Pipeline",
+      "type": "composite",
+      "level": "IV",
+      "rarity": "rare",
+      "description": "Designs and implements production ML pipelines with experiment tracking (MLflow, W&B), feature stores (Feast), orchestration (Kubeflow, Airflow), and automated retraining workflows including model evaluation gates and A/B deployment.",
+      "prerequisites": [
+        "data-analysis",
+        "automated-testing",
+        "code-generation"
+      ],
+      "derivatives": [],
+      "conditions": "Requires access to a container orchestration environment and model registry.",
+      "evidence": [
+        {
+          "class": "A",
+          "source": "https://arxiv.org/abs/2502.18530",
+          "evaluator": "mbtiongson1",
+          "date": "2026-04-30",
+          "notes": "Xue et al. (2025) — IMPROVE: Iterative Model Pipeline Refinement and Optimization Leveraging LLM Experts; iterative component-level refinement consistently outperforms single-step zero-shot LLM-based ML pipeline optimization with theoretical convergence guarantees."
+        },
+        {
+          "class": "B",
+          "source": "https://github.com/Jeffallan/claude-skills/blob/main/skills/ml-pipeline/SKILL.md",
+          "evaluator": "mbtiongson1",
+          "date": "2026-04-30",
+          "notes": "Jeffallan/claude-skills — reproducible ml-pipeline skill: full lifecycle from data validation and feature engineering through distributed training, experiment tracking, model evaluation gates, A/B testing, and automated retraining with DVC/Feast/MLflow/Kubeflow."
+        }
+      ],
+      "knownAgents": [],
+      "status": "provisional",
+      "createdAt": "2026-04-30",
+      "updatedAt": "2026-04-30",
+      "version": "0.1.0"
     }
   ],
   "edges": [
@@ -4593,6 +4918,160 @@
       "condition": "",
       "levelFloor": "I",
       "evidenceRefs": []
+    },
+    {
+      "sourceSkillId": "write-report",
+      "targetSkillId": "prd-generation",
+      "edgeType": "prerequisite",
+      "condition": "",
+      "levelFloor": "III",
+      "evidenceRefs": []
+    },
+    {
+      "sourceSkillId": "plan-decompose",
+      "targetSkillId": "prd-generation",
+      "edgeType": "prerequisite",
+      "condition": "",
+      "levelFloor": "III",
+      "evidenceRefs": []
+    },
+    {
+      "sourceSkillId": "plan-decompose",
+      "targetSkillId": "vertical-slice-planning",
+      "edgeType": "prerequisite",
+      "condition": "",
+      "levelFloor": "II",
+      "evidenceRefs": []
+    },
+    {
+      "sourceSkillId": "route-intent",
+      "targetSkillId": "vertical-slice-planning",
+      "edgeType": "prerequisite",
+      "condition": "",
+      "levelFloor": "II",
+      "evidenceRefs": []
+    },
+    {
+      "sourceSkillId": "evaluate-output",
+      "targetSkillId": "design-review",
+      "edgeType": "prerequisite",
+      "condition": "",
+      "levelFloor": "II",
+      "evidenceRefs": []
+    },
+    {
+      "sourceSkillId": "plan-decompose",
+      "targetSkillId": "design-review",
+      "edgeType": "prerequisite",
+      "condition": "",
+      "levelFloor": "II",
+      "evidenceRefs": []
+    },
+    {
+      "sourceSkillId": "issue-triage",
+      "targetSkillId": "route-intent",
+      "edgeType": "enhances",
+      "condition": "",
+      "levelFloor": "III",
+      "evidenceRefs": []
+    },
+    {
+      "sourceSkillId": "prd-generation",
+      "targetSkillId": "vertical-slice-planning",
+      "edgeType": "enhances",
+      "condition": "",
+      "levelFloor": "III",
+      "evidenceRefs": []
+    },
+    {
+      "sourceSkillId": "research",
+      "targetSkillId": "literature-review",
+      "edgeType": "prerequisite",
+      "condition": "",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "literature-review#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "cite-sources",
+      "targetSkillId": "literature-review",
+      "edgeType": "prerequisite",
+      "condition": "",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "literature-review#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "summarize",
+      "targetSkillId": "literature-review",
+      "edgeType": "prerequisite",
+      "condition": "",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "literature-review#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "write-report",
+      "targetSkillId": "scientific-writing",
+      "edgeType": "prerequisite",
+      "condition": "",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "scientific-writing#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "cite-sources",
+      "targetSkillId": "scientific-writing",
+      "edgeType": "prerequisite",
+      "condition": "",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "scientific-writing#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "scientific-visualization",
+      "targetSkillId": "scientific-writing",
+      "edgeType": "prerequisite",
+      "condition": "",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "scientific-writing#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "data-analysis",
+      "targetSkillId": "ml-pipeline",
+      "edgeType": "prerequisite",
+      "condition": "",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "ml-pipeline#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "automated-testing",
+      "targetSkillId": "ml-pipeline",
+      "edgeType": "prerequisite",
+      "condition": "",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "ml-pipeline#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "code-generation",
+      "targetSkillId": "ml-pipeline",
+      "edgeType": "prerequisite",
+      "condition": "",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "ml-pipeline#evidence[0]"
+      ]
     }
   ]
 }

--- a/graph/named/index.json
+++ b/graph/named/index.json
@@ -49,6 +49,28 @@
         "links": {
           "github": "https://github.com/addyosmani/agent-skills/blob/main/skills/test-driven-development/SKILL.md"
         }
+      },
+      {
+        "id": "mattpocock/tdd",
+        "name": "TDD",
+        "contributor": "mattpocock",
+        "origin": false,
+        "genericSkillRef": "test-driven-development",
+        "status": "named",
+        "level": "III",
+        "description": "Enforces strict vertical-slice TDD \u2014 one test then one implementation at a time \u2014 explicitly blocking horizontal slicing (all tests first, then all code). Tests verify behaviour through public interfaces only; mocking internal collaborators is treated as an anti-pattern.",
+        "title": "Vertical-Slice TDD",
+        "catalogRef": "mattpocock-tdd",
+        "tags": [
+          "tdd",
+          "red-green-refactor",
+          "vertical-slicing",
+          "tracer-bullet",
+          "public-interface-testing"
+        ],
+        "links": {
+          "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/tdd/SKILL.md"
+        }
       }
     ],
     "document-editing": [
@@ -73,6 +95,28 @@
         "links": {
           "github": "https://github.com/anthropics/skills/blob/main/skills/pptx/SKILL.md"
         }
+      },
+      {
+        "id": "mattpocock/edit-article",
+        "name": "Edit Article",
+        "contributor": "mattpocock",
+        "origin": false,
+        "genericSkillRef": "document-editing",
+        "status": "named",
+        "level": "II",
+        "description": "Edits articles by first sectioning them as a DAG of information dependencies, confirming the section order, then rewriting each section for clarity and flow with a 240-character-per-paragraph constraint.",
+        "title": "The Section-by-Section Rewrite",
+        "catalogRef": "mattpocock-edit-article",
+        "tags": [
+          "article-editing",
+          "prose-rewrite",
+          "information-dag",
+          "section-structure",
+          "clarity"
+        ],
+        "links": {
+          "github": "https://github.com/mattpocock/skills/blob/main/skills/personal/edit-article/SKILL.md"
+        }
       }
     ],
     "tool-creation": [
@@ -95,6 +139,28 @@
         ],
         "links": {
           "github": "https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md"
+        }
+      },
+      {
+        "id": "mattpocock/write-a-skill",
+        "name": "Write a Skill",
+        "contributor": "mattpocock",
+        "origin": false,
+        "genericSkillRef": "tool-creation",
+        "status": "named",
+        "level": "III",
+        "description": "Guides creation of new agent skills through a structured requirements interview, then produces a SKILL.md with a trigger-aware description, progressive-disclosure layout, and optional bundled scripts or reference files \u2014 ready for installation in any Claude Code, Cursor, or Codex CLI skills directory.",
+        "title": "The Skill Scaffolder",
+        "catalogRef": "mattpocock-write-a-skill",
+        "tags": [
+          "skill-authoring",
+          "meta-agent",
+          "claude-code",
+          "skill-scaffolding",
+          "progressive-disclosure"
+        ],
+        "links": {
+          "github": "https://github.com/mattpocock/skills/blob/main/skills/productivity/write-a-skill/SKILL.md"
         }
       }
     ],
@@ -119,6 +185,28 @@
         ],
         "links": {
           "github": "https://github.com/cognition-labs/devin"
+        }
+      },
+      {
+        "id": "mattpocock/diagnose",
+        "name": "Diagnose",
+        "contributor": "mattpocock",
+        "origin": false,
+        "genericSkillRef": "autonomous-debug",
+        "status": "named",
+        "level": "II",
+        "description": "Drives a rigorous five-phase debugging discipline \u2014 build a feedback loop, minimise, hypothesise, instrument, fix and regression-test \u2014 refusing to proceed until a fast deterministic pass/fail signal exists. Applies to hard bugs and performance regressions.",
+        "title": "The Disciplined Diagnosis Loop",
+        "catalogRef": "mattpocock-diagnose",
+        "tags": [
+          "debugging",
+          "diagnosis",
+          "feedback-loop",
+          "regression",
+          "root-cause-analysis"
+        ],
+        "links": {
+          "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/diagnose/SKILL.md"
         }
       }
     ],
@@ -260,6 +348,175 @@
         }
       }
     ],
+    "design-review": [
+      {
+        "id": "mattpocock/grill-me",
+        "name": "Grill Me",
+        "contributor": "mattpocock",
+        "origin": false,
+        "genericSkillRef": "design-review",
+        "status": "named",
+        "level": "II",
+        "description": "Conducts a relentless one-question-at-a-time interview about a plan or design, walking every branch of the decision tree with a recommended answer per question, resolving dependencies in order, and substituting codebase exploration wherever a question can be answered empirically.",
+        "title": "The Relentless Interviewer",
+        "catalogRef": "mattpocock-grill-me",
+        "tags": [
+          "design-review",
+          "decision-tree",
+          "socratic-method",
+          "plan-stress-test",
+          "one-question-at-a-time"
+        ],
+        "links": {
+          "github": "https://github.com/mattpocock/skills/blob/main/skills/productivity/grill-me/SKILL.md"
+        }
+      },
+      {
+        "id": "mattpocock/grill-with-docs",
+        "name": "Grill With Docs",
+        "contributor": "mattpocock",
+        "origin": true,
+        "genericSkillRef": "design-review",
+        "status": "named",
+        "level": "III",
+        "description": "Stress-tests a plan against the project's domain model by relentlessly questioning each design decision one at a time, surfacing language conflicts with CONTEXT.md, cross-referencing code contradictions, and crystallising decisions as inline CONTEXT.md updates and ADRs as they are resolved.",
+        "title": "The Domain-Aware Interrogator",
+        "catalogRef": "mattpocock-grill-with-docs",
+        "tags": [
+          "design-review",
+          "domain-model",
+          "ubiquitous-language",
+          "adr",
+          "context-md",
+          "socratic-method"
+        ],
+        "links": {
+          "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/grill-with-docs/SKILL.md"
+        }
+      }
+    ],
+    "refactor-code": [
+      {
+        "id": "mattpocock/improve-codebase-architecture",
+        "name": "Improve Codebase Architecture",
+        "contributor": "mattpocock",
+        "origin": false,
+        "genericSkillRef": "refactor-code",
+        "status": "named",
+        "level": "III",
+        "description": "Identifies architectural deepening opportunities in a codebase \u2014 shallow modules with high interface-to-implementation ratios \u2014 using domain-glossary vocabulary and the deletion test, then grills the developer on the chosen candidate to design a deep-module replacement with better locality and testability.",
+        "title": "The Depth Seeker",
+        "catalogRef": "mattpocock-improve-codebase-architecture",
+        "tags": [
+          "architecture-review",
+          "deep-modules",
+          "refactoring",
+          "locality",
+          "testability",
+          "deletion-test"
+        ],
+        "links": {
+          "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/improve-codebase-architecture/SKILL.md"
+        }
+      }
+    ],
+    "vertical-slice-planning": [
+      {
+        "id": "mattpocock/to-issues",
+        "name": "To Issues",
+        "contributor": "mattpocock",
+        "origin": true,
+        "genericSkillRef": "vertical-slice-planning",
+        "status": "named",
+        "level": "III",
+        "description": "Breaks a plan, spec, or PRD into independently-grabbable GitHub issues as tracer-bullet vertical slices that each cut through all integration layers end-to-end. Classifies each slice HITL or AFK, maps dependency chains, quizzes the user on granularity, and publishes structured issues with acceptance criteria in dependency order.",
+        "title": "The Vertical Slicer",
+        "catalogRef": "mattpocock-to-issues",
+        "tags": [
+          "vertical-slicing",
+          "issue-decomposition",
+          "tracer-bullet",
+          "hitl",
+          "afk",
+          "acceptance-criteria"
+        ],
+        "links": {
+          "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/to-issues/SKILL.md"
+        }
+      }
+    ],
+    "prd-generation": [
+      {
+        "id": "mattpocock/to-prd",
+        "name": "To PRD",
+        "contributor": "mattpocock",
+        "origin": true,
+        "genericSkillRef": "prd-generation",
+        "status": "named",
+        "level": "II",
+        "description": "Synthesises the current conversation context and codebase knowledge into a fully-structured PRD \u2014 problem statement, extensive numbered user stories, implementation decisions (modules, interfaces, schema), testing decisions, and out-of-scope items \u2014 then publishes it to the project issue tracker.",
+        "title": "The PRD Synthesiser",
+        "catalogRef": "mattpocock-to-prd",
+        "tags": [
+          "prd",
+          "requirements",
+          "user-stories",
+          "product-management",
+          "issue-tracker"
+        ],
+        "links": {
+          "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/to-prd/SKILL.md"
+        }
+      }
+    ],
+    "issue-triage": [
+      {
+        "id": "mattpocock/triage",
+        "name": "Triage",
+        "contributor": "mattpocock",
+        "origin": true,
+        "genericSkillRef": "issue-triage",
+        "status": "named",
+        "level": "III",
+        "description": "Moves GitHub issues through a two-category (bug/enhancement) \u00d7 five-state (needs-triage/needs-info/ready-for-agent/ready-for-human/wontfix) state machine. Reproduces bugs from issue steps, runs a domain-aware grilling session when needed, writes structured agent briefs, and appends AI-generated triage notes with the required disclaimer.",
+        "title": "The State-Machine Triager",
+        "catalogRef": "mattpocock-triage",
+        "tags": [
+          "issue-triage",
+          "state-machine",
+          "bug-reproduction",
+          "agent-brief",
+          "github-issues"
+        ],
+        "links": {
+          "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/triage/SKILL.md"
+        }
+      }
+    ],
+    "code-explain": [
+      {
+        "id": "mattpocock/zoom-out",
+        "name": "Zoom Out",
+        "contributor": "mattpocock",
+        "origin": true,
+        "genericSkillRef": "code-explain",
+        "status": "named",
+        "level": "II",
+        "description": "Signals the agent to ascend one layer of abstraction and produce a map of all relevant modules, callers, and domain-glossary terms in the unfamiliar code area, without explaining implementation details.",
+        "title": "The Abstraction Lift",
+        "catalogRef": "mattpocock-zoom-out",
+        "tags": [
+          "code-navigation",
+          "abstraction",
+          "module-map",
+          "domain-glossary",
+          "codebase-orientation"
+        ],
+        "links": {
+          "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/zoom-out/SKILL.md"
+        }
+      }
+    ],
     "multi-agent-orchestration-v": [
       {
         "id": "ruvnet/flow-nexus-swarm",
@@ -387,6 +644,19 @@
     ],
     "martin-stepanoski": [
       "martin-stepanoski/nielsen-heuristics-audit"
+    ],
+    "mattpocock": [
+      "mattpocock/diagnose",
+      "mattpocock/edit-article",
+      "mattpocock/grill-me",
+      "mattpocock/grill-with-docs",
+      "mattpocock/improve-codebase-architecture",
+      "mattpocock/tdd",
+      "mattpocock/to-issues",
+      "mattpocock/to-prd",
+      "mattpocock/triage",
+      "mattpocock/write-a-skill",
+      "mattpocock/zoom-out"
     ],
     "ruvnet": [
       "ruvnet/flow-nexus-swarm"

--- a/graph/real_skill_catalog.json
+++ b/graph/real_skill_catalog.json
@@ -381,6 +381,240 @@
         "documentation",
         "readme"
       ]
+    },
+    {
+      "id": "mattpocock-diagnose",
+      "name": "mattpocock/diagnose",
+      "contributor": "mattpocock",
+      "title": "The Disciplined Diagnosis Loop",
+      "description": "Enforces a five-phase debugging discipline prioritising the feedback loop above all else — refuses to proceed until a fast deterministic pass/fail signal exists.",
+      "sourceRepo": "mattpocock/skills",
+      "url": "https://github.com/mattpocock/skills/blob/main/skills/engineering/diagnose/SKILL.md",
+      "mapsToGaia": [
+        "autonomous-debug"
+      ],
+      "promotedNamedSkillId": "mattpocock/diagnose",
+      "addedAt": "2026-04-30",
+      "tags": [
+        "debugging",
+        "diagnosis",
+        "feedback-loop",
+        "regression",
+        "root-cause-analysis"
+      ]
+    },
+    {
+      "id": "mattpocock-tdd",
+      "name": "mattpocock/tdd",
+      "contributor": "mattpocock",
+      "title": "Vertical-Slice TDD",
+      "description": "Enforces strict vertical-slice TDD, blocking horizontal slicing (all tests first, then all code) and requiring tests against public interfaces only.",
+      "sourceRepo": "mattpocock/skills",
+      "url": "https://github.com/mattpocock/skills/blob/main/skills/engineering/tdd/SKILL.md",
+      "mapsToGaia": [
+        "test-driven-development"
+      ],
+      "promotedNamedSkillId": "mattpocock/tdd",
+      "addedAt": "2026-04-30",
+      "tags": [
+        "tdd",
+        "red-green-refactor",
+        "vertical-slicing",
+        "tracer-bullet",
+        "public-interface-testing"
+      ]
+    },
+    {
+      "id": "mattpocock-zoom-out",
+      "name": "mattpocock/zoom-out",
+      "contributor": "mattpocock",
+      "title": "The Abstraction Lift",
+      "description": "Signals the agent to ascend one layer of abstraction and produce a map of all relevant modules, callers, and domain-glossary terms.",
+      "sourceRepo": "mattpocock/skills",
+      "url": "https://github.com/mattpocock/skills/blob/main/skills/engineering/zoom-out/SKILL.md",
+      "mapsToGaia": [
+        "code-explain"
+      ],
+      "promotedNamedSkillId": "mattpocock/zoom-out",
+      "addedAt": "2026-04-30",
+      "tags": [
+        "code-navigation",
+        "abstraction",
+        "module-map",
+        "domain-glossary",
+        "codebase-orientation"
+      ]
+    },
+    {
+      "id": "mattpocock-edit-article",
+      "name": "mattpocock/edit-article",
+      "contributor": "mattpocock",
+      "title": "The Section-by-Section Rewrite",
+      "description": "Edits articles by modelling them as a DAG of information dependencies, confirming section order, then rewriting each section with a 240-character-per-paragraph constraint.",
+      "sourceRepo": "mattpocock/skills",
+      "url": "https://github.com/mattpocock/skills/blob/main/skills/personal/edit-article/SKILL.md",
+      "mapsToGaia": [
+        "document-editing"
+      ],
+      "promotedNamedSkillId": "mattpocock/edit-article",
+      "addedAt": "2026-04-30",
+      "tags": [
+        "article-editing",
+        "prose-rewrite",
+        "information-dag",
+        "section-structure",
+        "clarity"
+      ]
+    },
+    {
+      "id": "mattpocock-write-a-skill",
+      "name": "mattpocock/write-a-skill",
+      "contributor": "mattpocock",
+      "title": "The Skill Scaffolder",
+      "description": "Guides creation of new agent skills via structured interview, producing a SKILL.md with trigger-aware description, progressive-disclosure layout, and optional bundled scripts.",
+      "sourceRepo": "mattpocock/skills",
+      "url": "https://github.com/mattpocock/skills/blob/main/skills/productivity/write-a-skill/SKILL.md",
+      "mapsToGaia": [
+        "tool-creation"
+      ],
+      "promotedNamedSkillId": "mattpocock/write-a-skill",
+      "addedAt": "2026-04-30",
+      "tags": [
+        "skill-authoring",
+        "meta-agent",
+        "claude-code",
+        "skill-scaffolding",
+        "progressive-disclosure"
+      ]
+    },
+    {
+      "id": "mattpocock-triage",
+      "name": "mattpocock/triage",
+      "contributor": "mattpocock",
+      "title": "The State-Machine Triager",
+      "description": "Moves GitHub issues through a two-category x five-state machine with bug reproduction, agent-brief writing, and structured triage notes bearing an AI-generation disclaimer.",
+      "sourceRepo": "mattpocock/skills",
+      "url": "https://github.com/mattpocock/skills/blob/main/skills/engineering/triage/SKILL.md",
+      "mapsToGaia": [
+        "issue-triage"
+      ],
+      "promotedNamedSkillId": "mattpocock/triage",
+      "addedAt": "2026-04-30",
+      "tags": [
+        "issue-triage",
+        "state-machine",
+        "bug-reproduction",
+        "agent-brief",
+        "github-issues"
+      ]
+    },
+    {
+      "id": "mattpocock-to-prd",
+      "name": "mattpocock/to-prd",
+      "contributor": "mattpocock",
+      "title": "The PRD Synthesiser",
+      "description": "Synthesises conversation context and codebase knowledge into a fully-structured PRD with user stories, implementation decisions, and testing decisions, then publishes to the issue tracker.",
+      "sourceRepo": "mattpocock/skills",
+      "url": "https://github.com/mattpocock/skills/blob/main/skills/engineering/to-prd/SKILL.md",
+      "mapsToGaia": [
+        "prd-generation"
+      ],
+      "promotedNamedSkillId": "mattpocock/to-prd",
+      "addedAt": "2026-04-30",
+      "tags": [
+        "prd",
+        "requirements",
+        "user-stories",
+        "product-management",
+        "issue-tracker"
+      ]
+    },
+    {
+      "id": "mattpocock-to-issues",
+      "name": "mattpocock/to-issues",
+      "contributor": "mattpocock",
+      "title": "The Vertical Slicer",
+      "description": "Breaks a plan into independently-demoable vertical slices, classifies each HITL or AFK, maps dependency chains, and publishes structured GitHub issues with acceptance criteria in dependency order.",
+      "sourceRepo": "mattpocock/skills",
+      "url": "https://github.com/mattpocock/skills/blob/main/skills/engineering/to-issues/SKILL.md",
+      "mapsToGaia": [
+        "vertical-slice-planning"
+      ],
+      "promotedNamedSkillId": "mattpocock/to-issues",
+      "addedAt": "2026-04-30",
+      "tags": [
+        "vertical-slicing",
+        "issue-decomposition",
+        "tracer-bullet",
+        "hitl",
+        "afk",
+        "acceptance-criteria"
+      ]
+    },
+    {
+      "id": "mattpocock-grill-with-docs",
+      "name": "mattpocock/grill-with-docs",
+      "contributor": "mattpocock",
+      "title": "The Domain-Aware Interrogator",
+      "description": "Stress-tests a plan against the project's domain model, challenging language against CONTEXT.md, cross-referencing code, and persisting resolved decisions as inline glossary updates and ADRs.",
+      "sourceRepo": "mattpocock/skills",
+      "url": "https://github.com/mattpocock/skills/blob/main/skills/engineering/grill-with-docs/SKILL.md",
+      "mapsToGaia": [
+        "design-review"
+      ],
+      "promotedNamedSkillId": "mattpocock/grill-with-docs",
+      "addedAt": "2026-04-30",
+      "tags": [
+        "design-review",
+        "domain-model",
+        "ubiquitous-language",
+        "adr",
+        "context-md",
+        "socratic-method"
+      ]
+    },
+    {
+      "id": "mattpocock-grill-me",
+      "name": "mattpocock/grill-me",
+      "contributor": "mattpocock",
+      "title": "The Relentless Interviewer",
+      "description": "Conducts a relentless one-question-at-a-time interview walking every branch of the decision tree with a recommended answer, substituting codebase exploration wherever empirically determinable.",
+      "sourceRepo": "mattpocock/skills",
+      "url": "https://github.com/mattpocock/skills/blob/main/skills/productivity/grill-me/SKILL.md",
+      "mapsToGaia": [
+        "design-review"
+      ],
+      "promotedNamedSkillId": "mattpocock/grill-me",
+      "addedAt": "2026-04-30",
+      "tags": [
+        "design-review",
+        "decision-tree",
+        "socratic-method",
+        "plan-stress-test",
+        "one-question-at-a-time"
+      ]
+    },
+    {
+      "id": "mattpocock-improve-codebase-architecture",
+      "name": "mattpocock/improve-codebase-architecture",
+      "contributor": "mattpocock",
+      "title": "The Depth Seeker",
+      "description": "Identifies shallow modules via the deletion test, presents deepening opportunities with locality/leverage analysis, then grills the developer on the chosen candidate to design a deep-module replacement.",
+      "sourceRepo": "mattpocock/skills",
+      "url": "https://github.com/mattpocock/skills/blob/main/skills/engineering/improve-codebase-architecture/SKILL.md",
+      "mapsToGaia": [
+        "refactor-code"
+      ],
+      "promotedNamedSkillId": "mattpocock/improve-codebase-architecture",
+      "addedAt": "2026-04-30",
+      "tags": [
+        "architecture-review",
+        "deep-modules",
+        "refactoring",
+        "locality",
+        "testability",
+        "deletion-test"
+      ]
     }
   ]
 }

--- a/registry.md
+++ b/registry.md
@@ -24,6 +24,7 @@
 | ◇ Conversational Agent | Extra Skill | III | Uncommon | Provisional |
 | ◇ Data Analysis | Extra Skill | III | Uncommon | Provisional |
 | ○ Data Visualize | Intrinsic Skill | II | Common | Provisional |
+| ◇ Design Review | Extra Skill | III | Rare | Provisional |
 | ○ Detect Anomaly | Intrinsic Skill | II | Uncommon | Provisional |
 | ○ Diff Content | Intrinsic Skill | I | Common | Provisional |
 | ◇ Document Analyst | Extra Skill | III | Uncommon | Provisional |
@@ -49,11 +50,14 @@
 | ○ Hypothesis Generation | Intrinsic Skill | II | Rare | Provisional |
 | ○ Image Caption | Intrinsic Skill | II | Uncommon | Provisional |
 | ○ Image Generate | Intrinsic Skill | II | Uncommon | Provisional |
+| ○ Issue Triage | Intrinsic Skill | IV | Uncommon | Provisional |
 | ◇ Knowledge Graph Construction | Extra Skill | III | Uncommon | Provisional |
 | ◇ Knowledge Harvest | Extra Skill | IV | Rare | Provisional |
+| ◇ Literature Review | Extra Skill | IV | Uncommon | Provisional |
 | ○ Logical Inference | Intrinsic Skill | I | Uncommon | Provisional |
 | ○ Math Reason | Intrinsic Skill | II | Uncommon | Provisional |
 | ○ Memory Manage | Intrinsic Skill | II | Uncommon | Provisional |
+| ◇ ML Pipeline | Extra Skill | IV | Rare | Provisional |
 | ◇ Multi-Agent Debate | Extra Skill | IV | Rare | Provisional |
 | ◆ Grand Conductor: Multi-Agent Orchestration | Ultimate Skill | V | Divine | Provisional |
 | ◇ Multimodal Reasoning | Extra Skill | III | Rare | Provisional |
@@ -64,6 +68,7 @@
 | ○ Parse PDF | Intrinsic Skill | I | Common | Provisional |
 | ◇ Plan and Execute | Extra Skill | IV | Rare | Provisional |
 | ○ Plan and Decompose | Intrinsic Skill | I | Common | Provisional |
+| ◇ PRD Generation | Extra Skill | IV | Uncommon | Provisional |
 | ○ Prompt Injection Defense | Intrinsic Skill | III | Uncommon | Provisional |
 | ◇ Prompt Optimization | Extra Skill | IV | Uncommon | Provisional |
 | ○ Question Answer | Intrinsic Skill | 0 | Common | Provisional |
@@ -79,6 +84,8 @@
 | ○ Reward Modeling | Intrinsic Skill | II | Rare | Provisional |
 | ○ Route Intent | Intrinsic Skill | I | Common | Provisional |
 | ◆ True Dragon: Autonomous Scientific Discovery | Ultimate Skill | V | Divine | Provisional |
+| ○ Scientific Visualization | Intrinsic Skill | II | Uncommon | Provisional |
+| ◇ Scientific Writing | Extra Skill | III | Uncommon | Provisional |
 | ○ Score Relevance | Intrinsic Skill | I | Common | Provisional |
 | ○ Self-Consistency | Intrinsic Skill | IV | Rare | Provisional |
 | ○ Self-Critique | Intrinsic Skill | I | Uncommon | Provisional |
@@ -86,6 +93,7 @@
 | ○ Sentiment Analysis | Intrinsic Skill | 0 | Common | Provisional |
 | ○ Skill Discovery | Intrinsic Skill | 0 | Common | Provisional |
 | ○ Speech to Text | Intrinsic Skill | II | Common | Provisional |
+| ○ Statistical Analysis | Intrinsic Skill | III | Uncommon | Provisional |
 | ○ Structured Output Generation | Intrinsic Skill | I | Common | Provisional |
 | ○ Summarize | Intrinsic Skill | 0 | Common | Provisional |
 | ○ Test-Driven Development | Intrinsic Skill | 0 | Uncommon | Provisional |
@@ -100,6 +108,7 @@
 | ◇ Translation Pipeline | Extra Skill | III | Uncommon | Provisional |
 | ◇ Tree of Thought | Extra Skill | IV | Rare | Provisional |
 | ○ UX Audit | Intrinsic Skill | 0 | Uncommon | Provisional |
+| ◇ Vertical Slice Planning | Extra Skill | III | Uncommon | Provisional |
 | ○ Visual Question Answering | Intrinsic Skill | III | Uncommon | Provisional |
 | ◇ Voice Agent | Extra Skill | III | Uncommon | Provisional |
 | ◇ Web Scrape | Extra Skill | III | Uncommon | Provisional |

--- a/scripts/add_skills_batch5.py
+++ b/scripts/add_skills_batch5.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Batch 5: Add 5 scientific-domain skills sourced from GitHub /skills repos."""
+import json
+
+GRAPH_PATH = "graph/gaia.json"
+
+NEW_SKILLS = [
+    {
+        "id": "statistical-analysis",
+        "name": "Statistical Analysis",
+        "type": "atomic",
+        "level": "III",
+        "rarity": "uncommon",
+        "description": "Performs hypothesis testing, regression analysis, and Bayesian modelling with effect size calculation and APA-formatted statistical reporting using scipy, statsmodels, and PyMC.",
+        "prerequisites": [],
+        "derivatives": [],
+        "conditions": "",
+        "evidence": [
+            {
+                "class": "A",
+                "source": "https://arxiv.org/abs/2511.06701",
+                "evaluator": "mbtiongson1",
+                "date": "2026-04-30",
+                "notes": "Sargsyan (2025) — Structural Enforcement of Statistical Rigor in AI-Driven Discovery; monadic architecture achieves 1.1% false discovery rate vs 41% for naive LLM approaches across automated hypothesis-testing pipelines."
+            },
+            {
+                "class": "B",
+                "source": "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/scientific-skills/statistical-analysis/SKILL.md",
+                "evaluator": "mbtiongson1",
+                "date": "2026-04-30",
+                "notes": "K-Dense-AI scientific-agent-skills — reproducible statistical-analysis skill covering parametric, non-parametric, and Bayesian workflows with scipy/statsmodels/pingouin/PyMC and APA-formatted output."
+            }
+        ],
+        "knownAgents": [],
+        "status": "provisional",
+        "createdAt": "2026-04-30",
+        "updatedAt": "2026-04-30",
+        "version": "0.1.0"
+    },
+    {
+        "id": "scientific-visualization",
+        "name": "Scientific Visualization",
+        "type": "atomic",
+        "level": "II",
+        "rarity": "uncommon",
+        "description": "Creates publication-ready scientific figures with multi-panel layouts, statistical annotations, colorblind-safe palettes, and journal-specific formatting (Nature, Science, Cell) using matplotlib, seaborn, and plotly.",
+        "prerequisites": [],
+        "derivatives": [
+            "scientific-writing"
+        ],
+        "conditions": "",
+        "evidence": [
+            {
+                "class": "B",
+                "source": "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/scientific-skills/scientific-visualization/SKILL.md",
+                "evaluator": "mbtiongson1",
+                "date": "2026-04-30",
+                "notes": "K-Dense-AI scientific-agent-skills — reproducible scientific-visualization skill orchestrating matplotlib, seaborn, and plotly for journal-quality multi-panel figures with PDF/EPS/TIFF/PNG export and accessibility annotations."
+            }
+        ],
+        "knownAgents": [],
+        "status": "provisional",
+        "createdAt": "2026-04-30",
+        "updatedAt": "2026-04-30",
+        "version": "0.1.0"
+    },
+    {
+        "id": "literature-review",
+        "name": "Literature Review",
+        "type": "composite",
+        "level": "IV",
+        "rarity": "uncommon",
+        "description": "Conducts systematic multi-database academic literature searches following PRISMA/SWARM protocols, screens and synthesises findings, verifies all citations, and generates a structured review report.",
+        "prerequisites": [
+            "research",
+            "cite-sources",
+            "summarize"
+        ],
+        "derivatives": [],
+        "conditions": "Requires access to academic databases (PubMed, bioRxiv, ChEMBL, or equivalent).",
+        "evidence": [
+            {
+                "class": "A",
+                "source": "https://arxiv.org/abs/2501.05468",
+                "evaluator": "mbtiongson1",
+                "date": "2026-04-30",
+                "notes": "Rouzrokh et al. (2025) — LatteReview: multi-agent framework for systematic review automation; modular agents for title/abstract screening, relevance scoring, and structured data extraction with RAG and multimodal support."
+            },
+            {
+                "class": "B",
+                "source": "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/scientific-skills/literature-review/SKILL.md",
+                "evaluator": "mbtiongson1",
+                "date": "2026-04-30",
+                "notes": "K-Dense-AI scientific-agent-skills — reproducible literature-review skill: seven-phase workflow from research-question planning through multi-database search, screening, extraction, synthesis, citation verification to final PDF output."
+            }
+        ],
+        "knownAgents": [],
+        "status": "provisional",
+        "createdAt": "2026-04-30",
+        "updatedAt": "2026-04-30",
+        "version": "0.1.0"
+    },
+    {
+        "id": "scientific-writing",
+        "name": "Scientific Writing",
+        "type": "composite",
+        "level": "III",
+        "rarity": "uncommon",
+        "description": "Composes research manuscripts in IMRAD structure with reporting-guideline compliance (CONSORT, STROBE, PRISMA), citation management, publication-quality figures, and LaTeX/PDF formatting.",
+        "prerequisites": [
+            "write-report",
+            "cite-sources",
+            "scientific-visualization"
+        ],
+        "derivatives": [],
+        "conditions": "",
+        "evidence": [
+            {
+                "class": "A",
+                "source": "https://arxiv.org/abs/2405.20477",
+                "evaluator": "mbtiongson1",
+                "date": "2026-04-30",
+                "notes": "Chamoun et al. (ACL 2024 Findings) — SWIFT: automated focused feedback for scientific writing; multi-component LLM system (planner, investigator, reviewer, controller) rated more specific and helpful than human reviewers on 300 peer-reviewed manuscripts."
+            },
+            {
+                "class": "B",
+                "source": "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/scientific-skills/scientific-writing/SKILL.md",
+                "evaluator": "mbtiongson1",
+                "date": "2026-04-30",
+                "notes": "K-Dense-AI scientific-agent-skills — reproducible scientific-writing skill: two-stage outline-to-prose pipeline with IMRAD structure, multi-style citation management, and reporting-guideline validation (CONSORT, STROBE, PRISMA, STARD, TRIPOD)."
+            }
+        ],
+        "knownAgents": [],
+        "status": "provisional",
+        "createdAt": "2026-04-30",
+        "updatedAt": "2026-04-30",
+        "version": "0.1.0"
+    },
+    {
+        "id": "ml-pipeline",
+        "name": "ML Pipeline",
+        "type": "composite",
+        "level": "IV",
+        "rarity": "rare",
+        "description": "Designs and implements production ML pipelines with experiment tracking (MLflow, W&B), feature stores (Feast), orchestration (Kubeflow, Airflow), and automated retraining workflows including model evaluation gates and A/B deployment.",
+        "prerequisites": [
+            "data-analysis",
+            "automated-testing",
+            "code-generation"
+        ],
+        "derivatives": [],
+        "conditions": "Requires access to a container orchestration environment and model registry.",
+        "evidence": [
+            {
+                "class": "A",
+                "source": "https://arxiv.org/abs/2502.18530",
+                "evaluator": "mbtiongson1",
+                "date": "2026-04-30",
+                "notes": "Xue et al. (2025) — IMPROVE: Iterative Model Pipeline Refinement and Optimization Leveraging LLM Experts; iterative component-level refinement consistently outperforms single-step zero-shot LLM-based ML pipeline optimization with theoretical convergence guarantees."
+            },
+            {
+                "class": "B",
+                "source": "https://github.com/Jeffallan/claude-skills/blob/main/skills/ml-pipeline/SKILL.md",
+                "evaluator": "mbtiongson1",
+                "date": "2026-04-30",
+                "notes": "Jeffallan/claude-skills — reproducible ml-pipeline skill: full lifecycle from data validation and feature engineering through distributed training, experiment tracking, model evaluation gates, A/B testing, and automated retraining with DVC/Feast/MLflow/Kubeflow."
+            }
+        ],
+        "knownAgents": [],
+        "status": "provisional",
+        "createdAt": "2026-04-30",
+        "updatedAt": "2026-04-30",
+        "version": "0.1.0"
+    }
+]
+
+# Existing skill IDs whose derivatives arrays need patching
+DERIVATIVE_PATCHES = {
+    "research":         ["literature-review"],
+    "cite-sources":     ["literature-review", "scientific-writing"],
+    "summarize":        ["literature-review"],
+    "write-report":     ["scientific-writing"],
+    "data-analysis":    ["ml-pipeline"],
+    "automated-testing": ["ml-pipeline"],
+    "code-generation":  ["ml-pipeline"],
+}
+
+NEW_EDGES = [
+    # literature-review
+    {"sourceSkillId": "research",      "targetSkillId": "literature-review", "edgeType": "prerequisite", "condition": "", "levelFloor": "II", "evidenceRefs": ["literature-review#evidence[0]"]},
+    {"sourceSkillId": "cite-sources",  "targetSkillId": "literature-review", "edgeType": "prerequisite", "condition": "", "levelFloor": "II", "evidenceRefs": ["literature-review#evidence[0]"]},
+    {"sourceSkillId": "summarize",     "targetSkillId": "literature-review", "edgeType": "prerequisite", "condition": "", "levelFloor": "II", "evidenceRefs": ["literature-review#evidence[0]"]},
+    # scientific-writing
+    {"sourceSkillId": "write-report",             "targetSkillId": "scientific-writing", "edgeType": "prerequisite", "condition": "", "levelFloor": "II", "evidenceRefs": ["scientific-writing#evidence[0]"]},
+    {"sourceSkillId": "cite-sources",             "targetSkillId": "scientific-writing", "edgeType": "prerequisite", "condition": "", "levelFloor": "II", "evidenceRefs": ["scientific-writing#evidence[0]"]},
+    {"sourceSkillId": "scientific-visualization", "targetSkillId": "scientific-writing", "edgeType": "prerequisite", "condition": "", "levelFloor": "II", "evidenceRefs": ["scientific-writing#evidence[0]"]},
+    # ml-pipeline
+    {"sourceSkillId": "data-analysis",    "targetSkillId": "ml-pipeline", "edgeType": "prerequisite", "condition": "", "levelFloor": "II", "evidenceRefs": ["ml-pipeline#evidence[0]"]},
+    {"sourceSkillId": "automated-testing","targetSkillId": "ml-pipeline", "edgeType": "prerequisite", "condition": "", "levelFloor": "II", "evidenceRefs": ["ml-pipeline#evidence[0]"]},
+    {"sourceSkillId": "code-generation",  "targetSkillId": "ml-pipeline", "edgeType": "prerequisite", "condition": "", "levelFloor": "II", "evidenceRefs": ["ml-pipeline#evidence[0]"]},
+]
+
+
+def main():
+    with open(GRAPH_PATH, encoding='utf-8') as f:
+        graph = json.load(f)
+
+    existing_ids = {s["id"] for s in graph["skills"]}
+
+    for skill in NEW_SKILLS:
+        if skill["id"] in existing_ids:
+            print(f"  SKIP (exists): {skill['id']}")
+            continue
+        graph["skills"].append(skill)
+        print(f"  + skill: {skill['id']}")
+
+    for skill_id, new_derivs in DERIVATIVE_PATCHES.items():
+        for s in graph["skills"]:
+            if s["id"] == skill_id:
+                for d in new_derivs:
+                    if d not in s.get("derivatives", []):
+                        s.setdefault("derivatives", []).append(d)
+                        print(f"  ~ {skill_id}.derivatives += {d}")
+                s["updatedAt"] = "2026-04-30"
+                break
+
+    existing_edge_keys = {(e["sourceSkillId"], e["targetSkillId"]) for e in graph["edges"]}
+    for edge in NEW_EDGES:
+        key = (edge["sourceSkillId"], edge["targetSkillId"])
+        if key in existing_edge_keys:
+            print(f"  SKIP edge (exists): {key}")
+            continue
+        graph["edges"].append(edge)
+        print(f"  + edge: {edge['sourceSkillId']} -> {edge['targetSkillId']} ({edge['edgeType']})")
+
+    # Update registry-curation evidence to note this batch
+    for s in graph["skills"]:
+        if s["id"] == "registry-curation":
+            s["evidence"].append({
+                "class": "B",
+                "source": "https://github.com/mbtiongson1/gaia-skill-tree",
+                "evaluator": "mbtiongson1",
+                "date": "2026-04-30",
+                "notes": "Batch 5 curation: 5 skills added (2 atomic, 3 composite) -- statistical-analysis, scientific-visualization, literature-review, scientific-writing, ml-pipeline."
+            })
+            s["updatedAt"] = "2026-04-30"
+            break
+
+    graph["generatedAt"] = "2026-04-30"
+
+    with open(GRAPH_PATH, 'w', encoding='utf-8') as f:
+        json.dump(graph, f, indent=2, ensure_ascii=False)
+        f.write('\n')
+
+    print("\nDone — graph/gaia.json updated.")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/atomic/cite-sources.md
+++ b/skills/atomic/cite-sources.md
@@ -16,6 +16,8 @@ _None._
 ## Unlocks
 - [Grounding](../composite/grounding.md)
 - [Research](../composite/research.md)
+- [Literature Review](../composite/literature-review.md)
+- [Scientific Writing](../composite/scientific-writing.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/skills/atomic/code-generation.md
+++ b/skills/atomic/code-generation.md
@@ -18,6 +18,7 @@ _None._
 - [Code Review Pipeline](../composite/code-review-pipeline.md)
 - [Registry Curation](../composite/registry-curation.md)
 - [Tool Creation](../composite/tool-creation.md)
+- [ML Pipeline](../composite/ml-pipeline.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/skills/atomic/evaluate-output.md
+++ b/skills/atomic/evaluate-output.md
@@ -20,6 +20,7 @@ _None._
 - [Prompt Optimization](../composite/prompt-optimization.md)
 - [Guardrails](../composite/guardrails.md)
 - [Agent Evaluation](../composite/agent-eval.md)
+- [Design Review](../composite/design-review.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/skills/atomic/issue-triage.md
+++ b/skills/atomic/issue-triage.md
@@ -1,0 +1,30 @@
+# [IV · Intrinsic Skill] Issue Triage
+**ID:** issue-triage  
+**Type:** Intrinsic Skill  
+**Level:** IV  
+**Rarity:** Uncommon  
+**Status:** Provisional
+
+---
+
+## Description
+Classifies incoming issue reports through a structured state machine, assigns triage roles (bug/enhancement, needs-info/ready-for-agent/wontfix), reproduces bugs, requests missing detail, and produces structured resolution briefs for agent or human handoff.
+
+## Prerequisites
+_None._
+
+## Unlocks
+_None._
+
+## Evidence
+| Class | Source | Evaluator | Date |
+|---|---|---|---|
+| B | https://github.com/mattpocock/skills/blob/main/skills/engineering/triage/SKILL.md | mbtiongson1 | 2026-04-30 |
+| A | https://arxiv.org/abs/2501.18908 | mbtiongson1 | 2026-04-30 |
+| A | https://arxiv.org/abs/2504.18804 | mbtiongson1 | 2026-04-30 |
+
+## Known Agents
+_None verified yet._
+
+---
+*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*

--- a/skills/atomic/plan-decompose.md
+++ b/skills/atomic/plan-decompose.md
@@ -18,6 +18,9 @@ _None._
 - [ReAct Reasoning](../composite/re-act-reasoning.md)
 - [Tree of Thought](../composite/tree-of-thought.md)
 - [Workflow Automation](../composite/workflow-automation.md)
+- [PRD Generation](../composite/prd-generation.md)
+- [Vertical Slice Planning](../composite/vertical-slice-planning.md)
+- [Design Review](../composite/design-review.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/skills/atomic/route-intent.md
+++ b/skills/atomic/route-intent.md
@@ -16,6 +16,7 @@ _None._
 ## Unlocks
 - [Plan and Execute](../composite/plan-and-execute.md)
 - [Conversational Agent](../composite/conversational-agent.md)
+- [Vertical Slice Planning](../composite/vertical-slice-planning.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/skills/atomic/scientific-visualization.md
+++ b/skills/atomic/scientific-visualization.md
@@ -1,0 +1,28 @@
+# [II · Intrinsic Skill] Scientific Visualization
+**ID:** scientific-visualization  
+**Type:** Intrinsic Skill  
+**Level:** II  
+**Rarity:** Uncommon  
+**Status:** Provisional
+
+---
+
+## Description
+Creates publication-ready scientific figures with multi-panel layouts, statistical annotations, colorblind-safe palettes, and journal-specific formatting (Nature, Science, Cell) using matplotlib, seaborn, and plotly.
+
+## Prerequisites
+_None._
+
+## Unlocks
+- [Scientific Writing](../composite/scientific-writing.md)
+
+## Evidence
+| Class | Source | Evaluator | Date |
+|---|---|---|---|
+| B | https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/scientific-skills/scientific-visualization/SKILL.md | mbtiongson1 | 2026-04-30 |
+
+## Known Agents
+_None verified yet._
+
+---
+*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*

--- a/skills/atomic/statistical-analysis.md
+++ b/skills/atomic/statistical-analysis.md
@@ -1,0 +1,29 @@
+# [III · Intrinsic Skill] Statistical Analysis
+**ID:** statistical-analysis  
+**Type:** Intrinsic Skill  
+**Level:** III  
+**Rarity:** Uncommon  
+**Status:** Provisional
+
+---
+
+## Description
+Performs hypothesis testing, regression analysis, and Bayesian modelling with effect size calculation and APA-formatted statistical reporting using scipy, statsmodels, and PyMC.
+
+## Prerequisites
+_None._
+
+## Unlocks
+_None._
+
+## Evidence
+| Class | Source | Evaluator | Date |
+|---|---|---|---|
+| A | https://arxiv.org/abs/2511.06701 | mbtiongson1 | 2026-04-30 |
+| B | https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/scientific-skills/statistical-analysis/SKILL.md | mbtiongson1 | 2026-04-30 |
+
+## Known Agents
+_None verified yet._
+
+---
+*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*

--- a/skills/atomic/summarize.md
+++ b/skills/atomic/summarize.md
@@ -17,6 +17,7 @@ _None._
 - [Research](../composite/research.md)
 - [Document Analyst](../composite/document-analyst.md)
 - [Data Analysis](../composite/data-analysis.md)
+- [Literature Review](../composite/literature-review.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/skills/atomic/write-report.md
+++ b/skills/atomic/write-report.md
@@ -15,6 +15,8 @@ _None._
 
 ## Unlocks
 - [Ghostwrite](../composite/ghostwrite.md)
+- [PRD Generation](../composite/prd-generation.md)
+- [Scientific Writing](../composite/scientific-writing.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/skills/composite/automated-testing.md
+++ b/skills/composite/automated-testing.md
@@ -17,6 +17,7 @@ Generates test suites, executes them in a sandbox, interprets failures, and iter
 
 ## Unlocks
 - [True Craftsman: Full-Stack Developer](../legendary/full-stack-developer.md)
+- [ML Pipeline](../composite/ml-pipeline.md)
 
 ## Fusion Condition
 _None specified._

--- a/skills/composite/data-analysis.md
+++ b/skills/composite/data-analysis.md
@@ -17,6 +17,7 @@ Conducts end-to-end quantitative analysis: queries data via SQL, computes statis
 
 ## Unlocks
 - [True Oracle: Autonomous Data Scientist](../legendary/autonomous-data-scientist.md)
+- [ML Pipeline](../composite/ml-pipeline.md)
 
 ## Fusion Condition
 _None specified._

--- a/skills/composite/design-review.md
+++ b/skills/composite/design-review.md
@@ -1,0 +1,33 @@
+# [III · Extra Skill] Design Review
+**ID:** design-review  
+**Type:** Extra Skill  
+**Level:** III  
+**Rarity:** Rare  
+**Status:** Provisional
+
+---
+
+## Description
+Stress-tests a plan or design through relentless targeted questioning, walking the decision tree branch-by-branch, resolving concept dependencies, surfacing contradictions against the existing codebase, and crystallising ubiquitous language — optionally persisting resolved decisions to CONTEXT.md and ADRs.
+
+## Prerequisites
+- [Evaluate Output](../atomic/evaluate-output.md)
+- [Plan and Decompose](../atomic/plan-decompose.md)
+
+## Unlocks
+_None._
+
+## Fusion Condition
+_None specified._
+
+## Evidence
+| Class | Source | Evaluator | Date |
+|---|---|---|---|
+| B | https://github.com/mattpocock/skills/blob/main/skills/productivity/grill-me/SKILL.md | mbtiongson1 | 2026-04-30 |
+| B | https://github.com/mattpocock/skills/blob/main/skills/engineering/grill-with-docs/SKILL.md | mbtiongson1 | 2026-04-30 |
+
+## Known Agents
+_None verified yet._
+
+---
+*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*

--- a/skills/composite/literature-review.md
+++ b/skills/composite/literature-review.md
@@ -1,0 +1,34 @@
+# [IV · Extra Skill] Literature Review
+**ID:** literature-review  
+**Type:** Extra Skill  
+**Level:** IV  
+**Rarity:** Uncommon  
+**Status:** Provisional
+
+---
+
+## Description
+Conducts systematic multi-database academic literature searches following PRISMA/SWARM protocols, screens and synthesises findings, verifies all citations, and generates a structured review report.
+
+## Prerequisites
+- [Research](../composite/research.md)
+- [Cite Sources](../atomic/cite-sources.md)
+- [Summarize](../atomic/summarize.md)
+
+## Unlocks
+_None._
+
+## Fusion Condition
+Requires access to academic databases (PubMed, bioRxiv, ChEMBL, or equivalent).
+
+## Evidence
+| Class | Source | Evaluator | Date |
+|---|---|---|---|
+| A | https://arxiv.org/abs/2501.05468 | mbtiongson1 | 2026-04-30 |
+| B | https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/scientific-skills/literature-review/SKILL.md | mbtiongson1 | 2026-04-30 |
+
+## Known Agents
+_None verified yet._
+
+---
+*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*

--- a/skills/composite/ml-pipeline.md
+++ b/skills/composite/ml-pipeline.md
@@ -1,0 +1,34 @@
+# [IV · Extra Skill] ML Pipeline
+**ID:** ml-pipeline  
+**Type:** Extra Skill  
+**Level:** IV  
+**Rarity:** Rare  
+**Status:** Provisional
+
+---
+
+## Description
+Designs and implements production ML pipelines with experiment tracking (MLflow, W&B), feature stores (Feast), orchestration (Kubeflow, Airflow), and automated retraining workflows including model evaluation gates and A/B deployment.
+
+## Prerequisites
+- [Data Analysis](../composite/data-analysis.md)
+- [Automated Testing](../composite/automated-testing.md)
+- [Code Generation](../atomic/code-generation.md)
+
+## Unlocks
+_None._
+
+## Fusion Condition
+Requires access to a container orchestration environment and model registry.
+
+## Evidence
+| Class | Source | Evaluator | Date |
+|---|---|---|---|
+| A | https://arxiv.org/abs/2502.18530 | mbtiongson1 | 2026-04-30 |
+| B | https://github.com/Jeffallan/claude-skills/blob/main/skills/ml-pipeline/SKILL.md | mbtiongson1 | 2026-04-30 |
+
+## Known Agents
+_None verified yet._
+
+---
+*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*

--- a/skills/composite/prd-generation.md
+++ b/skills/composite/prd-generation.md
@@ -1,0 +1,33 @@
+# [IV · Extra Skill] PRD Generation
+**ID:** prd-generation  
+**Type:** Extra Skill  
+**Level:** IV  
+**Rarity:** Uncommon  
+**Status:** Provisional
+
+---
+
+## Description
+Synthesizes conversation context and codebase knowledge into a structured Product Requirements Document containing a problem statement, extensive user stories, implementation decisions, module boundaries, testing decisions, and out-of-scope items.
+
+## Prerequisites
+- [Write Report](../atomic/write-report.md)
+- [Plan and Decompose](../atomic/plan-decompose.md)
+
+## Unlocks
+_None._
+
+## Fusion Condition
+_None specified._
+
+## Evidence
+| Class | Source | Evaluator | Date |
+|---|---|---|---|
+| B | https://github.com/mattpocock/skills/blob/main/skills/engineering/to-prd/SKILL.md | mbtiongson1 | 2026-04-30 |
+| A | https://arxiv.org/abs/2507.19113 | mbtiongson1 | 2026-04-30 |
+
+## Known Agents
+_None verified yet._
+
+---
+*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*

--- a/skills/composite/registry-curation.md
+++ b/skills/composite/registry-curation.md
@@ -28,6 +28,7 @@ Requires write access to the canonical graph and a passing validation suite.
 | B | https://github.com/mbtiongson1/gaia-skill-tree | mbtiongson1 | 2026-04-28 |
 | B | https://github.com/mbtiongson1/gaia-skill-tree | mbtiongson1 | 2026-04-29 |
 | B | https://github.com/mbtiongson1/gaia-skill-tree | mbtiongson1 | 2026-04-30 |
+| B | https://github.com/mbtiongson1/gaia-skill-tree | mbtiongson1 | 2026-04-30 |
 
 ## Known Agents
 _None verified yet._

--- a/skills/composite/research.md
+++ b/skills/composite/research.md
@@ -20,6 +20,7 @@ Conducts multi-source information gathering, synthesis, and citation for a given
 - [Ghostwrite](../composite/ghostwrite.md)
 - [Registry Curation](../composite/registry-curation.md)
 - [True Dragon: Autonomous Scientific Discovery](../legendary/scientific-discovery.md)
+- [Literature Review](../composite/literature-review.md)
 
 ## Fusion Condition
 _None specified._

--- a/skills/composite/scientific-writing.md
+++ b/skills/composite/scientific-writing.md
@@ -1,0 +1,34 @@
+# [III · Extra Skill] Scientific Writing
+**ID:** scientific-writing  
+**Type:** Extra Skill  
+**Level:** III  
+**Rarity:** Uncommon  
+**Status:** Provisional
+
+---
+
+## Description
+Composes research manuscripts in IMRAD structure with reporting-guideline compliance (CONSORT, STROBE, PRISMA), citation management, publication-quality figures, and LaTeX/PDF formatting.
+
+## Prerequisites
+- [Write Report](../atomic/write-report.md)
+- [Cite Sources](../atomic/cite-sources.md)
+- [Scientific Visualization](../atomic/scientific-visualization.md)
+
+## Unlocks
+_None._
+
+## Fusion Condition
+_None specified._
+
+## Evidence
+| Class | Source | Evaluator | Date |
+|---|---|---|---|
+| A | https://arxiv.org/abs/2405.20477 | mbtiongson1 | 2026-04-30 |
+| B | https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/scientific-skills/scientific-writing/SKILL.md | mbtiongson1 | 2026-04-30 |
+
+## Known Agents
+_None verified yet._
+
+---
+*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*

--- a/skills/composite/vertical-slice-planning.md
+++ b/skills/composite/vertical-slice-planning.md
@@ -1,0 +1,32 @@
+# [III · Extra Skill] Vertical Slice Planning
+**ID:** vertical-slice-planning  
+**Type:** Extra Skill  
+**Level:** III  
+**Rarity:** Uncommon  
+**Status:** Provisional
+
+---
+
+## Description
+Decomposes a product plan into independently-demoable vertical slices that each cut through all integration layers end-to-end. Classifies each slice as HITL (human-in-the-loop) or AFK (autonomous), identifies dependency ordering, and publishes structured issues with acceptance criteria.
+
+## Prerequisites
+- [Plan and Decompose](../atomic/plan-decompose.md)
+- [Route Intent](../atomic/route-intent.md)
+
+## Unlocks
+_None._
+
+## Fusion Condition
+_None specified._
+
+## Evidence
+| Class | Source | Evaluator | Date |
+|---|---|---|---|
+| B | https://github.com/mattpocock/skills/blob/main/skills/engineering/to-issues/SKILL.md | mbtiongson1 | 2026-04-30 |
+
+## Known Agents
+_None verified yet._
+
+---
+*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*

--- a/tree.md
+++ b/tree.md
@@ -44,7 +44,7 @@ Shared prerequisites marked (↑ see above) on second occurrence.
   │  ├─ ○ upsonic/unittest-generator - Generate Test  [II]
   │  ├─ ○ /execute-bash  [I]
   │  └─ ○ /error-interpretation  [I]
-  └─ ○ /refactor-code  [II]
+  └─ ○ mattpocock/improve-codebase-architecture - Refactor Code  [II]
 
 ◆ /scientific-discovery  [V]
 ─────────────────────────────────────────────────────────────────

--- a/users/gaiabot/skill-tree.md
+++ b/users/gaiabot/skill-tree.md
@@ -54,7 +54,7 @@
   │  ├─ · ○ upsonic/unittest-generator - Generate Test  [II]
   │  ├─ · ○ /execute-bash  [I]
   │  └─ · ○ /error-interpretation  [I]
-  └─ · ○ /refactor-code  [II]
+  └─ · ○ mattpocock/improve-codebase-architecture - Refactor Code  [II]
 
 · ◆ /scientific-discovery  [V]
   ├─ · ○ /hypothesis-generate  [II]

--- a/users/mbtiongson1/skill-tree.md
+++ b/users/mbtiongson1/skill-tree.md
@@ -57,7 +57,7 @@
   │  ├─ · ○ upsonic/unittest-generator - Generate Test  [II]
   │  ├─ · ○ /execute-bash  [I]
   │  └─ · ○ /error-interpretation  [I]
-  └─ · ○ /refactor-code  [II]
+  └─ · ○ mattpocock/improve-codebase-architecture - Refactor Code  [II]
 
 · ◆ /scientific-discovery  [V]
   ├─ · ○ /hypothesis-generate  [II]


### PR DESCRIPTION
## Summary

- **2 atomic skills**: `statistical-analysis`, `scientific-visualization`
- **3 composite skills**: `literature-review`, `scientific-writing`, `ml-pipeline`
- **Sources**: `K-Dense-AI/scientific-agent-skills` (4 skills) and `Jeffallan/claude-skills` (1 skill) — found via GitHub search for repos with `/skills` directories and verified `SKILL.md` files
- **9 prerequisite edges** added; **8 existing skills** had their `derivatives` arrays patched

## Evidence

| Skill | Class A | Class B |
|---|---|---|
| `statistical-analysis` | arxiv.org/abs/2511.06701 (Sargsyan 2025 — 1.1% vs 41% FDR) | K-Dense-AI SKILL.md |
| `scientific-visualization` | — | K-Dense-AI SKILL.md |
| `literature-review` | arxiv.org/abs/2501.05468 (LatteReview, Jan 2025) | K-Dense-AI SKILL.md |
| `scientific-writing` | arxiv.org/abs/2405.20477 (SWIFT, ACL 2024 Findings) | K-Dense-AI SKILL.md |
| `ml-pipeline` | arxiv.org/abs/2502.18530 (IMPROVE, Feb 2025) | Jeffallan/claude-skills SKILL.md |

## Validation

- `python scripts/validate.py` exits with 11 pre-existing `catalogRef` errors (all in `graph/named/mattpocock/`) that exist on the parent branch — no new errors introduced by this PR
- `generateProjections.py` and `exportGexf.py` both pass

## Test plan

- [ ] `PYTHONIOENCODING=utf-8 python scripts/validate.py` — 11 pre-existing errors, no regressions
- [ ] All 5 new skill `.md` files exist under `skills/atomic/` and `skills/composite/`
- [ ] Edge count increased by 9 in `graph/gaia.json`
- [ ] `registry.md` and `tree.md` include the 5 new skills