### PR TITLE
feat: living CLI, 8 new skills, v2.0.0 (MAJOR — tier rename)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "enabledPlugins": {
+    "frontend-design@claude-plugins-official": false
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": ["gaia _hook --event file_edit 2>/dev/null || true"]
+      }
+    ]
+  }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,8 +174,8 @@ Review flow for intake PRs:
 ```
 
 Examples:
-- `[atomic] parse-csv — adds CSV parsing as a primitive Intrinsic Skill`
-- `[composite] autonomous-debug — combines code-generation + execute-bash + error-interpretation`
+- `[basic] parse-csv — adds CSV parsing as a primitive Basic Skill`
+- `[extra] autonomous-debug — combines code-generation + execute-bash + error-interpretation`
 - `[reclassify] web-scrape — upgrade from Awakened (II) to Named (III) with new evidence`
 
 ---

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The snapshot below shows the upgrade-path structure. Each legendary traces
 back through its full prerequisite chain.
 
 ```
-GAIA SKILL TREE  v1.0.0
+GAIA SKILL TREE  v2.0.0
 ═════════════════════════════════════════════════════════════════
 
 ◆ karpathy/autoresearch - Wisdom King: Autonomous Research Agent  [VI]
@@ -210,6 +210,9 @@ gaia init --user your-github-username --scan AGENTS.md --scan scripts
 | `gaia status` | Shows the configured user's registered skill-tree summary. |
 | `gaia tree` | Lists unlocked skills for the configured user. |
 | `gaia fuse <skillId>` | Adds a pending fusion candidate to the user's skill tree. |
+| `gaia appraise [skillId]` | Renders a skill card with prereq status, derivatives, and contextual actions. Defaults to the most recently unlocked skill. |
+| `gaia promote [skillId] [--name "Display Name"]` | Advances an eligible skill to the next level. Optionally renames your named variant. |
+| `gaia paths` | Shows a progression summary: skills ready to fuse, one prerequisite away, and all reachable paths. |
 
 ### View the skill graph
 
@@ -295,7 +298,7 @@ gaia-skill-tree/
 ├── mcp-server/                   ← TypeScript MCP server (agent-native integration)
 ├── schema/                       ← JSON Schema definitions
 ├── schema/realSkillCatalog.schema.json ← Schema for graph/real_skill_catalog.json
-├── skills/                       ← GENERATED skill pages (atomic, composite, legendary)
+├── skills/                       ← GENERATED skill pages (basic, extra, ultimate)
 ├── users/                        ← Personal skill trees by GitHub username
 ├── scripts/                      ← Validation, projection, and analysis scripts
 ├── scripts/crawlers/             ← Bot crawlers (MCP registries, npm, VS Code, HuggingFace)

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -74,7 +74,7 @@ Every 90 days, the maintainers will conduct a full re-audit of the registry to:
 ## 5. Release Cadence
 
 ### 5.1 Registry Snapshots
-The registry is updated continuously as PRs are merged. Every month, a new version (e.g., `v1.1.0`) is tagged as a **Frontier Release**, including:
+The registry is updated continuously as PRs are merged. Every month, a new version (e.g., `v2.1.0`) is tagged as a **Frontier Release**, including:
 - A summary of all new skills.
 - Updated rarity scores based on real user tree data.
 - The **Frontier Report** (graph analytics and gaps).

