### PR TITLE
docs: replace Rarity/Status with Tier/Skill Call; add Pure/Undeveloped section

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ GAIA SKILL TREE  v1.0.0
 | composite | ◇ | **Extra Skill** | Emerges from combining 2+ intrinsic skills — transcends its parts |
 | legendary | ◆ | **Ultimate Skill** | High-complexity emergent capability — strict evidence bar, <1% agent prevalence |
 
-## Rank System
+## Rank System — The Transcendent Line
 
 Skills level up through evidence, not declaration:
 
@@ -114,7 +114,7 @@ Skills level up through evidence, not declaration:
 | `III` | **Evolved** | Class B | Reproducible, fully documented |
 | `IV` | **Hardened** | Class B or A | Failure modes known; battle-tested |
 | `V` | **Transcendent** | Class B or A | Composable and self-improving |
-| `VI` | **Transcendent ◆** | Class A | Apex — peer-reviewed, named to the agent who unlocked it |
+| `VI` | **Transcendent ★** | Class A | Apex — peer-reviewed, named to the agent who unlocked it |
 
 ---
 
@@ -288,7 +288,7 @@ gaia-skill-tree/
 ├── src/gaia_cli/                 ← Python package source for the gaia CLI (pip-installable)
 ├── plugin/                       ← TypeScript CLI wrapper + GitHub Action for per-repo integration
 ├── pyproject.toml                ← Package metadata and optional dependencies (e.g. [embeddings])
-├── registry.md                   ← GENERATED flat index of all skills
+├── registry.md                   ← GENERATED flat index — connected skills + Pure/Undeveloped section
 ├── combinations.md               ← GENERATED fusion recipe matrix
 ├── tree.md                       ← GENERATED full ASCII skill graph
 ├── real-skills.html              ← GENERATED linked catalog of real named skills

--- a/registry.md
+++ b/registry.md
@@ -1,119 +1,126 @@
 # Gaia Skill Registry
 
-| Name | Class | Rank | Rarity | Status |
+| Name | Class | Rank | Tier | Skill Call |
 |---|---|---|---|---|
