### PR TITLE
feat(cli): auto-resolve registry from .gaia/ without --registry

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
     "PostToolUse": [
       {
         "matcher": "Write|Edit",
-        "hooks": ["gaia _hook --event file_edit 2>/dev/null || true"]
+        "hooks": [{"type": "command", "command": "gaia _hook --event file_edit 2>/dev/null || true"}]
       }
     ]
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gaia-cli"
-version = "2.2.0"
+version = "2.2.1"
 description = "Gaia AI Agent Skill Registry CLI"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -121,6 +121,7 @@ def init_command(args):
         "gaiaRegistryRef": args.registry_ref or DEFAULT_REGISTRY_REF,
         "scanPaths": scan_paths,
         "autoPromptCombinations": args.auto_prompt_combinations,
+        "localRegistryPath": os.path.abspath("."),
     }
     with open(config_path, 'w', encoding='utf-8') as f:
         json.dump(config, f, indent=2)
@@ -623,7 +624,13 @@ def main():
     parser.add_argument(
         '--registry',
         default=None,
-        help="Path to a local Gaia registry checkout. Defaults to bundled read-only registry data.",
+        help="Path to a local Gaia registry checkout. Defaults to auto-resolved local or global registry.",
+    )
+    parser.add_argument(
+        '--global', '-g',
+        dest='global_flag',
+        action='store_true',
+        help="Use global GAIA_HOME registry, ignoring any local .gaia/ config.",
     )
     subparsers = parser.add_subparsers(dest='command')
     init_parser = subparsers.add_parser('init')
@@ -689,8 +696,7 @@ def main():
     hook_parser = subparsers.add_parser('_hook', help=argparse.SUPPRESS)
     hook_parser.add_argument('--event', default='file_edit', help=argparse.SUPPRESS)
     args = parser.parse_args()
-    args.registry_explicit = args.registry is not None
-    args.registry = resolve_registry_path(args.registry)
+    args.registry = resolve_registry_path(args.registry, global_flag=args.global_flag)
     require_explicit_writable_registry(parser, args)
     if args.command == 'init':
         init_command(args)

--- a/src/gaia_cli/registry.py
+++ b/src/gaia_cli/registry.py
@@ -9,10 +9,17 @@ from pathlib import Path
 WRITE_COMMANDS = {"push", "name", "fuse", "embed", "sync", "promote"}
 
 
+def _gaia_home_dir() -> Path:
+    """Return the gaia data home: $GAIA_HOME if set, else ~/.gaia."""
+    gaia_home = os.environ.get("GAIA_HOME")
+    if gaia_home:
+        return Path(gaia_home)
+    return Path.home() / ".gaia"
+
+
 def _global_config_path() -> Path:
-    """Return ~/.gaia/config.json, honouring GAIA_HOME if set."""
-    home = os.environ.get("GAIA_HOME") or Path.home()
-    return Path(home) / ".gaia" / "config.json"
+    """Return the global gaia config path, honouring GAIA_HOME if set."""
+    return _gaia_home_dir() / "config.json"
 
 
 def bundled_registry_path():
@@ -33,6 +40,22 @@ def read_global_registry():
     return None
 
 
+def read_local_registry() -> str | None:
+    """Return registry path from .gaia/config.json in CWD, or None if not found."""
+    local_cfg = Path(".gaia") / "config.json"
+    if not local_cfg.exists():
+        return None
+    try:
+        data = json.loads(local_cfg.read_text(encoding="utf-8"))
+        registry_path = data.get("localRegistryPath") or os.path.abspath(".")
+        p = Path(registry_path)
+        if p.is_dir() and (p / "graph" / "gaia.json").exists():
+            return str(p)
+    except (OSError, json.JSONDecodeError):
+        pass
+    return None
+
+
 def write_global_registry(path: str) -> None:
     """Persist the registry path to the global ~/.gaia/config.json."""
     cfg = _global_config_path()
@@ -49,10 +72,16 @@ def write_global_registry(path: str) -> None:
         json.dump(existing, f, indent=2)
 
 
-def resolve_registry_path(explicit_registry=None):
-    """Resolve the registry path: explicit → global config → bundled data."""
+def resolve_registry_path(explicit_registry=None, global_flag=False):
+    """Resolve the registry path: explicit → --global → local .gaia → global config → bundled."""
     if explicit_registry:
         return os.path.abspath(os.path.expanduser(explicit_registry))
+    if global_flag:
+        global_reg = read_global_registry()
+        return global_reg if global_reg else str(bundled_registry_path())
+    local_reg = read_local_registry()
+    if local_reg:
+        return local_reg
     global_reg = read_global_registry()
     if global_reg:
         return global_reg
