### PR TITLE
docs: add Windows PATH fix for gaia after pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ cd gaia-skill-tree
 
 pip install -e ".[embeddings]"  # install CLI + semantic search support
 
+# ── Windows only: if `gaia` is not recognized after install ──────────────
+# Run this in PowerShell to add the user Scripts folder to your PATH:
+#   $env:PATH += ";" + (python -c "import sysconfig; print(sysconfig.get_path('scripts', 'nt_user'))")
+# To persist across sessions, add that path via System → Environment Variables → Path.
+# ─────────────────────────────────────────────────────────────────────────
+
 gaia init                        # auto-detects your GitHub username and
                                  # skill files (AGENTS.md, SKILLS.md,
                                  # .gemini/, .claude/skills/, etc.)

--- a/docs/index.html
+++ b/docs/index.html
@@ -596,6 +596,9 @@
 <span class="comment"># Strongly recommended — enables semantic search</span>
 <span class="cmd">pip install</span> -e <span class="str">".[embeddings]"</span>
 <span class="cmd">gaia embed</span>          <span class="comment"># ~30 sec, run once</span></pre>
+        <pre><span class="comment"># Windows only — if `gaia` is not recognized after install, run in PowerShell:</span>
+<span class="kw">$env:PATH</span> += <span class="str">";"</span> + (<span class="cmd">python</span> -c <span class="str">"import sysconfig; print(sysconfig.get_path('scripts', 'nt_user'))"</span>)
+<span class="comment"># To persist: add that path via System → Environment Variables → Path</span></pre>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary

- **README.md** — adds a commented-out PowerShell one-liner in the Quickstart block (right after `pip install`) explaining how to fix `gaia` not being recognized on Windows
- **docs/index.html** — adds a matching `<pre>` block in Step 2 (Install the CLI) with the same fix, styled with existing color classes

## Problem

On Windows, `pip install -e ".[embeddings]"` warns that `gaia.exe` is installed in a user-local Scripts path not on PATH (e.g. `…\Python313\Scripts`). New users hit this immediately and have no guidance on how to fix it.

## Fix

```powershell
$env:PATH += ";" + (python -c "import sysconfig; print(sysconfig.get_path('scripts', 'nt_user'))")
# To persist: add that path via System → Environment Variables → Path
```

Uses `sysconfig` so it resolves correctly for any Windows Python variant (Store, official installer, etc.) without hard-coding a version string.

## Test plan

- [ ] Verify README quickstart block renders correctly in GitHub markdown preview
- [ ] Open `docs/index.html` locally (`python -m http.server 8080`) and confirm Step 2 shows the Windows callout block with correct syntax highlighting