-| ◇ Agent Evaluation | Extra Skill | III | Uncommon | Provisional |
-| ○ API Call | Intrinsic Skill | II | Common | Provisional |
-| ○ Audience Model | Intrinsic Skill | I | Common | Provisional |
-| ◇ Automated Testing | Extra Skill | III | Uncommon | Provisional |
-| ◆ True Oracle: Autonomous Data Scientist | Ultimate Skill | V | Divine | Provisional |
-| ◇ Autonomous Debug | Extra Skill | IV | Rare | Provisional |
-| ◆ Wisdom King: Autonomous Research Agent | Ultimate Skill | VI | Divine | Provisional |
-| ◇ Browser Automation | Extra Skill | III | Uncommon | Provisional |
-| ○ Chain-of-Thought Reasoning | Intrinsic Skill | I | Uncommon | Provisional |
-| ○ Chunk Document | Intrinsic Skill | I | Common | Provisional |
-| ○ Cite Sources | Intrinsic Skill | I | Common | Provisional |
-| ○ Classify | Intrinsic Skill | 0 | Common | Provisional |
-| ○ Code Execution | Intrinsic Skill | II | Common | Provisional |
-| ○ Code Explain | Intrinsic Skill | II | Common | Provisional |
-| ○ Code Generation | Intrinsic Skill | I | Common | Provisional |
-| ◇ Code Review Pipeline | Extra Skill | III | Uncommon | Provisional |
-| ○ Computer Use | Intrinsic Skill | II | Rare | Provisional |
-| ◇ Content Moderation | Extra Skill | III | Uncommon | Provisional |
-| ○ Context Compression | Intrinsic Skill | III | Common | Provisional |
-| ◇ Conversational Agent | Extra Skill | III | Uncommon | Provisional |
-| ◇ Data Analysis | Extra Skill | III | Uncommon | Provisional |
-| ○ Data Visualize | Intrinsic Skill | II | Common | Provisional |
-| ◇ Design Review | Extra Skill | III | Rare | Provisional |
-| ○ Detect Anomaly | Intrinsic Skill | II | Uncommon | Provisional |
-| ○ Diff Content | Intrinsic Skill | I | Common | Provisional |
-| ◇ Document Analyst | Extra Skill | III | Uncommon | Provisional |
-| ◇ Document Digitization | Extra Skill | III | Uncommon | Provisional |
-| ○ Document Editing | Intrinsic Skill | 0 | Common | Provisional |
-| ○ Embed Text | Intrinsic Skill | I | Common | Provisional |
-| ○ Error Interpretation | Intrinsic Skill | I | Common | Provisional |
-| ○ Evaluate Output | Intrinsic Skill | I | Common | Provisional |
-| ○ Execute Bash | Intrinsic Skill | I | Common | Provisional |
-| ○ Extract Entities | Intrinsic Skill | I | Common | Provisional |
-| ○ Few-Shot Learning | Intrinsic Skill | IV | Common | Provisional |
-| ○ Fine-Tune | Intrinsic Skill | IV | Uncommon | Provisional |
-| ○ Format Output | Intrinsic Skill | 0 | Common | Provisional |
-| ○ Framework Upgrade | Intrinsic Skill | 0 | Common | Provisional |
-| ◆ True Craftsman: Full-Stack Developer | Ultimate Skill | V | Divine | Provisional |
-| ◇ Function Calling | Extra Skill | III | Uncommon | Provisional |
-| ○ Generate SQL | Intrinsic Skill | II | Common | Provisional |
-| ○ Generate Test | Intrinsic Skill | II | Common | Provisional |
-| ○ Generate Text | Intrinsic Skill | 0 | Common | Provisional |
-| ◇ Ghostwrite | Extra Skill | IV | Rare | Provisional |
-| ◇ Grounding | Extra Skill | III | Uncommon | Provisional |
-| ◇ Guardrails | Extra Skill | III | Uncommon | Provisional |
-| ○ Hypothesis Generation | Intrinsic Skill | II | Rare | Provisional |
-| ○ Image Caption | Intrinsic Skill | II | Uncommon | Provisional |
-| ○ Image Generate | Intrinsic Skill | II | Uncommon | Provisional |
-| ○ Issue Triage | Intrinsic Skill | IV | Uncommon | Provisional |
-| ◇ Knowledge Graph Construction | Extra Skill | III | Uncommon | Provisional |
-| ◇ Knowledge Harvest | Extra Skill | IV | Rare | Provisional |
-| ◇ Literature Review | Extra Skill | IV | Uncommon | Provisional |
-| ○ Logical Inference | Intrinsic Skill | I | Uncommon | Provisional |
-| ○ Math Reason | Intrinsic Skill | II | Uncommon | Provisional |
-| ○ Memory Manage | Intrinsic Skill | II | Uncommon | Provisional |
-| ◇ ML Pipeline | Extra Skill | IV | Rare | Provisional |
-| ◇ Multi-Agent Debate | Extra Skill | IV | Rare | Provisional |
-| ◆ Grand Conductor: Multi-Agent Orchestration | Ultimate Skill | V | Divine | Provisional |
-| ◇ Multimodal Reasoning | Extra Skill | III | Rare | Provisional |
-| ○ Object Detection | Intrinsic Skill | II | Uncommon | Provisional |
-| ○ OCR | Intrinsic Skill | II | Uncommon | Provisional |
-| ○ Parse HTML | Intrinsic Skill | I | Common | Provisional |
-| ○ Parse JSON | Intrinsic Skill | I | Common | Provisional |
-| ○ Parse PDF | Intrinsic Skill | I | Common | Provisional |
-| ◇ Plan and Execute | Extra Skill | IV | Rare | Provisional |
-| ○ Plan and Decompose | Intrinsic Skill | I | Common | Provisional |
-| ◇ PRD Generation | Extra Skill | IV | Uncommon | Provisional |
-| ○ Prompt Injection Defense | Intrinsic Skill | III | Uncommon | Provisional |
-| ◇ Prompt Optimization | Extra Skill | IV | Uncommon | Provisional |
-| ○ Question Answer | Intrinsic Skill | 0 | Common | Provisional |
-| ◇ RAG Pipeline | Extra Skill | III | Uncommon | Provisional |
-| ○ Rank | Intrinsic Skill | I | Common | Provisional |
-| ◇ ReAct Reasoning | Extra Skill | III | Uncommon | Provisional |
-| ◆ True Herald: Real-Time Voice Assistant | Ultimate Skill | V | Divine | Provisional |
-| ◆ True Sage: Recursive Self-Improvement | Ultimate Skill | V | Divine | Provisional |
-| ○ Refactor Code | Intrinsic Skill | II | Uncommon | Provisional |
-| ◇ Registry Curation | Extra Skill | IV | Rare | Provisional |
-| ◇ Research | Extra Skill | III | Uncommon | Provisional |
-| ○ Retrieve | Intrinsic Skill | I | Common | Provisional |
-| ○ Reward Modeling | Intrinsic Skill | II | Rare | Provisional |
-| ○ Route Intent | Intrinsic Skill | I | Common | Provisional |
-| ◆ True Dragon: Autonomous Scientific Discovery | Ultimate Skill | V | Divine | Provisional |
-| ○ Scientific Visualization | Intrinsic Skill | II | Uncommon | Provisional |
-| ◇ Scientific Writing | Extra Skill | III | Uncommon | Provisional |
-| ○ Score Relevance | Intrinsic Skill | I | Common | Provisional |
-| ○ Self-Consistency | Intrinsic Skill | IV | Rare | Provisional |
-| ○ Self-Critique | Intrinsic Skill | I | Uncommon | Provisional |
-| ○ Semantic Cache | Intrinsic Skill | IV | Rare | Provisional |
-| ○ Sentiment Analysis | Intrinsic Skill | 0 | Common | Provisional |
-| ○ Skill Discovery | Intrinsic Skill | 0 | Common | Provisional |
-| ○ Speech to Text | Intrinsic Skill | II | Common | Provisional |
-| ○ Statistical Analysis | Intrinsic Skill | III | Uncommon | Provisional |
-| ○ Structured Output Generation | Intrinsic Skill | I | Common | Provisional |
-| ○ Summarize | Intrinsic Skill | 0 | Common | Provisional |
-| ○ Test-Driven Development | Intrinsic Skill | 0 | Uncommon | Provisional |
-| ○ Text to Speech | Intrinsic Skill | II | Common | Provisional |
-| ◇ Text-to-SQL Pipeline | Extra Skill | III | Uncommon | Provisional |
-| ○ Tokenize | Intrinsic Skill | 0 | Common | Provisional |
-| ◇ Tool Chaining | Extra Skill | III | Uncommon | Provisional |
-| ◇ Tool Creation | Extra Skill | IV | Rare | Provisional |
-| ○ Tool Select | Intrinsic Skill | I | Common | Provisional |
-| ○ Tool Use | Intrinsic Skill | I | Uncommon | Provisional |
-| ○ Translate | Intrinsic Skill | 0 | Common | Provisional |
-| ◇ Translation Pipeline | Extra Skill | III | Uncommon | Provisional |
-| ◇ Tree of Thought | Extra Skill | IV | Rare | Provisional |
-| ○ UX Audit | Intrinsic Skill | 0 | Uncommon | Provisional |
-| ◇ Vertical Slice Planning | Extra Skill | III | Uncommon | Provisional |
-| ○ Visual Question Answering | Intrinsic Skill | III | Uncommon | Provisional |
-| ◇ Voice Agent | Extra Skill | III | Uncommon | Provisional |
-| ◇ Web Scrape | Extra Skill | III | Uncommon | Provisional |
-| ○ Web Search | Intrinsic Skill | I | Common | Provisional |
-| ◇ Workflow Automation | Extra Skill | IV | Uncommon | Provisional |
-| ○ Write Report | Intrinsic Skill | I | Common | Provisional |
+| ◇ Agent Evaluation | Extra Skill | III | Evolved | `/agent-eval` |
+| ○ API Call | Intrinsic Skill | II | Named | `/api-call` |
+| ○ Audience Model | Intrinsic Skill | I | Awakened | `/audience-model` |
+| ◇ Automated Testing | Extra Skill | III | Evolved | `/automated-testing` |
+| ◆ True Oracle: Autonomous Data Scientist | Ultimate Skill | V | Transcendent | `/autonomous-data-scientist` |
+| ◇ Autonomous Debug | Extra Skill | IV | Hardened | `/autonomous-debug` |
+| ◆ Wisdom King: Autonomous Research Agent | Ultimate Skill | VI | Transcendent â˜… | `/autonomous-research-agent` |
+| ◇ Browser Automation | Extra Skill | III | Evolved | `/browser-automation` |
+| ○ Chain-of-Thought Reasoning | Intrinsic Skill | I | Awakened | `/chain-of-thought` |
+| ○ Chunk Document | Intrinsic Skill | I | Awakened | `/chunk-document` |
+| ○ Cite Sources | Intrinsic Skill | I | Awakened | `/cite-sources` |
+| ○ Classify | Intrinsic Skill | 0 | Basic | `/classify` |
+| ○ Code Generation | Intrinsic Skill | I | Awakened | `/code-generation` |
+| ◇ Code Review Pipeline | Extra Skill | III | Evolved | `/code-review-pipeline` |
+| ○ Computer Use | Intrinsic Skill | II | Named | `/computer-use` |
+| ◇ Content Moderation | Extra Skill | III | Evolved | `/content-moderation` |
+| ◇ Conversational Agent | Extra Skill | III | Evolved | `/conversational-agent` |
+| ◇ Data Analysis | Extra Skill | III | Evolved | `/data-analysis` |
+| ○ Data Visualize | Intrinsic Skill | II | Named | `/data-visualize` |
+| ◇ Design Review | Extra Skill | III | Evolved | `/design-review` |
+| ○ Diff Content | Intrinsic Skill | I | Awakened | `/diff-content` |
+| ◇ Document Analyst | Extra Skill | III | Evolved | `/document-analyst` |
+| ◇ Document Digitization | Extra Skill | III | Evolved | `/document-digitization` |
+| ○ Embed Text | Intrinsic Skill | I | Awakened | `/embed-text` |
+| ○ Error Interpretation | Intrinsic Skill | I | Awakened | `/error-interpretation` |
+| ○ Evaluate Output | Intrinsic Skill | I | Awakened | `/evaluate-output` |
+| ○ Execute Bash | Intrinsic Skill | I | Awakened | `/execute-bash` |
+| ○ Extract Entities | Intrinsic Skill | I | Awakened | `/extract-entities` |
+| ○ Format Output | Intrinsic Skill | 0 | Basic | `/format-output` |
+| ◆ True Craftsman: Full-Stack Developer | Ultimate Skill | V | Transcendent | `/full-stack-developer` |
+| ◇ Function Calling | Extra Skill | III | Evolved | `/function-calling` |
+| ○ Generate SQL | Intrinsic Skill | II | Named | `/generate-sql` |
+| ○ Generate Test | Intrinsic Skill | II | Named | `/generate-test` |
+| ○ Generate Text | Intrinsic Skill | 0 | Basic | `/generate-text` |
+| ◇ Ghostwrite | Extra Skill | IV | Hardened | `/ghostwrite` |
+| ◇ Grounding | Extra Skill | III | Evolved | `/grounding` |
+| ◇ Guardrails | Extra Skill | III | Evolved | `/guardrails` |
+| ○ Hypothesis Generation | Intrinsic Skill | II | Named | `/hypothesis-generate` |
+| ○ Image Caption | Intrinsic Skill | II | Named | `/image-caption` |
+| ◇ Knowledge Graph Construction | Extra Skill | III | Evolved | `/knowledge-graph-build` |
+| ◇ Knowledge Harvest | Extra Skill | IV | Hardened | `/knowledge-harvest` |
+| ◇ Literature Review | Extra Skill | IV | Hardened | `/literature-review` |
+| ○ Logical Inference | Intrinsic Skill | I | Awakened | `/logical-inference` |
+| ○ Math Reason | Intrinsic Skill | II | Named | `/math-reason` |
+| ○ Memory Manage | Intrinsic Skill | II | Named | `/memory-manage` |
+| ◇ ML Pipeline | Extra Skill | IV | Hardened | `/ml-pipeline` |
+| ◇ Multi-Agent Debate | Extra Skill | IV | Hardened | `/multi-agent-debate` |
+| ◆ Grand Conductor: Multi-Agent Orchestration | Ultimate Skill | V | Transcendent | `/multi-agent-orchestration-v` |
+| ◇ Multimodal Reasoning | Extra Skill | III | Evolved | `/multimodal-reasoning` |
+| ○ Parse HTML | Intrinsic Skill | I | Awakened | `/parse-html` |
+| ○ Parse JSON | Intrinsic Skill | I | Awakened | `/parse-json` |
+| ○ Parse PDF | Intrinsic Skill | I | Awakened | `/parse-pdf` |
+| ◇ Plan and Execute | Extra Skill | IV | Hardened | `/plan-and-execute` |
+| ○ Plan and Decompose | Intrinsic Skill | I | Awakened | `/plan-decompose` |
+| ◇ PRD Generation | Extra Skill | IV | Hardened | `/prd-generation` |
+| ◇ Prompt Optimization | Extra Skill | IV | Hardened | `/prompt-optimization` |
+| ○ Question Answer | Intrinsic Skill | 0 | Basic | `/question-answer` |
+| ◇ RAG Pipeline | Extra Skill | III | Evolved | `/rag-pipeline` |
+| ○ Rank | Intrinsic Skill | I | Awakened | `/rank` |
+| ◇ ReAct Reasoning | Extra Skill | III | Evolved | `/re-act-reasoning` |
+| ◆ True Herald: Real-Time Voice Assistant | Ultimate Skill | V | Transcendent | `/real-time-voice-assistant` |
+| ◆ True Sage: Recursive Self-Improvement | Ultimate Skill | V | Transcendent | `/recursive-self-improvement` |
+| ○ Refactor Code | Intrinsic Skill | II | Named | `/refactor-code` |
+| ◇ Registry Curation | Extra Skill | IV | Hardened | `/registry-curation` |
+| ◇ Research | Extra Skill | III | Evolved | `/research` |
+| ○ Retrieve | Intrinsic Skill | I | Awakened | `/retrieve` |
+| ○ Route Intent | Intrinsic Skill | I | Awakened | `/route-intent` |
+| ◆ True Dragon: Autonomous Scientific Discovery | Ultimate Skill | V | Transcendent | `/scientific-discovery` |
+| ○ Scientific Visualization | Intrinsic Skill | II | Named | `/scientific-visualization` |
+| ◇ Scientific Writing | Extra Skill | III | Evolved | `/scientific-writing` |
+| ○ Score Relevance | Intrinsic Skill | I | Awakened | `/score-relevance` |
+| ○ Self-Critique | Intrinsic Skill | I | Awakened | `/self-critique` |
+| ○ Sentiment Analysis | Intrinsic Skill | 0 | Basic | `/sentiment-analysis` |
+| ○ Speech to Text | Intrinsic Skill | II | Named | `/speech-to-text` |
+| ○ Structured Output Generation | Intrinsic Skill | I | Awakened | `/structured-output` |
+| ○ Summarize | Intrinsic Skill | 0 | Basic | `/summarize` |
+| ○ Text to Speech | Intrinsic Skill | II | Named | `/text-to-speech` |
+| ◇ Text-to-SQL Pipeline | Extra Skill | III | Evolved | `/text-to-sql-pipeline` |
+| ○ Tokenize | Intrinsic Skill | 0 | Basic | `/tokenize` |
+| ◇ Tool Chaining | Extra Skill | III | Evolved | `/tool-chaining` |
+| ◇ Tool Creation | Extra Skill | IV | Hardened | `/tool-creation` |
+| ○ Tool Select | Intrinsic Skill | I | Awakened | `/tool-select` |
+| ○ Tool Use | Intrinsic Skill | I | Awakened | `/tool-use` |
+| ○ Translate | Intrinsic Skill | 0 | Basic | `/translate` |
+| ◇ Translation Pipeline | Extra Skill | III | Evolved | `/translation-pipeline` |
+| ◇ Tree of Thought | Extra Skill | IV | Hardened | `/tree-of-thought` |
+| ◇ Vertical Slice Planning | Extra Skill | III | Evolved | `/vertical-slice-planning` |
+| ◇ Voice Agent | Extra Skill | III | Evolved | `/voice-agent` |
+| ◇ Web Scrape | Extra Skill | III | Evolved | `/web-scrape` |
+| ○ Web Search | Intrinsic Skill | I | Awakened | `/web-search` |
+| ◇ Workflow Automation | Extra Skill | IV | Hardened | `/workflow-automation` |
+| ○ Write Report | Intrinsic Skill | I | Awakened | `/write-report` |
+
+## Pure / Undeveloped
+
+*Atomic skills with no connections to the upgrade graph — no prerequisites and not referenced as a component of any other skill.*
+
+| Name | Class | Rank | Tier | Skill Call |
+|---|---|---|---|---|
+| ○ Code Execution | Intrinsic Skill | II | Named | `/code-execution` |
+| ○ Code Explain | Intrinsic Skill | II | Named | `/code-explain` |
+| ○ Context Compression | Intrinsic Skill | III | Evolved | `/context-compression` |
+| ○ Detect Anomaly | Intrinsic Skill | II | Named | `/detect-anomaly` |
+| ○ Document Editing | Intrinsic Skill | 0 | Basic | `/document-editing` |
+| ○ Few-Shot Learning | Intrinsic Skill | IV | Hardened | `/few-shot-learning` |
+| ○ Fine-Tune | Intrinsic Skill | IV | Hardened | `/fine-tune` |
+| ○ Framework Upgrade | Intrinsic Skill | 0 | Basic | `/framework-upgrade` |
+| ○ Image Generate | Intrinsic Skill | II | Named | `/image-generate` |
+| ○ Issue Triage | Intrinsic Skill | IV | Hardened | `/issue-triage` |
+| ○ Object Detection | Intrinsic Skill | II | Named | `/object-detection` |
+| ○ OCR | Intrinsic Skill | II | Named | `/ocr` |
+| ○ Prompt Injection Defense | Intrinsic Skill | III | Evolved | `/prompt-injection-defense` |
+| ○ Reward Modeling | Intrinsic Skill | II | Named | `/reward-modeling` |
+| ○ Self-Consistency | Intrinsic Skill | IV | Hardened | `/self-consistency` |
+| ○ Semantic Cache | Intrinsic Skill | IV | Hardened | `/semantic-cache` |
+| ○ Skill Discovery | Intrinsic Skill | 0 | Basic | `/skill-discovery` |
+| ○ Statistical Analysis | Intrinsic Skill | III | Evolved | `/statistical-analysis` |
+| ○ Test-Driven Development | Intrinsic Skill | 0 | Basic | `/test-driven-development` |
+| ○ UX Audit | Intrinsic Skill | 0 | Basic | `/ux-audit` |
+| ○ Visual Question Answering | Intrinsic Skill | III | Evolved | `/vision-qa` |
 
 *Generated from gaia.json v1.0.0.*

