### PR TITLE
feat: skill-sources registry, gaia-curate contributor tracking, and Contributors section in README

### DIFF
--- a/.claude/skills/gaia-curate/skill.md
+++ b/.claude/skills/gaia-curate/skill.md
@@ -1,7 +1,7 @@
 ---
 name: gaia-curate
 description: Expand the Gaia skill registry with new popular AI agent skills, fully evidenced and validated, then push a PR. Use this skill when the user asks to "update the tree", "add new skills to Gaia", "curate the registry", "expand the skill graph", or explicitly types /gaia-curate.
-version: 1.5.0
+version: 1.6.0
 ---
 
 # gaia-curate
@@ -9,6 +9,8 @@ version: 1.5.0
 Expand the Gaia skill registry (`graph/gaia.json`) with new popular AI agent skills, fully evidenced and validated, then push a PR.
 
 ## What this skill does
+
+0. **Load the sources registry** — read `graph/skill-sources.md` before doing any research. This is the authoritative list of known skill marketplaces, GitHub orgs, and registries. Use every listed source as a research target in step 2. When you discover a new marketplace or skill collection repo not yet in that file, append it following the format described at the bottom of the file — include it in the same PR.
 
 1. **Read the current graph** — load `graph/gaia.json` to see every existing skill ID so nothing is duplicated.
 2. **Research** — for each candidate skill, gather concrete evidence using ALL of the following channels (in order of priority):
@@ -140,6 +142,16 @@ git clone https://github.com/mbtiongson1/gaia-skill-tree.git
 cd gaia-skill-tree
 ```
 
+## Recording contributors
+
+After the PR is opened, add the contributor's GitHub username to the `## Contributors` section of `README.md` (at the bottom of the file, before the License section) if not already listed. Use the format:
+
+```markdown
+| @username | Brief description of contribution |
+```
+
+If the `## Contributors` section does not exist yet, create it. Commit this change in the same PR as the skill additions. This ensures every person who runs `/gaia-curate` is permanently thanked in the project.
+
 ## Output
 
 At the end, report:
@@ -148,3 +160,4 @@ At the end, report:
 - Validation result summary
 - Any existing skills whose `derivatives` arrays were patched
 - Review decisions applied (accepted / renamed / dropped)
+- Contributor recorded in README

--- a/README.md
+++ b/README.md
@@ -330,6 +330,24 @@ For full instructions, including evidence requirements, PR templates, naming
 rules, and reviewer criteria, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 