@@ -73,9 +102,9 @@ def require_explicit_writable_registry(parser, args):
         return
     if registry_path == bundled:
         parser.error(
-            f"`gaia {args.command}` needs a writable registry checkout. "
-            "Run `gaia init` once from your gaia-skill-tree clone to register it globally, "
-            "or pass --registry PATH explicitly."
+            f"`gaia {args.command}` needs a writable registry. Either:\n"
+            "  • Run `gaia init` from your gaia-skill-tree clone (sets localRegistryPath automatically), or\n"
+            "  • Pass --registry PATH explicitly."
         )
     parser.error(
         f"`gaia {args.command}` requires --registry PATH to point at a writable registry directory."

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -120,7 +120,114 @@ def test_write_commands_require_explicit_registry(tmp_path):
 
     assert result.returncode == 2
     assert "writable registry" in result.stderr
-    assert "--registry PATH" in result.stderr
+
+
+def test_local_registry_auto_resolves_for_read_only_command(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / ".gaia").mkdir()
+    (project / ".gaia" / "config.json").write_text(
+        json.dumps({"gaiaUser": "juno", "scanPaths": ["."], "localRegistryPath": str(REPO_ROOT)})
+    )
+
+    result = run_python(
+        ["-m", "gaia_cli", "doctor"],
+        cwd=project,
+        env={"GAIA_HOME": str(tmp_path / "home")},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Registry graph: found" in result.stdout
+
+
+def test_local_registry_auto_resolves_for_write_command(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / ".gaia").mkdir()
+    (project / ".gaia" / "config.json").write_text(
+        json.dumps({"gaiaUser": "juno", "scanPaths": ["."], "localRegistryPath": str(REPO_ROOT)})
+    )
+    (project / "notes.md").write_text("web-search\n")
+
+    result = run_python(
+        ["-m", "gaia_cli", "push", "--dry-run"],
+        cwd=project,
+        env={"GAIA_HOME": str(tmp_path / "home")},
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_global_flag_skips_local_gaia(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / ".gaia").mkdir()
+    (project / ".gaia" / "config.json").write_text(
+        json.dumps({"gaiaUser": "juno", "scanPaths": ["."], "localRegistryPath": str(REPO_ROOT)})
+    )
+
+    result = run_python(
+        ["-m", "gaia_cli", "--global", "doctor"],
+        cwd=project,
+        env={"GAIA_HOME": str(tmp_path / "home")},
+    )
+
+    # No global registry configured → falls to bundled, which still has graph data
+    assert result.returncode == 0, result.stderr
+    assert "Registry graph: found" in result.stdout
+
+
+def test_local_registry_fallback_to_cwd_when_no_localRegistryPath(tmp_path):
+    # CWD is a registry clone (has graph/gaia.json), .gaia/config.json has no localRegistryPath
+    registry = tmp_path / "registry"
+    registry.mkdir()
+    (registry / "graph").mkdir()
+    (registry / "graph" / "gaia.json").write_text(json.dumps({"skills": [], "edges": []}))
+    (registry / ".gaia").mkdir()
+    (registry / ".gaia" / "config.json").write_text(
+        json.dumps({"gaiaUser": "juno", "scanPaths": ["."]})
+    )
+
+    from gaia_cli.registry import read_local_registry
+    import os
+
+    orig_cwd = os.getcwd()
+    try:
+        os.chdir(registry)
+        result = read_local_registry()
+        assert result == str(registry)
+    finally:
+        os.chdir(orig_cwd)
+
+
+def test_init_writes_local_registry_path(tmp_path):
+    result = run_python(
+        ["-m", "gaia_cli", "init", "--user", "testuser", "--yes"],
+        cwd=tmp_path,
+        env={"GAIA_HOME": str(tmp_path / "home")},
+    )
+
+    assert result.returncode == 0, result.stderr
+    cfg = json.loads((tmp_path / ".gaia" / "config.json").read_text())
+    assert cfg.get("localRegistryPath") == str(tmp_path)
+
+
+def test_gaia_home_is_data_dir_not_home_dir(tmp_path):
+    # GAIA_HOME should be treated as the gaia data dir: config at $GAIA_HOME/config.json
+    gaia_home = tmp_path / "mydata"
+    gaia_home.mkdir()
+    (gaia_home / "config.json").write_text(
+        json.dumps({"defaultRegistry": str(REPO_ROOT)})
+    )
+
+    result = run_python(
+        ["-m", "gaia_cli", "--global", "doctor"],
+        cwd=tmp_path,
+        env={"GAIA_HOME": str(gaia_home)},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Registry graph: found" in result.stdout
 
 
 def test_install_cache_honors_gaia_home(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- **Auto-resolution chain**: `--registry` → `--global` → `.gaia/config.json` (`localRegistryPath`) → `$GAIA_HOME/config.json` → bundled. Users no longer need `--registry` for any command when working inside a project with `.gaia/`.
- **`gaia init` writes `localRegistryPath`**: The CWD absolute path is saved into `.gaia/config.json` at init time, so write commands (`push`, `embed`, `fuse`, etc.) auto-resolve without any flags.
- **`--global` / `-g` flag**: New top-level flag to skip local `.gaia/` detection and go straight to the global GAIA_HOME registry.
- **GAIA_HOME semantics fix**: `$GAIA_HOME` is now treated as the gaia data directory (`$GAIA_HOME/config.json`), aligning with `install.py`'s existing convention. Previously `registry.py` incorrectly treated it as a home dir and appended `.gaia/config.json`.

## Test plan

- [x] `test_bundled_registry_is_used_for_read_only_doctor_without_registry` — no local/global config → bundled
- [x] `test_scan_can_use_explicit_writable_registry` — explicit `--registry` still wins
- [x] `test_write_commands_require_explicit_registry` — no `localRegistryPath`, CWD not a registry → still blocked
- [x] `test_local_registry_auto_resolves_for_read_only_command` — `.gaia/config.json` with `localRegistryPath` → auto-resolves for `doctor`
- [x] `test_local_registry_auto_resolves_for_write_command` — same config → `push --dry-run` works without `--registry`
- [x] `test_global_flag_skips_local_gaia` — `--global` bypasses `.gaia/` even when present
- [x] `test_local_registry_fallback_to_cwd_when_no_localRegistryPath` — `.gaia/` exists, no field, CWD has `graph/gaia.json` → CWD used
- [x] `test_init_writes_local_registry_path` — `gaia init` writes `localRegistryPath` into `.gaia/config.json`
- [x] `test_gaia_home_is_data_dir_not_home_dir` — `$GAIA_HOME/config.json` read correctly (not `$GAIA_HOME/.gaia/config.json`)
- [x] Full suite: 244 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)