--- a/scripts/generateProjections.py
+++ b/scripts/generateProjections.py
@@ -59,6 +59,10 @@ def get_rarity_label(meta, rarity):
     return meta.get("rarityLabels", {}).get(rarity, rarity.capitalize())
 
 
+def get_tier_label(meta, level):
+    return meta.get("levelLabels", {}).get(str(level), str(level))
+
+
 def get_tier_symbol(skill_type):
     return {"atomic": "○", "composite": "◇", "legendary": "◆"}.get(skill_type, "·")
 
@@ -143,15 +147,15 @@ def main():
 
         type_label = get_type_label(meta, skill_type)
         level_label = get_level_label(meta, level)
-        rarity_label = get_rarity_label(meta, rarity)
+        tier_label = get_tier_label(meta, level)
 
         with open(file_path, "w", encoding="utf-8") as f:
             f.write(f"# [{level_label} · {type_label}] {skill_name}\n")
             f.write(f"**ID:** {skill_id}  \n")
             f.write(f"**Type:** {type_label}  \n")
             f.write(f"**Level:** {level_label}  \n")
-            f.write(f"**Rarity:** {rarity_label}  \n")
-            f.write(f"**Status:** {skill.get('status', '').capitalize()}\n\n")
+            f.write(f"**Tier:** {tier_label}  \n")
+            f.write(f"**Skill Call:** `/{skill_id}`\n\n")
             f.write("---\n\n")
 
             f.write("## Description\n")
@@ -219,16 +223,49 @@ def main():
     # generate registry.md
     with open("registry.md", "w", encoding="utf-8") as f:
         f.write("# Gaia Skill Registry\n\n")
-        f.write("| Name | Class | Rank | Rarity | Status |\n")
+        f.write("| Name | Class | Rank | Tier | Skill Call |\n")
         f.write("|---|---|---|---|---|\n")
+
+        # collect orphaned atomic IDs for the pure section
+        all_prereq_ids = set()
         for skill in skills:
+            for pid in skill.get("prerequisites", []):
+                all_prereq_ids.add(pid)
+        orphan_ids = {
+            s["id"] for s in skills
+            if s.get("type") == "atomic"
+            and s["id"] not in all_prereq_ids
+            and not s.get("prerequisites")
+        }
+
+        for skill in skills:
+            if skill["id"] in orphan_ids:
+                continue
             skill_type = skill.get("type", "atomic")
             symbol = get_tier_symbol(skill_type)
             type_label = get_type_label(meta, skill_type)
-            level_label = get_level_label(meta, skill.get("level"))
-            rarity_label = get_rarity_label(meta, skill.get("rarity"))
+            level = skill.get("level")
+            level_label = get_level_label(meta, level)
+            tier_label = get_tier_label(meta, level)
             name_display = f"{symbol} {skill.get('name')}"
-            f.write(f"| {name_display} | {type_label} | {level_label} | {rarity_label} | {skill.get('status', '').capitalize()} |\n")
+            skill_call = f"`/{skill.get('id')}`"
+            f.write(f"| {name_display} | {type_label} | {level_label} | {tier_label} | {skill_call} |\n")
+
+        f.write("\n")
+        f.write("## Pure / Undeveloped\n\n")
+        f.write("*Atomic skills with no connections to the upgrade graph — no prerequisites and not referenced as a component of any other skill.*\n\n")
+        f.write("| Name | Class | Rank | Tier | Skill Call |\n")
+        f.write("|---|---|---|---|---|\n")
+        for skill in skills:
+            if skill["id"] not in orphan_ids:
+                continue
+            level = skill.get("level")
+            level_label = get_level_label(meta, level)
+            tier_label = get_tier_label(meta, level)
+            name_display = f"○ {skill.get('name')}"
+            skill_call = f"`/{skill.get('id')}`"
+            f.write(f"| {name_display} | Intrinsic Skill | {level_label} | {tier_label} | {skill_call} |\n")
+
         f.write(f"\n*Generated from gaia.json v{version}.*\n")
 
     # generate combinations.md
@@ -287,14 +324,15 @@ def main():
                 f.write(f"**Last Updated:** {tree.get('updatedAt', 'unknown')}  \n")
                 stats = tree.get("stats", {})
                 f.write(f"**Total Skills Unlocked:** {stats.get('totalUnlocked', 0)}  \n")
-                f.write(f"**Highest Rarity:** {get_rarity_label(meta, stats.get('highestRarity', 'none'))}  \n")
+                highest_level = stats.get('highestLevel', stats.get('highestRarity', ''))
+                f.write(f"**Highest Tier:** {get_tier_label(meta, highest_level)}  \n")
                 f.write(f"**Deepest Lineage:** {stats.get('deepestLineage', 0)}\n\n")
                 f.write("---\n\n")
 
                 f.write("## Unlocked Skills\n\n")
                 unlocked = tree.get("unlockedSkills", [])
                 if unlocked:
-                    f.write("| Skill | Class | Rank | Rarity | Unlocked In | Date |\n")
+                    f.write("| Skill | Class | Rank | Tier | Unlocked In | Date |\n")
                     f.write("|---|---|---|---|---|---|\n")
                     for us in unlocked:
                         sid = us.get("skillId", "")