+## Contributors
+
+Thank you to everyone who has expanded the Gaia registry.
+
+| Contributor | Contribution |
+|---|---|
+| [@mbtiongson1](https://github.com/mbtiongson1) | Creator & maintainer — graph design, CLI, MCP server, curation pipeline |
+| [@rico-tiongson](https://github.com/rico-tiongson) | Early contributor |
+| [@karpathy](https://github.com/karpathy) | Origin named skill: `karpathy/autoresearch` (AutoResearch — The Scholar's Compass) |
+| [@mattpocock](https://github.com/mattpocock) | Named skills: diagnose, tdd, to-prd, triage, zoom-out, and 6 others |
+| [@intelligentcode-ai](https://github.com/intelligentcode-ai) | Named skills: database-engineer, devops-engineer, mcp-client, security-engineer, and 5 others |
+| [@ruvnet](https://github.com/ruvnet) | Named skill: `ruvnet/flow-nexus-swarm` (Grand Conductor: Multi-Agent Orchestration) |
+| [@GLINCKER](https://github.com/GLINCKER) | Named skill: `glincker/readme-generator` (Write Report) |
+| [@spring-ai-alibaba](https://github.com/spring-ai-alibaba) | Named skill: `spring-ai/readme-generate` |
+| [@balukosuri](https://github.com/balukosuri) | Evidence: community reproduction of Karpathy's autoresearch as a universal skill |
+
+---
+
 ## License
 
 MIT — see [LICENSE](LICENSE).

--- a/graph/skill-sources.md
+++ b/graph/skill-sources.md
@@ -1,0 +1,65 @@
+# Gaia Skill Sources
+
+Authoritative list of known skill sources and marketplaces. `gaia-curate` agents read this file at the start of every curation run and append new sources as they are discovered.
+
+**Format:** one row per source. Columns: Name | URL | Type | Search method | Notes
+
+---
+
+## Registries & Marketplaces
+
+| Name | URL | Type | Search |
+|---|---|---|---|
+| SkillsMP | https://skillsmp.com | marketplace | `GET /api/v1/skills/search?q=<skill>` — 50 req/day unauthenticated |
+| GLINCKER Claude Marketplace | https://github.com/GLINCKER/claude-code-marketplace | github-repo | `gh api repos/GLINCKER/claude-code-marketplace/contents/skills` |
+| MCP.so Registry | https://mcp.so | mcp-registry | `WebFetch /servers` — list all MCP servers as skill evidence candidates |
+| Smithery MCP Registry | https://smithery.ai | mcp-registry | `WebFetch /` — browse MCP tool listings |
+
+## GitHub Orgs / Repos with Skill Collections
+
+| Name | URL | Type | Search |
+|---|---|---|---|
+| mattpocock/skills | https://github.com/mattpocock/skills | github-repo | `gh api repos/mattpocock/skills/contents/skills` |
+| intelligentcode-ai/skills | https://github.com/intelligentcode-ai/skills | github-repo | `gh api repos/intelligentcode-ai/skills/contents/skills` |
+| ruvnet/ruflo | https://github.com/ruvnet/ruflo | github-repo | orchestration platform; check `/skills` and `/.claude/skills` |
+| karpathy/autoresearch | https://github.com/karpathy/autoresearch | github-repo | origin implementation of autonomous-research-agent |
+| spring-ai-alibaba/examples | https://github.com/spring-ai-alibaba/examples | github-repo | `gh api repos/spring-ai-alibaba/examples/contents/.claude/skills` |
+| balukosuri/Andrej-Karpathy-s-Autoresearch-As-a-Universal-Skill | https://github.com/balukosuri/Andrej-Karpathy-s-Autoresearch-As-a-Universal-Skill | github-repo | community reproduction of autoresearch as a general agent skill |
+
+## Academic / Evidence Sources
+
+| Name | URL | Type | Search |
+|---|---|---|---|
+| arXiv (cs.AI / cs.CL) | https://arxiv.org | paper-index | `WebSearch "<skill> arxiv 2024 2025 2026 agent benchmark"` — Class A evidence |
+| Papers With Code | https://paperswithcode.com | paper-index | `WebSearch "<skill> site:paperswithcode.com"` — benchmarks + code links |
+
+## Package / Extension Registries
+
+| Name | URL | Type | Search |
+|---|---|---|---|
+| npm | https://www.npmjs.com | package-registry | crawled by `scripts/crawlers/crawl_npm.py`; topics: `ai-agent`, `llm-tool` |
+| VS Code Marketplace | https://marketplace.visualstudio.com | extension-registry | crawled by `scripts/crawlers/crawl_vscode.py`; tag: `ai-agent` |
+| HuggingFace | https://huggingface.co | model-hub | crawled by `scripts/crawlers/crawl_huggingface.py`; spaces tagged `agent` |
+
+## GitHub Topic Searches (ad-hoc)
+
+Run these during every curation pass to surface new repos:
+
+```bash
+gh search repos --topic="ai-agent-skills" --sort=stars --limit=20
+gh search repos --topic="claude-skills" --sort=stars --limit=20
+gh search repos --topic="llm-agent" --sort=stars --limit=20
+gh search repos "<skill-name> agent" --sort=stars --limit=10
+```
+
+---
+
+## How to add a new source
+
+When `gaia-curate` discovers a new marketplace, registry, or skill collection repo not already listed:
+
+1. Add a row to the appropriate table above.
+2. Include the URL, type, and a one-line search instruction.
+3. Commit the change in the same PR as the skill additions that led to its discovery.
+
+_Never remove a source; mark it stale with a `<!-- stale: <reason> -->` comment if it goes offline._


### PR DESCRIPTION
## Summary

- **`graph/skill-sources.md`** — new persistent registry of known skill marketplaces, GitHub orgs, and evidence sources (SkillsMP, GLINCKER marketplace, MCP registries, mattpocock/skills, intelligentcode-ai/skills, ruvnet/ruflo, karpathy/autoresearch, spring-ai-alibaba, balukosuri, arXiv, Papers With Code, npm, VS Code, HuggingFace). `gaia-curate` agents read this at the start of every curation run and append new sources as they are discovered.
- **`.claude/skills/gaia-curate/skill.md`** (v1.5 → v1.6) — adds step 0 to load `graph/skill-sources.md` before researching; adds post-PR step to record the contributor's GitHub username in `README.md`'s Contributors section.
- **`README.md`** — adds `## Contributors` section thanking all current named-skill contributors and evidence contributors.

## Test plan

- [x] `graph/skill-sources.md` is well-formed markdown with all source URLs resolvable
- [x] `gaia-curate` skill file loads cleanly and step 0 references `graph/skill-sources.md`
- [x] Contributors section appears correctly in rendered README