--- a/graph/gaia.json
+++ b/graph/gaia.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./schema/skill.schema.json",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "generatedAt": "2026-04-30T00:00:00Z",
   "meta": {
     "typeLabels": {

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia-registry/mcp-server",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "MCP server for the Gaia Skill Registry — agent-native skill detection, fusion, and progression",
   "type": "module",
   "main": "dist/index.js",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia-registry/cli",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "description": "Gaia CLI - Integrate your AI agent skills with the Gaia registry",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gaia-cli"
-version = "1.0.0"
+version = "2.0.0"
 description = "Gaia AI Agent Skill Registry CLI"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/gaia_cli/cardRenderer.py
+++ b/src/gaia_cli/cardRenderer.py
@@ -1,0 +1,587 @@
+"""Render skill data as ASCII collectible cards for terminal display.
+
+Supports 24-bit truecolor ANSI with 256-color fallback.
+Respects NO_COLOR env var and non-TTY pipe detection.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import textwrap
+from typing import Optional
+
+# Enable VT100 processing on Windows
+if sys.platform == "win32":
+    os.system("")
+
+
+# ─── ANSI color support ────────────────────────────────────────────────────
+
+def _use_color() -> bool:
+    """Return False if NO_COLOR is set or stdout is not a TTY."""
+    if os.environ.get("NO_COLOR"):
+        return False
+    if not hasattr(sys.stdout, "isatty"):
+        return False
+    return sys.stdout.isatty()
+
+
+def _use_truecolor() -> bool:
+    """Return True if terminal supports 24-bit color."""
+    colorterm = os.environ.get("COLORTERM", "")
+    return colorterm in ("truecolor", "24bit")
+
+
+def fg(r: int, g: int, b: int) -> str:
+    """Foreground color escape."""
+    if not _use_color():
+        return ""
+    if _use_truecolor():
+        return f"\033[38;2;{r};{g};{b}m"
+    index = 16 + (36 * (r // 51)) + (6 * (g // 51)) + (b // 51)
+    return f"\033[38;5;{index}m"
+
+
+def bg(r: int, g: int, b: int) -> str:
+    """Background color escape."""
+    if not _use_color():
+        return ""
+    if _use_truecolor():
+        return f"\033[48;2;{r};{g};{b}m"
+    index = 16 + (36 * (r // 51)) + (6 * (g // 51)) + (b // 51)
+    return f"\033[48;5;{index}m"
+
+
+def reset() -> str:
+    """Reset all attributes."""
+    return "\033[0m" if _use_color() else ""
+
+
+def bold() -> str:
+    """Bold text."""
+    return "\033[1m" if _use_color() else ""
+
+
+def dim() -> str:
+    """Dim text."""
+    return "\033[2m" if _use_color() else ""
+
+
+# ─── Color palette ─────────────────────────────────────────────────────────
+
+TIER_COLORS = {
+    "basic": (56, 189, 248),
+    "extra": (192, 132, 252),
+    "ultimate": (245, 158, 11),
+}
+COLOR_SUCCESS = (134, 239, 172)
+COLOR_MISSING = (100, 116, 139)
+COLOR_TEXT = (226, 232, 240)
+COLOR_MUTED = (148, 163, 184)
+COLOR_GOLD = (251, 191, 36)
+
+
+# ─── Style constants ────────────────────────────────────────────────────────
+
+CARD_WIDTH = 48
+
+# Box-drawing characters (rounded for appraise cards)
+TL = "╭"
+TR = "╮"
+BL = "╰"
+BR = "╯"
+H = "─"
+V = "│"
+LT = "├"
+RT = "┤"
+
+# Tier glyphs
+TIER_GLYPHS = {
+    "basic": "○",      # ○
+    "extra": "◇",      # ◇
+    "ultimate": "◆",   # ◆
+}
+
+# Rarity decorators (shown in card header)
+RARITY_LABELS = {
+    "common": "Common",
+    "uncommon": "Uncommon",
+    "rare": "Rare",
+    "epic": "Epic",
+    "legendary": "Legendary",
+}
+
+# Level display
+LEVEL_LABELS = {
+    "0": "Lv.0 Basic",
+    "I": "Lv.I Awakened",
+    "II": "Lv.II Named",
+    "III": "Lv.III Evolved",
+    "IV": "Lv.IV Hardened",
+    "V": "Lv.V Transcendent",
+    "VI": "Lv.VI Transcendent ★",
+}
+
+
+# ─── Helper functions ───────────────────────────────────────────────────────
+
+
+def _pad(text: str, width: int, align: str = "left") -> str:
+    """Pad text to a fixed width with given alignment."""
+    if len(text) > width:
+        return text[: width - 1] + "…"
+    if align == "center":
+        return text.center(width)
+    if align == "right":
+        return text.rjust(width)
+    return text.ljust(width)
+
+
+def _wrap_lines(text: str, width: int) -> list[str]:
+    """Word-wrap text to fit within width."""
+    words = text.split()
+    lines: list[str] = []
+    current = ""
+    for word in words:
+        if not current:
+            current = word
+        elif len(current) + 1 + len(word) <= width:
+            current += " " + word
+        else:
+            lines.append(current)
+            current = word
+    if current:
+        lines.append(current)
+    return lines or [""]
+
+
+def _fit_list(items: list[str], max_width: int, prefix: str = "") -> str:
+    """
+    Join items with commas, fitting within max_width.
+
+    Shows as many items as will fit; appends '+N more' for omitted items.
+    The prefix (e.g. 'Prereqs: ') is included in width calculation.
+    """
+    if not items:
+        return prefix + "(none)"
+    remaining_width = max_width - len(prefix)
+    shown: list[str] = []
+    used = 0
+    for i, item in enumerate(items):
+        # Calculate width needed for this item (including ", " separator)
+        sep = ", " if shown else ""
+        # Reserve space for the "+N more" suffix if there are remaining items
+        remaining_items = len(items) - i - 1
+        suffix = f" +{remaining_items} more" if remaining_items > 0 else ""
+        needed = len(sep) + len(item)
+        # Check if adding this item still leaves room for the suffix if we stop here
+        if shown and used + needed + (len(suffix) if remaining_items > 0 else 0) > remaining_width:
+            break
+        shown.append(item)
+        used += needed
+
+    omitted = len(items) - len(shown)
+    result = ", ".join(shown)
+    if omitted > 0:
+        result += f" +{omitted} more"
+    return prefix + result
+
+
+def _separator(width: int = CARD_WIDTH) -> str:
+    """Return a horizontal separator line."""
+    inner = width - 2
+    return f"{LT}{H * inner}{RT}"
+
+
+def _line(content: str, width: int = CARD_WIDTH) -> str:
+    """Wrap content in card border characters."""
+    inner = width - 4  # V + space + content + space + V
+    return f"{V} {_pad(content, inner)} {V}"
+
+
+def _top_border(width: int = CARD_WIDTH) -> str:
+    inner = width - 2
+    return f"{TL}{H * inner}{TR}"
+
+
+def _bottom_border(width: int = CARD_WIDTH) -> str:
+    inner = width - 2
+    return f"{BL}{H * inner}{BR}"
+
+
+# ─── Main rendering ─────────────────────────────────────────────────────────
+
+
+def render_card(skill: dict, *, width: int = CARD_WIDTH) -> str:
+    """
+    Render a single skill as an ASCII card.
+
+    Args:
+        skill: A skill dict (from gaia.json skills array).
+        width: Card width in characters (default 48).
+
+    Returns:
+        Multi-line string representing the card.
+    """
+    inner = width - 4  # usable content width
+
+    tier = skill.get("type", "basic")
+    glyph = TIER_GLYPHS.get(tier, "○")
+    name = skill.get("name", skill.get("id", "Unknown"))
+    rarity = skill.get("rarity", "common")
+    rarity_label = RARITY_LABELS.get(rarity, rarity.capitalize())
+    level = skill.get("level", "0")
+    level_label = LEVEL_LABELS.get(level, f"Lv.{level}")
+    description = skill.get("description", "")
+    prereqs = skill.get("prerequisites", [])
+    derivatives = skill.get("derivatives", [])
+    status = skill.get("status", "provisional")
+    evidence_count = len(skill.get("evidence", []))
+    skill_id = skill.get("id", "unknown")
+
+    lines: list[str] = []
+
+    # Top border
+    lines.append(_top_border(width))
+
+    # Header: glyph + name + rarity
+    header_left = f"{glyph} {name}"
+    header_right = f"[{rarity_label}]"
+    available = inner - len(header_right) - 1
+    if len(header_left) > available:
+        header_left = header_left[: available - 1] + "…"
+    header = f"{header_left}{' ' * (inner - len(header_left) - len(header_right))}{header_right}"
+    lines.append(f"{V} {header} {V}")
+
+    # Sub-header: level + tier label
+    sub_left = level_label
+    sub_right = f"{tier.capitalize()} Skill"
+    sub_line = f"{sub_left}{' ' * (inner - len(sub_left) - len(sub_right))}{sub_right}"
+    lines.append(f"{V} {sub_line} {V}")
+
+    # Separator
+    lines.append(_separator(width))
+
+    # Description (wrapped)
+    desc_lines = _wrap_lines(description, inner) if description else ["(no description)"]
+    for dl in desc_lines[:4]:  # cap at 4 lines
+        lines.append(_line(dl, width))
+    if len(desc_lines) > 4:
+        lines.append(_line("...", width))
+
+    # Separator
+    lines.append(_separator(width))
+
+    # Prerequisites
+    if prereqs:
+        prereq_str = _fit_list(prereqs, inner, prefix="Prereqs: ")
+        lines.append(_line(prereq_str, width))
+    else:
+        lines.append(_line("Prereqs: (none)", width))
+
+    # Derivatives
+    if derivatives:
+        deriv_str = _fit_list(derivatives, inner, prefix="Unlocks: ")
+        lines.append(_line(deriv_str, width))
+    else:
+        lines.append(_line("Unlocks: (none)", width))
+
+    # Separator
+    lines.append(_separator(width))
+
+    # Footer: ID + status + evidence
+    footer_left = skill_id
+    footer_right = f"{status} | ev:{evidence_count}"
+    footer_line = f"{footer_left}{' ' * (inner - len(footer_left) - len(footer_right))}{footer_right}"
+    lines.append(f"{V} {footer_line} {V}")
+
+    # Bottom border
+    lines.append(_bottom_border(width))
+
+    return "\n".join(lines)
+
+
+def render_card_compact(skill: dict) -> str:
+    """
+    Render a compact single-line card summary.
+
+    Format: [glyph] name (level) [rarity] — first 60 chars of description
+    """
+    tier = skill.get("type", "basic")
+    glyph = TIER_GLYPHS.get(tier, "○")
+    name = skill.get("name", skill.get("id", "Unknown"))
+    level = skill.get("level", "0")
+    rarity = skill.get("rarity", "common")
+    desc = skill.get("description", "")
+    short_desc = desc[:60] + "…" if len(desc) > 60 else desc
+    return f"{glyph} {name} (Lv.{level}) [{rarity}] — {short_desc}"
+
+
+def render_cards(skills: list[dict], *, width: int = CARD_WIDTH, compact: bool = False) -> str:
+    """
+    Render multiple skills as cards.
+
+    Args:
+        skills: List of skill dicts.
+        width: Card width (ignored in compact mode).
+        compact: If True, render one-line summaries instead of full cards.
+
+    Returns:
+        Multi-line string with all cards.
+    """
+    if compact:
+        return "\n".join(render_card_compact(s) for s in skills)
+    return "\n\n".join(render_card(s, width=width) for s in skills)
+
+
+def load_and_render(
+    skill_id: str,
+    registry_path: str = ".",
+    *,
+    compact: bool = False,
+    width: int = CARD_WIDTH,
+) -> Optional[str]:
+    """
+    Load a skill by ID from the registry and render its card.
+
+    Args:
+        skill_id: The kebab-case skill ID.
+        registry_path: Path to the registry root.
+        compact: Use compact rendering.
+        width: Card width.
+
+    Returns:
+        Rendered card string, or None if skill not found.
+    """
+    graph_path = os.path.join(registry_path, "graph", "gaia.json")
+    if not os.path.exists(graph_path):
+        return None
+
+    with open(graph_path, "r", encoding="utf-8") as f:
+        graph_data = json.load(f)
+
+    skill_map = {s["id"]: s for s in graph_data.get("skills", [])}
+    skill = skill_map.get(skill_id)
+    if skill is None:
+        return None
+
+    if compact:
+        return render_card_compact(skill)
+    return render_card(skill, width=width)
+
+
+# ─── Appraise card (colored, with prereq status + actions) ─────────────────
+
+
+def render_appraise_card(
+    skill_data: dict,
+    prereq_status: dict,
+    derivatives: list,
+    actions: list[str],
+    owned: bool = False,
+) -> str:
+    """
+    Rich appraise card with ANSI color.
+
+    Args:
+        skill_data: skill dict from gaia.json
+        prereq_status: {prereq_id: True/False} — True = user has it
+        derivatives: list of derivative skill dicts [{id, name, type}]
+        actions: list of action labels (e.g. ["[F] Fuse", "[P] Promote"])
+        owned: whether user owns this skill
+    """
+    width = CARD_WIDTH
+    inner = width - 4
+
+    tier = skill_data.get("type", "basic")
+    tc = TIER_COLORS.get(tier, (56, 189, 248))
+    glyph = TIER_GLYPHS.get(tier, "○")
+    name = skill_data.get("name", skill_data.get("id", "?"))
+    level = skill_data.get("level", "0")
+    rarity = skill_data.get("rarity", "common")
+    desc = skill_data.get("description", "")
+
+    bc = fg(*tc)  # border color
+    r = reset()
+
+    lines = []
+
+    # Top border
+    lines.append(f"{bc}{TL}{H * (width - 2)}{TR}{r}")
+
+    # Header line: glyph + name + level
+    level_str = f"Level {level}"
+    header_left = f"{glyph} {name}"
+    space = inner - len(header_left) - len(level_str)
+    if space < 1:
+        header_left = header_left[: inner - len(level_str) - 2] + "…"
+        space = 1
+    lines.append(f"{bc}{V}{r} {bold()}{fg(*tc)}{header_left}{r}{' ' * space}{dim()}{level_str}{r} {bc}{V}{r}")
+
+    # Thin divider
+    lines.append(f"{bc}{V}{r} {fg(*COLOR_MUTED)}{H * inner}{r} {bc}{V}{r}")
+
+    # Type + rarity
+    type_str = f"Type: {tier.capitalize()}"
+    rarity_str = f"Rarity: {rarity}"
+    meta = f"{type_str}    {rarity_str}"
+    lines.append(f"{bc}{V}{r} {fg(*COLOR_MUTED)}{_pad(meta, inner)}{r} {bc}{V}{r}")
+
+    # Blank
+    lines.append(f"{bc}{V}{r} {' ' * inner} {bc}{V}{r}")
+
+    # Description
+    for dl in textwrap.wrap(desc, inner)[:3]:
+        lines.append(f"{bc}{V}{r} {fg(*COLOR_TEXT)}{_pad(dl, inner)}{r} {bc}{V}{r}")
+
+    # Blank
+    lines.append(f"{bc}{V}{r} {' ' * inner} {bc}{V}{r}")
+
+    # Prerequisites with check/circle
+    lines.append(f"{bc}{V}{r} {bold()}Prerequisites:{r}{' ' * (inner - 14)} {bc}{V}{r}")
+    if prereq_status:
+        prereq_items = []
+        for pid, has in prereq_status.items():
+            icon = f"{fg(*COLOR_SUCCESS)}✓{r}" if has else f"{fg(*COLOR_MISSING)}○{r}"
+            prereq_items.append(f"  {icon} {pid}")
+        # Two-column layout
+        col_w = inner // 2
+        for i in range(0, len(prereq_items), 2):
+            left = prereq_items[i] if i < len(prereq_items) else ""
+            right = prereq_items[i + 1] if i + 1 < len(prereq_items) else ""
+            # Rough padding (ANSI codes make len unreliable, but good enough)
+            raw_left = left.replace(fg(*COLOR_SUCCESS), "").replace(fg(*COLOR_MISSING), "").replace(r, "")
+            pad_l = col_w - len(raw_left)
+            if pad_l < 0:
+                pad_l = 0
+            combined = left + " " * pad_l + right
+            lines.append(f"{bc}{V}{r} {combined}{' ' * max(0, inner - len(raw_left) - pad_l - len(right.replace(fg(*COLOR_SUCCESS), '').replace(fg(*COLOR_MISSING), '').replace(r, '')))} {bc}{V}{r}")
+    else:
+        lines.append(f"{bc}{V}{r}   {fg(*COLOR_MUTED)}(none){r}{' ' * (inner - 8)} {bc}{V}{r}")
+
+    # Blank
+    lines.append(f"{bc}{V}{r} {' ' * inner} {bc}{V}{r}")
+
+    # Derivatives (unlocks)
+    if derivatives:
+        deriv_line = "Unlocks: " + ", ".join(d.get("id", d) if isinstance(d, dict) else d for d in derivatives[:4])
+        if len(derivatives) > 4:
+            deriv_line += f" +{len(derivatives) - 4} more"
+        lines.append(f"{bc}{V}{r} {fg(*COLOR_MUTED)}{_pad(deriv_line, inner)}{r} {bc}{V}{r}")
+    else:
+        lines.append(f"{bc}{V}{r} {fg(*COLOR_MUTED)}{_pad('Unlocks: (terminal skill)', inner)}{r} {bc}{V}{r}")
+
+    # Blank
+    lines.append(f"{bc}{V}{r} {' ' * inner} {bc}{V}{r}")
+
+    # Actions divider + actions
+    lines.append(f"{bc}{V}{r} {fg(*COLOR_MUTED)}{H * inner}{r} {bc}{V}{r}")
+    if actions:
+        actions_str = "  ".join(actions)
+        lines.append(f"{bc}{V}{r} {bold()}{_pad(actions_str, inner)}{r} {bc}{V}{r}")
+
+    # Owned badge
+    if owned:
+        badge = f"{fg(*COLOR_GOLD)}★ OWNED{r}"
+        lines.append(f"{bc}{V}{r} {badge}{' ' * (inner - 7)} {bc}{V}{r}")
+
+    # Bottom border
+    lines.append(f"{bc}{BL}{H * (width - 2)}{BR}{r}")
+
+    return "\n".join(lines)
+
+
+# ─── Unlock celebration ────────────────────────────────────────────────────
+
+
+def render_unlock_card(skill_data: dict, new_paths: list) -> str:
+    """Celebratory unlock card with ASCII art."""
+    tier = skill_data.get("type", "basic")
+    tc = TIER_COLORS.get(tier, (56, 189, 248))
+    name = skill_data.get("name", skill_data.get("id", "?"))
+    glyph = TIER_GLYPHS.get(tier, "○")
+    level = skill_data.get("level", "0")
+    rarity = skill_data.get("rarity", "common")
+
+    gc = fg(*COLOR_GOLD)
+    tc_fg = fg(*tc)
+    r = reset()
+    b = bold()
+
+    art = [
+        f"{gc}        ✦  ·  ✦        {r}",
+        f"{gc}     ·  ╱────╲  ·     {r}",
+        f"{gc}    ✦  │ {tc_fg}{glyph}{glyph}{glyph}{glyph}{gc} │  ✦    {r}",
+        f"{gc}     ·  ╲────╱  ·     {r}",
+        f"{gc}        ✦  ·  ✦        {r}",
+        f"",
+        f"    {b}{gc}═══ SKILL UNLOCKED ═══{r}",
+        f"",
+        f"    {tc_fg}{b}{glyph} {name}{r}",
+        f"    {fg(*COLOR_MUTED)}Level {level} • {tier.capitalize()} • {rarity}{r}",
+    ]
+
+    if new_paths:
+        art.append(f"")
+        art.append(f"    {fg(*COLOR_TEXT)}New paths opened:{r}")
+        for p in new_paths[:4]:
+            pname = p.get("name", p.get("skillId", "?")) if isinstance(p, dict) else p
+            dist = p.get("distance", "?") if isinstance(p, dict) else "?"
+            art.append(f"      {fg(*COLOR_MUTED)}→{r} {pname} ({dist} away)")
+
+    return "\n".join(art)
+
+
+# ─── Path summary ─────────────────────────────────────────────────────────
+
+
+def render_path_summary(paths: dict) -> str:
+    """Compact summary of progression state."""
+    near = len(paths.get("nearUnlocks", []))
+    one = len(paths.get("oneAway", []))
+    avail = len(paths.get("availablePaths", []))
+
+    gc = fg(*COLOR_GOLD)
+    mc = fg(*COLOR_MUTED)
+    r = reset()
+    b = bold()
+
+    parts = []
+    if near:
+        parts.append(f"{gc}{b}{near}{r} ready to fuse")
+    if one:
+        parts.append(f"{b}{one}{r} one away")
+    if avail:
+        parts.append(f"{mc}{avail}{r} reachable")
+
+    if not parts:
+        return f"{mc}No progression paths from current state.{r}"
+
+    return f"⚡ {' │ '.join(parts)}"
+
+
+# ─── Promotion prompt ──────────────────────────────────────────────────────
+
+
+def render_promotion_prompt(skill_data: dict, proposed_level: str) -> str:
+    """Prompt shown when a skill is eligible for promotion."""
+    name = skill_data.get("name", skill_data.get("id", "?"))
+    skill_id = skill_data.get("id", "?")
+    gc = fg(*COLOR_GOLD)
+    r = reset()
+    b = bold()
+
+    from gaia_cli.promotion import LEVEL_NAMES
+    level_name = LEVEL_NAMES.get(proposed_level, proposed_level)
+
+    return "\n".join([
+        f"",
+        f"  {gc}┌─ Promotion Available ─────────────────────┐{r}",
+        f"  {gc}│{r}  {b}{name}{r} can advance to {b}Level {proposed_level}{r} ({level_name})",
+        f"  {gc}│{r}  Run: {b}gaia promote {skill_id}{r}",
+        f"  {gc}│{r}  Rename? {dim()}gaia promote {skill_id} --name \"My Name\"{r}",
+        f"  {gc}└───────────────────────────────────────────┘{r}",
+        f"",
+    ])

--- a/src/gaia_cli/hook.py
+++ b/src/gaia_cli/hook.py
@@ -1,0 +1,123 @@
+"""Claude Code hook integration for Gaia skill scanning.
+
+Entry point invoked by Claude Code PostToolUse hook after file edits.
+Orchestrates scan → path computation → unlock/promotion notifications.
+"""
+
+import json
+import os
+import sys
+
+from gaia_cli.scanner import load_config, scan_repo_detailed
+from gaia_cli.resolver import resolve_skills
+from gaia_cli.registry import registry_graph_path, resolve_registry_path
+from gaia_cli.treeManager import load_tree
+from gaia_cli.pathEngine import compute_paths, load_paths, save_paths, diff_paths
+from gaia_cli.cardRenderer import render_unlock_card, render_path_summary, render_promotion_prompt
+
+
+def should_trigger(changed_files: list[str] | None, config: dict) -> bool:
+    """Check if changed files overlap with configured scan paths."""
+    if not changed_files:
+        return True  # No file info — trigger anyway (safe default)
+    scan_paths = config.get("scanPaths", [])
+    if not scan_paths:
+        return True
+    for f in changed_files:
+        normalized = f.replace("\\", "/")
+        for sp in scan_paths:
+            if normalized.startswith(sp.replace("\\", "/")):
+                return True
+    return False
+
+
+def hook_entry(event: str = "file_edit", registry_path: str | None = None) -> None:
+    """
+    Entry point called by Claude Code hook or `gaia _hook`.
+
+    1. Checks .gaia/config.json exists
+    2. Loads previous paths
+    3. Runs scan + resolve + compute
+    4. Diffs old vs new paths
+    5. If new nearUnlocks: prints unlock card(s)
+    6. If promotions available: prints promotion prompt
+    7. Saves updated paths
+    """
+    config = load_config()
+    if not config:
+        return  # Not a Gaia-initialized repo
+
+    registry = resolve_registry_path(registry_path)
+    username = config.get("gaiaUser")
+    if not username:
+        return
+
+    # Load previous state
+    old_paths = load_paths()
+
+    # Run scan pipeline
+    try:
+        scan_result = scan_repo_detailed()
+    except Exception:
+        return  # Scan failure shouldn't crash the hook
+
+    tokens = scan_result.get("tokens", set())
+    graph_path = registry_graph_path(registry)
+    if not os.path.exists(graph_path):
+        return
+
+    detected_ids = resolve_skills(list(tokens), graph_path)
+
+    # Load user tree
+    tree_data = load_tree(username, registry)
+    owned_ids = []
+    if tree_data:
+        owned_ids = [s.get("skillId") for s in tree_data.get("unlockedSkills", [])]
+
+    # Load graph
+    try:
+        with open(graph_path, "r", encoding="utf-8") as f:
+            graph_data = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return
+
+    # Compute new paths
+    new_paths = compute_paths(graph_data, owned_ids, detected_ids)
+    new_paths["userId"] = username
+
+    # Diff
+    changes = diff_paths(old_paths, new_paths)
+
+    # Build skill lookup
+    skill_map = {s["id"]: s for s in graph_data.get("skills", [])}
+
+    # Render unlock cards for new near-unlocks
+    if changes.get("new_near_unlocks"):
+        for skill_id in changes["new_near_unlocks"]:
+            skill = skill_map.get(skill_id)
+            if skill:
+                # Find newly opened paths from this unlock
+                opened = [
+                    p for p in new_paths.get("availablePaths", [])
+                    if p.get("distance", 99) <= 2
+                ]
+                print(render_unlock_card(skill, opened[:3]))
+                print()
+
+    # Show path summary if anything changed
+    if changes.get("new_near_unlocks") or changes.get("new_one_away"):
+        print(render_path_summary(new_paths))
+        print()
+
+    # Show promotion prompts
+    if changes.get("promotions_available"):
+        from gaia_cli.promotion import check_promotion_eligibility
+        if tree_data:
+            eligible = check_promotion_eligibility(graph_data, tree_data)
+            for promo in eligible[:2]:
+                skill = skill_map.get(promo["skillId"])
+                if skill:
+                    print(render_promotion_prompt(skill, promo.get("nextLevel", "II")))
+
+    # Persist
+    save_paths(new_paths)

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -19,6 +19,23 @@ from gaia_cli.registry import (
     require_explicit_writable_registry,
     resolve_registry_path,
 )
+from gaia_cli.pathEngine import compute_paths, load_paths, save_paths, diff_paths
+from gaia_cli.cardRenderer import (
+    render_card,
+    render_appraise_card,
+    render_unlock_card,
+    render_path_summary,
+    render_promotion_prompt,
+    load_and_render,
+)
+from gaia_cli.promotion import (
+    check_promotion_eligibility,
+    promote_skill,
+    promotion_state,
+    next_level,
+    LEVEL_NAMES,
+)
+from gaia_cli.hook import hook_entry
 
 DEFAULT_REGISTRY_REF = "https://github.com/mbtiongson1/gaia-skill-tree"
 
@@ -48,23 +65,26 @@ def scan_command(args):
     if not config:
         print("Gaia not initialized. Run `gaia init` first.")
         return
-    print("Scanning repository...")
+    quiet = getattr(args, 'quiet', False)
+    if not quiet:
+        print("Scanning repository...")
     scan_result = scan_repo_detailed()
     raw_tokens = scan_result["tokens"]
     graph_path = registry_graph_path(args.registry)
     resolved = resolve_skills(raw_tokens, registry_path=graph_path)
-    print(
-        f"Scanned {scan_result['files_scanned']} file(s) across "
-        f"{len(scan_result['paths_found'])} configured path(s)."
-    )
-    if scan_result["paths_missing"]:
-        print("Missing scan paths: " + ", ".join(scan_result["paths_missing"]))
-    print(f"Found {scan_result['candidate_count']} candidate token(s).")
-    print(f"Matched {len(resolved)} canonical skill(s).")
-    if resolved:
-        print(", ".join(resolved))
-    else:
-        print('Tip: try `gaia search "code review"` or expand scanPaths.')
+    if not quiet:
+        print(
+            f"Scanned {scan_result['files_scanned']} file(s) across "
+            f"{len(scan_result['paths_found'])} configured path(s)."
+        )
+        if scan_result["paths_missing"]:
+            print("Missing scan paths: " + ", ".join(scan_result["paths_missing"]))
+        print(f"Found {scan_result['candidate_count']} candidate token(s).")
+        print(f"Matched {len(resolved)} canonical skill(s).")
+        if resolved:
+            print(", ".join(resolved))
+        else:
+            print('Tip: try `gaia search "code review"` or expand scanPaths.')
     username = config.get('gaiaUser')
     tree = load_tree(username, registry_path=args.registry)
     if tree:
@@ -72,11 +92,42 @@ def scan_command(args):
             graph_data = json.load(f)
         unlocked = [s.get('skillId') for s in tree.get('unlockedSkills', [])]
         combos = get_combinations(graph_data, unlocked, resolved)
-        if combos:
+        if combos and not quiet:
             print("\nNew combination candidates detected:")
             for c in combos:
                 print(f"- {c['candidateResult']} (Requires: {', '.join(c['detectedSkills'])})")
             print("Run `gaia fuse [skillId]` to confirm and add to your tree.")
+
+        # Path engine integration
+        old_paths = load_paths()
+        owned_ids = [s.get('skillId') for s in tree.get('unlockedSkills', [])]
+        new_paths = compute_paths(graph_data, owned_ids, resolved)
+        new_paths["userId"] = username
+        changes = diff_paths(old_paths, new_paths)
+        save_paths(new_paths)
+
+        # Show unlock cards for newly reachable skills
+        skill_map = {s['id']: s for s in graph_data.get('skills', [])}
+        if changes.get("new_near_unlocks"):
+            print()
+            for sid in changes["new_near_unlocks"]:
+                skill = skill_map.get(sid)
+                if skill:
+                    opened = [p for p in new_paths.get("availablePaths", []) if p.get("distance", 99) <= 2]
+                    print(render_unlock_card(skill, opened[:3]))
+                    print()
+
+        # Path summary
+        if new_paths.get("nearUnlocks") or new_paths.get("oneAway"):
+            print(render_path_summary(new_paths))
+
+        # Promotion hints
+        eligible = check_promotion_eligibility(graph_data, tree)
+        if eligible:
+            for promo in eligible[:2]:
+                skill = skill_map.get(promo["skillId"])
+                if skill:
+                    print(render_promotion_prompt(skill, promo.get("nextLevel", "II")))
 
 def status_command(args):
     config = load_config()
@@ -94,6 +145,187 @@ def status_command(args):
         print(f"Or create users/{username}/skill-tree.json in the registry.")
         return
     show_status(tree)
+
+
+def appraise_command(args):
+    """Render an appraise card for a skill."""
+    config = load_config()
+    if not config:
+        print("Gaia not initialized. Run `gaia init` first.")
+        return
+
+    graph_path = registry_graph_path(args.registry)
+    if not os.path.exists(graph_path):
+        print("Registry graph not found.")
+        return
+
+    with open(graph_path, 'r', encoding='utf-8') as f:
+        graph_data = json.load(f)
+
+    skill_map = {s['id']: s for s in graph_data.get('skills', [])}
+    username = config.get('gaiaUser')
+    tree = load_tree(username, registry_path=args.registry)
+
+    # Determine which skill to appraise
+    skill_id = getattr(args, 'skillId', None)
+    if not skill_id:
+        # Default: most recently unlocked skill
+        if tree and tree.get('unlockedSkills'):
+            sorted_skills = sorted(
+                tree['unlockedSkills'],
+                key=lambda s: s.get('unlockedAt', ''),
+                reverse=True,
+            )
+            skill_id = sorted_skills[0]['skillId']
+        else:
+            # Fall back to most recent near-unlock from paths
+            paths = load_paths()
+            if paths and paths.get('nearUnlocks'):
+                skill_id = paths['nearUnlocks'][0]['skillId']
+            else:
+                print("No skill to appraise. Pass a skill ID or run `gaia scan` first.")
+                return
+
+    skill = skill_map.get(skill_id)
+    if not skill:
+        print(f"Skill '{skill_id}' not found in registry.")
+        return
+
+    # Build prereq status
+    owned_ids = set()
+    if tree:
+        owned_ids = {s['skillId'] for s in tree.get('unlockedSkills', [])}
+    # Also include detected skills from paths
+    paths = load_paths()
+    detected_ids = set()
+    if paths:
+        for nu in paths.get("nearUnlocks", []):
+            detected_ids.update(nu.get("satisfiedPrereqs", []))
+        for oa in paths.get("oneAway", []):
+            detected_ids.update(oa.get("satisfiedPrereqs", []))
+    available = owned_ids | detected_ids
+
+    prereq_status = {}
+    for p in skill.get('prerequisites', []):
+        prereq_status[p] = p in available
+
+    # Derivatives
+    derivatives = []
+    for d_id in skill.get('derivatives', []):
+        d_skill = skill_map.get(d_id)
+        if d_skill:
+            derivatives.append(d_skill)
+        else:
+            derivatives.append({"id": d_id, "name": d_id, "type": "unknown"})
+
+    # Contextual actions
+    owned = skill_id in owned_ids
+    actions = []
+    if not owned and all(prereq_status.values()) and prereq_status:
+        actions.append("[F] Fuse")
+    if owned:
+        state = promotion_state(skill_id, tree, graph_data)
+        if state == "eligible":
+            actions.append("[P] Promote")
+    actions.append("[S] Scan")
+    if derivatives:
+        actions.append("[→] Paths")
+
+    print(render_appraise_card(skill, prereq_status, derivatives, actions, owned=owned))
+
+
+def promote_command(args):
+    """Run promotion flow for an eligible skill."""
+    config = load_config()
+    if not config:
+        print("Gaia not initialized.")
+        return
+
+    username = config.get('gaiaUser')
+    graph_path = registry_graph_path(args.registry)
+
+    if not os.path.exists(graph_path):
+        print("Registry graph not found.")
+        return
+
+    with open(graph_path, 'r', encoding='utf-8') as f:
+        graph_data = json.load(f)
+
+    tree = load_tree(username, registry_path=args.registry)
+    if not tree:
+        print(f"No skill tree found for user '{username}'.")
+        return
+
+    skill_id = getattr(args, 'skillId', None)
+    display_name = getattr(args, 'name', None)
+
+    if not skill_id:
+        # Auto-select first eligible
+        eligible = check_promotion_eligibility(graph_data, tree)
+        if not eligible:
+            print("No skills eligible for promotion.")
+            return
+        skill_id = eligible[0]["skillId"]
+        print(f"Auto-selected: {skill_id}")
+
+    # Check state
+    state = promotion_state(skill_id, tree, graph_data)
+    if state == "not_unlocked":
+        print(f"Skill '{skill_id}' is not in your tree.")
+        return
+    elif state == "max_level":
+        print(f"Skill '{skill_id}' is already at maximum level.")
+        return
+    elif state == "blocked":
+        print(f"Skill '{skill_id}' cannot be promoted (evidence requirements not met).")
+        return
+
+    # Execute promotion
+    result = promote_skill(username, skill_id, args.registry, new_display_name=display_name)
+
+    # Show celebration
+    skill_map = {s['id']: s for s in graph_data.get('skills', [])}
+    skill = skill_map.get(skill_id, {"id": skill_id, "name": skill_id, "type": "basic"})
+    level_name = LEVEL_NAMES.get(result["newLevel"], result["newLevel"])
+    print(f"\n✦ {skill.get('name', skill_id)} promoted to Level {result['newLevel']} ({level_name})!")
+    if display_name:
+        print(f"  Renamed to: {display_name}")
+    print()
+
+
+def paths_command(args):
+    """Display current progression paths."""
+    paths = load_paths()
+    if not paths:
+        print("No paths computed yet. Run `gaia scan` first.")
+        return
+
+    print(render_path_summary(paths))
+    print()
+
+    near = paths.get("nearUnlocks", [])
+    if near:
+        print("Ready to fuse:")
+        for n in near:
+            print(f"  ◇ {n.get('name', n['skillId'])} ({n.get('type', '?')})")
+            prereqs = n.get('satisfiedPrereqs', [])
+            if prereqs:
+                print(f"    from: {', '.join(prereqs)}")
+        print()
+
+    one_away = paths.get("oneAway", [])
+    if one_away:
+        print("One prerequisite away:")
+        for o in one_away[:8]:
+            print(f"  ○ {o.get('name', o['skillId'])} — missing: {o.get('missingPrereq', '?')}")
+        if len(one_away) > 8:
+            print(f"  ... and {len(one_away) - 8} more")
+        print()
+
+
+def hook_command(args):
+    """Internal command invoked by Claude Code hook."""
+    hook_entry(event=getattr(args, 'event', 'file_edit'))
 
 
 def doctor_command(args):
@@ -300,6 +532,11 @@ def uninstall_command(args):
 
 
 def main():
+    # Ensure UTF-8 output on Windows (avoids cp1252 UnicodeEncodeError for box-drawing)
+    if sys.platform == "win32" and hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
     parser = argparse.ArgumentParser(prog="gaia", description="Gaia Plugin CLI")
     parser.add_argument(
         '--registry',
@@ -317,7 +554,8 @@ def main():
         action='store_true',
         help='Enable automatic prompts for detected skill combinations',
     )
-    subparsers.add_parser('scan')
+    scan_parser = subparsers.add_parser('scan')
+    scan_parser.add_argument('--quiet', action='store_true', help="Suppress scan output; only show notifications")
     subparsers.add_parser('status')
     subparsers.add_parser('doctor')
     subparsers.add_parser('tree')
@@ -357,6 +595,15 @@ def main():
     graph_parser.add_argument('--no-open', dest='open', action='store_false', help="Do not open the generated graph")
     uninstall_parser = subparsers.add_parser('uninstall', help="Uninstall a named skill")
     uninstall_parser.add_argument('skill_id', help="Named skill ID to uninstall (e.g. karpathy/autoresearch)")
+    # --- New commands ---
+    appraise_parser = subparsers.add_parser('appraise', help="Inspect a skill card with status and actions")
+    appraise_parser.add_argument('skillId', nargs='?', default=None, help="Skill ID to appraise (default: most recent)")
+    promote_parser = subparsers.add_parser('promote', help="Promote a skill eligible for level-up")
+    promote_parser.add_argument('skillId', nargs='?', default=None, help="Skill ID to promote (default: first eligible)")
+    promote_parser.add_argument('--name', help="Optional display name for the promoted skill")
+    subparsers.add_parser('paths', help="Show progression paths from current state")
+    hook_parser = subparsers.add_parser('_hook', help=argparse.SUPPRESS)
+    hook_parser.add_argument('--event', default='file_edit', help=argparse.SUPPRESS)
     args = parser.parse_args()
     args.registry_explicit = args.registry is not None
     args.registry = resolve_registry_path(args.registry)
@@ -389,6 +636,14 @@ def main():
         graph_command(args)
     elif args.command == 'uninstall':
         uninstall_command(args)
+    elif args.command == 'appraise':
+        appraise_command(args)
+    elif args.command == 'promote':
+        promote_command(args)
+    elif args.command == 'paths':
+        paths_command(args)
+    elif args.command == '_hook':
+        hook_command(args)
     else:
         parser.print_help()
 

--- a/src/gaia_cli/pathEngine.py
+++ b/src/gaia_cli/pathEngine.py
@@ -1,0 +1,203 @@
+"""Compute and persist available progression paths for a user."""
+
+import json
+import os
+from collections import deque
+from datetime import datetime, timezone
+
+from gaia_cli.registry import registry_graph_path, resolve_registry_path
+from gaia_cli.resolver import resolve_skills
+from gaia_cli.scanner import load_config, scan_repo_detailed
+from gaia_cli.treeManager import load_tree
+
+PATHS_FILE = ".gaia/paths.json"
+MAX_BFS_DISTANCE = 5
+
+
+def compute_paths(graph_data: dict, owned_ids: list, detected_ids: list) -> dict:
+    """
+    Compute progression paths from current state.
+
+    Args:
+        graph_data: parsed gaia.json
+        owned_ids: list of skill IDs the user has unlocked
+        detected_ids: list of skill IDs detected in the repo (resolved from scanner)
+
+    Returns dict with:
+        - nearUnlocks: skills whose ALL prerequisites are in (owned | detected), not already owned
+        - oneAway: skills missing exactly 1 prerequisite
+        - availablePaths: BFS forward from owned through derivatives, with distance
+        - computedAt: ISO timestamp
+    """
+    available = set(owned_ids) | set(detected_ids)
+    skill_map = {s["id"]: s for s in graph_data.get("skills", [])}
+
+    near_unlocks = []
+    one_away = []
+
+    for skill in graph_data.get("skills", []):
+        if skill.get("type") not in ("extra", "ultimate"):
+            continue
+        sid = skill["id"]
+        if sid in available:
+            continue
+        prereqs = skill.get("prerequisites", [])
+        missing = [p for p in prereqs if p not in available]
+        if len(missing) == 0:
+            near_unlocks.append({
+                "skillId": sid,
+                "name": skill.get("name", sid),
+                "type": skill.get("type"),
+                "satisfiedPrereqs": prereqs,
+            })
+        elif len(missing) == 1:
+            one_away.append({
+                "skillId": sid,
+                "name": skill.get("name", sid),
+                "type": skill.get("type"),
+                "missingPrereq": missing[0],
+                "satisfiedPrereqs": [p for p in prereqs if p in available],
+            })
+
+    # BFS forward from owned through derivatives
+    available_paths = {}
+    owned_set = set(owned_ids)
+    queue = deque()
+
+    for sid in owned_ids:
+        if sid in skill_map:
+            for deriv in skill_map[sid].get("derivatives", []):
+                if deriv not in owned_set and deriv in skill_map:
+                    if deriv not in available_paths:
+                        available_paths[deriv] = 1
+                        queue.append((deriv, 1))
+
+    while queue:
+        current_id, dist = queue.popleft()
+        if dist >= MAX_BFS_DISTANCE:
+            continue
+        current_skill = skill_map.get(current_id)
+        if not current_skill:
+            continue
+        for deriv in current_skill.get("derivatives", []):
+            if deriv not in owned_set and deriv in skill_map:
+                new_dist = dist + 1
+                if deriv not in available_paths or available_paths[deriv] > new_dist:
+                    available_paths[deriv] = new_dist
+                    queue.append((deriv, new_dist))
+
+    # Convert to list format
+    paths_list = [
+        {
+            "skillId": sid,
+            "name": skill_map[sid].get("name", sid),
+            "distance": d,
+        }
+        for sid, d in sorted(available_paths.items(), key=lambda x: x[1])
+        if sid in skill_map
+    ]
+
+    return {
+        "nearUnlocks": near_unlocks,
+        "oneAway": one_away,
+        "availablePaths": paths_list,
+        "computedAt": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def regenerate_paths(registry_path: str) -> dict:
+    """
+    Full pipeline: load config, load user tree, scan+resolve, compute paths,
+    save to .gaia/paths.json. Returns the computed paths dict.
+    """
+    config = load_config()
+    if not config:
+        raise RuntimeError("No .gaia/config.json found. Run 'gaia init' first.")
+
+    username = config.get("gaiaUser")
+    if not username:
+        raise RuntimeError("No gaiaUser set in .gaia/config.json.")
+
+    # Load user's skill tree
+    tree_data = load_tree(username, registry_path)
+    owned_ids = []
+    if tree_data:
+        for entry in tree_data.get("unlockedSkills", []):
+            owned_ids.append(entry.get("skillId"))
+
+    # Scan repo and resolve skill tokens
+    scan_result = scan_repo_detailed()
+    tokens = scan_result.get("tokens", set())
+    graph_path = registry_graph_path(registry_path)
+    detected_ids = resolve_skills(list(tokens), graph_path)
+
+    # Load graph data
+    with open(graph_path, "r", encoding="utf-8") as f:
+        graph_data = json.load(f)
+
+    # Compute paths
+    paths = compute_paths(graph_data, owned_ids, detected_ids)
+    paths["userId"] = username
+
+    # Save
+    save_paths(paths)
+    return paths
+
+
+def load_paths() -> dict | None:
+    """Load .gaia/paths.json, return None if doesn't exist."""
+    if not os.path.exists(PATHS_FILE):
+        return None
+    with open(PATHS_FILE, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_paths(paths: dict) -> None:
+    """Write .gaia/paths.json with proper encoding."""
+    os.makedirs(os.path.dirname(PATHS_FILE), exist_ok=True)
+    with open(PATHS_FILE, "w", encoding="utf-8") as f:
+        json.dump(paths, f, indent=2, ensure_ascii=False)
+
+
+def diff_paths(old_paths: dict | None, new_paths: dict) -> dict:
+    """
+    Compare old vs new paths.
+
+    Returns:
+        {
+            "new_near_unlocks": [skill_ids newly in nearUnlocks],
+            "new_one_away": [skill_ids newly in oneAway],
+            "promotions_available": [skill_ids whose derivatives just got near-unlocked]
+        }
+    """
+    new_near_ids = {e["skillId"] for e in new_paths.get("nearUnlocks", [])}
+    new_one_away_ids = {e["skillId"] for e in new_paths.get("oneAway", [])}
+
+    if old_paths is None:
+        old_near_ids = set()
+        old_one_away_ids = set()
+    else:
+        old_near_ids = {e["skillId"] for e in old_paths.get("nearUnlocks", [])}
+        old_one_away_ids = {e["skillId"] for e in old_paths.get("oneAway", [])}
+
+    newly_near = new_near_ids - old_near_ids
+    newly_one_away = new_one_away_ids - old_one_away_ids
+
+    # promotions_available: owned skills whose derivatives just appeared in nearUnlocks
+    # We need owned skill info from the new_paths context; use userId to infer,
+    # but since we don't store owned_ids in paths, we check which skills
+    # have derivatives in the newly_near set by looking at availablePaths distance=1
+    # Actually, we can infer from the nearUnlocks satisfiedPrereqs:
+    # any prerequisite that is satisfied (i.e., owned or detected) and whose
+    # derivative just appeared in nearUnlocks means that prereq is promotion-eligible.
+    promotions = set()
+    for entry in new_paths.get("nearUnlocks", []):
+        if entry["skillId"] in newly_near:
+            for prereq in entry.get("satisfiedPrereqs", []):
+                promotions.add(prereq)
+
+    return {
+        "new_near_unlocks": sorted(newly_near),
+        "new_one_away": sorted(newly_one_away),
+        "promotions_available": sorted(promotions),
+    }

--- a/src/gaia_cli/promotion.py
+++ b/src/gaia_cli/promotion.py
@@ -1,0 +1,194 @@
+"""Skill-tree level promotion logic.
+
+Provides helpers to check promotion eligibility, advance a skill's level,
+and inspect the current promotion state for a given skill.
+"""
+
+import json
+import os
+from datetime import date
+
+from .treeManager import load_tree, save_tree
+
+LEVEL_ORDER = ["0", "I", "II", "III", "IV", "V", "VI"]
+LEVEL_NAMES = {
+    "0": "Basic",
+    "I": "Awakened",
+    "II": "Named",
+    "III": "Evolved",
+    "IV": "Hardened",
+    "V": "Transcendent",
+    "VI": "Transcendent ★",
+}
+
+# Evidence class floors per level — None means no evidence required.
+EVIDENCE_FLOOR = {
+    "0": None,
+    "I": None,
+    "II": {"C", "B", "A"},
+    "III": {"B", "A"},
+    "IV": {"B", "A"},
+    "V": {"B", "A"},
+    "VI": {"A"},
+}
+
+
+def next_level(current: str) -> str | None:
+    """Return the next level string, or None if already at max."""
+    try:
+        idx = LEVEL_ORDER.index(current)
+    except ValueError:
+        return None
+    if idx >= len(LEVEL_ORDER) - 1:
+        return None
+    return LEVEL_ORDER[idx + 1]
+
+
+def _get_skill_from_graph(graph_data: dict, skill_id: str) -> dict | None:
+    """Look up a skill node by ID in the graph data."""
+    for skill in graph_data.get("skills", []):
+        if skill["id"] == skill_id:
+            return skill
+    return None
+
+
+def _get_skill_from_tree(tree_data: dict, skill_id: str) -> dict | None:
+    """Look up a skill entry by ID in the user's tree."""
+    for entry in tree_data.get("unlockedSkills", []):
+        if entry["skillId"] == skill_id:
+            return entry
+    return None
+
+
+def _meets_evidence_floor(graph_skill: dict, target_level: str) -> bool:
+    """Check whether the graph skill has evidence meeting the floor for target_level."""
+    required_classes = EVIDENCE_FLOOR.get(target_level)
+    if required_classes is None:
+        return True
+    evidence_list = graph_skill.get("evidence", [])
+    for ev in evidence_list:
+        if ev.get("class") in required_classes:
+            return True
+    return False
+
+
+def check_promotion_eligibility(graph_data: dict, tree_data: dict) -> list[dict]:
+    """Return a list of skills eligible for promotion.
+
+    Each entry is a dict with keys:
+        - skillId: the skill identifier
+        - currentLevel: the level in the user's tree
+        - nextLevel: the level it would be promoted to
+        - name: display name from the graph
+    """
+    eligible = []
+    for entry in tree_data.get("unlockedSkills", []):
+        skill_id = entry["skillId"]
+        current = entry["level"]
+        target = next_level(current)
+        if target is None:
+            continue
+        graph_skill = _get_skill_from_graph(graph_data, skill_id)
+        if graph_skill is None:
+            continue
+        if _meets_evidence_floor(graph_skill, target):
+            eligible.append({
+                "skillId": skill_id,
+                "currentLevel": current,
+                "nextLevel": target,
+                "name": graph_skill.get("name", skill_id),
+            })
+    return eligible
+
+
+def promote_skill(
+    username: str,
+    skill_id: str,
+    registry_path: str,
+    new_display_name: str | None = None,
+) -> dict:
+    """Promote a skill to the next level in the user's tree.
+
+    Args:
+        username: GitHub username.
+        skill_id: The skill ID to promote.
+        registry_path: Path to the registry root (where users/ lives).
+        new_display_name: Optional new display name (unused in tree storage
+            but returned in the result dict for downstream consumers).
+
+    Returns:
+        A dict with keys: skillId, previousLevel, newLevel, displayName.
+
+    Raises:
+        ValueError: If the skill is not found in the tree or is already at max level.
+    """
+    tree_data = load_tree(username, registry_path)
+    if tree_data is None:
+        raise ValueError(f"No skill tree found for user '{username}'.")
+
+    entry = _get_skill_from_tree(tree_data, skill_id)
+    if entry is None:
+        raise ValueError(f"Skill '{skill_id}' not found in {username}'s tree.")
+
+    current = entry["level"]
+    target = next_level(current)
+    if target is None:
+        raise ValueError(
+            f"Skill '{skill_id}' is already at maximum level ({current})."
+        )
+
+    # Update the level in-place
+    entry["level"] = target
+
+    # Update the tree's updatedAt timestamp
+    tree_data["updatedAt"] = date.today().isoformat()
+
+    save_tree(username, tree_data, registry_path)
+
+    # Load graph to get display name if not provided
+    display_name = new_display_name
+    if display_name is None:
+        graph_path = os.path.join(registry_path, "graph", "gaia.json")
+        if os.path.exists(graph_path):
+            with open(graph_path, "r", encoding="utf-8") as f:
+                graph_data = json.load(f)
+            graph_skill = _get_skill_from_graph(graph_data, skill_id)
+            if graph_skill:
+                display_name = graph_skill.get("name", skill_id)
+        if display_name is None:
+            display_name = skill_id
+
+    return {
+        "skillId": skill_id,
+        "previousLevel": current,
+        "newLevel": target,
+        "displayName": display_name,
+    }
+
+
+def promotion_state(skill_id: str, tree_data: dict, graph_data: dict) -> str:
+    """Return the promotion state for a skill.
+
+    Possible return values:
+        - "not_unlocked" — skill is not in the user's tree
+        - "max_level" — skill is already at max level (VI)
+        - "eligible" — skill can be promoted (evidence requirement met)
+        - "blocked" — next level requires evidence the graph skill lacks
+    """
+    entry = _get_skill_from_tree(tree_data, skill_id)
+    if entry is None:
+        return "not_unlocked"
+
+    current = entry["level"]
+    target = next_level(current)
+    if target is None:
+        return "max_level"
+
+    graph_skill = _get_skill_from_graph(graph_data, skill_id)
+    if graph_skill is None:
+        return "blocked"
+
+    if _meets_evidence_floor(graph_skill, target):
+        return "eligible"
+
+    return "blocked"

--- a/src/gaia_cli/registry.py
+++ b/src/gaia_cli/registry.py
@@ -5,7 +5,7 @@ from importlib import resources
 from pathlib import Path
 
 
-WRITE_COMMANDS = {"push", "name", "fuse", "embed", "sync"}
+WRITE_COMMANDS = {"push", "name", "fuse", "embed", "sync", "promote"}
 
 
 def bundled_registry_path():

--- a/tests/test_card_renderer.py
+++ b/tests/test_card_renderer.py
@@ -1,0 +1,419 @@
+"""Tests for gaia_cli.cardRenderer."""
+
+import json
+import os
+
+import pytest
+
+from gaia_cli.cardRenderer import (
+    CARD_WIDTH,
+    TIER_GLYPHS,
+    RARITY_LABELS,
+    LEVEL_LABELS,
+    render_card,
+    render_card_compact,
+    render_cards,
+    load_and_render,
+    _pad,
+    _wrap_lines,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def basic_skill():
+    """A minimal basic-tier skill."""
+    return {
+        "id": "tokenize",
+        "name": "Tokenize",
+        "type": "basic",
+        "level": "0",
+        "rarity": "common",
+        "description": "Splits input text into discrete tokens suitable for downstream processing by language models.",
+        "prerequisites": [],
+        "derivatives": ["rag-pipeline"],
+        "evidence": [
+            {"class": "C", "source": "https://example.com", "evaluator": "tester", "date": "2026-01-01"}
+        ],
+        "status": "provisional",
+    }
+
+
+@pytest.fixture
+def extra_skill():
+    """An extra-tier skill with prerequisites."""
+    return {
+        "id": "rag-pipeline",
+        "name": "RAG Pipeline",
+        "type": "extra",
+        "level": "II",
+        "rarity": "uncommon",
+        "description": "Retrieval-augmented generation pipeline combining retrieval, ranking, and synthesis.",
+        "prerequisites": ["tokenize", "retrieve", "rank"],
+        "derivatives": ["autonomous-research-agent"],
+        "evidence": [
+            {"class": "B", "source": "https://example.com/a", "evaluator": "alice", "date": "2026-01-01"},
+            {"class": "B", "source": "https://example.com/b", "evaluator": "bob", "date": "2026-01-01"},
+        ],
+        "status": "validated",
+    }
+
+
+@pytest.fixture
+def ultimate_skill():
+    """An ultimate-tier skill."""
+    return {
+        "id": "autonomous-research-agent",
+        "name": "Autonomous Research Agent",
+        "type": "ultimate",
+        "level": "III",
+        "rarity": "legendary",
+        "description": "Fully autonomous agent that formulates hypotheses, designs experiments, collects evidence, and synthesizes findings.",
+        "prerequisites": ["rag-pipeline", "code-generation", "tool-use", "planning"],
+        "derivatives": [],
+        "evidence": [
+            {"class": "A", "source": "https://example.com/a", "evaluator": "a", "date": "2026-01-01"},
+            {"class": "B", "source": "https://example.com/b", "evaluator": "b", "date": "2026-01-01"},
+            {"class": "B", "source": "https://example.com/c", "evaluator": "c", "date": "2026-01-01"},
+        ],
+        "status": "validated",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helper function tests
+# ---------------------------------------------------------------------------
+
+
+class TestPad:
+    def test_left_pad_shorter(self):
+        assert _pad("hi", 6) == "hi    "
+
+    def test_left_pad_exact(self):
+        assert _pad("hello", 5) == "hello"
+
+    def test_truncates_long(self):
+        result = _pad("a very long string", 10)
+        assert len(result) == 10
+        assert result.endswith("…")
+
+    def test_center_alignment(self):
+        result = _pad("hi", 6, "center")
+        assert result == "  hi  "
+
+    def test_right_alignment(self):
+        result = _pad("hi", 6, "right")
+        assert result == "    hi"
+
+
+class TestWrapLines:
+    def test_short_text_single_line(self):
+        result = _wrap_lines("hello world", 20)
+        assert result == ["hello world"]
+
+    def test_long_text_wraps(self):
+        text = "one two three four five six"
+        result = _wrap_lines(text, 10)
+        for line in result:
+            assert len(line) <= 10
+
+    def test_empty_string_returns_single_empty(self):
+        result = _wrap_lines("", 20)
+        assert result == [""]
+
+    def test_single_long_word_not_broken(self):
+        result = _wrap_lines("superlongword", 5)
+        assert result == ["superlongword"]
+
+
+# ---------------------------------------------------------------------------
+# render_card tests
+# ---------------------------------------------------------------------------
+
+
+class TestRenderCard:
+    def test_basic_skill_card_structure(self, basic_skill):
+        card = render_card(basic_skill)
+        lines = card.split("\n")
+
+        # First line is top border (rounded or square)
+        assert lines[0][0] in ("┌", "╭")
+        assert lines[0][-1] in ("┐", "╮")
+        # Last line is bottom border
+        assert lines[-1][0] in ("└", "╰")
+        assert lines[-1][-1] in ("┘", "╯")
+
+    def test_contains_skill_name(self, basic_skill):
+        card = render_card(basic_skill)
+        assert "Tokenize" in card
+
+    def test_contains_tier_glyph(self, basic_skill):
+        card = render_card(basic_skill)
+        assert TIER_GLYPHS["basic"] in card
+
+    def test_contains_rarity_label(self, basic_skill):
+        card = render_card(basic_skill)
+        assert "[Common]" in card
+
+    def test_contains_level_label(self, basic_skill):
+        card = render_card(basic_skill)
+        assert "Lv.0 Basic" in card
+
+    def test_contains_description(self, basic_skill):
+        card = render_card(basic_skill)
+        # At least the first word of the description
+        assert "Splits" in card
+
+    def test_contains_prereqs_none(self, basic_skill):
+        card = render_card(basic_skill)
+        assert "Prereqs: (none)" in card
+
+    def test_contains_prereqs_listed(self, extra_skill):
+        card = render_card(extra_skill)
+        assert "tokenize" in card
+        assert "retrieve" in card
+        assert "rank" in card
+
+    def test_contains_derivatives(self, basic_skill):
+        card = render_card(basic_skill)
+        assert "rag-pipeline" in card
+
+    def test_contains_status_and_evidence(self, basic_skill):
+        card = render_card(basic_skill)
+        assert "provisional" in card
+        assert "ev:1" in card
+
+    def test_contains_skill_id_in_footer(self, basic_skill):
+        card = render_card(basic_skill)
+        assert "tokenize" in card
+
+    def test_all_lines_same_width(self, basic_skill):
+        card = render_card(basic_skill)
+        lines = card.split("\n")
+        for line in lines:
+            assert len(line) == CARD_WIDTH, f"Line width {len(line)} != {CARD_WIDTH}: {repr(line)}"
+
+    def test_custom_width(self, basic_skill):
+        card = render_card(basic_skill, width=60)
+        lines = card.split("\n")
+        for line in lines:
+            assert len(line) == 60
+
+    def test_extra_skill_shows_diamond(self, extra_skill):
+        card = render_card(extra_skill)
+        assert TIER_GLYPHS["extra"] in card
+
+    def test_ultimate_skill_shows_filled_diamond(self, ultimate_skill):
+        card = render_card(ultimate_skill)
+        assert TIER_GLYPHS["ultimate"] in card
+
+    def test_ultimate_skill_shows_legendary_rarity(self, ultimate_skill):
+        card = render_card(ultimate_skill)
+        assert "[Legendary]" in card
+
+    def test_long_description_truncated(self):
+        skill = {
+            "id": "verbose-skill",
+            "name": "Verbose",
+            "type": "basic",
+            "level": "0",
+            "rarity": "common",
+            "description": " ".join(["word"] * 100),
+            "prerequisites": [],
+            "derivatives": [],
+            "evidence": [],
+            "status": "provisional",
+        }
+        card = render_card(skill)
+        # Should have the "..." truncation indicator or at most 4 desc lines
+        lines = card.split("\n")
+        # Card should not be excessively long
+        assert len(lines) <= 20
+
+    def test_many_prerequisites_truncated(self):
+        skill = {
+            "id": "many-prereqs",
+            "name": "Many Prereqs",
+            "type": "ultimate",
+            "level": "IV",
+            "rarity": "epic",
+            "description": "A skill with many prerequisites.",
+            "prerequisites": [f"skill-{i}" for i in range(8)],
+            "derivatives": [],
+            "evidence": [],
+            "status": "validated",
+        }
+        card = render_card(skill)
+        # Should show some items and then "+N more" for the remainder
+        assert "+5 more" in card
+        assert "skill-0" in card
+
+    def test_many_derivatives_truncated(self):
+        skill = {
+            "id": "many-derivs",
+            "name": "Many Derivs",
+            "type": "basic",
+            "level": "0",
+            "rarity": "common",
+            "description": "A skill with many derivatives.",
+            "prerequisites": [],
+            "derivatives": [f"skill-{i}" for i in range(6)],
+            "evidence": [],
+            "status": "provisional",
+        }
+        card = render_card(skill)
+        # Should show some items and then "+N more" for the remainder
+        assert "+3 more" in card
+        assert "skill-0" in card
+
+    def test_missing_optional_fields_defaults_gracefully(self):
+        """Card should render even with minimal skill data."""
+        skill = {"id": "bare-skill"}
+        card = render_card(skill)
+        assert "bare-skill" in card
+        assert "○" in card  # defaults to basic glyph
+
+
+# ---------------------------------------------------------------------------
+# render_card_compact tests
+# ---------------------------------------------------------------------------
+
+
+class TestRenderCardCompact:
+    def test_single_line(self, basic_skill):
+        result = render_card_compact(basic_skill)
+        assert "\n" not in result
+
+    def test_contains_glyph(self, basic_skill):
+        result = render_card_compact(basic_skill)
+        assert "○" in result
+
+    def test_contains_name(self, basic_skill):
+        result = render_card_compact(basic_skill)
+        assert "Tokenize" in result
+
+    def test_contains_level(self, basic_skill):
+        result = render_card_compact(basic_skill)
+        assert "(Lv.0)" in result
+
+    def test_contains_rarity(self, basic_skill):
+        result = render_card_compact(basic_skill)
+        assert "[common]" in result
+
+    def test_long_description_truncated(self):
+        skill = {
+            "id": "x",
+            "name": "X",
+            "type": "basic",
+            "level": "0",
+            "rarity": "common",
+            "description": "A" * 100,
+        }
+        result = render_card_compact(skill)
+        assert "…" in result
+
+
+# ---------------------------------------------------------------------------
+# render_cards tests
+# ---------------------------------------------------------------------------
+
+
+class TestRenderCards:
+    def test_multiple_cards_separated(self, basic_skill, extra_skill):
+        result = render_cards([basic_skill, extra_skill])
+        # Full cards are separated by double newlines
+        assert "\n\n" in result
+        assert "Tokenize" in result
+        assert "RAG Pipeline" in result
+
+    def test_compact_mode(self, basic_skill, extra_skill):
+        result = render_cards([basic_skill, extra_skill], compact=True)
+        lines = result.split("\n")
+        assert len(lines) == 2
+
+    def test_empty_list(self):
+        result = render_cards([])
+        assert result == ""
+
+    def test_compact_empty_list(self):
+        result = render_cards([], compact=True)
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# load_and_render tests
+# ---------------------------------------------------------------------------
+
+
+class TestLoadAndRender:
+    def test_load_existing_skill(self, tmp_path):
+        """Should load and render a skill from gaia.json."""
+        graph_dir = tmp_path / "graph"
+        graph_dir.mkdir()
+        graph_data = {
+            "skills": [
+                {
+                    "id": "web-scrape",
+                    "name": "Web Scrape",
+                    "type": "basic",
+                    "level": "0",
+                    "rarity": "common",
+                    "description": "Scrapes data from web pages.",
+                    "prerequisites": [],
+                    "derivatives": [],
+                    "evidence": [],
+                    "status": "provisional",
+                }
+            ]
+        }
+        (graph_dir / "gaia.json").write_text(json.dumps(graph_data))
+
+        result = load_and_render("web-scrape", str(tmp_path))
+        assert result is not None
+        assert "Web Scrape" in result
+        assert "┌" in result or "╭" in result
+
+    def test_load_nonexistent_skill_returns_none(self, tmp_path):
+        """Should return None for a skill not in the registry."""
+        graph_dir = tmp_path / "graph"
+        graph_dir.mkdir()
+        (graph_dir / "gaia.json").write_text(json.dumps({"skills": []}))
+
+        result = load_and_render("no-such-skill", str(tmp_path))
+        assert result is None
+
+    def test_load_missing_registry_returns_none(self, tmp_path):
+        """Should return None when gaia.json does not exist."""
+        result = load_and_render("anything", str(tmp_path / "no-such-dir"))
+        assert result is None
+
+    def test_load_compact_mode(self, tmp_path):
+        """Should render in compact mode when requested."""
+        graph_dir = tmp_path / "graph"
+        graph_dir.mkdir()
+        graph_data = {
+            "skills": [
+                {
+                    "id": "classify",
+                    "name": "Classify",
+                    "type": "basic",
+                    "level": "0",
+                    "rarity": "common",
+                    "description": "Assigns labels.",
+                    "prerequisites": [],
+                    "derivatives": [],
+                    "evidence": [],
+                    "status": "provisional",
+                }
+            ]
+        }
+        (graph_dir / "gaia.json").write_text(json.dumps(graph_data))
+
+        result = load_and_render("classify", str(tmp_path), compact=True)
+        assert result is not None
+        assert "\n" not in result
+        assert "Classify" in result

--- a/tests/test_path_engine.py
+++ b/tests/test_path_engine.py
@@ -1,0 +1,364 @@
+"""Tests for gaia_cli.pathEngine."""
+
+import json
+import os
+
+import pytest
+
+from gaia_cli.pathEngine import (
+    compute_paths,
+    diff_paths,
+    load_paths,
+    save_paths,
+    regenerate_paths,
+    PATHS_FILE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mini_graph():
+    """Mini graph: 3 basic + 2 extra skills."""
+    return {
+        "skills": [
+            {
+                "id": "skill-a",
+                "name": "Skill A",
+                "type": "basic",
+                "level": "0",
+                "prerequisites": [],
+                "derivatives": ["skill-d"],
+            },
+            {
+                "id": "skill-b",
+                "name": "Skill B",
+                "type": "basic",
+                "level": "0",
+                "prerequisites": [],
+                "derivatives": ["skill-d", "skill-e"],
+            },
+            {
+                "id": "skill-c",
+                "name": "Skill C",
+                "type": "basic",
+                "level": "0",
+                "prerequisites": [],
+                "derivatives": ["skill-e"],
+            },
+            {
+                "id": "skill-d",
+                "name": "Skill D",
+                "type": "extra",
+                "level": "I",
+                "prerequisites": ["skill-a", "skill-b"],
+                "derivatives": [],
+            },
+            {
+                "id": "skill-e",
+                "name": "Skill E",
+                "type": "extra",
+                "level": "I",
+                "prerequisites": ["skill-b", "skill-c"],
+                "derivatives": [],
+            },
+        ]
+    }
+
+
+# ---------------------------------------------------------------------------
+# compute_paths tests
+# ---------------------------------------------------------------------------
+
+class TestComputePaths:
+    def test_near_unlocks_all_prereqs_met(self, mini_graph):
+        """Skill D should be near-unlock when both A and B are available."""
+        owned = ["skill-a", "skill-b"]
+        detected = []
+        result = compute_paths(mini_graph, owned, detected)
+
+        near_ids = [e["skillId"] for e in result["nearUnlocks"]]
+        assert "skill-d" in near_ids
+        # skill-e is missing skill-c, so NOT near-unlock
+        assert "skill-e" not in near_ids
+
+    def test_near_unlocks_with_detected(self, mini_graph):
+        """detected_ids count toward prerequisite satisfaction."""
+        owned = ["skill-a"]
+        detected = ["skill-b"]
+        result = compute_paths(mini_graph, owned, detected)
+
+        near_ids = [e["skillId"] for e in result["nearUnlocks"]]
+        assert "skill-d" in near_ids
+
+    def test_one_away_detection(self, mini_graph):
+        """Skill E should be one-away when only B is available (missing C)."""
+        owned = ["skill-b"]
+        detected = []
+        result = compute_paths(mini_graph, owned, detected)
+
+        one_away_entries = {e["skillId"]: e for e in result["oneAway"]}
+        assert "skill-e" in one_away_entries
+        assert one_away_entries["skill-e"]["missingPrereq"] == "skill-c"
+        assert one_away_entries["skill-e"]["satisfiedPrereqs"] == ["skill-b"]
+
+    def test_one_away_not_when_zero_missing(self, mini_graph):
+        """Skill D should NOT be in oneAway if all prereqs are met."""
+        owned = ["skill-a", "skill-b"]
+        detected = []
+        result = compute_paths(mini_graph, owned, detected)
+
+        one_away_ids = [e["skillId"] for e in result["oneAway"]]
+        assert "skill-d" not in one_away_ids
+
+    def test_already_owned_excluded(self, mini_graph):
+        """Skills already owned should not appear in nearUnlocks or oneAway."""
+        owned = ["skill-a", "skill-b", "skill-d"]
+        detected = []
+        result = compute_paths(mini_graph, owned, detected)
+
+        near_ids = [e["skillId"] for e in result["nearUnlocks"]]
+        one_away_ids = [e["skillId"] for e in result["oneAway"]]
+        assert "skill-d" not in near_ids
+        assert "skill-d" not in one_away_ids
+
+    def test_basic_skills_excluded(self, mini_graph):
+        """Basic skills never appear in nearUnlocks or oneAway."""
+        owned = []
+        detected = []
+        result = compute_paths(mini_graph, owned, detected)
+
+        all_ids = (
+            [e["skillId"] for e in result["nearUnlocks"]]
+            + [e["skillId"] for e in result["oneAway"]]
+        )
+        for sid in ["skill-a", "skill-b", "skill-c"]:
+            assert sid not in all_ids
+
+    def test_available_paths_bfs_distance(self, mini_graph):
+        """BFS from owned skill-a should find skill-d at distance 1."""
+        owned = ["skill-a"]
+        detected = []
+        result = compute_paths(mini_graph, owned, detected)
+
+        paths_map = {e["skillId"]: e["distance"] for e in result["availablePaths"]}
+        assert "skill-d" in paths_map
+        assert paths_map["skill-d"] == 1
+
+    def test_available_paths_excludes_owned(self, mini_graph):
+        """BFS should not include already-owned skills in availablePaths."""
+        owned = ["skill-a", "skill-d"]
+        detected = []
+        result = compute_paths(mini_graph, owned, detected)
+
+        paths_ids = [e["skillId"] for e in result["availablePaths"]]
+        assert "skill-a" not in paths_ids
+        assert "skill-d" not in paths_ids
+
+    def test_available_paths_multi_hop(self):
+        """BFS correctly computes multi-hop distances."""
+        graph = {
+            "skills": [
+                {"id": "s1", "name": "S1", "type": "basic", "prerequisites": [], "derivatives": ["s2"]},
+                {"id": "s2", "name": "S2", "type": "extra", "prerequisites": ["s1"], "derivatives": ["s3"]},
+                {"id": "s3", "name": "S3", "type": "extra", "prerequisites": ["s2"], "derivatives": ["s4"]},
+                {"id": "s4", "name": "S4", "type": "ultimate", "prerequisites": ["s3"], "derivatives": []},
+            ]
+        }
+        result = compute_paths(graph, ["s1"], [])
+        paths_map = {e["skillId"]: e["distance"] for e in result["availablePaths"]}
+        assert paths_map["s2"] == 1
+        assert paths_map["s3"] == 2
+        assert paths_map["s4"] == 3
+
+    def test_available_paths_capped_at_max_distance(self):
+        """BFS should not go beyond MAX_BFS_DISTANCE=5."""
+        skills = []
+        for i in range(8):
+            skills.append({
+                "id": f"s{i}",
+                "name": f"S{i}",
+                "type": "basic" if i == 0 else "extra",
+                "prerequisites": [f"s{i-1}"] if i > 0 else [],
+                "derivatives": [f"s{i+1}"] if i < 7 else [],
+            })
+        graph = {"skills": skills}
+        result = compute_paths(graph, ["s0"], [])
+        paths_map = {e["skillId"]: e["distance"] for e in result["availablePaths"]}
+        # Distance 5 should be reachable
+        assert paths_map.get("s5") == 5
+        # Distance 6 should not be
+        assert "s6" not in paths_map
+
+    def test_computed_at_present(self, mini_graph):
+        """Result should include a computedAt ISO timestamp."""
+        result = compute_paths(mini_graph, [], [])
+        assert "computedAt" in result
+        # Should be parseable as ISO format
+        from datetime import datetime
+        datetime.fromisoformat(result["computedAt"])
+
+
+# ---------------------------------------------------------------------------
+# diff_paths tests
+# ---------------------------------------------------------------------------
+
+class TestDiffPaths:
+    def test_diff_detects_new_near_unlocks(self):
+        old = {"nearUnlocks": [{"skillId": "x"}], "oneAway": []}
+        new = {"nearUnlocks": [{"skillId": "x"}, {"skillId": "y", "satisfiedPrereqs": ["a"]}], "oneAway": []}
+        diff = diff_paths(old, new)
+        assert "y" in diff["new_near_unlocks"]
+        assert "x" not in diff["new_near_unlocks"]
+
+    def test_diff_detects_new_one_away(self):
+        old = {"nearUnlocks": [], "oneAway": [{"skillId": "a"}]}
+        new = {"nearUnlocks": [], "oneAway": [{"skillId": "a"}, {"skillId": "b"}]}
+        diff = diff_paths(old, new)
+        assert "b" in diff["new_one_away"]
+        assert "a" not in diff["new_one_away"]
+
+    def test_diff_with_none_old_first_run(self):
+        """When old_paths is None (first run), everything is new."""
+        new = {
+            "nearUnlocks": [{"skillId": "x", "satisfiedPrereqs": ["p1"]}],
+            "oneAway": [{"skillId": "y"}],
+        }
+        diff = diff_paths(None, new)
+        assert "x" in diff["new_near_unlocks"]
+        assert "y" in diff["new_one_away"]
+
+    def test_diff_promotions_available(self):
+        """Prereqs of newly near-unlocked skills are promotion candidates."""
+        old = {"nearUnlocks": [], "oneAway": []}
+        new = {
+            "nearUnlocks": [{"skillId": "combo", "satisfiedPrereqs": ["base-a", "base-b"]}],
+            "oneAway": [],
+        }
+        diff = diff_paths(old, new)
+        assert "base-a" in diff["promotions_available"]
+        assert "base-b" in diff["promotions_available"]
+
+    def test_diff_no_changes(self):
+        paths = {"nearUnlocks": [{"skillId": "x", "satisfiedPrereqs": []}], "oneAway": [{"skillId": "y"}]}
+        diff = diff_paths(paths, paths)
+        assert diff["new_near_unlocks"] == []
+        assert diff["new_one_away"] == []
+        assert diff["promotions_available"] == []
+
+
+# ---------------------------------------------------------------------------
+# save_paths / load_paths round-trip
+# ---------------------------------------------------------------------------
+
+class TestPersistence:
+    def test_save_load_round_trip(self, tmp_path, monkeypatch):
+        """save_paths then load_paths should return the same data."""
+        paths_file = str(tmp_path / ".gaia" / "paths.json")
+        monkeypatch.setattr("gaia_cli.pathEngine.PATHS_FILE", paths_file)
+
+        data = {
+            "nearUnlocks": [{"skillId": "test-skill", "satisfiedPrereqs": ["a", "b"]}],
+            "oneAway": [],
+            "availablePaths": [{"skillId": "far", "name": "Far", "distance": 3}],
+            "computedAt": "2026-01-01T00:00:00+00:00",
+            "userId": "testuser",
+        }
+        save_paths(data)
+        loaded = load_paths()
+        assert loaded == data
+
+    def test_load_paths_returns_none_when_missing(self, tmp_path, monkeypatch):
+        """load_paths returns None when the file does not exist."""
+        monkeypatch.setattr("gaia_cli.pathEngine.PATHS_FILE", str(tmp_path / "nope.json"))
+        assert load_paths() is None
+
+    def test_save_paths_creates_directory(self, tmp_path, monkeypatch):
+        """save_paths creates the parent directory if it doesn't exist."""
+        paths_file = str(tmp_path / "nested" / "dir" / "paths.json")
+        monkeypatch.setattr("gaia_cli.pathEngine.PATHS_FILE", paths_file)
+        save_paths({"test": True})
+        assert os.path.exists(paths_file)
+
+
+# ---------------------------------------------------------------------------
+# regenerate_paths (integration with mocks)
+# ---------------------------------------------------------------------------
+
+class TestRegeneratePaths:
+    def test_regenerate_paths_end_to_end(self, tmp_path, monkeypatch):
+        """Full pipeline with mocked scanner/resolver/tree/graph."""
+        # Setup .gaia/config.json
+        gaia_dir = tmp_path / ".gaia"
+        gaia_dir.mkdir()
+        config = {"gaiaUser": "alice", "scanPaths": ["src"]}
+        (gaia_dir / "config.json").write_text(json.dumps(config))
+
+        # Setup user tree
+        user_dir = tmp_path / "users" / "alice"
+        user_dir.mkdir(parents=True)
+        tree = {
+            "userId": "alice",
+            "unlockedSkills": [
+                {"skillId": "web-scrape", "level": "0"},
+                {"skillId": "parse-json", "level": "0"},
+            ],
+        }
+        (user_dir / "skill-tree.json").write_text(json.dumps(tree))
+
+        # Setup graph
+        graph_dir = tmp_path / "graph"
+        graph_dir.mkdir()
+        graph_data = {
+            "skills": [
+                {"id": "web-scrape", "name": "Web Scrape", "type": "basic", "prerequisites": [], "derivatives": ["data-pipeline"]},
+                {"id": "parse-json", "name": "Parse JSON", "type": "basic", "prerequisites": [], "derivatives": ["data-pipeline"]},
+                {"id": "http-client", "name": "HTTP Client", "type": "basic", "prerequisites": [], "derivatives": []},
+                {"id": "data-pipeline", "name": "Data Pipeline", "type": "extra", "prerequisites": ["web-scrape", "parse-json"], "derivatives": []},
+            ]
+        }
+        (graph_dir / "gaia.json").write_text(json.dumps(graph_data))
+
+        # Paths file location
+        paths_file = str(gaia_dir / "paths.json")
+        monkeypatch.setattr("gaia_cli.pathEngine.PATHS_FILE", paths_file)
+
+        # Mock scanner to return a known token (http-client detected in repo)
+        monkeypatch.setattr(
+            "gaia_cli.pathEngine.scan_repo_detailed",
+            lambda: {"tokens": {"http-client"}, "files_scanned": 1, "candidate_count": 1, "paths_found": [], "paths_missing": []},
+        )
+        monkeypatch.setattr(
+            "gaia_cli.pathEngine.load_config",
+            lambda: config,
+        )
+
+        registry_path = str(tmp_path)
+        result = regenerate_paths(registry_path)
+
+        # Verify near-unlocks: data-pipeline has prereqs web-scrape + parse-json (both owned)
+        near_ids = [e["skillId"] for e in result["nearUnlocks"]]
+        assert "data-pipeline" in near_ids
+
+        # Verify userId and computedAt are present
+        assert result["userId"] == "alice"
+        assert "computedAt" in result
+
+        # Verify file was written
+        assert os.path.exists(paths_file)
+        loaded = json.loads(open(paths_file, "r", encoding="utf-8").read())
+        assert loaded["userId"] == "alice"
+
+    def test_regenerate_paths_no_config_raises(self, monkeypatch):
+        """Should raise RuntimeError when config is missing."""
+        monkeypatch.setattr("gaia_cli.pathEngine.load_config", lambda: None)
+        with pytest.raises(RuntimeError, match="No .gaia/config.json"):
+            regenerate_paths(".")
+
+    def test_regenerate_paths_no_user_raises(self, monkeypatch):
+        """Should raise RuntimeError when gaiaUser is not set."""
+        monkeypatch.setattr("gaia_cli.pathEngine.load_config", lambda: {"scanPaths": []})
+        with pytest.raises(RuntimeError, match="No gaiaUser"):
+            regenerate_paths(".")

--- a/tests/test_promotion.py
+++ b/tests/test_promotion.py
@@ -1,0 +1,315 @@
+"""Tests for src/gaia_cli/promotion.py — level promotion logic."""
+
+import json
+import os
+from datetime import date
+
+import pytest
+
+from gaia_cli.promotion import (
+    LEVEL_ORDER,
+    LEVEL_NAMES,
+    next_level,
+    check_promotion_eligibility,
+    promote_skill,
+    promotion_state,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_graph(*skills):
+    """Build a minimal graph_data dict from skill dicts."""
+    return {"skills": list(skills), "edges": []}
+
+
+def _make_skill(skill_id, name=None, level="0", evidence=None):
+    """Build a minimal skill node."""
+    return {
+        "id": skill_id,
+        "name": name or skill_id.replace("-", " ").title(),
+        "type": "basic",
+        "level": level,
+        "rarity": "common",
+        "description": f"Test skill: {skill_id}",
+        "prerequisites": [],
+        "derivatives": [],
+        "conditions": "",
+        "evidence": evidence or [],
+        "knownAgents": [],
+        "status": "provisional",
+        "createdAt": "2026-01-01",
+        "updatedAt": "2026-01-01",
+        "version": "0.1.0",
+    }
+
+
+def _make_tree(username, unlocked_skills):
+    """Build a minimal tree_data dict."""
+    return {
+        "userId": username,
+        "updatedAt": "2026-01-01",
+        "unlockedSkills": unlocked_skills,
+        "pendingCombinations": [],
+        "stats": {
+            "totalUnlocked": len(unlocked_skills),
+            "highestRarity": "common",
+            "deepestLineage": 0,
+        },
+    }
+
+
+def _make_unlocked(skill_id, level="I"):
+    """Build a minimal unlockedSkill entry."""
+    return {
+        "skillId": skill_id,
+        "level": level,
+        "unlockedAt": "2026-01-01",
+        "unlockedIn": "test/repo",
+    }
+
+
+def _write_tree(tmp_path, username, tree_data):
+    """Write tree_data to the expected file path under tmp_path."""
+    tree_dir = tmp_path / "users" / username
+    tree_dir.mkdir(parents=True, exist_ok=True)
+    tree_path = tree_dir / "skill-tree.json"
+    tree_path.write_text(json.dumps(tree_data, indent=2))
+    return tree_path
+
+
+# ---------------------------------------------------------------------------
+# Tests: next_level
+# ---------------------------------------------------------------------------
+
+
+class TestNextLevel:
+    def test_basic_to_awakened(self):
+        assert next_level("0") == "I"
+
+    def test_awakened_to_named(self):
+        assert next_level("I") == "II"
+
+    def test_transcendent_to_transcendent_star(self):
+        assert next_level("V") == "VI"
+
+    def test_max_level_returns_none(self):
+        assert next_level("VI") is None
+
+    def test_invalid_level_returns_none(self):
+        assert next_level("X") is None
+
+    def test_full_progression(self):
+        level = "0"
+        visited = [level]
+        while True:
+            nxt = next_level(level)
+            if nxt is None:
+                break
+            visited.append(nxt)
+            level = nxt
+        assert visited == LEVEL_ORDER
+
+
+# ---------------------------------------------------------------------------
+# Tests: check_promotion_eligibility
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPromotionEligibility:
+    def test_basic_skill_eligible_no_evidence_needed(self):
+        """Level 0 -> I requires no evidence, so skill is eligible."""
+        graph = _make_graph(_make_skill("tokenize"))
+        tree = _make_tree("alice", [_make_unlocked("tokenize", "0")])
+        eligible = check_promotion_eligibility(graph, tree)
+        assert len(eligible) == 1
+        assert eligible[0]["skillId"] == "tokenize"
+        assert eligible[0]["currentLevel"] == "0"
+        assert eligible[0]["nextLevel"] == "I"
+
+    def test_level_I_to_II_eligible_with_class_C_evidence(self):
+        """Level I -> II requires class C/B/A evidence."""
+        ev = [{"class": "C", "source": "http://example.com", "evaluator": "x", "date": "2026-01-01", "notes": ""}]
+        graph = _make_graph(_make_skill("tokenize", evidence=ev))
+        tree = _make_tree("alice", [_make_unlocked("tokenize", "I")])
+        eligible = check_promotion_eligibility(graph, tree)
+        assert len(eligible) == 1
+        assert eligible[0]["nextLevel"] == "II"
+
+    def test_level_I_to_II_not_eligible_without_evidence(self):
+        """Level I -> II blocked if no evidence at all."""
+        graph = _make_graph(_make_skill("tokenize"))
+        tree = _make_tree("alice", [_make_unlocked("tokenize", "I")])
+        eligible = check_promotion_eligibility(graph, tree)
+        assert len(eligible) == 0
+
+    def test_level_II_to_III_requires_class_B(self):
+        """Level II -> III requires class B or A evidence."""
+        ev_c_only = [{"class": "C", "source": "http://x.com", "evaluator": "x", "date": "2026-01-01", "notes": ""}]
+        graph = _make_graph(_make_skill("tokenize", evidence=ev_c_only))
+        tree = _make_tree("alice", [_make_unlocked("tokenize", "II")])
+        eligible = check_promotion_eligibility(graph, tree)
+        assert len(eligible) == 0  # C is not enough for III
+
+    def test_level_II_to_III_eligible_with_class_B(self):
+        ev_b = [{"class": "B", "source": "http://x.com", "evaluator": "x", "date": "2026-01-01", "notes": ""}]
+        graph = _make_graph(_make_skill("tokenize", evidence=ev_b))
+        tree = _make_tree("alice", [_make_unlocked("tokenize", "II")])
+        eligible = check_promotion_eligibility(graph, tree)
+        assert len(eligible) == 1
+        assert eligible[0]["nextLevel"] == "III"
+
+    def test_max_level_not_eligible(self):
+        """A skill at level VI cannot be promoted further."""
+        ev = [{"class": "A", "source": "http://x.com", "evaluator": "x", "date": "2026-01-01", "notes": ""}]
+        graph = _make_graph(_make_skill("tokenize", evidence=ev))
+        tree = _make_tree("alice", [_make_unlocked("tokenize", "VI")])
+        eligible = check_promotion_eligibility(graph, tree)
+        assert len(eligible) == 0
+
+    def test_multiple_skills_mixed_eligibility(self):
+        """Only eligible skills appear in the result list."""
+        ev_b = [{"class": "B", "source": "http://x.com", "evaluator": "x", "date": "2026-01-01", "notes": ""}]
+        graph = _make_graph(
+            _make_skill("tokenize", evidence=ev_b),
+            _make_skill("classify"),  # no evidence
+        )
+        tree = _make_tree("alice", [
+            _make_unlocked("tokenize", "0"),   # eligible (no evidence needed for 0->I)
+            _make_unlocked("classify", "I"),   # not eligible (no evidence for I->II)
+        ])
+        eligible = check_promotion_eligibility(graph, tree)
+        assert len(eligible) == 1
+        assert eligible[0]["skillId"] == "tokenize"
+
+    def test_skill_not_in_graph_skipped(self):
+        """If a tree skill doesn't exist in the graph, it's skipped."""
+        graph = _make_graph()  # empty graph
+        tree = _make_tree("alice", [_make_unlocked("phantom", "I")])
+        eligible = check_promotion_eligibility(graph, tree)
+        assert len(eligible) == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: promote_skill
+# ---------------------------------------------------------------------------
+
+
+class TestPromoteSkill:
+    def test_promotes_skill_one_level(self, tmp_path):
+        tree_data = _make_tree("alice", [_make_unlocked("tokenize", "I")])
+        _write_tree(tmp_path, "alice", tree_data)
+        result = promote_skill("alice", "tokenize", str(tmp_path), new_display_name="Tokenize")
+        assert result["skillId"] == "tokenize"
+        assert result["previousLevel"] == "I"
+        assert result["newLevel"] == "II"
+        assert result["displayName"] == "Tokenize"
+
+    def test_persists_new_level_to_disk(self, tmp_path):
+        tree_data = _make_tree("bob", [_make_unlocked("classify", "II")])
+        _write_tree(tmp_path, "bob", tree_data)
+        promote_skill("bob", "classify", str(tmp_path), new_display_name="Classify")
+        # Re-read from disk
+        tree_path = tmp_path / "users" / "bob" / "skill-tree.json"
+        saved = json.loads(tree_path.read_text())
+        entry = next(s for s in saved["unlockedSkills"] if s["skillId"] == "classify")
+        assert entry["level"] == "III"
+
+    def test_updates_updated_at(self, tmp_path):
+        tree_data = _make_tree("carol", [_make_unlocked("tokenize", "0")])
+        _write_tree(tmp_path, "carol", tree_data)
+        promote_skill("carol", "tokenize", str(tmp_path), new_display_name="Tokenize")
+        tree_path = tmp_path / "users" / "carol" / "skill-tree.json"
+        saved = json.loads(tree_path.read_text())
+        assert saved["updatedAt"] == date.today().isoformat()
+
+    def test_raises_if_no_tree(self, tmp_path):
+        with pytest.raises(ValueError, match="No skill tree found"):
+            promote_skill("nobody", "tokenize", str(tmp_path))
+
+    def test_raises_if_skill_not_in_tree(self, tmp_path):
+        tree_data = _make_tree("alice", [_make_unlocked("tokenize", "I")])
+        _write_tree(tmp_path, "alice", tree_data)
+        with pytest.raises(ValueError, match="not found"):
+            promote_skill("alice", "nonexistent", str(tmp_path))
+
+    def test_raises_if_already_max_level(self, tmp_path):
+        tree_data = _make_tree("alice", [_make_unlocked("tokenize", "VI")])
+        _write_tree(tmp_path, "alice", tree_data)
+        with pytest.raises(ValueError, match="maximum level"):
+            promote_skill("alice", "tokenize", str(tmp_path))
+
+    def test_reads_display_name_from_graph_when_not_provided(self, tmp_path):
+        tree_data = _make_tree("alice", [_make_unlocked("tokenize", "I")])
+        _write_tree(tmp_path, "alice", tree_data)
+        # Write a graph file
+        graph_dir = tmp_path / "graph"
+        graph_dir.mkdir(parents=True, exist_ok=True)
+        graph_data = _make_graph(_make_skill("tokenize", name="Tokenize"))
+        (graph_dir / "gaia.json").write_text(json.dumps(graph_data))
+        result = promote_skill("alice", "tokenize", str(tmp_path))
+        assert result["displayName"] == "Tokenize"
+
+    def test_fallback_display_name_when_no_graph(self, tmp_path):
+        tree_data = _make_tree("alice", [_make_unlocked("tokenize", "I")])
+        _write_tree(tmp_path, "alice", tree_data)
+        # No graph file exists
+        result = promote_skill("alice", "tokenize", str(tmp_path))
+        assert result["displayName"] == "tokenize"
+
+
+# ---------------------------------------------------------------------------
+# Tests: promotion_state
+# ---------------------------------------------------------------------------
+
+
+class TestPromotionState:
+    def test_not_unlocked(self):
+        graph = _make_graph(_make_skill("tokenize"))
+        tree = _make_tree("alice", [])
+        assert promotion_state("tokenize", tree, graph) == "not_unlocked"
+
+    def test_max_level(self):
+        graph = _make_graph(_make_skill("tokenize"))
+        tree = _make_tree("alice", [_make_unlocked("tokenize", "VI")])
+        assert promotion_state("tokenize", tree, graph) == "max_level"
+
+    def test_eligible_no_evidence_needed(self):
+        graph = _make_graph(_make_skill("tokenize"))
+        tree = _make_tree("alice", [_make_unlocked("tokenize", "0")])
+        assert promotion_state("tokenize", tree, graph) == "eligible"
+
+    def test_eligible_with_evidence(self):
+        ev = [{"class": "B", "source": "http://x.com", "evaluator": "x", "date": "2026-01-01", "notes": ""}]
+        graph = _make_graph(_make_skill("tokenize", evidence=ev))
+        tree = _make_tree("alice", [_make_unlocked("tokenize", "I")])
+        assert promotion_state("tokenize", tree, graph) == "eligible"
+
+    def test_blocked_by_evidence(self):
+        graph = _make_graph(_make_skill("tokenize"))  # no evidence
+        tree = _make_tree("alice", [_make_unlocked("tokenize", "I")])
+        assert promotion_state("tokenize", tree, graph) == "blocked"
+
+    def test_blocked_skill_not_in_graph(self):
+        graph = _make_graph()  # empty
+        tree = _make_tree("alice", [_make_unlocked("phantom", "II")])
+        assert promotion_state("phantom", tree, graph) == "blocked"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Constants
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    def test_level_order_length(self):
+        assert len(LEVEL_ORDER) == 7
+
+    def test_level_names_keys_match_order(self):
+        assert list(LEVEL_NAMES.keys()) == LEVEL_ORDER
+
+    def test_level_names_has_star_at_end(self):
+        assert LEVEL_NAMES["VI"] == "Transcendent ★"


### PR DESCRIPTION
## Summary

- **Living CLI** — `gaia appraise`, `gaia promote`, `gaia paths`, and a Claude Code PostToolUse hook that renders unlock cards and promotion prompts automatically after every file edit
- **8 new skills** — `mcp-integration`, `parallel-execution`, `requirements-analysis`, `schema-design`, `e2e-testing`, `security-audit`, `release-automation`, `deployment-automation` (from intelligentcode-ai/skills)
- **Tier rename** — `atomic/composite/legendary` → `basic/extra/ultimate` across the entire codebase (schema, graph, projections, docs, CLI, tests)
- **Version bump** — `1.0.0 → 2.0.0` (MAJOR: schema enum values removed)
- **Evidence** — Class B evidence added to `autonomous-research-agent`
- **`/version-update` skill** — new Claude Code slash command for automated SemVer classification

## Breaking Changes

`schema/skill.schema.json` enum values `atomic`, `composite`, `legendary` removed; replaced by `basic`, `extra`, `ultimate`. All graph data migrated in the same branch.

## New CLI Commands

| Command | Description |
|---|---|
| `gaia appraise [skillId]` | Colored ANSI card with prereq status (✓/○), derivatives, and contextual actions |
| `gaia promote [skillId] [--name]` | Level-up an eligible skill; optionally rename your variant |
| `gaia paths` | Near-unlocks, one-away skills, and full BFS reachable summary |

## Test plan

- [ ] `pytest tests/` — 207 passing (2 pre-existing packaging failures unrelated to this branch)
- [ ] `python scripts/validate.py` — schema + DAG + evidence validation passes
- [ ] `gaia appraise web-scrape --registry .` — renders ANSI card
- [ ] `gaia scan --registry .` — shows path summary and unlock cards
- [ ] `gaia paths --registry .` — shows near-unlocks and one-away list
- [ ] `gaia promote --registry .` — levels up first eligible skill
- [ ] PostToolUse hook fires after file edit in a Gaia-initialized repo