@@ -302,11 +340,12 @@ def main():
                         sk_type = sk.get("type", "")
                         symbol = get_tier_symbol(sk_type)
                         type_label = get_type_label(meta, sk_type)
-                        level_label = get_level_label(meta, us.get("level", ""))
-                        rarity_label = get_rarity_label(meta, sk.get("rarity", ""))
+                        level = us.get("level", sk.get("level", ""))
+                        level_label = get_level_label(meta, level)
+                        tier_label = get_tier_label(meta, level)
                         name_display = f"{symbol} {sk.get('name', sid)}"
                         f.write(f"| {name_display} | {type_label} | "
-                                f"{level_label} | {rarity_label} | "
+                                f"{level_label} | {tier_label} | "
                                 f"{us.get('unlockedIn', '')} | {us.get('unlockedAt', '')} |\n")
                 else:
                     f.write("_No skills unlocked yet._\n")
@@ -363,6 +402,19 @@ def main():
 def _generate_tree(skills, skill_map, meta, version, date_str, named_map=None):
     legendaries = _sorted_legendaries(skills)
 
+    # compute orphaned atomics
+    all_prereq_ids = set()
+    for s in skills:
+        for pid in s.get("prerequisites", []):
+            all_prereq_ids.add(pid)
+    pure_skills = sorted(
+        [s for s in skills
+         if s.get("type") == "atomic"
+         and s["id"] not in all_prereq_ids
+         and not s.get("prerequisites")],
+        key=lambda s: s.get("id", "")
+    )
+
     lines = []
     lines.append("# Gaia Skill Tree")
     lines.append("")
@@ -393,6 +445,20 @@ def _generate_tree(skills, skill_map, meta, version, date_str, named_map=None):
             lines.extend(_render_subtree(prereq_id, skill_map, meta, "  ", is_last, seen,
                                          named_map=named_map))
 
+        lines.append("")
+
+    if pure_skills:
+        lines.append("═" * 70)
+        lines.append("Pure / Undeveloped — atomic skills not yet wired into any upgrade path.")
+        lines.append("═" * 70)
+        lines.append("")
+        for ps in pure_skills:
+            pid = ps.get("id")
+            level_label = get_level_label(meta, ps.get("level"))
+            tier_label = get_tier_label(meta, ps.get("level"))
+            named_id = (named_map or {}).get(pid)
+            display = f"{named_id} - {ps.get('name')}" if named_id else f"/{pid}"
+            lines.append(f"  ○ {display}  [{level_label} · {tier_label}]")
         lines.append("")
 
     lines.append("```")

--- a/skills/atomic/api-call.md
+++ b/skills/atomic/api-call.md
@@ -2,8 +2,8 @@
 **ID:** api-call  
 **Type:** Intrinsic Skill  
 **Level:** II  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Named  
+**Skill Call:** `/api-call`
 
 ---
 

--- a/skills/atomic/audience-model.md
+++ b/skills/atomic/audience-model.md
@@ -2,8 +2,8 @@
 **ID:** audience-model  
 **Type:** Intrinsic Skill  
 **Level:** I  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Awakened  
+**Skill Call:** `/audience-model`
 
 ---
 

--- a/skills/atomic/chain-of-thought.md
+++ b/skills/atomic/chain-of-thought.md
@@ -2,8 +2,8 @@
 **ID:** chain-of-thought  
 **Type:** Intrinsic Skill  
 **Level:** I  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Awakened  
+**Skill Call:** `/chain-of-thought`
 
 ---
 

--- a/skills/atomic/chunk-document.md
+++ b/skills/atomic/chunk-document.md
@@ -2,8 +2,8 @@
 **ID:** chunk-document  
 **Type:** Intrinsic Skill  
 **Level:** I  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Awakened  
+**Skill Call:** `/chunk-document`
 
 ---
 

--- a/skills/atomic/cite-sources.md
+++ b/skills/atomic/cite-sources.md
@@ -2,8 +2,8 @@
 **ID:** cite-sources  
 **Type:** Intrinsic Skill  
 **Level:** I  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Awakened  
+**Skill Call:** `/cite-sources`
 
 ---
 

--- a/skills/atomic/classify.md
+++ b/skills/atomic/classify.md
@@ -2,8 +2,8 @@
 **ID:** classify  
 **Type:** Intrinsic Skill  
 **Level:** 0  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Basic  
+**Skill Call:** `/classify`
 
 ---
 

--- a/skills/atomic/code-execution.md
+++ b/skills/atomic/code-execution.md
@@ -2,8 +2,8 @@
 **ID:** code-execution  
 **Type:** Intrinsic Skill  
 **Level:** II  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Named  
+**Skill Call:** `/code-execution`
 
 ---
 

--- a/skills/atomic/code-explain.md
+++ b/skills/atomic/code-explain.md
@@ -2,8 +2,8 @@
 **ID:** code-explain  
 **Type:** Intrinsic Skill  
 **Level:** II  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Named  
+**Skill Call:** `/code-explain`
 
 ---
 

--- a/skills/atomic/code-generation.md
+++ b/skills/atomic/code-generation.md
@@ -2,8 +2,8 @@
 **ID:** code-generation  
 **Type:** Intrinsic Skill  
 **Level:** I  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Awakened  
+**Skill Call:** `/code-generation`
 
 ---
 

--- a/skills/atomic/computer-use.md
+++ b/skills/atomic/computer-use.md
@@ -2,8 +2,8 @@
 **ID:** computer-use  
 **Type:** Intrinsic Skill  
 **Level:** II  
-**Rarity:** Rare  
-**Status:** Provisional
+**Tier:** Named  
+**Skill Call:** `/computer-use`
 
 ---
 

--- a/skills/atomic/context-compression.md
+++ b/skills/atomic/context-compression.md
@@ -2,8 +2,8 @@
 **ID:** context-compression  
 **Type:** Intrinsic Skill  
 **Level:** III  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Evolved  
+**Skill Call:** `/context-compression`
 
 ---
 

--- a/skills/atomic/data-visualize.md
+++ b/skills/atomic/data-visualize.md
@@ -2,8 +2,8 @@
 **ID:** data-visualize  
 **Type:** Intrinsic Skill  
 **Level:** II  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Named  
+**Skill Call:** `/data-visualize`
 
 ---
 

--- a/skills/atomic/detect-anomaly.md
+++ b/skills/atomic/detect-anomaly.md
@@ -2,8 +2,8 @@
 **ID:** detect-anomaly  
 **Type:** Intrinsic Skill  
 **Level:** II  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Named  
+**Skill Call:** `/detect-anomaly`
 
 ---
 

--- a/skills/atomic/diff-content.md
+++ b/skills/atomic/diff-content.md
@@ -2,8 +2,8 @@
 **ID:** diff-content  
 **Type:** Intrinsic Skill  
 **Level:** I  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Awakened  
+**Skill Call:** `/diff-content`
 
 ---
 

--- a/skills/atomic/document-editing.md
+++ b/skills/atomic/document-editing.md
@@ -2,8 +2,8 @@
 **ID:** document-editing  
 **Type:** Intrinsic Skill  
 **Level:** 0  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Basic  
+**Skill Call:** `/document-editing`
 
 ---
 

--- a/skills/atomic/embed-text.md
+++ b/skills/atomic/embed-text.md
@@ -2,8 +2,8 @@
 **ID:** embed-text  
 **Type:** Intrinsic Skill  
 **Level:** I  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Awakened  
+**Skill Call:** `/embed-text`
 
 ---
 

--- a/skills/atomic/error-interpretation.md
+++ b/skills/atomic/error-interpretation.md
@@ -2,8 +2,8 @@
 **ID:** error-interpretation  
 **Type:** Intrinsic Skill  
 **Level:** I  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Awakened  
+**Skill Call:** `/error-interpretation`
 
 ---
 

--- a/skills/atomic/evaluate-output.md
+++ b/skills/atomic/evaluate-output.md
@@ -2,8 +2,8 @@
 **ID:** evaluate-output  
 **Type:** Intrinsic Skill  
 **Level:** I  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Awakened  
+**Skill Call:** `/evaluate-output`
 
 ---
 

--- a/skills/atomic/execute-bash.md
+++ b/skills/atomic/execute-bash.md
@@ -2,8 +2,8 @@
 **ID:** execute-bash  
 **Type:** Intrinsic Skill  
 **Level:** I  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Awakened  
+**Skill Call:** `/execute-bash`
 
 ---
 

--- a/skills/atomic/extract-entities.md
+++ b/skills/atomic/extract-entities.md
@@ -2,8 +2,8 @@
 **ID:** extract-entities  
 **Type:** Intrinsic Skill  
 **Level:** I  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Awakened  
+**Skill Call:** `/extract-entities`
 
 ---
 

--- a/skills/atomic/few-shot-learning.md
+++ b/skills/atomic/few-shot-learning.md
@@ -2,8 +2,8 @@
 **ID:** few-shot-learning  
 **Type:** Intrinsic Skill  
 **Level:** IV  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Hardened  
+**Skill Call:** `/few-shot-learning`
 
 ---
 

--- a/skills/atomic/fine-tune.md
+++ b/skills/atomic/fine-tune.md
@@ -2,8 +2,8 @@
 **ID:** fine-tune  
 **Type:** Intrinsic Skill  
 **Level:** IV  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Hardened  
+**Skill Call:** `/fine-tune`
 
 ---
 

