### PR TITLE
feat: auto-register registry path on gaia init (zero-config push)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,10 +189,8 @@ gaia init
 
 # Preview detected skills and proposed intake
 gaia scan
-gaia push --dry-run
-
-# Submit the batch intake record for review
-gaia push
+gaia push --dry-run   # preview the JSON
+gaia push             # write intake + open a PR
 ```
 
 Intake PRs are draft review artifacts. Accepted candidates are promoted later

--- a/combinations.md
+++ b/combinations.md
@@ -52,4 +52,4 @@
 | ◇ Extra Skill: /web-scrape | Extra Skill | Web Search, Parse HTML, Extract Entities | III | Structured output mode required. |
 | ◇ Extra Skill: /workflow-automation | Extra Skill | Plan and Decompose, Tool Use, API Call | IV |  |
 
-*Generated from gaia.json v2.1.3.*
+*Generated from gaia.json v2.1.4.*

--- a/graph/gaia.json
+++ b/graph/gaia.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./schema/skill.schema.json",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "generatedAt": "2026-04-30T00:00:00Z",
   "meta": {
     "typeLabels": {

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia-registry/mcp-server",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "MCP server for the Gaia Skill Registry — agent-native skill detection, fusion, and progression",
   "type": "module",
   "main": "dist/index.js",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia-registry/cli",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Gaia CLI - Integrate your AI agent skills with the Gaia registry",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gaia-cli"
-version = "2.1.3"
+version = "2.1.4"
 description = "Gaia AI Agent Skill Registry CLI"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/registry.md
+++ b/registry.md
@@ -143,4 +143,4 @@
 | `/recursive-self-improvement` | Transcendent | `/autonomous-debug`, `/evaluate-output`, `/plan-and-execute` |
 | `/scientific-discovery` | Transcendent | `/hypothesis-generate`, `/research`, `/math-reason` |
 
-*Generated from gaia.json v2.1.3.*
+*Generated from gaia.json v2.1.4.*

--- a/skills/basic/api-call.md
+++ b/skills/basic/api-call.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/audience-model.md
+++ b/skills/basic/audience-model.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/chain-of-thought.md
+++ b/skills/basic/chain-of-thought.md
@@ -29,4 +29,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/chunk-document.md
+++ b/skills/basic/chunk-document.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/cite-sources.md
+++ b/skills/basic/cite-sources.md
@@ -28,4 +28,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/classify.md
+++ b/skills/basic/classify.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/code-execution.md
+++ b/skills/basic/code-execution.md
@@ -28,4 +28,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/code-explain.md
+++ b/skills/basic/code-explain.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/code-generation.md
+++ b/skills/basic/code-generation.md
@@ -29,4 +29,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/computer-use.md
+++ b/skills/basic/computer-use.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/context-compression.md
+++ b/skills/basic/context-compression.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/data-visualize.md
+++ b/skills/basic/data-visualize.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/detect-anomaly.md
+++ b/skills/basic/detect-anomaly.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/diff-content.md
+++ b/skills/basic/diff-content.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/document-editing.md
+++ b/skills/basic/document-editing.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/embed-text.md
+++ b/skills/basic/embed-text.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/error-interpretation.md
+++ b/skills/basic/error-interpretation.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/evaluate-output.md
+++ b/skills/basic/evaluate-output.md
@@ -32,4 +32,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/execute-bash.md
+++ b/skills/basic/execute-bash.md
@@ -29,4 +29,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/extract-entities.md
+++ b/skills/basic/extract-entities.md
@@ -30,4 +30,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/few-shot-learning.md
+++ b/skills/basic/few-shot-learning.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/fine-tune.md
+++ b/skills/basic/fine-tune.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/format-output.md
+++ b/skills/basic/format-output.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/framework-upgrade.md
+++ b/skills/basic/framework-upgrade.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/generate-sql.md
+++ b/skills/basic/generate-sql.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/generate-test.md
+++ b/skills/basic/generate-test.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/generate-text.md
+++ b/skills/basic/generate-text.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/hypothesis-generate.md
+++ b/skills/basic/hypothesis-generate.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/image-caption.md
+++ b/skills/basic/image-caption.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/image-generate.md
+++ b/skills/basic/image-generate.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/issue-triage.md
+++ b/skills/basic/issue-triage.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/logical-inference.md
+++ b/skills/basic/logical-inference.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/math-reason.md
+++ b/skills/basic/math-reason.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/mcp-integration.md
+++ b/skills/basic/mcp-integration.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/memory-manage.md
+++ b/skills/basic/memory-manage.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/object-detection.md
+++ b/skills/basic/object-detection.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/ocr.md
+++ b/skills/basic/ocr.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/parallel-execution.md
+++ b/skills/basic/parallel-execution.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/parse-html.md
+++ b/skills/basic/parse-html.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/parse-json.md
+++ b/skills/basic/parse-json.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/parse-pdf.md
+++ b/skills/basic/parse-pdf.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/plan-decompose.md
+++ b/skills/basic/plan-decompose.md
@@ -31,4 +31,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/prompt-injection-defense.md
+++ b/skills/basic/prompt-injection-defense.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/question-answer.md
+++ b/skills/basic/question-answer.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/rank.md
+++ b/skills/basic/rank.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/refactor-code.md
+++ b/skills/basic/refactor-code.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/requirements-analysis.md
+++ b/skills/basic/requirements-analysis.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/retrieve.md
+++ b/skills/basic/retrieve.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/reward-modeling.md
+++ b/skills/basic/reward-modeling.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/route-intent.md
+++ b/skills/basic/route-intent.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/schema-design.md
+++ b/skills/basic/schema-design.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/scientific-visualization.md
+++ b/skills/basic/scientific-visualization.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/score-relevance.md
+++ b/skills/basic/score-relevance.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/self-consistency.md
+++ b/skills/basic/self-consistency.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/self-critique.md
+++ b/skills/basic/self-critique.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/semantic-cache.md
+++ b/skills/basic/semantic-cache.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/sentiment-analysis.md
+++ b/skills/basic/sentiment-analysis.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/skill-discovery.md
+++ b/skills/basic/skill-discovery.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/speech-to-text.md
+++ b/skills/basic/speech-to-text.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/statistical-analysis.md
+++ b/skills/basic/statistical-analysis.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/structured-output.md
+++ b/skills/basic/structured-output.md
@@ -29,4 +29,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/summarize.md
+++ b/skills/basic/summarize.md
@@ -28,4 +28,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/test-driven-development.md
+++ b/skills/basic/test-driven-development.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/text-to-speech.md
+++ b/skills/basic/text-to-speech.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/tokenize.md
+++ b/skills/basic/tokenize.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/tool-select.md
+++ b/skills/basic/tool-select.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/tool-use.md
+++ b/skills/basic/tool-use.md
@@ -29,4 +29,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/translate.md
+++ b/skills/basic/translate.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/ux-audit.md
+++ b/skills/basic/ux-audit.md
@@ -25,4 +25,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/vision-qa.md
+++ b/skills/basic/vision-qa.md
@@ -26,4 +26,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/web-search.md
+++ b/skills/basic/web-search.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/basic/write-report.md
+++ b/skills/basic/write-report.md
@@ -27,4 +27,4 @@ _None._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/agent-eval.md
+++ b/skills/extra/agent-eval.md
@@ -31,4 +31,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/automated-testing.md
+++ b/skills/extra/automated-testing.md
@@ -32,4 +32,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/autonomous-debug.md
+++ b/skills/extra/autonomous-debug.md
@@ -30,4 +30,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/browser-automation.md
+++ b/skills/extra/browser-automation.md
@@ -31,4 +31,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/code-review-pipeline.md
+++ b/skills/extra/code-review-pipeline.md
@@ -31,4 +31,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/content-moderation.md
+++ b/skills/extra/content-moderation.md
@@ -30,4 +30,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/conversational-agent.md
+++ b/skills/extra/conversational-agent.md
@@ -30,4 +30,4 @@ Requires persistent memory store across turns.
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/data-analysis.md
+++ b/skills/extra/data-analysis.md
@@ -31,4 +31,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/deployment-automation.md
+++ b/skills/extra/deployment-automation.md
@@ -29,4 +29,4 @@ Requires environment credentials and a configured pipeline definition.
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/design-review.md
+++ b/skills/extra/design-review.md
@@ -30,4 +30,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/document-analyst.md
+++ b/skills/extra/document-analyst.md
@@ -31,4 +31,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/document-digitization.md
+++ b/skills/extra/document-digitization.md
@@ -30,4 +30,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/e2e-testing.md
+++ b/skills/extra/e2e-testing.md
@@ -30,4 +30,4 @@ Requires a live or containerised target environment; browser automation must be 
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/function-calling.md
+++ b/skills/extra/function-calling.md
@@ -31,4 +31,4 @@ Requires an available function or tool catalog with machine-readable argument sc
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/ghostwrite.md
+++ b/skills/extra/ghostwrite.md
@@ -30,4 +30,4 @@ Requires research output as input context.
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/grounding.md
+++ b/skills/extra/grounding.md
@@ -31,4 +31,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/guardrails.md
+++ b/skills/extra/guardrails.md
@@ -31,4 +31,4 @@ Requires a defined policy schema and an evaluation loop.
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/knowledge-graph-build.md
+++ b/skills/extra/knowledge-graph-build.md
@@ -31,4 +31,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/knowledge-harvest.md
+++ b/skills/extra/knowledge-harvest.md
@@ -30,4 +30,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/literature-review.md
+++ b/skills/extra/literature-review.md
@@ -31,4 +31,4 @@ Requires access to academic databases (PubMed, bioRxiv, ChEMBL, or equivalent).
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/ml-pipeline.md
+++ b/skills/extra/ml-pipeline.md
@@ -31,4 +31,4 @@ Requires access to a container orchestration environment and model registry.
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/multi-agent-debate.md
+++ b/skills/extra/multi-agent-debate.md
@@ -31,4 +31,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/multimodal-reasoning.md
+++ b/skills/extra/multimodal-reasoning.md
@@ -30,4 +30,4 @@ Requires vision-language model capability.
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/plan-and-execute.md
+++ b/skills/extra/plan-and-execute.md
@@ -30,4 +30,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/prd-generation.md
+++ b/skills/extra/prd-generation.md
@@ -30,4 +30,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/prompt-optimization.md
+++ b/skills/extra/prompt-optimization.md
@@ -30,4 +30,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/rag-pipeline.md
+++ b/skills/extra/rag-pipeline.md
@@ -34,4 +34,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/re-act-reasoning.md
+++ b/skills/extra/re-act-reasoning.md
@@ -31,4 +31,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/registry-curation.md
+++ b/skills/extra/registry-curation.md
@@ -34,4 +34,4 @@ Requires write access to the canonical graph and a passing validation suite.
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/release-automation.md
+++ b/skills/extra/release-automation.md
@@ -30,4 +30,4 @@ Requires write access to the repository and a configured release token.
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/research.md
+++ b/skills/extra/research.md
@@ -34,4 +34,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/scientific-writing.md
+++ b/skills/extra/scientific-writing.md
@@ -31,4 +31,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/security-audit.md
+++ b/skills/extra/security-audit.md
@@ -30,4 +30,4 @@ Requires access to the full codebase or diff; output must include severity class
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/text-to-sql-pipeline.md
+++ b/skills/extra/text-to-sql-pipeline.md
@@ -30,4 +30,4 @@ Requires schema context in prompt.
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/tool-chaining.md
+++ b/skills/extra/tool-chaining.md
@@ -30,4 +30,4 @@ Requires at least two distinct tools whose data schemas are compatible for chain
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/tool-creation.md
+++ b/skills/extra/tool-creation.md
@@ -31,4 +31,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/translation-pipeline.md
+++ b/skills/extra/translation-pipeline.md
@@ -30,4 +30,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/tree-of-thought.md
+++ b/skills/extra/tree-of-thought.md
@@ -30,4 +30,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/vertical-slice-planning.md
+++ b/skills/extra/vertical-slice-planning.md
@@ -29,4 +29,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/voice-agent.md
+++ b/skills/extra/voice-agent.md
@@ -30,4 +30,4 @@ Requires real-time audio I/O or audio file access.
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/web-scrape.md
+++ b/skills/extra/web-scrape.md
@@ -30,4 +30,4 @@ Structured output mode required.
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/extra/workflow-automation.md
+++ b/skills/extra/workflow-automation.md
@@ -33,4 +33,4 @@ _None specified._
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/ultimate/autonomous-data-scientist.md
+++ b/skills/ultimate/autonomous-data-scientist.md
@@ -32,4 +32,4 @@ Requires dataset access and compute environment. Minimum 3 Class A/B evidence so
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/ultimate/autonomous-research-agent.md
+++ b/skills/ultimate/autonomous-research-agent.md
@@ -31,4 +31,4 @@ Requires extensive multi-system validation before level advancement.
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/ultimate/full-stack-developer.md
+++ b/skills/ultimate/full-stack-developer.md
@@ -32,4 +32,4 @@ Requires access to repository, execution environment, and test runner. Minimum 3
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/ultimate/multi-agent-orchestration-v.md
+++ b/skills/ultimate/multi-agent-orchestration-v.md
@@ -30,4 +30,4 @@ Requires extensive multi-system validation before level advancement.
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/ultimate/real-time-voice-assistant.md
+++ b/skills/ultimate/real-time-voice-assistant.md
@@ -32,4 +32,4 @@ Requires real-time audio pipeline, <500ms end-to-end latency target, and persist
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/ultimate/recursive-self-improvement.md
+++ b/skills/ultimate/recursive-self-improvement.md
@@ -30,4 +30,4 @@ Requires extensive multi-system validation before level advancement.
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/skills/ultimate/scientific-discovery.md
+++ b/skills/ultimate/scientific-discovery.md
@@ -32,4 +32,4 @@ Requires laboratory tool access or simulation environment. Minimum 3 Class A/B e
 _None verified yet._
 
 ---
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -18,6 +18,7 @@ from gaia_cli.registry import (
     registry_graph_path,
     require_explicit_writable_registry,
     resolve_registry_path,
+    write_global_registry,
 )
 from gaia_cli.pathEngine import compute_paths, load_paths, save_paths, diff_paths
 from gaia_cli.cardRenderer import (
@@ -126,6 +127,13 @@ def init_command(args):
     print(f"Initialized Gaia configuration at {config_path}")
     print(f"  user:       {username}")
     print(f"  scanPaths:  {scan_paths}")
+
+    # If we're inside a registry clone, register its path globally so that
+    # commands like `gaia push` work from any project without --registry.
+    if os.path.exists("graph/gaia.json"):
+        registry_abs = os.path.abspath(".")
+        write_global_registry(registry_abs)
+        print(f"  registry:   {registry_abs} (saved to ~/.gaia/config.json)")
 
 
 def scan_command(args):

--- a/src/gaia_cli/registry.py
+++ b/src/gaia_cli/registry.py
@@ -1,5 +1,6 @@
 """Registry path resolution for the Gaia CLI."""
 
+import json
 import os
 from importlib import resources
 from pathlib import Path
@@ -7,16 +8,49 @@ from pathlib import Path
 
 WRITE_COMMANDS = {"push", "name", "fuse", "embed", "sync", "promote"}
 
+_GLOBAL_CONFIG_PATH = Path.home() / ".gaia" / "config.json"
+
 
 def bundled_registry_path():
     """Return the bundled read-only registry data path."""
     return resources.files("gaia_cli").joinpath("data")
 
 
+def read_global_registry():
+    """Return the globally-registered registry path, or None if not set."""
+    try:
+        with open(_GLOBAL_CONFIG_PATH, encoding="utf-8") as f:
+            data = json.load(f)
+        path = data.get("defaultRegistry")
+        if path and Path(path).is_dir():
+            return path
+    except (OSError, json.JSONDecodeError, KeyError):
+        pass
+    return None
+
+
+def write_global_registry(path: str) -> None:
+    """Persist the registry path to the global ~/.gaia/config.json."""
+    _GLOBAL_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    existing = {}
+    if _GLOBAL_CONFIG_PATH.exists():
+        try:
+            with open(_GLOBAL_CONFIG_PATH, encoding="utf-8") as f:
+                existing = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            pass
+    existing["defaultRegistry"] = str(Path(path).resolve())
+    with open(_GLOBAL_CONFIG_PATH, "w", encoding="utf-8") as f:
+        json.dump(existing, f, indent=2)
+
+
 def resolve_registry_path(explicit_registry=None):
-    """Resolve the registry path, honoring explicit paths before package data."""
+    """Resolve the registry path: explicit → global config → bundled data."""
     if explicit_registry:
         return os.path.abspath(os.path.expanduser(explicit_registry))
+    global_reg = read_global_registry()
+    if global_reg:
+        return global_reg
     return str(bundled_registry_path())
 
 
@@ -25,17 +59,19 @@ def registry_graph_path(registry_path):
 
 
 def require_explicit_writable_registry(parser, args):
-    """Reject mutating commands unless --registry points at a writable checkout."""
+    """Reject mutating commands unless the registry resolves to a writable checkout."""
     if args.command not in WRITE_COMMANDS:
         return
-    if getattr(args, "registry_explicit", False):
-        registry_path = Path(args.registry)
-        if registry_path.is_dir() and os.access(registry_path, os.W_OK):
-            return
+    registry_path = Path(args.registry)
+    bundled = Path(str(bundled_registry_path()))
+    if registry_path != bundled and registry_path.is_dir() and os.access(registry_path, os.W_OK):
+        return
+    if registry_path == bundled:
         parser.error(
-            f"{args.command} requires --registry PATH to point at a writable registry directory."
+            f"`gaia {args.command}` needs a writable registry checkout. "
+            "Run `gaia init` once from your gaia-skill-tree clone to register it globally, "
+            "or pass --registry PATH explicitly."
         )
     parser.error(
-        f"{args.command} requires an explicit writable registry. "
-        "Pass --registry PATH pointing at a local Gaia registry checkout."
+        f"`gaia {args.command}` requires --registry PATH to point at a writable registry directory."
     )

--- a/src/gaia_cli/registry.py
+++ b/src/gaia_cli/registry.py
@@ -8,7 +8,11 @@ from pathlib import Path
 
 WRITE_COMMANDS = {"push", "name", "fuse", "embed", "sync", "promote"}
 
-_GLOBAL_CONFIG_PATH = Path.home() / ".gaia" / "config.json"
+
+def _global_config_path() -> Path:
+    """Return ~/.gaia/config.json, honouring GAIA_HOME if set."""
+    home = os.environ.get("GAIA_HOME") or Path.home()
+    return Path(home) / ".gaia" / "config.json"
 
 
 def bundled_registry_path():
@@ -19,7 +23,7 @@ def bundled_registry_path():
 def read_global_registry():
     """Return the globally-registered registry path, or None if not set."""
     try:
-        with open(_GLOBAL_CONFIG_PATH, encoding="utf-8") as f:
+        with open(_global_config_path(), encoding="utf-8") as f:
             data = json.load(f)
         path = data.get("defaultRegistry")
         if path and Path(path).is_dir():
@@ -31,16 +35,17 @@ def read_global_registry():
 
 def write_global_registry(path: str) -> None:
     """Persist the registry path to the global ~/.gaia/config.json."""
-    _GLOBAL_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    cfg = _global_config_path()
+    cfg.parent.mkdir(parents=True, exist_ok=True)
     existing = {}
-    if _GLOBAL_CONFIG_PATH.exists():
+    if cfg.exists():
         try:
-            with open(_GLOBAL_CONFIG_PATH, encoding="utf-8") as f:
+            with open(cfg, encoding="utf-8") as f:
                 existing = json.load(f)
         except (OSError, json.JSONDecodeError):
             pass
     existing["defaultRegistry"] = str(Path(path).resolve())
-    with open(_GLOBAL_CONFIG_PATH, "w", encoding="utf-8") as f:
+    with open(cfg, "w", encoding="utf-8") as f:
         json.dump(existing, f, indent=2)
 
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -119,7 +119,7 @@ def test_write_commands_require_explicit_registry(tmp_path):
     )
 
     assert result.returncode == 2
-    assert "requires an explicit writable registry" in result.stderr
+    assert "writable registry" in result.stderr
     assert "--registry PATH" in result.stderr
 
 

--- a/tree.md
+++ b/tree.md
@@ -1,7 +1,7 @@
 # Gaia Skill Tree
 
 ```
