### PR TITLE
Add 'Repo Docs Before PR' named skill and regenerate docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ Use this catalog to bucket popular named skills from sources such as VoltAgent's
 <!-- gaia:cli-start -->
 ```text
 usage: gaia [-h] [--registry REGISTRY] [--global] [--version]
-            {help,init,scan,pull,tree,push,version,mcp,release,graph,appraise,promote,docs,skills} ...
+            {help,init,scan,pull,tree,push,version,mcp,release,graph,appraise,promote,docs,skills}
+            ...
 
 Gaia Registry CLI
 
@@ -174,10 +175,10 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
-  --registry REGISTRY   Path to a local Gaia registry checkout. Defaults to auto-
-                        resolved local or global registry.
-  --global, -g          Use global GAIA_HOME registry, ignoring any local .gaia/
-                        config.
+  --registry REGISTRY   Path to a local Gaia registry checkout. Defaults to
+                        auto-resolved local or global registry.
+  --global, -g          Use global GAIA_HOME registry, ignoring any local
+                        .gaia/ config.
   --version, -v         Print the Gaia CLI version and exit.
 
 Quick usage:
@@ -197,7 +198,7 @@ Quick usage:
   gaia skills list [--exclude-pending]
   gaia skills search <query> [--exclude-pending]
   gaia skills info <skill_id> [--exclude-pending]
-  gaia skills install <skill_id> [--global | --local]
+  gaia skills install <skill> [--global | --local]
   gaia skills uninstall <skill_id>
 
 ```

--- a/registry/named/gaiabot/repo-docs-before-pr.md
+++ b/registry/named/gaiabot/repo-docs-before-pr.md
@@ -1,0 +1,28 @@
+---
+id: gaiabot/repo-docs-before-pr
+name: Repo Docs Before PR
+contributor: gaiabot
+origin: false
+genericSkillRef: write-report
+status: awakened
+level: II
+description: Builds and validates repository documentation as a pre-PR guardrail by running the local docs pipeline (including stale-doc checks), then surfaces actionable diffs so pull requests do not fail CI on documentation freshness.
+links:
+  docs: https://github.com/mbtiongson1/gaia-skill-tree#docs
+tags:
+  - documentation
+  - ci
+  - pre-pr
+  - quality-gate
+  - repo-maintenance
+createdAt: "2026-05-01"
+updatedAt: "2026-05-01"
+---
+
+## Overview
+
+Repo Docs Before PR is a repository hygiene skill that enforces docs freshness before opening a pull request. It runs the project's local docs build command, checks whether generated documentation is stale, and asks the agent to stage regenerated files as part of the same change set.
+
+## Notes
+
+This implementation targets repositories that expose a dedicated docs build command (for Gaia: `gaia docs build`), and is intended to prevent avoidable CI failures caused by stale generated docs.


### PR DESCRIPTION
### Motivation
- Prevent CI failures caused by stale generated documentation by providing a reusable pre-PR workflow that runs the repo docs pipeline and surfaces actionable diffs. 

### Description
- Add a new named skill file `registry/named/gaiabot/repo-docs-before-pr.md` implementing a `Repo Docs Before PR` skill that runs the local docs build/check as a pre-PR guardrail. 
- Regenerate repository docs using the local build pipeline, which updated the README generated CLI usage block (including the `gaia skills install <skill>` usage change). 
- Prepare a PR payload proposing the new named skill and the regenerated docs snippets.

### Testing
- Attempted `gaia docs build`, which failed in this environment because the `gaia` CLI is not on `PATH` (command not found). 
- Ran `PYTHONPATH=src python scripts/build_docs.py` which succeeded and printed "Documentation regenerated.". 
- Ran `PYTHONPATH=src python scripts/build_docs.py --check` which succeeded and printed "Documentation is up to date.".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f4fad52c2c832795be29bd211c2eb4)