--- a/skills/atomic/format-output.md
+++ b/skills/atomic/format-output.md
@@ -2,8 +2,8 @@
 **ID:** format-output  
 **Type:** Intrinsic Skill  
 **Level:** 0  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Basic  
+**Skill Call:** `/format-output`
 
 ---
 

--- a/skills/atomic/framework-upgrade.md
+++ b/skills/atomic/framework-upgrade.md
@@ -2,8 +2,8 @@
 **ID:** framework-upgrade  
 **Type:** Intrinsic Skill  
 **Level:** 0  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Basic  
+**Skill Call:** `/framework-upgrade`
 
 ---
 

--- a/skills/atomic/generate-sql.md
+++ b/skills/atomic/generate-sql.md
@@ -2,8 +2,8 @@
 **ID:** generate-sql  
 **Type:** Intrinsic Skill  
 **Level:** II  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Named  
+**Skill Call:** `/generate-sql`
 
 ---
 

--- a/skills/atomic/generate-test.md
+++ b/skills/atomic/generate-test.md
@@ -2,8 +2,8 @@
 **ID:** generate-test  
 **Type:** Intrinsic Skill  
 **Level:** II  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Named  
+**Skill Call:** `/generate-test`
 
 ---
 

--- a/skills/atomic/generate-text.md
+++ b/skills/atomic/generate-text.md
@@ -2,8 +2,8 @@
 **ID:** generate-text  
 **Type:** Intrinsic Skill  
 **Level:** 0  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Basic  
+**Skill Call:** `/generate-text`
 
 ---
 

--- a/skills/atomic/hypothesis-generate.md
+++ b/skills/atomic/hypothesis-generate.md
@@ -2,8 +2,8 @@
 **ID:** hypothesis-generate  
 **Type:** Intrinsic Skill  
 **Level:** II  
-**Rarity:** Rare  
-**Status:** Provisional
+**Tier:** Named  
+**Skill Call:** `/hypothesis-generate`
 
 ---
 

--- a/skills/atomic/image-caption.md
+++ b/skills/atomic/image-caption.md
@@ -2,8 +2,8 @@
 **ID:** image-caption  
 **Type:** Intrinsic Skill  
 **Level:** II  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Named  
+**Skill Call:** `/image-caption`
 
 ---
 

--- a/skills/atomic/image-generate.md
+++ b/skills/atomic/image-generate.md
@@ -2,8 +2,8 @@
 **ID:** image-generate  
 **Type:** Intrinsic Skill  
 **Level:** II  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Named  
+**Skill Call:** `/image-generate`
 
 ---
 

--- a/skills/atomic/issue-triage.md
+++ b/skills/atomic/issue-triage.md
@@ -2,8 +2,8 @@
 **ID:** issue-triage  
 **Type:** Intrinsic Skill  
 **Level:** IV  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Hardened  
+**Skill Call:** `/issue-triage`
 
 ---
 

--- a/skills/atomic/logical-inference.md
+++ b/skills/atomic/logical-inference.md
@@ -2,8 +2,8 @@
 **ID:** logical-inference  
 **Type:** Intrinsic Skill  
 **Level:** I  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Awakened  
+**Skill Call:** `/logical-inference`
 
 ---
 

--- a/skills/atomic/math-reason.md
+++ b/skills/atomic/math-reason.md
@@ -2,8 +2,8 @@
 **ID:** math-reason  
 **Type:** Intrinsic Skill  
 **Level:** II  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Named  
+**Skill Call:** `/math-reason`
 
 ---
 

--- a/skills/atomic/memory-manage.md
+++ b/skills/atomic/memory-manage.md
@@ -2,8 +2,8 @@
 **ID:** memory-manage  
 **Type:** Intrinsic Skill  
 **Level:** II  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Named  
+**Skill Call:** `/memory-manage`
 
 ---
 

--- a/skills/atomic/object-detection.md
+++ b/skills/atomic/object-detection.md
@@ -2,8 +2,8 @@
 **ID:** object-detection  
 **Type:** Intrinsic Skill  
 **Level:** II  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Named  
+**Skill Call:** `/object-detection`
 
 ---
 

--- a/skills/atomic/ocr.md
+++ b/skills/atomic/ocr.md
@@ -2,8 +2,8 @@
 **ID:** ocr  
 **Type:** Intrinsic Skill  
 **Level:** II  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Named  
+**Skill Call:** `/ocr`
 
 ---
 

--- a/skills/atomic/parse-html.md
+++ b/skills/atomic/parse-html.md
@@ -2,8 +2,8 @@
 **ID:** parse-html  
 **Type:** Intrinsic Skill  
 **Level:** I  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Awakened  
+**Skill Call:** `/parse-html`
 
 ---
 

--- a/skills/atomic/parse-json.md
+++ b/skills/atomic/parse-json.md
@@ -2,8 +2,8 @@
 **ID:** parse-json  
 **Type:** Intrinsic Skill  
 **Level:** I  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Awakened  
+**Skill Call:** `/parse-json`
 
 ---
 

--- a/skills/atomic/parse-pdf.md
+++ b/skills/atomic/parse-pdf.md
@@ -2,8 +2,8 @@
 **ID:** parse-pdf  
 **Type:** Intrinsic Skill  
 **Level:** I  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Awakened  
+**Skill Call:** `/parse-pdf`
 
 ---
 

--- a/skills/atomic/plan-decompose.md
+++ b/skills/atomic/plan-decompose.md
@@ -2,8 +2,8 @@
 **ID:** plan-decompose  
 **Type:** Intrinsic Skill  
 **Level:** I  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Awakened  
+**Skill Call:** `/plan-decompose`
 
 ---
 

--- a/skills/atomic/prompt-injection-defense.md
+++ b/skills/atomic/prompt-injection-defense.md
@@ -2,8 +2,8 @@
 **ID:** prompt-injection-defense  
 **Type:** Intrinsic Skill  
 **Level:** III  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Evolved  
+**Skill Call:** `/prompt-injection-defense`
 
 ---
 

--- a/skills/atomic/question-answer.md
+++ b/skills/atomic/question-answer.md
@@ -2,8 +2,8 @@
 **ID:** question-answer  
 **Type:** Intrinsic Skill  
 **Level:** 0  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Basic  
+**Skill Call:** `/question-answer`
 
 ---
 

--- a/skills/atomic/rank.md
+++ b/skills/atomic/rank.md
@@ -2,8 +2,8 @@
 **ID:** rank  
 **Type:** Intrinsic Skill  
 **Level:** I  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Awakened  
+**Skill Call:** `/rank`
 
 ---
 

--- a/skills/atomic/refactor-code.md
+++ b/skills/atomic/refactor-code.md
@@ -2,8 +2,8 @@
 **ID:** refactor-code  
 **Type:** Intrinsic Skill  
 **Level:** II  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Named  
+**Skill Call:** `/refactor-code`
 
 ---
 

--- a/skills/atomic/retrieve.md
+++ b/skills/atomic/retrieve.md
@@ -2,8 +2,8 @@
 **ID:** retrieve  
 **Type:** Intrinsic Skill  
 **Level:** I  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Awakened  
+**Skill Call:** `/retrieve`
 
 ---
 

--- a/skills/atomic/reward-modeling.md
+++ b/skills/atomic/reward-modeling.md
@@ -2,8 +2,8 @@
 **ID:** reward-modeling  
 **Type:** Intrinsic Skill  
 **Level:** II  
-**Rarity:** Rare  
-**Status:** Provisional
+**Tier:** Named  
+**Skill Call:** `/reward-modeling`
 
 ---
 

--- a/skills/atomic/route-intent.md
+++ b/skills/atomic/route-intent.md
@@ -2,8 +2,8 @@
 **ID:** route-intent  
 **Type:** Intrinsic Skill  
 **Level:** I  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Awakened  
+**Skill Call:** `/route-intent`
 
 ---
 

--- a/skills/atomic/scientific-visualization.md
+++ b/skills/atomic/scientific-visualization.md
@@ -2,8 +2,8 @@
 **ID:** scientific-visualization  
 **Type:** Intrinsic Skill  
 **Level:** II  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Named  
+**Skill Call:** `/scientific-visualization`
 
 ---
 

--- a/skills/atomic/score-relevance.md
+++ b/skills/atomic/score-relevance.md
@@ -2,8 +2,8 @@
 **ID:** score-relevance  
 **Type:** Intrinsic Skill  
 **Level:** I  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Awakened  
+**Skill Call:** `/score-relevance`
 
 ---
 

--- a/skills/atomic/self-consistency.md
+++ b/skills/atomic/self-consistency.md
@@ -2,8 +2,8 @@
 **ID:** self-consistency  
 **Type:** Intrinsic Skill  
 **Level:** IV  
-**Rarity:** Rare  
-**Status:** Provisional
+**Tier:** Hardened  
+**Skill Call:** `/self-consistency`
 
 ---
 

--- a/skills/atomic/self-critique.md
+++ b/skills/atomic/self-critique.md
@@ -2,8 +2,8 @@
 **ID:** self-critique  
 **Type:** Intrinsic Skill  
 **Level:** I  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Awakened  
+**Skill Call:** `/self-critique`
 
 ---
 

--- a/skills/atomic/semantic-cache.md
+++ b/skills/atomic/semantic-cache.md
@@ -2,8 +2,8 @@
 **ID:** semantic-cache  
 **Type:** Intrinsic Skill  
 **Level:** IV  
-**Rarity:** Rare  
-**Status:** Provisional
+**Tier:** Hardened  
+**Skill Call:** `/semantic-cache`
 
 ---
 

