### PR TITLE
Add HTTP fallback to GitHub crawler when `gh` CLI is missing

### DIFF
--- a/scripts/crawlers/github/crawler.py
+++ b/scripts/crawlers/github/crawler.py
@@ -5,6 +5,8 @@ import os
 import subprocess
 import sys
 import time
+import urllib.parse
+import urllib.request
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -21,7 +23,7 @@ BATCH_SIZE = 30
 
 
 def gh_api(endpoint: str) -> dict | None:
-    """Call GitHub API via gh CLI and return parsed JSON."""
+    """Call GitHub API via gh CLI and fall back to direct HTTP if unavailable."""
     try:
         result = subprocess.run(
             ["gh", "api", endpoint, "--paginate"],
@@ -31,16 +33,39 @@ def gh_api(endpoint: str) -> dict | None:
         )
         if result.returncode != 0:
             print(f"  gh api error: {result.stderr.strip()}")
-            return None
-        return json.loads(result.stdout)
+        else:
+            return json.loads(result.stdout)
     except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError) as e:
         print(f"  gh api exception: {e}")
+
+    token = os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN")
+    if not token:
+        print("  GitHub token not found; set GITHUB_TOKEN or GH_TOKEN for HTTP fallback")
+        return None
+
+    url = f"https://api.github.com{endpoint}"
+    if endpoint.startswith("/search/repositories") and "per_page=" not in endpoint:
+        sep = "&" if "?" in endpoint else "?"
+        url = f"{url}{sep}per_page=20"
+
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "gaia-skill-tree-crawler",
+    }
+    try:
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req, timeout=30) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except Exception as e:
+        print(f"  HTTP fallback error: {e}")
         return None
 
 
 def search_repos_by_topic(topic: str, min_stars: int = MIN_STARS, limit: int = 20) -> list[dict]:
     """Search GitHub repos by topic, sorted by stars."""
-    query = f"topic:{topic}+stars:>={min_stars}"
+    query = urllib.parse.quote_plus(f"topic:{topic} stars:>={min_stars}")
     endpoint = f"/search/repositories?q={query}&sort=stars&order=desc&per_page={limit}"
     data = gh_api(endpoint)
     if not data:

--- a/tests/test_crawlers.py
+++ b/tests/test_crawlers.py
@@ -2,6 +2,8 @@
 
 import sys
 import os
+import json
+import subprocess
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts", "crawlers"))
 
@@ -9,6 +11,7 @@ from common.taxonomy_mapper import map_to_skills
 from common.evidence_scorer import compute_score
 from common.candidate_builder import build_candidate, normalize_id
 from common.dedup import load_existing_skills, deduplicate
+from github.crawler import gh_api
 
 
 class TestTaxonomyMapper:
@@ -84,3 +87,41 @@ class TestDedup:
         result = deduplicate(candidates)
         assert len(result) == 1
         assert result[0]["id"] == "brand-new-skill-xyz"
+
+
+class TestGithubCrawler:
+    def test_gh_api_http_fallback_without_token(self, monkeypatch):
+        def raise_fnf(*_args, **_kwargs):
+            raise FileNotFoundError("gh")
+
+        monkeypatch.setattr(subprocess, "run", raise_fnf)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+
+        assert gh_api("/search/repositories?q=test") is None
+
+    def test_gh_api_http_fallback_with_token(self, monkeypatch):
+        class DummyResponse:
+            def read(self):
+                return json.dumps({"items": [{"id": 1}]}).encode("utf-8")
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+        def raise_fnf(*_args, **_kwargs):
+            raise FileNotFoundError("gh")
+
+        def fake_urlopen(_req, timeout=30):
+            assert timeout == 30
+            return DummyResponse()
+
+        monkeypatch.setattr(subprocess, "run", raise_fnf)
+        monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+        monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+        data = gh_api("/search/repositories?q=test")
+        assert data is not None
+        assert data["items"][0]["id"] == 1


### PR DESCRIPTION
### Motivation
- The GitHub crawler failed in environments without the `gh` CLI (`FileNotFoundError: 'gh'`) and returned zero candidates, so the crawler needs a resilient fallback path.
- Search query construction could produce unsafe endpoints, so queries should be URL-encoded for reliable HTTP requests.

### Description
- Implemented a fallback in `gh_api()` in `scripts/crawlers/github/crawler.py` that uses direct HTTPS requests to `https://api.github.com` when the `gh` CLI is unavailable, honoring `GITHUB_TOKEN` or `GH_TOKEN` for authentication.
- Added `urllib.parse` and `urllib.request` usage and appropriate request headers and timeout handling for the HTTP fallback path.
- URL-encoded search queries in `search_repos_by_topic()` using `urllib.parse.quote_plus` before building the search endpoint.
- Added unit tests in `tests/test_crawlers.py` to cover both the no-token case and the token-backed HTTP fallback, and adjusted imports accordingly.

### Testing
- Ran `pytest -q tests/test_crawlers.py`, and all tests passed (`15 passed`).
- Existing crawler unit tests were preserved and the new fallback tests validate behavior when `gh` is missing and when an HTTP fallback token is present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f3fe7afeac8327aebbf36f5a017281)