### PR TITLE
feat: add autoresearch evidence, living CLI, security hardening (v2.1.0)

### DIFF
--- a/combinations.md
+++ b/combinations.md
@@ -52,4 +52,4 @@
 | ◇ Extra Skill: /web-scrape | Extra Skill | Web Search, Parse HTML, Extract Entities | III | Structured output mode required. |
 | ◇ Extra Skill: /workflow-automation | Extra Skill | Plan and Decompose, Tool Use, API Call | IV |  |
 
-*Generated from gaia.json v1.0.0.*
+*Generated from gaia.json v2.1.0.*

--- a/graph/gaia.json
+++ b/graph/gaia.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./schema/skill.schema.json",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "generatedAt": "2026-04-30T00:00:00Z",
   "meta": {
     "typeLabels": {

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia-registry/mcp-server",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "MCP server for the Gaia Skill Registry — agent-native skill detection, fusion, and progression",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp-server/src/graph/loader.ts
+++ b/mcp-server/src/graph/loader.ts
@@ -4,6 +4,8 @@ import type { GaiaGraph } from "./types.js";
 const REGISTRY_URL =
   "https://raw.githubusercontent.com/mbtiongson1/gaia-skill-tree/main/graph/gaia.json";
 
+const USERNAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9-]{0,37}[a-zA-Z0-9]$|^[a-zA-Z0-9]$/;
+
 let cachedGraph: GaiaGraph | null = null;
 
 export async function loadGraph(registryUrl?: string): Promise<GaiaGraph> {
@@ -61,8 +63,9 @@ export async function loadUserTree(
   username: string,
   registryUrl?: string
 ): Promise<Record<string, unknown> | null> {
+  if (!USERNAME_RE.test(username)) return null;
   const baseUrl = registryUrl ?? REGISTRY_URL.replace("/graph/gaia.json", "");
-  const url = `${baseUrl}/users/${username}/skill-tree.json`;
+  const url = `${baseUrl}/users/${encodeURIComponent(username)}/skill-tree.json`;
 
   try {
     const res = await fetch(url);

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -27,7 +27,7 @@ export function createServer(): McpServer {
   server.tool(
     "gaia_my_tree",
     "Show the current user's Gaia skill tree — unlocked skills, pending fusions, and progression stats.",
-    { username: z.string().optional().describe("GitHub username (defaults to configured GAIA_USER)") },
+    { username: z.string().regex(/^[a-zA-Z0-9][a-zA-Z0-9-]*$/, "Invalid GitHub username").max(39).optional().describe("GitHub username (defaults to configured GAIA_USER)") },
     async ({ username }) => {
       const result = await getMyTree(username);
       return { content: [{ type: "text", text: result }] };

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia-registry/cli",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Gaia CLI - Integrate your AI agent skills with the Gaia registry",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gaia-cli"
-version = "2.0.0"
+version = "2.1.0"
 description = "Gaia AI Agent Skill Registry CLI"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/registry.md
+++ b/registry.md
@@ -143,4 +143,4 @@
 | `/recursive-self-improvement` | Transcendent | `/autonomous-debug`, `/evaluate-output`, `/plan-and-execute` |
 | `/scientific-discovery` | Transcendent | `/hypothesis-generate`, `/research`, `/math-reason` |
 
-*Generated from gaia.json v1.0.0.*
+*Generated from gaia.json v2.1.0.*

--- a/skills/basic/api-call.md
+++ b/skills/basic/api-call.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/audience-model.md
+++ b/skills/basic/audience-model.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/chain-of-thought.md
+++ b/skills/basic/chain-of-thought.md
@@ -29,4 +29,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/chunk-document.md
+++ b/skills/basic/chunk-document.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/cite-sources.md
+++ b/skills/basic/cite-sources.md
@@ -28,4 +28,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/classify.md
+++ b/skills/basic/classify.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/code-execution.md
+++ b/skills/basic/code-execution.md
@@ -28,4 +28,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/code-explain.md
+++ b/skills/basic/code-explain.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/code-generation.md
+++ b/skills/basic/code-generation.md
@@ -29,4 +29,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/computer-use.md
+++ b/skills/basic/computer-use.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/context-compression.md
+++ b/skills/basic/context-compression.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/data-visualize.md
+++ b/skills/basic/data-visualize.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/detect-anomaly.md
+++ b/skills/basic/detect-anomaly.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/diff-content.md
+++ b/skills/basic/diff-content.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/document-editing.md
+++ b/skills/basic/document-editing.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/embed-text.md
+++ b/skills/basic/embed-text.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/error-interpretation.md
+++ b/skills/basic/error-interpretation.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/evaluate-output.md
+++ b/skills/basic/evaluate-output.md
@@ -32,4 +32,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/execute-bash.md
+++ b/skills/basic/execute-bash.md
@@ -29,4 +29,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/extract-entities.md
+++ b/skills/basic/extract-entities.md
@@ -30,4 +30,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/few-shot-learning.md
+++ b/skills/basic/few-shot-learning.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/fine-tune.md
+++ b/skills/basic/fine-tune.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/format-output.md
+++ b/skills/basic/format-output.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/framework-upgrade.md
+++ b/skills/basic/framework-upgrade.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/generate-sql.md
+++ b/skills/basic/generate-sql.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/generate-test.md
+++ b/skills/basic/generate-test.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/generate-text.md
+++ b/skills/basic/generate-text.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/hypothesis-generate.md
+++ b/skills/basic/hypothesis-generate.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/image-caption.md
+++ b/skills/basic/image-caption.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/image-generate.md
+++ b/skills/basic/image-generate.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/issue-triage.md
+++ b/skills/basic/issue-triage.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/logical-inference.md
+++ b/skills/basic/logical-inference.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/math-reason.md
+++ b/skills/basic/math-reason.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/mcp-integration.md
+++ b/skills/basic/mcp-integration.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/memory-manage.md
+++ b/skills/basic/memory-manage.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/object-detection.md
+++ b/skills/basic/object-detection.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/ocr.md
+++ b/skills/basic/ocr.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/parallel-execution.md
+++ b/skills/basic/parallel-execution.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/parse-html.md
+++ b/skills/basic/parse-html.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/parse-json.md
+++ b/skills/basic/parse-json.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/parse-pdf.md
+++ b/skills/basic/parse-pdf.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/plan-decompose.md
+++ b/skills/basic/plan-decompose.md
@@ -31,4 +31,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/prompt-injection-defense.md
+++ b/skills/basic/prompt-injection-defense.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/question-answer.md
+++ b/skills/basic/question-answer.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/rank.md
+++ b/skills/basic/rank.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/refactor-code.md
+++ b/skills/basic/refactor-code.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/requirements-analysis.md
+++ b/skills/basic/requirements-analysis.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/retrieve.md
+++ b/skills/basic/retrieve.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/reward-modeling.md
+++ b/skills/basic/reward-modeling.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/route-intent.md
+++ b/skills/basic/route-intent.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/schema-design.md
+++ b/skills/basic/schema-design.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/scientific-visualization.md
+++ b/skills/basic/scientific-visualization.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/score-relevance.md
+++ b/skills/basic/score-relevance.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/self-consistency.md
+++ b/skills/basic/self-consistency.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/self-critique.md
+++ b/skills/basic/self-critique.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/semantic-cache.md
+++ b/skills/basic/semantic-cache.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/sentiment-analysis.md
+++ b/skills/basic/sentiment-analysis.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/skill-discovery.md
+++ b/skills/basic/skill-discovery.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/speech-to-text.md
+++ b/skills/basic/speech-to-text.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/statistical-analysis.md
+++ b/skills/basic/statistical-analysis.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/structured-output.md
+++ b/skills/basic/structured-output.md
@@ -29,4 +29,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/summarize.md
+++ b/skills/basic/summarize.md
@@ -28,4 +28,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/test-driven-development.md
+++ b/skills/basic/test-driven-development.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/text-to-speech.md
+++ b/skills/basic/text-to-speech.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/tokenize.md
+++ b/skills/basic/tokenize.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/tool-select.md
+++ b/skills/basic/tool-select.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/tool-use.md
+++ b/skills/basic/tool-use.md
@@ -29,4 +29,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/translate.md
+++ b/skills/basic/translate.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/ux-audit.md
+++ b/skills/basic/ux-audit.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/vision-qa.md
+++ b/skills/basic/vision-qa.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/web-search.md
+++ b/skills/basic/web-search.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/write-report.md
+++ b/skills/basic/write-report.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/agent-eval.md
+++ b/skills/extra/agent-eval.md
@@ -31,4 +31,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/automated-testing.md
+++ b/skills/extra/automated-testing.md
@@ -32,4 +32,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/autonomous-debug.md
+++ b/skills/extra/autonomous-debug.md
@@ -30,4 +30,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/browser-automation.md
+++ b/skills/extra/browser-automation.md
@@ -31,4 +31,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/code-review-pipeline.md
+++ b/skills/extra/code-review-pipeline.md
@@ -31,4 +31,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/content-moderation.md
+++ b/skills/extra/content-moderation.md
@@ -30,4 +30,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/conversational-agent.md
+++ b/skills/extra/conversational-agent.md
@@ -30,4 +30,4 @@ Requires persistent memory store across turns.
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/data-analysis.md
+++ b/skills/extra/data-analysis.md
@@ -31,4 +31,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/deployment-automation.md
+++ b/skills/extra/deployment-automation.md
@@ -29,4 +29,4 @@ Requires environment credentials and a configured pipeline definition.
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/design-review.md
+++ b/skills/extra/design-review.md
@@ -30,4 +30,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/document-analyst.md
+++ b/skills/extra/document-analyst.md
@@ -31,4 +31,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/document-digitization.md
+++ b/skills/extra/document-digitization.md
@@ -30,4 +30,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/e2e-testing.md
+++ b/skills/extra/e2e-testing.md
@@ -30,4 +30,4 @@ Requires a live or containerised target environment; browser automation must be 
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/function-calling.md
+++ b/skills/extra/function-calling.md
@@ -31,4 +31,4 @@ Requires an available function or tool catalog with machine-readable argument sc
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/ghostwrite.md
+++ b/skills/extra/ghostwrite.md
@@ -30,4 +30,4 @@ Requires research output as input context.
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/grounding.md
+++ b/skills/extra/grounding.md
@@ -31,4 +31,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/guardrails.md
+++ b/skills/extra/guardrails.md
@@ -31,4 +31,4 @@ Requires a defined policy schema and an evaluation loop.
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/knowledge-graph-build.md
+++ b/skills/extra/knowledge-graph-build.md
@@ -31,4 +31,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/knowledge-harvest.md
+++ b/skills/extra/knowledge-harvest.md
@@ -30,4 +30,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/literature-review.md
+++ b/skills/extra/literature-review.md
@@ -31,4 +31,4 @@ Requires access to academic databases (PubMed, bioRxiv, ChEMBL, or equivalent).
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/ml-pipeline.md
+++ b/skills/extra/ml-pipeline.md
@@ -31,4 +31,4 @@ Requires access to a container orchestration environment and model registry.
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/multi-agent-debate.md
+++ b/skills/extra/multi-agent-debate.md
@@ -31,4 +31,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/multimodal-reasoning.md
+++ b/skills/extra/multimodal-reasoning.md
@@ -30,4 +30,4 @@ Requires vision-language model capability.
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/plan-and-execute.md
+++ b/skills/extra/plan-and-execute.md
@@ -30,4 +30,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/prd-generation.md
+++ b/skills/extra/prd-generation.md
@@ -30,4 +30,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/prompt-optimization.md
+++ b/skills/extra/prompt-optimization.md
@@ -30,4 +30,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/rag-pipeline.md
+++ b/skills/extra/rag-pipeline.md
@@ -34,4 +34,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/re-act-reasoning.md
+++ b/skills/extra/re-act-reasoning.md
@@ -31,4 +31,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/registry-curation.md
+++ b/skills/extra/registry-curation.md
@@ -34,4 +34,4 @@ Requires write access to the canonical graph and a passing validation suite.
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/release-automation.md
+++ b/skills/extra/release-automation.md
@@ -30,4 +30,4 @@ Requires write access to the repository and a configured release token.
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/research.md
+++ b/skills/extra/research.md
@@ -34,4 +34,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/scientific-writing.md
+++ b/skills/extra/scientific-writing.md
@@ -31,4 +31,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/security-audit.md
+++ b/skills/extra/security-audit.md
@@ -30,4 +30,4 @@ Requires access to the full codebase or diff; output must include severity class
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/text-to-sql-pipeline.md
+++ b/skills/extra/text-to-sql-pipeline.md
@@ -30,4 +30,4 @@ Requires schema context in prompt.
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/tool-chaining.md
+++ b/skills/extra/tool-chaining.md
@@ -30,4 +30,4 @@ Requires at least two distinct tools whose data schemas are compatible for chain
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/tool-creation.md
+++ b/skills/extra/tool-creation.md
@@ -31,4 +31,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/translation-pipeline.md
+++ b/skills/extra/translation-pipeline.md
@@ -30,4 +30,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/tree-of-thought.md
+++ b/skills/extra/tree-of-thought.md
@@ -30,4 +30,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/vertical-slice-planning.md
+++ b/skills/extra/vertical-slice-planning.md
@@ -29,4 +29,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/voice-agent.md
+++ b/skills/extra/voice-agent.md
@@ -30,4 +30,4 @@ Requires real-time audio I/O or audio file access.
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/web-scrape.md
+++ b/skills/extra/web-scrape.md
@@ -30,4 +30,4 @@ Structured output mode required.
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/workflow-automation.md
+++ b/skills/extra/workflow-automation.md
@@ -33,4 +33,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/ultimate/autonomous-data-scientist.md
+++ b/skills/ultimate/autonomous-data-scientist.md
@@ -32,4 +32,4 @@ Requires dataset access and compute environment. Minimum 3 Class A/B evidence so
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/ultimate/autonomous-research-agent.md
+++ b/skills/ultimate/autonomous-research-agent.md
@@ -31,4 +31,4 @@ Requires extensive multi-system validation before level advancement.
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/ultimate/full-stack-developer.md
+++ b/skills/ultimate/full-stack-developer.md
@@ -32,4 +32,4 @@ Requires access to repository, execution environment, and test runner. Minimum 3
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/ultimate/multi-agent-orchestration-v.md
+++ b/skills/ultimate/multi-agent-orchestration-v.md
@@ -30,4 +30,4 @@ Requires extensive multi-system validation before level advancement.
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/ultimate/real-time-voice-assistant.md
+++ b/skills/ultimate/real-time-voice-assistant.md
@@ -32,4 +32,4 @@ Requires real-time audio pipeline, <500ms end-to-end latency target, and persist
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/ultimate/recursive-self-improvement.md
+++ b/skills/ultimate/recursive-self-improvement.md
@@ -30,4 +30,4 @@ Requires extensive multi-system validation before level advancement.
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/skills/ultimate/scientific-discovery.md
+++ b/skills/ultimate/scientific-discovery.md
@@ -32,4 +32,4 @@ Requires laboratory tool access or simulation environment. Minimum 3 Class A/B e
 _None verified yet._
 
 ---
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*

--- a/src/gaia_cli/name.py
+++ b/src/gaia_cli/name.py
@@ -7,6 +7,10 @@ in graph/named/{contributor}/{skill-name}.md
 import datetime
 import json
 import os
+import re
+
+_CONTRIBUTOR_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
+_SKILL_NAME_RE = re.compile(r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$")
 
 
 def find_awakened_skill(batch_path, skill_id):
@@ -64,6 +68,10 @@ def promote_to_named(skill_data, contributor, skill_name, registry_path):
         Absolute path to the written .md file.
     """
     today = datetime.date.today().isoformat()
+    if not _CONTRIBUTOR_RE.match(contributor):
+        raise ValueError(f"Invalid contributor: {contributor!r}")
+    if not _SKILL_NAME_RE.match(skill_name):
+        raise ValueError(f"Invalid skill_name: {skill_name!r}")
     named_id = f"{contributor}/{skill_name}"
     dest_dir = os.path.join(registry_path, "graph", "named", contributor)
     os.makedirs(dest_dir, exist_ok=True)

--- a/src/gaia_cli/treeManager.py
+++ b/src/gaia_cli/treeManager.py
@@ -1,15 +1,26 @@
 import json
 import os
+import re
+
+_USERNAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
+
+
+def _check_username(username: str) -> None:
+    if not username or not _USERNAME_RE.match(username):
+        raise ValueError(f"Invalid username: {username!r}")
+
 
 def load_tree(username, registry_path="."):
-    tree_path = os.path.join(registry_path, f"users/{username}/skill-tree.json")
+    _check_username(username)
+    tree_path = os.path.join(registry_path, "users", username, "skill-tree.json")
     if not os.path.exists(tree_path):
         return None
     with open(tree_path, 'r') as f:
         return json.load(f)
 
 def save_tree(username, tree_data, registry_path="."):
-    tree_path = os.path.join(registry_path, f"users/{username}/skill-tree.json")
+    _check_username(username)
+    tree_path = os.path.join(registry_path, "users", username, "skill-tree.json")
     os.makedirs(os.path.dirname(tree_path), exist_ok=True)
     with open(tree_path, 'w') as f:
         json.dump(tree_data, f, indent=2)

--- a/tests/test_treeManager.py
+++ b/tests/test_treeManager.py
@@ -1,0 +1,105 @@
+"""Tests for src/gaia_cli/treeManager.py — path-traversal rejection."""
+
+import json
+import pytest
+
+from gaia_cli.treeManager import load_tree, save_tree
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_tree(tmp_path, username, data):
+    user_dir = tmp_path / "users" / username
+    user_dir.mkdir(parents=True, exist_ok=True)
+    (user_dir / "skill-tree.json").write_text(json.dumps(data))
+
+
+_SAMPLE_TREE = {
+    "userId": "alice",
+    "updatedAt": "2026-01-01",
+    "unlockedSkills": [],
+    "pendingCombinations": [],
+    "stats": {"totalUnlocked": 0, "highestRarity": "common", "deepestLineage": 0},
+}
+
+
+# ---------------------------------------------------------------------------
+# load_tree — valid username
+# ---------------------------------------------------------------------------
+
+
+class TestLoadTreeValid:
+    def test_returns_tree_for_valid_username(self, tmp_path):
+        _write_tree(tmp_path, "alice", _SAMPLE_TREE)
+        result = load_tree("alice", registry_path=str(tmp_path))
+        assert result is not None
+        assert result["userId"] == "alice"
+
+    def test_returns_none_when_file_missing(self, tmp_path):
+        result = load_tree("alice", registry_path=str(tmp_path))
+        assert result is None
+
+    def test_accepts_username_with_dots_and_hyphens(self, tmp_path):
+        _write_tree(tmp_path, "alice.bob-99", _SAMPLE_TREE)
+        result = load_tree("alice.bob-99", registry_path=str(tmp_path))
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# load_tree — invalid username
+# ---------------------------------------------------------------------------
+
+
+class TestLoadTreeInvalid:
+    @pytest.mark.parametrize("bad", [
+        "../evil",
+        "../../etc/passwd",
+        "",
+        "/root",
+        "foo/bar",
+        "foo bar",
+        "foo\x00bar",
+        ".hidden",
+    ])
+    def test_raises_for_path_traversal(self, tmp_path, bad):
+        with pytest.raises(ValueError, match="Invalid username"):
+            load_tree(bad, registry_path=str(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# save_tree — valid username
+# ---------------------------------------------------------------------------
+
+
+class TestSaveTreeValid:
+    def test_writes_tree_to_correct_path(self, tmp_path):
+        save_tree("alice", _SAMPLE_TREE, registry_path=str(tmp_path))
+        expected = tmp_path / "users" / "alice" / "skill-tree.json"
+        assert expected.exists()
+        data = json.loads(expected.read_text())
+        assert data["userId"] == "alice"
+
+    def test_creates_parent_directories(self, tmp_path):
+        save_tree("newuser", _SAMPLE_TREE, registry_path=str(tmp_path))
+        assert (tmp_path / "users" / "newuser" / "skill-tree.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# save_tree — invalid username
+# ---------------------------------------------------------------------------
+
+
+class TestSaveTreeInvalid:
+    @pytest.mark.parametrize("bad", [
+        "../evil",
+        "../../etc/passwd",
+        "",
+        "/root",
+        "foo/bar",
+    ])
+    def test_raises_for_path_traversal(self, tmp_path, bad):
+        with pytest.raises(ValueError, match="Invalid username"):
+            save_tree(bad, _SAMPLE_TREE, registry_path=str(tmp_path))

--- a/tree.md
+++ b/tree.md
@@ -1,7 +1,7 @@
 # Gaia Skill Tree
 
 ```
-GAIA SKILL TREE  v1.0.0  ·  generated 2026-04-30
+GAIA SKILL TREE  v2.1.0  ·  generated 2026-04-30
 ══════════════════════════════════════════════════════════════════════
 Upgrade paths — each legendary shows its full prerequisite chain.
 Shared prerequisites marked (↑ see above) on second occurrence.
@@ -123,4 +123,4 @@ Pure / Undeveloped — basic skills not yet wired into any upgrade path.
 
 ```
 
-*Generated from gaia.json v1.0.0 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.0 on 2026-04-30. Do not edit directly.*


### PR DESCRIPTION
## Summary

- **[evidence]** `autonomous-research-agent` — adds Class B evidence from balukosuri community repo (Karpathy's autoresearch pattern)
- **[basic/extra]** 8 new skills from intelligentcode-ai: `mcp-integration`, `parallel-execution`, `requirements-analysis`, `schema-design`, `e2e-testing`, `security-audit`, `release-automation`, `deployment-automation`
- **feat** Living CLI — `gaia appraise`, `gaia promote`, `gaia paths`, PostToolUse hook integration (`cardRenderer`, `pathEngine`, `promotion` modules)
- **feat** `/version-update` and `/gaia-curate` skill updates; `skill-sources.md` registry
- **refactor** Rename `atomic/composite/legendary` → `basic/extra/ultimate` across entire codebase (schema, graph, CLI, MCP, docs)
- **fix** Defense-in-depth input validation: path-traversal guards in `treeManager.py`, `name.py`; URL sanitization in `loader.ts`; Zod `.regex().max(39)` on MCP `gaia_my_tree` username param
- **chore** Bump version `2.0.0` → `2.1.0` (MINOR — new features post breaking-change bump)

## Test plan

- [ ] `pytest tests/test_treeManager.py -v` — 14 new path-traversal rejection tests pass
- [ ] `pytest tests/test_promotion.py tests/test_lifecycle.py -v` — existing tests unaffected
- [ ] `cd mcp-server && npm test` — existing vitest suite passes
- [ ] `python scripts/validate.py` — graph validation passes (121 skills, 0 errors)
- [ ] `gaia status` smoke test with a normal username in `.gaia/config.json`
- [ ] Confirm all four version files read `2.1.0`