--- a/skills/atomic/sentiment-analysis.md
+++ b/skills/atomic/sentiment-analysis.md
@@ -2,8 +2,8 @@
 **ID:** sentiment-analysis  
 **Type:** Intrinsic Skill  
 **Level:** 0  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Basic  
+**Skill Call:** `/sentiment-analysis`
 
 ---
 

--- a/skills/atomic/skill-discovery.md
+++ b/skills/atomic/skill-discovery.md
@@ -2,8 +2,8 @@
 **ID:** skill-discovery  
 **Type:** Intrinsic Skill  
 **Level:** 0  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Basic  
+**Skill Call:** `/skill-discovery`
 
 ---
 

--- a/skills/atomic/speech-to-text.md
+++ b/skills/atomic/speech-to-text.md
@@ -2,8 +2,8 @@
 **ID:** speech-to-text  
 **Type:** Intrinsic Skill  
 **Level:** II  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Named  
+**Skill Call:** `/speech-to-text`
 
 ---
 

--- a/skills/atomic/statistical-analysis.md
+++ b/skills/atomic/statistical-analysis.md
@@ -2,8 +2,8 @@
 **ID:** statistical-analysis  
 **Type:** Intrinsic Skill  
 **Level:** III  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Evolved  
+**Skill Call:** `/statistical-analysis`
 
 ---
 

--- a/skills/atomic/structured-output.md
+++ b/skills/atomic/structured-output.md
@@ -2,8 +2,8 @@
 **ID:** structured-output  
 **Type:** Intrinsic Skill  
 **Level:** I  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Awakened  
+**Skill Call:** `/structured-output`
 
 ---
 

--- a/skills/atomic/summarize.md
+++ b/skills/atomic/summarize.md
@@ -2,8 +2,8 @@
 **ID:** summarize  
 **Type:** Intrinsic Skill  
 **Level:** 0  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Basic  
+**Skill Call:** `/summarize`
 
 ---
 

--- a/skills/atomic/test-driven-development.md
+++ b/skills/atomic/test-driven-development.md
@@ -2,8 +2,8 @@
 **ID:** test-driven-development  
 **Type:** Intrinsic Skill  
 **Level:** 0  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Basic  
+**Skill Call:** `/test-driven-development`
 
 ---
 

--- a/skills/atomic/text-to-speech.md
+++ b/skills/atomic/text-to-speech.md
@@ -2,8 +2,8 @@
 **ID:** text-to-speech  
 **Type:** Intrinsic Skill  
 **Level:** II  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Named  
+**Skill Call:** `/text-to-speech`
 
 ---
 

--- a/skills/atomic/tokenize.md
+++ b/skills/atomic/tokenize.md
@@ -2,8 +2,8 @@
 **ID:** tokenize  
 **Type:** Intrinsic Skill  
 **Level:** 0  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Basic  
+**Skill Call:** `/tokenize`
 
 ---
 

--- a/skills/atomic/tool-select.md
+++ b/skills/atomic/tool-select.md
@@ -2,8 +2,8 @@
 **ID:** tool-select  
 **Type:** Intrinsic Skill  
 **Level:** I  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Awakened  
+**Skill Call:** `/tool-select`
 
 ---
 

--- a/skills/atomic/tool-use.md
+++ b/skills/atomic/tool-use.md
@@ -2,8 +2,8 @@
 **ID:** tool-use  
 **Type:** Intrinsic Skill  
 **Level:** I  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Awakened  
+**Skill Call:** `/tool-use`
 
 ---
 

--- a/skills/atomic/translate.md
+++ b/skills/atomic/translate.md
@@ -2,8 +2,8 @@
 **ID:** translate  
 **Type:** Intrinsic Skill  
 **Level:** 0  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Basic  
+**Skill Call:** `/translate`
 
 ---
 

--- a/skills/atomic/ux-audit.md
+++ b/skills/atomic/ux-audit.md
@@ -2,8 +2,8 @@
 **ID:** ux-audit  
 **Type:** Intrinsic Skill  
 **Level:** 0  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Basic  
+**Skill Call:** `/ux-audit`
 
 ---
 

--- a/skills/atomic/vision-qa.md
+++ b/skills/atomic/vision-qa.md
@@ -2,8 +2,8 @@
 **ID:** vision-qa  
 **Type:** Intrinsic Skill  
 **Level:** III  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Evolved  
+**Skill Call:** `/vision-qa`
 
 ---
 

--- a/skills/atomic/web-search.md
+++ b/skills/atomic/web-search.md
@@ -2,8 +2,8 @@
 **ID:** web-search  
 **Type:** Intrinsic Skill  
 **Level:** I  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Awakened  
+**Skill Call:** `/web-search`
 
 ---
 

--- a/skills/atomic/write-report.md
+++ b/skills/atomic/write-report.md
@@ -2,8 +2,8 @@
 **ID:** write-report  
 **Type:** Intrinsic Skill  
 **Level:** I  
-**Rarity:** Common  
-**Status:** Provisional
+**Tier:** Awakened  
+**Skill Call:** `/write-report`
 
 ---
 

--- a/skills/composite/agent-eval.md
+++ b/skills/composite/agent-eval.md
@@ -2,8 +2,8 @@
 **ID:** agent-eval  
 **Type:** Extra Skill  
 **Level:** III  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Evolved  
+**Skill Call:** `/agent-eval`
 
 ---
 

--- a/skills/composite/automated-testing.md
+++ b/skills/composite/automated-testing.md
@@ -2,8 +2,8 @@
 **ID:** automated-testing  
 **Type:** Extra Skill  
 **Level:** III  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Evolved  
+**Skill Call:** `/automated-testing`
 
 ---
 

--- a/skills/composite/autonomous-debug.md
+++ b/skills/composite/autonomous-debug.md
@@ -2,8 +2,8 @@
 **ID:** autonomous-debug  
 **Type:** Extra Skill  
 **Level:** IV  
-**Rarity:** Rare  
-**Status:** Provisional
+**Tier:** Hardened  
+**Skill Call:** `/autonomous-debug`
 
 ---
 

--- a/skills/composite/browser-automation.md
+++ b/skills/composite/browser-automation.md
@@ -2,8 +2,8 @@
 **ID:** browser-automation  
 **Type:** Extra Skill  
 **Level:** III  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Evolved  
+**Skill Call:** `/browser-automation`
 
 ---
 

--- a/skills/composite/code-review-pipeline.md
+++ b/skills/composite/code-review-pipeline.md
@@ -2,8 +2,8 @@
 **ID:** code-review-pipeline  
 **Type:** Extra Skill  
 **Level:** III  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Evolved  
+**Skill Call:** `/code-review-pipeline`
 
 ---
 

--- a/skills/composite/content-moderation.md
+++ b/skills/composite/content-moderation.md
@@ -2,8 +2,8 @@
 **ID:** content-moderation  
 **Type:** Extra Skill  
 **Level:** III  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Evolved  
+**Skill Call:** `/content-moderation`
 
 ---
 

--- a/skills/composite/conversational-agent.md
+++ b/skills/composite/conversational-agent.md
@@ -2,8 +2,8 @@
 **ID:** conversational-agent  
 **Type:** Extra Skill  
 **Level:** III  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Evolved  
+**Skill Call:** `/conversational-agent`
 
 ---
 

--- a/skills/composite/data-analysis.md
+++ b/skills/composite/data-analysis.md
@@ -2,8 +2,8 @@
 **ID:** data-analysis  
 **Type:** Extra Skill  
 **Level:** III  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Evolved  
+**Skill Call:** `/data-analysis`
 
 ---
 

--- a/skills/composite/design-review.md
+++ b/skills/composite/design-review.md
@@ -2,8 +2,8 @@
 **ID:** design-review  
 **Type:** Extra Skill  
 **Level:** III  
-**Rarity:** Rare  
-**Status:** Provisional
+**Tier:** Evolved  
+**Skill Call:** `/design-review`
 
 ---
 

--- a/skills/composite/document-analyst.md
+++ b/skills/composite/document-analyst.md
@@ -2,8 +2,8 @@
 **ID:** document-analyst  
 **Type:** Extra Skill  
 **Level:** III  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Evolved  
+**Skill Call:** `/document-analyst`
 
 ---
 

--- a/skills/composite/document-digitization.md
+++ b/skills/composite/document-digitization.md
@@ -2,8 +2,8 @@
 **ID:** document-digitization  
 **Type:** Extra Skill  
 **Level:** III  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Evolved  
+**Skill Call:** `/document-digitization`
 
 ---
 

--- a/skills/composite/function-calling.md
+++ b/skills/composite/function-calling.md
@@ -2,8 +2,8 @@
 **ID:** function-calling  
 **Type:** Extra Skill  
 **Level:** III  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Evolved  
+**Skill Call:** `/function-calling`
 
 ---
 

--- a/skills/composite/ghostwrite.md
+++ b/skills/composite/ghostwrite.md
@@ -2,8 +2,8 @@
 **ID:** ghostwrite  
 **Type:** Extra Skill  
 **Level:** IV  
-**Rarity:** Rare  
-**Status:** Provisional
+**Tier:** Hardened  
+**Skill Call:** `/ghostwrite`
 
 ---
 

--- a/skills/composite/grounding.md
+++ b/skills/composite/grounding.md
@@ -2,8 +2,8 @@
 **ID:** grounding  
 **Type:** Extra Skill  
 **Level:** III  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Evolved  
+**Skill Call:** `/grounding`
 
 ---
 