-GAIA SKILL TREE  v2.1.3  ·  generated 2026-04-30
+GAIA SKILL TREE  v2.1.4  ·  generated 2026-04-30
 ══════════════════════════════════════════════════════════════════════
 Upgrade paths — each legendary shows its full prerequisite chain.
 Shared prerequisites marked (↑ see above) on second occurrence.
@@ -123,4 +123,4 @@ Pure / Undeveloped — basic skills not yet wired into any upgrade path.
 
 ```
 
-*Generated from gaia.json v2.1.3 on 2026-04-30. Do not edit directly.*
+*Generated from gaia.json v2.1.4 on 2026-04-30. Do not edit directly.*


### PR DESCRIPTION
## Summary
- `gaia init` now detects when it's run inside a registry clone (presence of `graph/gaia.json`) and saves the absolute path to `~/.gaia/config.json` as `defaultRegistry`
- `resolve_registry_path()` checks the global config before falling back to bundled data — `gaia push` works from any project without `--registry`
- Improved error message guides users to run `gaia init` in the registry clone if the global config is missing
- README and docs/index.html updated to show clean `gaia push` (no `--registry` flag needed)
- Bumps version 2.1.3 → 2.1.4

## Test plan
- [x] `cd gaia-skill-tree && gaia init` — output shows `registry: /path/to/gaia-skill-tree (saved to ~/.gaia/config.json)`
- [x] `cd /some/other/project && gaia push --dry-run` — works without `--registry`
- [x] `~/.gaia/config.json` contains `"defaultRegistry": "/abs/path/to/gaia-skill-tree"`
- [x] `gaia push` from a project with no global config gives the new helpful error message