### PR TITLE
[evidence] autonomous-research-agent — add class B evidence from balukosuri community repo

### DIFF
--- a/graph/gaia.json
+++ b/graph/gaia.json
@@ -1079,12 +1079,19 @@
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
           "notes": "Seed evidence â€” apex tier structural validation placeholder."
+        },
+        {
+          "class": "B",
+          "source": "https://github.com/balukosuri/Andrej-Karpathy-s-Autoresearch-As-a-Universal-Skill",
+          "evaluator": "mbtiongson1",
+          "date": "2026-04-30",
+          "notes": "Community reproduction of Karpathy's autoresearch pattern as a universal agent skill, demonstrating generalizability beyond the original repo."
         }
       ],
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-26",
-      "updatedAt": "2026-04-29",
+      "updatedAt": "2026-04-30",
       "version": "0.1.0"
     },
     {

--- a/skills/legendary/autonomous-research-agent.md
+++ b/skills/legendary/autonomous-research-agent.md
@@ -25,6 +25,7 @@ Requires extensive multi-system validation before level advancement.
 | Class | Source | Evaluator | Date |
 |---|---|---|---|
 | A | https://github.com/gaia-registry/gaia/blob/main/docs/evidence/seed.md | mbtiongson1 | 2026-04-29 |
+| B | https://github.com/balukosuri/Andrej-Karpathy-s-Autoresearch-As-a-Universal-Skill | mbtiongson1 | 2026-04-30 |
 
 ## Known Agents
 _None verified yet._


### PR DESCRIPTION
## Summary

- Adds class B evidence to the `autonomous-research-agent` legendary skill
- Source: https://github.com/balukosuri/Andrej-Karpathy-s-Autoresearch-As-a-Universal-Skill — community reproduction of Karpathy's autoresearch pattern demonstrating it as a generalizable autonomous agent skill
- Bumps `updatedAt` to 2026-04-30

## Evidence entry

```json
{
  "class": "B",
  "source": "https://github.com/balukosuri/Andrej-Karpathy-s-Autoresearch-As-a-Universal-Skill",
  "evaluator": "mbtiongson1",
  "date": "2026-04-30",
  "notes": "Community reproduction of Karpathy's autoresearch pattern as a universal agent skill, demonstrating generalizability beyond the original repo."
}
```

## Test plan

- [x] `python scripts/validate.py` passes
- [x] `autonomous-research-agent` now has 2 evidence entries (class A + class B)