--- a/skills/composite/guardrails.md
+++ b/skills/composite/guardrails.md
@@ -2,8 +2,8 @@
 **ID:** guardrails  
 **Type:** Extra Skill  
 **Level:** III  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Evolved  
+**Skill Call:** `/guardrails`
 
 ---
 

--- a/skills/composite/knowledge-graph-build.md
+++ b/skills/composite/knowledge-graph-build.md
@@ -2,8 +2,8 @@
 **ID:** knowledge-graph-build  
 **Type:** Extra Skill  
 **Level:** III  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Evolved  
+**Skill Call:** `/knowledge-graph-build`
 
 ---
 

--- a/skills/composite/knowledge-harvest.md
+++ b/skills/composite/knowledge-harvest.md
@@ -2,8 +2,8 @@
 **ID:** knowledge-harvest  
 **Type:** Extra Skill  
 **Level:** IV  
-**Rarity:** Rare  
-**Status:** Provisional
+**Tier:** Hardened  
+**Skill Call:** `/knowledge-harvest`
 
 ---
 

--- a/skills/composite/literature-review.md
+++ b/skills/composite/literature-review.md
@@ -2,8 +2,8 @@
 **ID:** literature-review  
 **Type:** Extra Skill  
 **Level:** IV  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Hardened  
+**Skill Call:** `/literature-review`
 
 ---
 

--- a/skills/composite/ml-pipeline.md
+++ b/skills/composite/ml-pipeline.md
@@ -2,8 +2,8 @@
 **ID:** ml-pipeline  
 **Type:** Extra Skill  
 **Level:** IV  
-**Rarity:** Rare  
-**Status:** Provisional
+**Tier:** Hardened  
+**Skill Call:** `/ml-pipeline`
 
 ---
 

--- a/skills/composite/multi-agent-debate.md
+++ b/skills/composite/multi-agent-debate.md
@@ -2,8 +2,8 @@
 **ID:** multi-agent-debate  
 **Type:** Extra Skill  
 **Level:** IV  
-**Rarity:** Rare  
-**Status:** Provisional
+**Tier:** Hardened  
+**Skill Call:** `/multi-agent-debate`
 
 ---
 

--- a/skills/composite/multimodal-reasoning.md
+++ b/skills/composite/multimodal-reasoning.md
@@ -2,8 +2,8 @@
 **ID:** multimodal-reasoning  
 **Type:** Extra Skill  
 **Level:** III  
-**Rarity:** Rare  
-**Status:** Provisional
+**Tier:** Evolved  
+**Skill Call:** `/multimodal-reasoning`
 
 ---
 

--- a/skills/composite/plan-and-execute.md
+++ b/skills/composite/plan-and-execute.md
@@ -2,8 +2,8 @@
 **ID:** plan-and-execute  
 **Type:** Extra Skill  
 **Level:** IV  
-**Rarity:** Rare  
-**Status:** Provisional
+**Tier:** Hardened  
+**Skill Call:** `/plan-and-execute`
 
 ---
 

--- a/skills/composite/prd-generation.md
+++ b/skills/composite/prd-generation.md
@@ -2,8 +2,8 @@
 **ID:** prd-generation  
 **Type:** Extra Skill  
 **Level:** IV  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Hardened  
+**Skill Call:** `/prd-generation`
 
 ---
 

--- a/skills/composite/prompt-optimization.md
+++ b/skills/composite/prompt-optimization.md
@@ -2,8 +2,8 @@
 **ID:** prompt-optimization  
 **Type:** Extra Skill  
 **Level:** IV  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Hardened  
+**Skill Call:** `/prompt-optimization`
 
 ---
 

--- a/skills/composite/rag-pipeline.md
+++ b/skills/composite/rag-pipeline.md
@@ -2,8 +2,8 @@
 **ID:** rag-pipeline  
 **Type:** Extra Skill  
 **Level:** III  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Evolved  
+**Skill Call:** `/rag-pipeline`
 
 ---
 

--- a/skills/composite/re-act-reasoning.md
+++ b/skills/composite/re-act-reasoning.md
@@ -2,8 +2,8 @@
 **ID:** re-act-reasoning  
 **Type:** Extra Skill  
 **Level:** III  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Evolved  
+**Skill Call:** `/re-act-reasoning`
 
 ---
 

--- a/skills/composite/registry-curation.md
+++ b/skills/composite/registry-curation.md
@@ -2,8 +2,8 @@
 **ID:** registry-curation  
 **Type:** Extra Skill  
 **Level:** IV  
-**Rarity:** Rare  
-**Status:** Provisional
+**Tier:** Hardened  
+**Skill Call:** `/registry-curation`
 
 ---
 

--- a/skills/composite/research.md
+++ b/skills/composite/research.md
@@ -2,8 +2,8 @@
 **ID:** research  
 **Type:** Extra Skill  
 **Level:** III  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Evolved  
+**Skill Call:** `/research`
 
 ---
 

--- a/skills/composite/scientific-writing.md
+++ b/skills/composite/scientific-writing.md
@@ -2,8 +2,8 @@
 **ID:** scientific-writing  
 **Type:** Extra Skill  
 **Level:** III  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Evolved  
+**Skill Call:** `/scientific-writing`
 
 ---
 

--- a/skills/composite/text-to-sql-pipeline.md
+++ b/skills/composite/text-to-sql-pipeline.md
@@ -2,8 +2,8 @@
 **ID:** text-to-sql-pipeline  
 **Type:** Extra Skill  
 **Level:** III  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Evolved  
+**Skill Call:** `/text-to-sql-pipeline`
 
 ---
 

--- a/skills/composite/tool-chaining.md
+++ b/skills/composite/tool-chaining.md
@@ -2,8 +2,8 @@
 **ID:** tool-chaining  
 **Type:** Extra Skill  
 **Level:** III  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Evolved  
+**Skill Call:** `/tool-chaining`
 
 ---
 

--- a/skills/composite/tool-creation.md
+++ b/skills/composite/tool-creation.md
@@ -2,8 +2,8 @@
 **ID:** tool-creation  
 **Type:** Extra Skill  
 **Level:** IV  
-**Rarity:** Rare  
-**Status:** Provisional
+**Tier:** Hardened  
+**Skill Call:** `/tool-creation`
 
 ---
 

--- a/skills/composite/translation-pipeline.md
+++ b/skills/composite/translation-pipeline.md
@@ -2,8 +2,8 @@
 **ID:** translation-pipeline  
 **Type:** Extra Skill  
 **Level:** III  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Evolved  
+**Skill Call:** `/translation-pipeline`
 
 ---
 

--- a/skills/composite/tree-of-thought.md
+++ b/skills/composite/tree-of-thought.md
@@ -2,8 +2,8 @@
 **ID:** tree-of-thought  
 **Type:** Extra Skill  
 **Level:** IV  
-**Rarity:** Rare  
-**Status:** Provisional
+**Tier:** Hardened  
+**Skill Call:** `/tree-of-thought`
 
 ---
 

--- a/skills/composite/vertical-slice-planning.md
+++ b/skills/composite/vertical-slice-planning.md
@@ -2,8 +2,8 @@
 **ID:** vertical-slice-planning  
 **Type:** Extra Skill  
 **Level:** III  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Evolved  
+**Skill Call:** `/vertical-slice-planning`
 
 ---
 

--- a/skills/composite/voice-agent.md
+++ b/skills/composite/voice-agent.md
@@ -2,8 +2,8 @@
 **ID:** voice-agent  
 **Type:** Extra Skill  
 **Level:** III  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Evolved  
+**Skill Call:** `/voice-agent`
 
 ---
 

--- a/skills/composite/web-scrape.md
+++ b/skills/composite/web-scrape.md
@@ -2,8 +2,8 @@
 **ID:** web-scrape  
 **Type:** Extra Skill  
 **Level:** III  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Evolved  
+**Skill Call:** `/web-scrape`
 
 ---
 

--- a/skills/composite/workflow-automation.md
+++ b/skills/composite/workflow-automation.md
@@ -2,8 +2,8 @@
 **ID:** workflow-automation  
 **Type:** Extra Skill  
 **Level:** IV  
-**Rarity:** Uncommon  
-**Status:** Provisional
+**Tier:** Hardened  
+**Skill Call:** `/workflow-automation`
 
 ---
 

--- a/skills/legendary/autonomous-data-scientist.md
+++ b/skills/legendary/autonomous-data-scientist.md
@@ -2,8 +2,8 @@
 **ID:** autonomous-data-scientist  
 **Type:** Ultimate Skill  
 **Level:** V  
-**Rarity:** Divine  
-**Status:** Provisional
+**Tier:** Transcendent  
+**Skill Call:** `/autonomous-data-scientist`
 
 ---
 

--- a/skills/legendary/autonomous-research-agent.md
+++ b/skills/legendary/autonomous-research-agent.md
@@ -2,8 +2,8 @@
 **ID:** autonomous-research-agent  
 **Type:** Ultimate Skill  
 **Level:** VI  
-**Rarity:** Divine  
-**Status:** Provisional
+**Tier:** Transcendent â˜…  
+**Skill Call:** `/autonomous-research-agent`
 
 ---
 

--- a/skills/legendary/full-stack-developer.md
+++ b/skills/legendary/full-stack-developer.md
@@ -2,8 +2,8 @@
 **ID:** full-stack-developer  
 **Type:** Ultimate Skill  
 **Level:** V  
-**Rarity:** Divine  
-**Status:** Provisional
+**Tier:** Transcendent  
+**Skill Call:** `/full-stack-developer`
 
 ---
 

