### PR TITLE
Improve mobile/responsive styles, navigation labels, and reveal-on-hash behavior

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -441,6 +441,7 @@
   }
   @media (max-width:700px){
     html,body{overflow-x:clip}
+    body{font-size:.95rem;line-height:1.58}
     nav{
       padding:.75rem .85rem;
       gap:.65rem;
@@ -451,9 +452,12 @@
     }
     .nav-logo{font-size:1rem;line-height:1.2;white-space:nowrap}
     nav ul{
-      gap:.75rem;font-size:.8rem;overflow-x:auto;max-width:100%;
+      gap:.55rem;font-size:.77rem;overflow-x:visible;max-width:100%;
       padding-bottom:.2rem;-webkit-overflow-scrolling:touch;scrollbar-width:none;
+      flex-wrap:wrap;
+      justify-content:flex-end;
     }
+    nav a,button.nav-tree{font-size:.77rem}
     nav ul::-webkit-scrollbar{display:none}
     #hero{min-height:100svh;padding:5.25rem 1rem 2.25rem}
     #canvas3d{transform:translateZ(0);will-change:transform;backface-visibility:hidden}
@@ -475,6 +479,12 @@
       backdrop-filter:none;
       -webkit-backdrop-filter:none;
     }
+    pre{
+      font-size:.76rem;
+      white-space:pre-wrap;
+      overflow-wrap:anywhere;
+      word-break:break-word;
+    }
     .se-topbar{
       background:#030712;
       backdrop-filter:none;
@@ -490,11 +500,12 @@
       animation:none;box-shadow:0 0 0 1px rgba(56,189,248,.2);
     }
     .tree-dialog::backdrop,.graph-dialog::backdrop{backdrop-filter:none}
-    .tree-dialog-header,.graph-dialog-header{padding:.85rem .9rem}
-    .tree-dialog-body{padding:.9rem .9rem 1.15rem}
+    .tree-dialog-header,.graph-dialog-header{padding:.85rem 1.05rem}
+    .tree-dialog-body{padding:1rem 1.15rem 1.25rem}
     .graph-dialog-header{flex-direction:column}
     .graph-dialog-actions{justify-content:flex-start}
     .graph-legend{top:auto;bottom:2.8rem;right:.5rem;transform:none;padding:.4rem .5rem;font-size:.65rem}
+    #named{scroll-margin-top:6.5rem;padding-top:1.25rem}
   }
 
   /* -- NAMED SKILLS -- */
@@ -861,6 +872,7 @@
   [data-section="start"].reveal,
   [data-section="workflow"].reveal{transition-duration:.65s}
   [data-section="explorer"].reveal{transition-duration:.7s}
+  #named.reveal{opacity:1;transform:none}
 
   /* ── SKILL EXPLORER OVERLAY ── */
   :root {
@@ -1034,11 +1046,10 @@
   <span class="nav-logo">◆ GAIA</span>
   <ul>
     <li><a href="#what">What</a></li>
-    <li><a href="#what">Tiers</a></li>
-    <li><a href="#start">Get Started</a></li>
-    <li><a href="#workflow">Workflow</a></li>
     <li><a href="#ranks">Ranks</a></li>
-    <li><a href="#named" class="nav-named-explorer">Named Skills Explorer</a></li>
+    <li><a href="#start">Start</a></li>
+    <li><a href="#workflow">Flow</a></li>
+    <li><a href="#named" class="nav-named-explorer">Named Skills</a></li>
     <li><button type="button" class="nav-tree" id="treeNavBtn">Tree</button></li>
   </ul>
 </nav>
@@ -2078,6 +2089,16 @@ const obs = new IntersectionObserver(entries => {
   entries.forEach(e => { if (e.isIntersecting) e.target.classList.add('visible'); });
 }, { threshold: 0.12 });
 document.querySelectorAll('.reveal').forEach(el => obs.observe(el));
+
+function revealHashTarget() {
+  if (!location.hash) return;
+  const target = document.querySelector(location.hash);
+  if (target && target.classList && target.classList.contains('reveal')) {
+    target.classList.add('visible');
+  }
+}
+window.addEventListener('hashchange', revealHashTarget);
+window.addEventListener('load', revealHashTarget);
 </script>
 
 <!-- ─── NAMED SKILLS DATA ─── -->


### PR DESCRIPTION
### Motivation
- Improve the small-screen presentation and readability of the site by tightening spacing, adjusting font sizes, and fixing wrapping/overflow issues. 
- Make the top navigation labels and ordering more concise and clear on mobile. 
- Ensure scroll-revealed sections become visible when navigated to via URL hash changes or page load.

### Description
- Adjusted mobile (`@media (max-width:700px)`) CSS: added `body` font sizing, tweaked `nav ul` gap/font-size/overflow and enabled `flex-wrap`/`justify-content`, set `nav a` and `button.nav-tree` font-size, and refined dialog and padding values. 
- Updated `pre` styling on mobile to set `font-size`, `white-space: pre-wrap`, `overflow-wrap: anywhere`, and `word-break: break-word` to improve code block wrapping. 
- Modified `#named` scroll/padding behavior for mobile and added a `#named.reveal` rule so the named skills section can be revealed programmatically. 
- Adjusted top navigation items in the HTML: reordered links and relabeled anchors (e.g. `Start`, `Flow`, `Named Skills`) and removed/streamlined a few items. 
- Added a `revealHashTarget()` helper and attached it to `hashchange` and `load` events so elements with the `.reveal` class targeted by URL hashes get the `visible` class on navigation or page load.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f52363a14c832799cb2df1a6d1e61e)