--- a/skills/legendary/multi-agent-orchestration-v.md
+++ b/skills/legendary/multi-agent-orchestration-v.md
@@ -2,8 +2,8 @@
 **ID:** multi-agent-orchestration-v  
 **Type:** Ultimate Skill  
 **Level:** V  
-**Rarity:** Divine  
-**Status:** Provisional
+**Tier:** Transcendent  
+**Skill Call:** `/multi-agent-orchestration-v`
 
 ---
 

--- a/skills/legendary/real-time-voice-assistant.md
+++ b/skills/legendary/real-time-voice-assistant.md
@@ -2,8 +2,8 @@
 **ID:** real-time-voice-assistant  
 **Type:** Ultimate Skill  
 **Level:** V  
-**Rarity:** Divine  
-**Status:** Provisional
+**Tier:** Transcendent  
+**Skill Call:** `/real-time-voice-assistant`
 
 ---
 

--- a/skills/legendary/recursive-self-improvement.md
+++ b/skills/legendary/recursive-self-improvement.md
@@ -2,8 +2,8 @@
 **ID:** recursive-self-improvement  
 **Type:** Ultimate Skill  
 **Level:** V  
-**Rarity:** Divine  
-**Status:** Provisional
+**Tier:** Transcendent  
+**Skill Call:** `/recursive-self-improvement`
 
 ---
 

--- a/skills/legendary/scientific-discovery.md
+++ b/skills/legendary/scientific-discovery.md
@@ -2,8 +2,8 @@
 **ID:** scientific-discovery  
 **Type:** Ultimate Skill  
 **Level:** V  
-**Rarity:** Divine  
-**Status:** Provisional
+**Tier:** Transcendent  
+**Skill Call:** `/scientific-discovery`
 
 ---
 

--- a/tree.md
+++ b/tree.md
@@ -91,6 +91,32 @@ Shared prerequisites marked (↑ see above) on second occurrence.
      ├─ ○ /plan-decompose  [I]
      └─ ○ /tool-select  [I]
 
+══════════════════════════════════════════════════════════════════════
+Pure / Undeveloped — atomic skills not yet wired into any upgrade path.
+══════════════════════════════════════════════════════════════════════
+
+  ○ /code-execution  [II · Named]
+  ○ mattpocock/zoom-out - Code Explain  [II · Named]
+  ○ /context-compression  [III · Evolved]
+  ○ /detect-anomaly  [II · Named]
+  ○ anthropic/pptx - Document Editing  [0 · Basic]
+  ○ /few-shot-learning  [IV · Hardened]
+  ○ /fine-tune  [IV · Hardened]
+  ○ laravel/upgrade-laravel-v13 - Framework Upgrade  [0 · Basic]
+  ○ /image-generate  [II · Named]
+  ○ mattpocock/triage - Issue Triage  [IV · Hardened]
+  ○ /object-detection  [II · Named]
+  ○ /ocr  [II · Named]
+  ○ /prompt-injection-defense  [III · Evolved]
+  ○ /reward-modeling  [II · Named]
+  ○ /self-consistency  [IV · Hardened]
+  ○ /semantic-cache  [IV · Hardened]
+  ○ vercel/find-skills - Skill Discovery  [0 · Basic]
+  ○ /statistical-analysis  [III · Evolved]
+  ○ addy-osmani/test-driven-development - Test-Driven Development  [0 · Basic]
+  ○ martin-stepanoski/nielsen-heuristics-audit - UX Audit  [0 · Basic]
+  ○ /vision-qa  [III · Evolved]
+
 ```
 
 *Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*

--- a/users/gaiabot/skill-tree.md
+++ b/users/gaiabot/skill-tree.md
@@ -1,19 +1,19 @@
 # Skill Tree — gaiabot
 **Last Updated:** 2026-04-26  
 **Total Skills Unlocked:** 4  
-**Highest Rarity:** Common  
+**Highest Tier:** common  
 **Deepest Lineage:** 1
 
 ---
 
 ## Unlocked Skills
 
-| Skill | Class | Rank | Rarity | Unlocked In | Date |
+| Skill | Class | Rank | Tier | Unlocked In | Date |
 |---|---|---|---|---|---|
-| ○ Route Intent | Intrinsic Skill | II | Common | gaia-registry/gaiabot-core | 2026-04-20 |
-| ○ Plan and Decompose | Intrinsic Skill | II | Common | gaia-registry/gaiabot-core | 2026-04-21 |
-| ○ Tool Select | Intrinsic Skill | II | Common | gaia-registry/gaiabot-core | 2026-04-22 |
-| ◇ Plan and Execute | Extra Skill | III | Rare | local-repo | 2026-04-26 |
+| ○ Route Intent | Intrinsic Skill | II | Named | gaia-registry/gaiabot-core | 2026-04-20 |
+| ○ Plan and Decompose | Intrinsic Skill | II | Named | gaia-registry/gaiabot-core | 2026-04-21 |
+| ○ Tool Select | Intrinsic Skill | II | Named | gaia-registry/gaiabot-core | 2026-04-22 |
+| ◇ Plan and Execute | Extra Skill | III | Evolved | local-repo | 2026-04-26 |
 
 ---
 

--- a/users/mbtiongson1/skill-tree.md
+++ b/users/mbtiongson1/skill-tree.md
@@ -1,22 +1,22 @@
 # Skill Tree — mbtiongson1
 **Last Updated:** 2026-04-26  
 **Total Skills Unlocked:** 7  
-**Highest Rarity:** Uncommon  
+**Highest Tier:** uncommon  
 **Deepest Lineage:** 2
 
 ---
 
 ## Unlocked Skills
 
-| Skill | Class | Rank | Rarity | Unlocked In | Date |
+| Skill | Class | Rank | Tier | Unlocked In | Date |
 |---|---|---|---|---|---|
-| ○ Web Search | Intrinsic Skill | II | Common | mbtiongson1/gaia-skill-tree | 2026-03-01 |
-| ○ Parse HTML | Intrinsic Skill | II | Common | mbtiongson1/gaia-skill-tree | 2026-03-05 |
-| ○ Extract Entities | Intrinsic Skill | II | Common | mbtiongson1/gaia-skill-tree | 2026-03-08 |
-| ○ Summarize | Intrinsic Skill | II | Common | mbtiongson1/gaia-skill-tree | 2026-03-10 |
-| ○ Cite Sources | Intrinsic Skill | II | Common | mbtiongson1/gaia-skill-tree | 2026-03-12 |
-| ◇ Web Scrape | Extra Skill | III | Uncommon | mbtiongson1/gaia-skill-tree | 2026-03-15 |
-| ◇ Research | Extra Skill | III | Uncommon | mbtiongson1/gaia-skill-tree | 2026-04-01 |
+| ○ Web Search | Intrinsic Skill | II | Named | mbtiongson1/gaia-skill-tree | 2026-03-01 |
+| ○ Parse HTML | Intrinsic Skill | II | Named | mbtiongson1/gaia-skill-tree | 2026-03-05 |
+| ○ Extract Entities | Intrinsic Skill | II | Named | mbtiongson1/gaia-skill-tree | 2026-03-08 |
+| ○ Summarize | Intrinsic Skill | II | Named | mbtiongson1/gaia-skill-tree | 2026-03-10 |
+| ○ Cite Sources | Intrinsic Skill | II | Named | mbtiongson1/gaia-skill-tree | 2026-03-12 |
+| ◇ Web Scrape | Extra Skill | III | Evolved | mbtiongson1/gaia-skill-tree | 2026-03-15 |
+| ◇ Research | Extra Skill | III | Evolved | mbtiongson1/gaia-skill-tree | 2026-04-01 |
 
 ---
 


### PR DESCRIPTION
## Summary

- **Rarity → Tier**: registry.md and all skill pages now show the rank name (Basic / Awakened / Named / Evolved / Hardened / Transcendent) instead of prevalence-based rarity labels — terminology now matches the "Transcendent line" rank progression
- **Status → Skill Call**: the `Provisional` status column is replaced with the skill's callable slug (e.g. `/web-search`, `/summarize`) across registry.md and all skill pages
- **Pure / Undeveloped**: 21 isolated atomic skills (no prerequisites, not referenced as prerequisites by any other skill) are now surfaced in a dedicated section at the bottom of both `registry.md` and `tree.md` so they are visible but clearly distinguished from the upgrade graph
- **README**: Rank System heading updated to "Rank System — The Transcendent Line"; `Transcendent ◆` corrected to `Transcendent ★` in rank table

## Files changed

| File | Change |
|---|---|
| `scripts/generateProjections.py` | Added `get_tier_label()`; updated registry, tree, skill page, and user tree generators |
| `registry.md` | New columns (Tier, Skill Call); Pure/Undeveloped section |
| `tree.md` | Pure/Undeveloped block at bottom |
| `skills/**/*.md` (113 files) | Rarity → Tier, Status → Skill Call in page header |
| `users/*/skill-tree.md` | Rarity → Tier in unlocked skills table and stats |
| `README.md` | Heading + rank table fix |

## Test plan

- [x] Run `python scripts/generateProjections.py` — should complete with no errors
- [x] Confirm `registry.md` main table shows Tier and Skill Call columns
- [x] Confirm `registry.md` Pure/Undeveloped section lists 21 skills
- [x] Confirm `tree.md` ends with the Pure/Undeveloped block
- [x] Spot-check one skill page (e.g. `skills/atomic/web-search.md`) for `Tier:` and `Skill Call:` fields