### PR TITLE
Remove `propose` intake flow; inline docs + interactive graph and sync CLI/registry text

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,1038 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Gaia — AI Agent Skill Registry</title>
-<link rel="stylesheet" href="css/styles.css">
+<style>
+  :root {
+    --basic:    #38bdf8;
+    --extra:    #c084fc;
+    --ultimate: #f59e0b;
+    --bg:       #030712;
+    --surface:  #0f172a;
+    --border:   #1e293b;
+    --text:     #e2e8f0;
+    --muted:    #64748b;
+    --code-bg:  #0f172a;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{
+    background:var(--bg);
+    color:var(--text);
+    font-family:'Inter',system-ui,sans-serif;
+    line-height:1.65;
+    overflow-x:hidden;
+  }
+  /* ── NAV ── */
+  nav{
+    position:fixed;top:0;left:0;right:0;z-index:100;
+    display:flex;align-items:center;justify-content:space-between;
+    padding:.9rem 2rem;
+    background:rgba(3,7,18,.75);
+    backdrop-filter:blur(12px);
+    border-bottom:1px solid var(--border);
+  }
+  .nav-logo{
+    font-size:1.15rem;font-weight:700;letter-spacing:.05em;
+    background:linear-gradient(90deg,var(--basic),var(--extra));
+    -webkit-background-clip:text;-webkit-text-fill-color:transparent;
+  }
+  nav ul{list-style:none;display:flex;gap:2rem}
+  nav a{color:var(--muted);text-decoration:none;font-size:.9rem;transition:color .2s}
+  nav a:hover{color:var(--text)}
+  .nav-tree{color:var(--ultimate)!important}
+  .nav-tree:hover{color:#fcd34d!important}
+  button.nav-tree{background:none;border:none;cursor:pointer;font:inherit;font-size:.9rem;padding:0}
+  .nav-named-explorer{color:#ef4444!important;font-weight:700}
+  .nav-named-explorer:hover{color:#f87171!important}
+  /* ── HERO ── */
+  #hero{
+    position:relative;min-height:100vh;
+    display:flex;flex-direction:column;align-items:center;justify-content:center;
+    text-align:center;padding:6rem 1.5rem 3rem;
+    overflow:hidden;
+  }
+  #canvas3d{
+    position:absolute;inset:0;width:100%;height:100%;
+    pointer-events:none;opacity:1;
+  }
+  .hero-content{position:relative;z-index:2;max-width:700px}
+  .hero-title,.hero-sub,.hero-cta,.scroll-hint{transition:opacity .24s ease,filter .24s ease,transform .24s ease}
+  #hero.hero-graph-peek .hero-title,
+  #hero.hero-graph-peek .hero-sub,
+  #hero.hero-graph-peek .hero-cta,
+  #hero.hero-graph-peek .scroll-hint{
+    opacity:0;filter:blur(8px);pointer-events:none;transform:translateY(10px);
+  }
+  .hero-eyebrow{
+    display:inline-block;margin-bottom:1.2rem;
+    font-size:.8rem;letter-spacing:.15em;text-transform:uppercase;
+    color:var(--basic);border:1px solid var(--basic);
+    padding:.45rem 1.05rem;border-radius:999px;
+    background:rgba(3,7,18,.58);
+    box-shadow:0 0 24px rgba(56,189,248,.18);
+  }
+  .graph-trigger{
+    appearance:none;font:inherit;cursor:pointer;position:relative;z-index:3;
+    transition:background .2s,border-color .2s,box-shadow .2s,transform .2s;
+  }
+  .graph-trigger:hover,.graph-trigger:focus-visible{
+    background:rgba(56,189,248,.16);border-color:#7dd3fc;color:#e0f2fe;
+    box-shadow:0 0 36px rgba(56,189,248,.34);transform:translateY(-1px);outline:none;
+  }
+  h1{font-size:clamp(2.4rem,6vw,4rem);font-weight:800;line-height:1.1;margin-bottom:1.2rem}
+  h1 span{
+    background:linear-gradient(135deg,var(--basic) 0%,var(--extra) 50%,var(--ultimate) 100%);
+    -webkit-background-clip:text;-webkit-text-fill-color:transparent;
+  }
+  .hero-sub{font-size:1.15rem;color:var(--muted);max-width:540px;margin:0 auto 2.4rem}
+  .hero-cta{display:flex;gap:1rem;justify-content:center;flex-wrap:wrap}
+  .btn{
+    padding:.75rem 1.8rem;border-radius:8px;font-size:.95rem;font-weight:600;
+    text-decoration:none;transition:all .2s;cursor:pointer;border:none;
+  }
+  .btn-primary{
+    background:linear-gradient(135deg,var(--basic),var(--extra));
+    color:#fff;box-shadow:0 0 20px rgba(56,189,248,.3);
+  }
+  .btn-primary:hover{box-shadow:0 0 32px rgba(56,189,248,.5);transform:translateY(-1px)}
+  .btn-ghost{
+    background:transparent;color:var(--text);
+    border:1px solid var(--border);
+  }
+  .btn-ghost:hover{border-color:var(--basic);color:var(--basic)}
+  .scroll-hint{
+    position:absolute;bottom:2rem;left:50%;transform:translateX(-50%);
+    color:var(--muted);font-size:.8rem;display:flex;flex-direction:column;align-items:center;gap:.4rem;
+    animation:bob 2.4s ease-in-out infinite;
+  }
+  .scroll-hint svg{width:20px;height:20px;stroke:var(--muted)}
+  @keyframes bob{0%,100%{transform:translateX(-50%) translateY(0)}50%{transform:translateX(-50%) translateY(6px)}}
+  /* ── SECTIONS ── */
+  section{padding:5rem 1.5rem;max-width:1000px;margin:0 auto}
+  h2{
+    font-size:clamp(1.6rem,4vw,2.2rem);font-weight:700;margin-bottom:.5rem;
+    background:linear-gradient(90deg,var(--text) 60%,var(--muted));
+    -webkit-background-clip:text;-webkit-text-fill-color:transparent;
+  }
+  .section-sub{color:var(--muted);margin-bottom:2.5rem;font-size:1rem}
+  /* ── TIER CARDS ── */
+  .tier-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1.2rem}
+  .tier-card{
+    background:var(--surface);border:1px solid var(--border);
+    border-radius:14px;padding:1.5rem;transition:transform .2s,box-shadow .2s;
+    position:relative;overflow:hidden;
+  }
+  .tier-card::before{
+    content:'';position:absolute;inset:0;border-radius:14px;
+    background:radial-gradient(ellipse at top left,var(--card-glow,.2) 0%,transparent 70%);
+    opacity:.35;pointer-events:none;
+  }
+  .tier-card:hover{transform:translateY(-3px);box-shadow:0 12px 40px rgba(0,0,0,.4)}
+  .tier-icon{font-size:2rem;margin-bottom:.8rem}
+  .tier-badge{
+    display:inline-block;font-size:.72rem;font-weight:700;letter-spacing:.1em;
+    padding:.25rem .7rem;border-radius:999px;margin-bottom:.8rem;
+  }
+  .tier-name{font-size:1.1rem;font-weight:700;margin-bottom:.4rem}
+  .tier-desc{font-size:.875rem;color:var(--muted)}
+  .basic   {--card-glow:rgba(56,189,248,.4)}
+  .extra   {--card-glow:rgba(192,132,252,.4)}
+  .ultimate{--card-glow:rgba(245,158,11,.4)}
+  .badge-basic   {background:rgba(56,189,248,.15);color:var(--basic);border:1px solid rgba(56,189,248,.3)}
+  .badge-extra   {background:rgba(192,132,252,.15);color:var(--extra);border:1px solid rgba(192,132,252,.3)}
+  .badge-ultimate{background:rgba(245,158,11,.15);color:var(--ultimate);border:1px solid rgba(245,158,11,.3)}
+  /* ── STEPS ── */
+  .steps{display:flex;flex-direction:column;gap:1.5rem}
+  .step{
+    display:grid;grid-template-columns:56px 1fr;gap:1.2rem;align-items:start;
+    background:var(--surface);border:1px solid var(--border);
+    border-radius:14px;padding:1.5rem;transition:border-color .2s;
+  }
+  .step:hover{border-color:var(--basic)}
+  .step-num{
+    width:44px;height:44px;border-radius:50%;
+    display:flex;align-items:center;justify-content:center;
+    font-weight:800;font-size:1rem;flex-shrink:0;
+    background:linear-gradient(135deg,var(--basic),var(--extra));
+    color:#fff;box-shadow:0 0 16px rgba(56,189,248,.35);
+  }
+  .step h3{font-size:1.05rem;font-weight:700;margin-bottom:.3rem}
+  .step p{font-size:.9rem;color:var(--muted);margin-bottom:.8rem}
+  pre{
+    background:var(--code-bg);border:1px solid var(--border);
+    border-radius:8px;padding:1rem 1.2rem;overflow-x:auto;
+    font-family:'JetBrains Mono','Fira Code','Courier New',monospace;
+    font-size:.83rem;line-height:1.6;color:#94a3b8;
+  }
+  .pre-wrap{position:relative}
+  .copy-btn{
+    position:absolute;top:.45rem;right:.45rem;
+    display:flex;align-items:center;justify-content:center;
+    width:28px;height:28px;padding:0;
+    color:var(--muted);background:rgba(15,23,42,.85);
+    border:1px solid var(--border);border-radius:5px;
+    cursor:pointer;transition:color .15s,border-color .15s,opacity .15s;
+    opacity:0;
+  }
+  .pre-wrap:hover .copy-btn{opacity:1}
+  .copy-btn:hover{color:var(--text);border-color:var(--basic)}
+  .copy-btn.copied{color:#86efac;border-color:#86efac}
+  .comment{color:#4b6378}
+  .cmd{color:#38bdf8}
+  .str{color:#86efac}
+  .kw{color:#a78bfa}
+  /* ── RANK TABLE ── */
+  .rank-table-wrap{overflow-x:auto;border-radius:12px;border:1px solid var(--border)}
+  table{width:100%;border-collapse:collapse}
+  thead tr{background:rgba(56,189,248,.06)}
+  th,td{padding:.85rem 1.1rem;text-align:left;font-size:.875rem;border-bottom:1px solid var(--border)}
+  th{font-weight:700;color:var(--text);letter-spacing:.04em}
+  td{color:var(--muted)}
+  tr:last-child td{border-bottom:none}
+  tr:hover td{color:var(--text);background:rgba(255,255,255,.025)}
+  .rank-badge{
+    display:inline-block;padding:.2rem .6rem;border-radius:999px;
+    font-size:.75rem;font-weight:700;
+  }
+  /* ── WORKFLOW ── */
+  .flow{display:flex;align-items:center;gap:.6rem;flex-wrap:wrap;margin-bottom:1.5rem}
+  .flow-node{
+    background:var(--surface);border:1px solid var(--border);
+    padding:.5rem 1.1rem;border-radius:8px;font-size:.85rem;font-weight:600;
+  }
+  .flow-arrow{color:var(--basic);font-size:1.2rem}
+  /* ── INSTALL CALLOUT ── */
+  .callout{
+    background:linear-gradient(135deg,rgba(56,189,248,.08),rgba(167,139,250,.08));
+    border:1px solid rgba(167,139,250,.25);border-radius:14px;
+    padding:1.8rem;margin:2rem 0;
+  }
+  .callout-title{font-weight:700;margin-bottom:.5rem;color:var(--extra)}
+  .callout p{font-size:.9rem;color:var(--muted)}
+  .qs-tip { display:flex;align-items:flex-start;gap:.55rem;margin-top:.5rem;padding:.5rem .85rem;background:rgba(56,189,248,.05);border:1px solid rgba(56,189,248,.18);border-left:3px solid rgba(56,189,248,.45);border-radius:0 7px 7px 0;font-size:.79rem;color:var(--muted);line-height:1.5; }
+  .qs-tip-icon { flex-shrink:0;color:var(--basic); }
+  .qs-tip code { font-family:'JetBrains Mono','Fira Code',monospace;font-size:.77rem;color:var(--text);background:rgba(255,255,255,.07);padding:.1rem .32rem;border-radius:3px; }
+  .os-tabs { display:flex;gap:.35rem;margin-bottom:.6rem; }
+  .os-tab { background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:.28rem .7rem;font-size:.76rem;color:var(--muted);cursor:pointer;font-family:inherit;transition:color .15s,border-color .15s,background .15s; }
+  .os-tab.active { color:var(--basic);border-color:rgba(56,189,248,.4);background:rgba(56,189,248,.06); }
+  .os-panel { display:none; }
+  .os-panel.active { display:block; }
+  /* ── UNNAMED SKILL POPUP ── */
+  .usp-backdrop {
+    position:fixed;inset:0;z-index:1200;
+    background:rgba(0,0,0,.65);backdrop-filter:blur(5px);
+    display:flex;align-items:center;justify-content:center;
+    opacity:0;pointer-events:none;transition:opacity .2s;
+  }
+  .usp-backdrop.open { opacity:1;pointer-events:auto; }
+  .usp-card {
+    position:relative;background:var(--surface);
+    border:1px solid rgba(56,189,248,.35);border-radius:16px;
+    padding:1.8rem 2rem 1.6rem;width:min(420px,92vw);
+    box-shadow:0 24px 70px rgba(0,0,0,.65),0 0 40px rgba(56,189,248,.1);
+    transform:scale(.94) translateY(10px);transition:transform .22s cubic-bezier(.4,0,.2,1);
+  }
+  .usp-backdrop.open .usp-card { transform:scale(1) translateY(0); }
+  .usp-x { position:absolute;top:.7rem;right:.9rem;background:transparent;border:none;color:var(--muted);font-size:1.05rem;cursor:pointer;padding:.25rem .45rem;transition:color .15s;line-height:1; }
+  .usp-x:hover { color:var(--text); }
+  .usp-glyph { font-size:1.9rem;margin-bottom:.55rem;line-height:1; }
+  .usp-name { font-size:1.1rem;font-weight:800;color:var(--text);margin-bottom:.2rem; }
+  .usp-id { font-family:'JetBrains Mono',monospace;font-size:.72rem;color:#ef4444;margin-bottom:.85rem; }
+  .usp-body { font-size:.87rem;color:var(--muted);line-height:1.6;margin-bottom:1.1rem; }
+  .usp-cta { color:var(--basic);font-weight:700; }
+  .usp-row {
+    display:flex;align-items:center;gap:.4rem;
+    background:var(--bg);border:1px solid rgba(56,189,248,.22);border-radius:8px;
+    padding:.42rem .75rem;
+    font-family:'JetBrains Mono','Fira Code',monospace;font-size:.78rem;color:var(--basic);
+  }
+  .usp-prompt { color:var(--muted);flex-shrink:0; }
+  .usp-cmd { flex:1; }
+  .usp-copy { background:transparent;border:none;color:var(--muted);cursor:pointer;display:flex;align-items:center;flex-shrink:0;padding:0;transition:color .15s; }
+  .usp-copy:hover { color:var(--basic); }
+  /* ── GLOSSARY ── */
+  .glossary{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:1rem}
+  .gloss-item{
+    background:var(--surface);border:1px solid var(--border);
+    border-radius:10px;padding:1rem 1.2rem;
+  }
+  .gloss-term{font-weight:700;font-size:.9rem;color:var(--basic);margin-bottom:.25rem}
+  .gloss-def{font-size:.82rem;color:var(--muted)}
+  /* ── GRAPH DIALOG ── */
+  .graph-dialog{
+    margin:auto;
+    width:min(1120px,94vw);height:min(760px,86vh);padding:0;
+    color:var(--text);background:rgba(3,7,18,.98);
+    border:1px solid rgba(56,189,248,.35);border-radius:20px;
+    box-shadow:0 30px 100px rgba(0,0,0,.72),0 0 55px rgba(56,189,248,.16);
+    overflow:hidden;
+  }
+  .graph-dialog::backdrop{background:rgba(0,0,0,.72);backdrop-filter:blur(6px)}
+  .graph-dialog-inner{display:flex;flex-direction:column;height:100%}
+  .graph-dialog-header{
+    display:flex;gap:1rem;align-items:flex-start;justify-content:space-between;
+    padding:1rem 1.2rem;border-bottom:1px solid var(--border);
+    background:linear-gradient(90deg,rgba(56,189,248,.1),rgba(167,139,250,.08));
+  }
+  .graph-dialog-title{font-weight:800;font-size:1rem;margin-bottom:.15rem}
+  .graph-dialog-sub{color:var(--muted);font-size:.82rem}
+  .graph-dialog-actions{display:flex;align-items:center;gap:.65rem;flex-wrap:wrap;justify-content:flex-end}
+  .graph-download,.graph-close{
+    color:var(--text);background:rgba(15,23,42,.84);border:1px solid var(--border);
+    border-radius:999px;text-decoration:none;font-size:.78rem;font-weight:700;
+    padding:.42rem .78rem;cursor:pointer;white-space:nowrap;
+  }
+  .graph-download:hover,.graph-close:hover,.graph-download:focus-visible,.graph-close:focus-visible{
+    border-color:var(--basic);color:var(--basic);outline:none;
+  }
+  .graph-canvas-wrap{position:relative;flex:1;min-height:0;background:radial-gradient(circle at center,rgba(15,23,42,.75),#020617 68%)}
+  #graphDialogCanvas{position:absolute;inset:0;width:100%;height:100%}
+  .graph-status{
+    position:absolute;left:1rem;bottom:1rem;z-index:2;
+    color:#94a3b8;font-size:.78rem;background:rgba(3,7,18,.68);
+    border:1px solid rgba(148,163,184,.18);border-radius:999px;padding:.35rem .75rem;
+  }
+  /* ── tree dialog ── */
+  .tree-dialog{
+    margin:auto;
+    width:min(840px,94vw);height:min(640px,86vh);padding:0;
+    color:var(--text);background:rgba(3,7,18,.98);
+    border:1px solid rgba(56,189,248,.45);border-radius:20px;
+    box-shadow:0 30px 100px rgba(0,0,0,.8),
+               0 0 70px rgba(56,189,248,.28),
+               0 0 30px rgba(255,255,255,.14),
+               0 0 110px rgba(192,132,252,.14);
+    overflow:hidden;
+    animation:tree-dialog-breathe 5s ease-in-out infinite;
+  }
+  @keyframes tree-dialog-breathe{
+    0%,100%{box-shadow:0 30px 100px rgba(0,0,0,.8),0 0 70px rgba(56,189,248,.28),0 0 30px rgba(255,255,255,.14),0 0 110px rgba(192,132,252,.14)}
+    50%{box-shadow:0 30px 100px rgba(0,0,0,.8),0 0 80px rgba(192,132,252,.32),0 0 36px rgba(255,255,255,.18),0 0 120px rgba(56,189,248,.16)}
+  }
+  .tree-dialog::backdrop{background:rgba(0,0,0,.72);backdrop-filter:blur(6px)}
+  .tree-dialog-inner{display:flex;flex-direction:column;height:100%}
+  .tree-dialog-header{
+    display:flex;gap:1rem;align-items:center;justify-content:space-between;
+    padding:.9rem 1.2rem;border-bottom:1px solid var(--border);flex-shrink:0;
+    background:linear-gradient(90deg,rgba(56,189,248,.1),rgba(167,139,250,.08));
+    cursor:grab;user-select:none;
+  }
+  .tree-dialog-header.dragging{cursor:grabbing}
+  .tree-dialog-title{font-weight:800;font-size:1rem}
+  .tree-dialog-actions{display:flex;align-items:center;gap:.6rem}
+  .tree-act-btn{
+    color:var(--text);background:rgba(15,23,42,.84);border:1px solid var(--border);
+    border-radius:999px;font-size:.78rem;font-weight:700;
+    padding:.42rem .78rem;cursor:pointer;white-space:nowrap;font-family:inherit;
+  }
+  .tree-act-btn:hover{border-color:var(--basic);color:var(--basic)}
+  .tree-act-btn.copied{border-color:#86efac;color:#86efac}
+  .tree-close-x{
+    display:flex;align-items:center;justify-content:center;
+    width:1.9rem;height:1.9rem;
+    color:var(--muted);background:transparent;border:1px solid var(--border);
+    border-radius:50%;font-size:.85rem;cursor:pointer;font-family:inherit;flex-shrink:0;
+  }
+  .tree-close-x:hover{border-color:var(--basic);color:var(--basic)}
+  .tree-dialog-body{flex:1;overflow:auto;padding:1.1rem 1.4rem;min-height:0}
+  .tree-dialog-body pre{
+    font-family:'JetBrains Mono','Fira Code','Courier New',monospace;
+    font-size:.78rem;line-height:1.65;color:var(--text);
+    white-space:pre;background:transparent;border:none;margin:0;padding:0;
+  }
+  .tree-skeleton{color:var(--muted);animation:tree-skeleton-pulse 1.5s ease-in-out infinite}
+  @keyframes tree-skeleton-pulse{0%,100%{opacity:.35}50%{opacity:.7}}
+  /* syntax highlighting */
+  @keyframes tree-rainbow-glow{
+    0%  {color:#38bdf8;text-shadow:0 0 10px rgba(56,189,248,.8),0 0 22px rgba(56,189,248,.4)}
+    18% {color:#a78bfa;text-shadow:0 0 10px rgba(167,139,250,.8),0 0 22px rgba(167,139,250,.4)}
+    36% {color:#f59e0b;text-shadow:0 0 10px rgba(245,158,11,.8),0 0 22px rgba(245,158,11,.4)}
+    54% {color:#ef4444;text-shadow:0 0 10px rgba(239,68,68,.8),0 0 22px rgba(239,68,68,.4)}
+    72% {color:#c084fc;text-shadow:0 0 10px rgba(192,132,252,.8),0 0 22px rgba(192,132,252,.4)}
+    90% {color:#34d399;text-shadow:0 0 10px rgba(52,211,153,.8),0 0 22px rgba(52,211,153,.4)}
+    100%{color:#38bdf8;text-shadow:0 0 10px rgba(56,189,248,.8),0 0 22px rgba(56,189,248,.4)}
+  }
+  .tree-ult-line{font-weight:700;animation:tree-rainbow-glow 4s linear infinite}
+  .tree-ult-contributor{color:#ef4444;font-weight:800;text-shadow:0 0 8px rgba(239,68,68,.6)}
+  .tree-ult-slash{color:var(--muted)}
+  .tree-ult-skillname,.tree-ult-id{color:#f59e0b}
+  .tree-extra-glyph{color:var(--extra)}
+  .tree-basic-glyph{color:var(--basic)}
+  .tree-sep{color:rgba(56,189,248,.2)}
+  .skill-tooltip{
+    position:absolute;pointer-events:none;display:none;z-index:10;
+    background:rgba(3,7,18,.9);border:1px solid rgba(148,163,184,.22);
+    border-radius:.6rem;padding:.6rem .85rem;min-width:148px;max-width:230px;
+    backdrop-filter:blur(8px);
+  }
+  .skill-tooltip-name{font-weight:800;font-size:1rem;line-height:1.2;margin-bottom:.38rem}
+  .skill-tooltip-row{display:flex;align-items:center;gap:.4rem .5rem;flex-wrap:wrap}
+  .skill-tooltip-badge{
+    font-size:.65rem;font-weight:800;letter-spacing:.06em;
+    padding:.14rem .42rem;border-radius:999px;border:1px solid currentColor;
+    opacity:.85;
+  }
+  .skill-tooltip-detail{color:#64748b;font-size:.72rem;font-weight:700;letter-spacing:.05em}
+  .skill-tooltip-type-basic{color:#38bdf8}
+  .skill-tooltip-type-extra{color:#c084fc}
+  .skill-tooltip-type-ultimate{color:#f59e0b}
+  .graph-search-wrap{position:absolute;top:.75rem;right:.75rem;z-index:10}
+  .graph-search{
+    background:rgba(3,7,18,.15);border:1px solid rgba(148,163,184,.15);
+    border-radius:999px;padding:.28rem .72rem;font-size:.74rem;
+    color:#e2e8f0;outline:none;width:130px;font-family:inherit;
+    transition:background .2s,border-color .2s,width .2s;
+  }
+  .graph-search::placeholder{color:rgba(148,163,184,.38)}
+  .graph-search:hover,.graph-search:focus{
+    background:rgba(3,7,18,.72);border-color:rgba(148,163,184,.5);width:175px;
+  }
+  .graph-legend{
+    position:absolute;top:50%;right:.75rem;transform:translateY(-50%);z-index:10;
+    display:flex;flex-direction:column;gap:.55rem;
+    background:rgba(3,7,18,.78);border:none;
+    border-radius:.6rem;padding:.5rem .65rem;backdrop-filter:blur(8px);
+    max-height:calc(100% - 3.5rem);overflow-y:auto;user-select:none;
+  }
+  .graph-legend-section{display:flex;flex-direction:column;gap:.18rem}
+  .graph-legend-heading{
+    font-size:.6rem;font-weight:700;letter-spacing:.1em;text-transform:uppercase;
+    color:#64748b;margin-bottom:.1rem;
+  }
+  .graph-legend-item{
+    display:flex;align-items:center;gap:.38rem;
+    font-size:.7rem;font-weight:600;color:#94a3b8;
+    padding:.18rem .38rem;border-radius:4px;cursor:pointer;
+    transition:background .15s,color .15s;
+  }
+  .graph-legend-item:hover{background:rgba(255,255,255,.06);color:#e2e8f0}
+  .graph-legend-item.active{background:rgba(56,189,248,.12);color:#e2e8f0;box-shadow:inset 0 0 0 1px rgba(56,189,248,.3)}
+  .graph-legend-swatch{border-radius:50%;flex-shrink:0}
+  .graph-legend-ranks{display:flex;flex-wrap:wrap;gap:.28rem;padding:.1rem 0}
+  .graph-legend-rank-pill{
+    display:inline-flex;align-items:center;justify-content:center;
+    width:22px;height:22px;border-radius:50%;
+    font-size:.6rem;font-weight:700;cursor:pointer;
+    transition:transform .15s,box-shadow .15s;
+  }
+  .graph-legend-rank-pill:hover{transform:scale(1.18);box-shadow:0 0 8px currentColor}
+  .graph-legend-rank-pill.active{transform:scale(1.18);box-shadow:0 0 10px currentColor,inset 0 0 0 1.5px currentColor}
+  .graph-label-toggle{
+    position:absolute;right:1rem;bottom:1rem;z-index:2;
+    color:#94a3b8;font-size:.72rem;font-weight:700;background:rgba(3,7,18,.68);
+    border:1px solid rgba(148,163,184,.18);border-radius:999px;padding:.3rem .7rem;
+    cursor:pointer;transition:border-color .2s,color .2s,background .2s;font-family:inherit;
+  }
+  .graph-label-toggle:hover{border-color:rgba(56,189,248,.5);color:#e2e8f0}
+  .graph-label-toggle.active{background:rgba(56,189,248,.12);border-color:rgba(56,189,248,.45);color:#e2e8f0}
+  .graph-redpill{
+    position:absolute;bottom:3.4rem;right:.75rem;z-index:10;
+    color:#f87171;font-size:.72rem;font-weight:700;background:rgba(3,7,18,.68);
+    border:1px solid rgba(239,68,68,.45);border-radius:999px;padding:.3rem .78rem;
+    cursor:pointer;transition:all .2s;font-family:inherit;white-space:nowrap;
+  }
+  .graph-redpill:hover{border-color:rgba(239,68,68,.75);color:#fca5a5;background:rgba(239,68,68,.08)}
+  .graph-redpill.active{
+    background:rgba(239,68,68,.18);border-color:rgba(239,68,68,.7);
+    color:#fca5a5;box-shadow:0 0 14px rgba(239,68,68,.35);
+  }
+  @media (max-width:700px){
+    html,body{overflow-x:clip}
+    body{font-size:.95rem;line-height:1.58}
+    nav{
+      padding:.75rem .85rem;
+      gap:.65rem;
+      align-items:flex-start;
+      background:#030712;
+      backdrop-filter:none;
+      -webkit-backdrop-filter:none;
+    }
+    .nav-logo{font-size:1rem;line-height:1.2;white-space:nowrap}
+    nav ul{
+      gap:.55rem;font-size:.77rem;overflow-x:visible;max-width:100%;
+      padding-bottom:.2rem;-webkit-overflow-scrolling:touch;scrollbar-width:none;
+      flex-wrap:wrap;
+      justify-content:flex-end;
+    }
+    nav a,button.nav-tree{font-size:.77rem}
+    nav ul::-webkit-scrollbar{display:none}
+    #hero{min-height:100svh;padding:5.25rem 1rem 2.25rem}
+    #canvas3d{transform:translateZ(0);will-change:transform;backface-visibility:hidden}
+    .hero-sub{font-size:1rem}
+    .scroll-hint{display:none}
+    section{padding:3.8rem 1rem}
+    .os-tab,.ns-tab,.ns-view-btn,.copy-btn,.se-copy-btn{
+      background:#0f172a;
+      box-shadow:none;
+      filter:none;
+      -webkit-filter:none;
+      transform:translateZ(0);
+      backface-visibility:hidden;
+    }
+    .pre-wrap,pre{
+      background:#0f172a;
+      filter:none;
+      -webkit-filter:none;
+      backdrop-filter:none;
+      -webkit-backdrop-filter:none;
+    }
+    pre{
+      font-size:.76rem;
+      white-space:pre-wrap;
+      overflow-wrap:anywhere;
+      word-break:break-word;
+    }
+    .se-topbar{
+      background:#030712;
+      backdrop-filter:none;
+      -webkit-backdrop-filter:none;
+    }
+    .skill-explorer{
+      top:52px;
+      background:#030712;
+    }
+    .tree-dialog,.graph-dialog{
+      width:100vw;max-width:100vw;height:100svh;max-height:100svh;
+      border-radius:0;border-left:none;border-right:none;
+      animation:none;box-shadow:0 0 0 1px rgba(56,189,248,.2);
+    }
+    .tree-dialog::backdrop,.graph-dialog::backdrop{backdrop-filter:none}
+    .tree-dialog-header,.graph-dialog-header{padding:.85rem 1.05rem}
+    .tree-dialog-body{padding:1rem 1.15rem 1.25rem}
+    .graph-dialog-header{flex-direction:column}
+    .graph-dialog-actions{justify-content:flex-start}
+    .graph-legend{top:auto;bottom:2.8rem;right:.5rem;transform:none;padding:.4rem .5rem;font-size:.65rem}
+  }
+
+  /* -- NAMED SKILLS -- */
+  #named { min-height:100vh; padding-top:4rem; scroll-margin-top:0; max-width:none; }
+  .ns-controls {
+    display:flex;flex-direction:column;gap:.7rem;margin-bottom:1.6rem;
+  }
+  .ns-filter-row { display:flex;align-items:center;gap:.6rem;flex-wrap:wrap; }
+  .ns-level-tabs{display:flex;gap:.4rem;flex-wrap:wrap;flex:1}
+  .ns-tab{
+    padding:.35rem .85rem;border-radius:999px;font-size:.8rem;font-weight:600;
+    background:transparent;color:var(--muted);
+    border:1px solid var(--border);cursor:pointer;font-family:inherit;
+    background-size:200% 100%;background-position:0% 0%;
+    transition:color .2s,border-color .2s,background-position .45s ease,background-color .2s;
+  }
+  .ns-tab:hover{color:var(--text);border-color:rgba(148,163,184,.4)}
+  /* per-level resting gradient + hover shift via bg-position */
+  .ns-tab[data-level="II"]  { --tc:99,202,183;  --tcolor:#63cab7 }
+  .ns-tab[data-level="III"] { --tc:167,139,250; --tcolor:#a78bfa }
+  .ns-tab[data-level="IV"]  { --tc:232,121,249; --tcolor:#e879f9 }
+  .ns-tab[data-level="V"]   { --tc:251,191,36;  --tcolor:#fbbf24 }
+  .ns-tab[data-level="VI"]  { --tc:251,191,36;  --tcolor:#fbbf24 }
+  .ns-tab[data-level="II"],.ns-tab[data-level="III"],.ns-tab[data-level="IV"],.ns-tab[data-level="V"],.ns-tab[data-level="VI"]{
+    background-image:linear-gradient(135deg, rgba(var(--tc),.06) 0%, rgba(var(--tc),.16) 50%, rgba(var(--tc),.06) 100%);
+    border-color:rgba(var(--tc),.22);
+  }
+  .ns-tab[data-level="II"]:hover,.ns-tab[data-level="III"]:hover,.ns-tab[data-level="IV"]:hover,.ns-tab[data-level="V"]:hover,.ns-tab[data-level="VI"]:hover{
+    background-position:100% 0%;border-color:rgba(var(--tc),.45);color:var(--tcolor);
+  }
+  .ns-tab.active[data-level="all"]{color:var(--basic);background:rgba(56,189,248,.1);border-color:rgba(56,189,248,.35)}
+  .ns-tab.active[data-level="II"]  {color:#63cab7;background-image:linear-gradient(135deg,rgba(99,202,183,.2),rgba(99,202,183,.07));background-position:100% 0%;border-color:rgba(99,202,183,.45)}
+  .ns-tab.active[data-level="III"] {color:#a78bfa;background-image:linear-gradient(135deg,rgba(167,139,250,.2),rgba(167,139,250,.07));background-position:100% 0%;border-color:rgba(167,139,250,.45)}
+  .ns-tab.active[data-level="IV"]  {color:#e879f9;background-image:linear-gradient(135deg,rgba(232,121,249,.2),rgba(232,121,249,.07));background-position:100% 0%;border-color:rgba(232,121,249,.45)}
+  .ns-tab.active[data-level="V"]   {color:#fbbf24;background-image:linear-gradient(135deg,rgba(251,191,36,.2),rgba(251,191,36,.07));background-position:100% 0%;border-color:rgba(251,191,36,.45)}
+  .ns-tab.active[data-level="VI"]  {color:#fbbf24;background-image:linear-gradient(135deg,rgba(251,191,36,.25),rgba(251,191,36,.09));background-position:100% 0%;border-color:rgba(251,191,36,.5)}
+  .ns-tab:disabled{opacity:.3;cursor:not-allowed;background-image:none}
+  .ns-tab:disabled:hover{color:var(--muted);border-color:var(--border);background-position:0% 0%}
+  .ns-view-btns { display:flex;gap:.3rem;border:1px solid var(--border);border-radius:8px;padding:2px; }
+  .ns-view-btn {
+    background:transparent;border:none;color:var(--muted);padding:.3rem .65rem;
+    border-radius:6px;cursor:pointer;font-size:.78rem;transition:background .15s,color .15s;
+    display:flex;align-items:center;gap:.3rem;font-family:inherit;
+  }
+  .ns-view-btn:hover{color:var(--text)}
+  .ns-view-btn.active{background:var(--surface);color:var(--basic)}
+  /* TILE VIEW */
+  .ns-grid-tile {
+    display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:1rem;
+  }
+  .ns-tile {
+    background:var(--surface);border:1px solid var(--border);border-radius:14px;
+    padding:1.3rem 1.2rem;cursor:pointer;transition:border-color .25s,box-shadow .25s,transform .15s;
+    display:flex;flex-direction:column;gap:.5rem;position:relative;overflow:hidden;
+    --ns-glow:rgba(56,189,248,.15);--ns-gc:56,189,248;
+  }
+  .ns-tile::before{
+    content:'';position:absolute;inset:0;border-radius:inherit;pointer-events:none;
+    background-image:linear-gradient(135deg, rgba(var(--ns-gc),.05) 0%, rgba(var(--ns-gc),.15) 50%, rgba(var(--ns-gc),.05) 100%);
+    background-size:200% 100%;background-position:0% 0%;
+    transition:background-position .45s ease;
+  }
+  .ns-tile:hover::before{background-position:100% 0%}
+  .ns-tile:hover{box-shadow:0 0 28px var(--ns-glow);border-color:rgba(var(--ns-gc),.38);transform:translateY(-2px)}
+  .ns-tile[data-level="II"] {--ns-glow:rgba(99,202,183,.25); --ns-gc:99,202,183}
+  .ns-tile[data-level="III"]{--ns-glow:rgba(167,139,250,.25);--ns-gc:167,139,250}
+  .ns-tile[data-level="IV"] {--ns-glow:rgba(232,121,249,.25);--ns-gc:232,121,249}
+  .ns-tile[data-level="V"]  {--ns-glow:rgba(251,191,36,.25); --ns-gc:251,191,36}
+  .ns-tile[data-level="VI"] {--ns-glow:rgba(251,191,36,.35); --ns-gc:251,191,36}
+  /* Tier outer glow — external box-shadow only, no border-color override */
+  .ns-tile[data-type="ultimate"]{--ct:245,158,11;box-shadow:0 0 10px rgba(245,158,11,.16),0 0 30px rgba(245,158,11,.07)}
+  .ns-tile[data-type="extra"]   {--ct:192,132,252;box-shadow:0 0 10px rgba(192,132,252,.16),0 0 30px rgba(192,132,252,.07)}
+  /* Gradient by rank: inner shadow = rank color (--ns-gc), outer = tier color (--ct) */
+  .ns-tile[data-type="ultimate"][data-level="III"],.ns-tile[data-type="extra"][data-level="III"]{box-shadow:0 0 8px rgba(var(--ns-gc),.22),0 0 22px rgba(var(--ct),.17),0 0 46px rgba(var(--ct),.07)}
+  .ns-tile[data-type="ultimate"][data-level="IV"],.ns-tile[data-type="extra"][data-level="IV"]  {box-shadow:0 0 11px rgba(var(--ns-gc),.32),0 0 28px rgba(var(--ct),.22),0 0 56px rgba(var(--ct),.1)}
+  .ns-tile[data-type="ultimate"][data-level="V"],.ns-tile[data-type="extra"][data-level="V"]    {box-shadow:0 0 15px rgba(var(--ns-gc),.42),0 0 36px rgba(var(--ct),.3),0 0 70px rgba(var(--ct),.13)}
+  .ns-tile[data-type="ultimate"][data-level="VI"],.ns-tile[data-type="extra"][data-level="VI"]  {box-shadow:0 0 19px rgba(var(--ns-gc),.52),0 0 46px rgba(var(--ct),.37),0 0 88px rgba(var(--ct),.16)}
+  /* List rows: outer glow by type, no border-color override */
+  .ns-list-row[data-type="ultimate"]{--ct:245,158,11;box-shadow:0 0 12px rgba(245,158,11,.1)}
+  .ns-list-row[data-type="extra"]   {--ct:192,132,252;box-shadow:0 0 12px rgba(192,132,252,.1)}
+  .ns-list-row[data-type="ultimate"][data-level="IV"],.ns-list-row[data-type="extra"][data-level="IV"]{box-shadow:0 0 9px rgba(var(--ns-gc),.2),0 0 20px rgba(var(--ct),.14)}
+  .ns-list-row[data-type="ultimate"][data-level="V"],.ns-list-row[data-type="extra"][data-level="V"]  {box-shadow:0 0 12px rgba(var(--ns-gc),.28),0 0 26px rgba(var(--ct),.2)}
+  .ns-list-row[data-type="ultimate"][data-level="VI"],.ns-list-row[data-type="extra"][data-level="VI"]{box-shadow:0 0 16px rgba(var(--ns-gc),.36),0 0 34px rgba(var(--ct),.28)}
+  .ns-tile-head { display:flex;align-items:center;gap:.5rem; }
+  .ns-tile-name { font-size:.95rem;font-weight:700;color:var(--text);line-height:1.3; }
+  .ns-tile-id { font-family:'JetBrains Mono',monospace;font-size:.72rem;color:#ef4444;white-space:nowrap;overflow:hidden;text-overflow:ellipsis; }
+  .ns-tile-tags { display:flex;gap:.3rem;flex-wrap:wrap;margin-top:.2rem; }
+  .ns-tile-arrow { margin-top:auto;text-align:right;color:var(--muted);font-size:.9rem;transition:color .2s; }
+  .ns-tile:hover .ns-tile-arrow{color:var(--basic)}
+  /* LIST VIEW */
+  .ns-grid-list { display:flex;flex-direction:column;gap:.4rem; }
+  .ns-list-row {
+    background:var(--surface);border:1px solid var(--border);border-radius:10px;
+    padding:.75rem 1.2rem;cursor:pointer;
+    display:flex;align-items:center;gap:1rem;
+    transition:border-color .25s,box-shadow .25s;
+    position:relative;overflow:hidden;
+    --ns-glow:rgba(56,189,248,.12);--ns-gc:56,189,248;
+  }
+  .ns-list-row::before{
+    content:'';position:absolute;inset:0;border-radius:inherit;pointer-events:none;
+    background-image:linear-gradient(90deg, rgba(var(--ns-gc),.05) 0%, rgba(var(--ns-gc),.14) 50%, rgba(var(--ns-gc),.05) 100%);
+    background-size:200% 100%;background-position:0% 0%;
+    transition:background-position .45s ease;
+  }
+  .ns-list-row:hover::before{background-position:100% 0%}
+  .ns-list-row:hover{border-color:rgba(var(--ns-gc),.35);box-shadow:0 0 16px rgba(var(--ns-gc),.15)}
+  .ns-list-row[data-level="II"] {--ns-glow:rgba(99,202,183,.18); --ns-gc:99,202,183}
+  .ns-list-row[data-level="III"]{--ns-glow:rgba(167,139,250,.18);--ns-gc:167,139,250}
+  .ns-list-row[data-level="IV"] {--ns-glow:rgba(232,121,249,.18);--ns-gc:232,121,249}
+  .ns-list-row[data-level="V"]  {--ns-glow:rgba(251,191,36,.18); --ns-gc:251,191,36}
+  .ns-list-row[data-level="VI"] {--ns-glow:rgba(251,191,36,.25); --ns-gc:251,191,36}
+  .ns-list-row[data-level="II"]{border-left:3px solid rgba(99,202,183,.5)}
+  .ns-list-row[data-level="III"]{border-left:3px solid rgba(167,139,250,.5)}
+  .ns-list-row[data-level="IV"]{border-left:3px solid rgba(232,121,249,.5)}
+  .ns-list-row[data-level="V"]{border-left:3px solid rgba(251,191,36,.5)}
+  .ns-list-row[data-level="VI"]{border-left:3px solid rgba(251,191,36,.7)}
+  .ns-lr-name { font-weight:700;font-size:.9rem;min-width:140px; }
+  .ns-lr-id { font-family:'JetBrains Mono',monospace;font-size:.76rem;color:#ef4444;flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis; }
+  .ns-lr-tags { display:flex;gap:.3rem;flex-wrap:nowrap;overflow:hidden; }
+  .ns-lr-arrow { color:var(--muted);font-size:1.1rem;margin-left:auto;flex-shrink:0;transition:color .2s; }
+  .ns-list-row:hover .ns-lr-arrow { color:var(--basic); }
+  /* TREE VIEW */
+  .ns-grid-tree { display:flex;flex-direction:column;gap:.6rem; }
+  .ns-tree-group { border:1px solid var(--border);border-radius:12px;overflow:hidden; }
+  .ns-tree-parent {
+    display:flex;align-items:center;gap:.7rem;padding:.85rem 1.2rem;
+    background:rgba(255,255,255,.025);cursor:pointer;
+    font-size:.82rem;font-weight:600;color:var(--muted);
+    transition:background .2s,box-shadow .25s;
+    position:relative;overflow:hidden;
+  }
+  .ns-tree-parent::before{
+    content:'';position:absolute;inset:0;pointer-events:none;
+    background:linear-gradient(90deg,rgba(56,189,248,.06) 0%,transparent 55%);
+    opacity:0;transform:translateX(-12%);
+    transition:opacity .35s,transform .42s;
+  }
+  .ns-tree-parent:hover{background:rgba(255,255,255,.04)}
+  .ns-tree-parent:hover::before{opacity:1;transform:translateX(0)}
+  .ns-tree-ref { color:var(--text);font-family:'JetBrains Mono',monospace;font-size:.8rem; }
+  .ns-tree-count { background:var(--border);color:var(--muted);padding:.1rem .45rem;border-radius:20px;font-size:.7rem; }
+  .ns-tree-children { display:flex;flex-direction:column;border-top:1px solid var(--border); }
+  .ns-tree-leaf {
+    display:flex;align-items:center;gap:.9rem;padding:.7rem 1.4rem;cursor:pointer;
+    border-bottom:1px solid var(--border);
+    position:relative;overflow:hidden;
+    --ns-glow:rgba(56,189,248,.1);--ns-gc:56,189,248;
+    transition:box-shadow .25s,border-color .25s;
+  }
+  .ns-tree-leaf::before{
+    content:'';position:absolute;inset:0;pointer-events:none;
+    background:radial-gradient(circle at 0% 50%, rgba(var(--ns-gc),.07) 0%, transparent 55%);
+    opacity:0;transform:scaleX(.8);transform-origin:left center;
+    transition:opacity .3s,transform .4s;
+  }
+  .ns-tree-leaf:hover::before{opacity:1;transform:scaleX(1.1) translateX(4%)}
+  .ns-tree-leaf:hover{box-shadow:inset 0 0 12px rgba(var(--ns-gc),.1)}
+  .ns-tree-leaf[data-level="II"] {--ns-gc:99,202,183}
+  .ns-tree-leaf[data-level="III"]{--ns-gc:167,139,250}
+  .ns-tree-leaf[data-level="IV"] {--ns-gc:232,121,249}
+  .ns-tree-leaf[data-level="V"]  {--ns-gc:251,191,36}
+  .ns-tree-leaf[data-level="VI"] {--ns-gc:251,191,36}
+  .ns-tree-leaf:last-child{border-bottom:none}
+  /* shared card bits */
+  .ns-loading,.ns-empty{
+    text-align:center;color:var(--muted);font-size:.9rem;
+    padding:3rem 1.5rem;border:1px dashed var(--border);border-radius:14px;
+  }
+  .ns-level-badge{font-size:.72rem;font-weight:700;padding:.22rem .62rem;border-radius:999px;border:1px solid;white-space:nowrap;letter-spacing:.04em}
+  .ns-origin{
+    flex-shrink:0;font-size:.65rem;font-weight:800;letter-spacing:.08em;
+    padding:.16rem .48rem;border-radius:999px;
+    background:rgba(245,158,11,.12);color:var(--ultimate);border:1px solid rgba(245,158,11,.3);
+  }
+  .ns-chip{font-size:.74rem;font-weight:600;padding:.2rem .58rem;border-radius:999px;border:1px solid;white-space:nowrap}
+  .ns-chip-prereq{color:#38bdf8;background:rgba(56,189,248,.08);border-color:rgba(56,189,248,.25)}
+  .ns-chip-deriv{color:#c084fc;background:rgba(192,132,252,.08);border-color:rgba(192,132,252,.25)}
+  .ns-chip-variant{color:#f59e0b;background:rgba(245,158,11,.08);border-color:rgba(245,158,11,.25)}
+  .ns-chip-ref{color:#63cab7;background:rgba(99,202,183,.08);border-color:rgba(99,202,183,.25)}
+  .ns-tag{font-size:.72rem;padding:.18rem .52rem;border-radius:999px;background:rgba(100,116,139,.1);color:var(--muted);border:1px solid var(--border)}
+  /* ── named h2 red ── */
+  #named h2 { color:#ef4444; }
+  /* ── search & sort controls ── */
+  .ns-search {
+    width:100%;
+    background:var(--surface);border:1px solid var(--border);border-radius:8px;
+    padding:.4rem .9rem;color:var(--text);font-size:.83rem;font-family:inherit;
+    outline:none;transition:border-color .2s;box-sizing:border-box;
+  }
+  .ns-search::placeholder { color:var(--muted); }
+  .ns-search:focus { border-color:rgba(56,189,248,.5); }
+  .ns-sort-sel {
+    background:var(--surface);border:1px solid var(--border);border-radius:8px;
+    padding:.35rem .7rem;color:var(--muted);font-size:.78rem;font-family:inherit;
+    cursor:pointer;outline:none;transition:border-color .2s,color .15s;
+  }
+  .ns-sort-sel:hover,.ns-sort-sel:focus { border-color:rgba(56,189,248,.4);color:var(--text); }
+  /* ── terminal install row (inside cards) ── */
+  .ns-install-row {
+    display:flex;align-items:center;gap:.4rem;
+    background:var(--bg);border:1px solid var(--border);border-radius:7px;
+    padding:.38rem .7rem;margin-top:.55rem;
+    font-family:'JetBrains Mono','Fira Code',monospace;font-size:.7rem;
+    color:var(--basic);overflow:hidden;flex-shrink:0;
+  }
+  .ns-install-prompt { color:var(--muted);flex-shrink:0; }
+  .ns-install-cmd-txt { flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap; }
+  .ns-install-copy {
+    background:transparent;border:none;color:var(--muted);padding:0;
+    cursor:pointer;display:flex;align-items:center;flex-shrink:0;transition:color .15s;
+  }
+  .ns-install-copy:hover { color:var(--basic); }
+  /* ── flowchart (tree) view ── */
+  .ns-grid-flow { display:flex;flex-direction:column;gap:1.6rem; }
+  .ns-fc-group { display:flex;flex-direction:column;align-items:center; }
+  .ns-fc-root {
+    display:flex;align-items:center;gap:.6rem;
+    background:rgba(56,189,248,.06);border:1px solid rgba(56,189,248,.3);
+    border-radius:10px;padding:.55rem 1.3rem;
+    font-size:.82rem;font-weight:700;color:var(--basic);white-space:nowrap;
+  }
+  .ns-fc-connector { width:2px;height:22px;background:linear-gradient(to bottom,rgba(56,189,248,.4),rgba(56,189,248,.1));flex-shrink:0; }
+  .ns-fc-branches-wrap { position:relative;width:100%;display:flex;flex-direction:column;align-items:center; }
+  .ns-fc-hbar { height:2px;background:rgba(56,189,248,.15);border-radius:1px;width:70%; }
+  .ns-fc-branches { display:flex;gap:.8rem;flex-wrap:wrap;justify-content:center;padding:.5rem; }
+  .ns-fc-leaf-wrap { display:flex;flex-direction:column;align-items:center;padding-top:20px;position:relative; }
+  .ns-fc-leaf-wrap::before {
+    content:'';position:absolute;top:0;left:50%;transform:translateX(-50%);
+    width:2px;height:20px;background:rgba(56,189,248,.2);
+  }
+  .ns-fc-card {
+    background:var(--surface);border:1px solid var(--border);border-radius:10px;
+    padding:.7rem .9rem;cursor:pointer;min-width:140px;max-width:200px;
+    position:relative;overflow:hidden;
+    transition:border-color .25s,box-shadow .25s,transform .15s;
+    --fc-glow:rgba(56,189,248,.2);--ns-gc:56,189,248;
+  }
+  .ns-fc-card::before{
+    content:'';position:absolute;inset:0;border-radius:inherit;pointer-events:none;
+    background-image:linear-gradient(135deg, rgba(var(--ns-gc),.05) 0%, rgba(var(--ns-gc),.15) 50%, rgba(var(--ns-gc),.05) 100%);
+    background-size:200% 100%;background-position:0% 0%;
+    transition:background-position .45s ease;
+  }
+  .ns-fc-card:hover::before{background-position:100% 0%}
+  .ns-fc-card:hover { border-color:rgba(var(--ns-gc),.38);box-shadow:0 0 18px var(--fc-glow);transform:translateY(-2px); }
+  .ns-fc-card[data-level="II"]  { --fc-glow:rgba(99,202,183,.25); --ns-gc:99,202,183 }
+  .ns-fc-card[data-level="III"] { --fc-glow:rgba(167,139,250,.25);--ns-gc:167,139,250 }
+  .ns-fc-card[data-level="IV"]  { --fc-glow:rgba(232,121,249,.3); --ns-gc:232,121,249 }
+  .ns-fc-card[data-level="V"]   { --fc-glow:rgba(251,191,36,.3);  --ns-gc:251,191,36  }
+  /* Flowchart card tier glow */
+  .ns-fc-card[data-type="ultimate"]{--ct:245,158,11;box-shadow:0 0 8px rgba(245,158,11,.16),0 0 22px rgba(245,158,11,.07)}
+  .ns-fc-card[data-type="extra"]   {--ct:192,132,252;box-shadow:0 0 8px rgba(192,132,252,.16),0 0 22px rgba(192,132,252,.07)}
+  .ns-fc-card[data-type="ultimate"][data-level="III"],.ns-fc-card[data-type="extra"][data-level="III"]{box-shadow:0 0 7px rgba(var(--ns-gc),.22),0 0 18px rgba(var(--ct),.16),0 0 38px rgba(var(--ct),.07)}
+  .ns-fc-card[data-type="ultimate"][data-level="IV"],.ns-fc-card[data-type="extra"][data-level="IV"]  {box-shadow:0 0 9px rgba(var(--ns-gc),.3),0 0 22px rgba(var(--ct),.2),0 0 46px rgba(var(--ct),.09)}
+  .ns-fc-card[data-type="ultimate"][data-level="V"],.ns-fc-card[data-type="extra"][data-level="V"]    {box-shadow:0 0 12px rgba(var(--ns-gc),.4),0 0 28px rgba(var(--ct),.28),0 0 58px rgba(var(--ct),.12)}
+  .ns-fc-card[data-type="ultimate"][data-level="VI"],.ns-fc-card[data-type="extra"][data-level="VI"]  {box-shadow:0 0 16px rgba(var(--ns-gc),.5),0 0 36px rgba(var(--ct),.35),0 0 72px rgba(var(--ct),.15)}
+  .ns-fc-card-name { font-size:.83rem;font-weight:700;color:var(--text);margin-bottom:.25rem; }
+  .ns-fc-card-id   { font-family:'JetBrains Mono',monospace;font-size:.68rem;color:#ef4444; }
+  .ns-none{color:var(--muted);font-size:.78rem;font-style:italic}
+  .ns-links{display:flex;gap:.5rem;flex-wrap:wrap;margin-top:.9rem}
+  /* ── GROUP LAYOUT ── */
+  .ns-group-header {
+    grid-column:1/-1;width:100%;
+    display:flex;align-items:center;gap:.5rem;
+    padding:.7rem 0 .35rem;margin-top:.6rem;
+    font-size:.75rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;
+    border-top:1px solid var(--border);color:var(--muted);
+  }
+  .ns-group-header:first-child { border-top:none;margin-top:0;padding-top:0; }
+  .ns-group-glyph { font-size:1rem; }
+  /* grab-to-scroll cursor on grid area */
+  #nsGrid { cursor: grab; user-select: none; }
+  #named.ns-grabbing, #named.ns-grabbing * { cursor: grabbing !important; }
+  .ns-link-btn{
+    font-size:.78rem;font-weight:600;padding:.3rem .78rem;border-radius:8px;
+    background:rgba(56,189,248,.07);color:var(--basic);
+    border:1px solid rgba(56,189,248,.22);text-decoration:none;transition:background .15s,border-color .15s;
+  }
+  .ns-link-btn:hover{background:rgba(56,189,248,.16);border-color:rgba(56,189,248,.45)}
+  /* ── FOOTER ── */
+  footer a{color:var(--basic);text-decoration:none}
+  /* ── SECTION DIVIDERS (redesigned) ── */
+  .section-divider{
+    height:1px;margin:0 auto;
+    width:55%;
+    background:linear-gradient(90deg,transparent,var(--border) 30%,var(--border) 70%,transparent);
+  }
+  .section-divider--glow{
+    height:2px;width:70%;
+    background:linear-gradient(90deg,transparent,rgba(239,68,68,.45) 30%,rgba(239,68,68,.45) 70%,transparent);
+    box-shadow:0 0 12px rgba(239,68,68,.25),0 0 30px rgba(239,68,68,.08);
+  }
+  .section-divider--brand{
+    height:2px;width:50%;
+    background:linear-gradient(90deg,transparent,rgba(56,189,248,.4) 20%,rgba(192,132,252,.4) 50%,rgba(245,158,11,.4) 80%,transparent);
+    box-shadow:0 0 10px rgba(56,189,248,.12);
+  }
+  /* ── SECTION BACKGROUND PROGRESSION ── */
+  [data-section]{position:relative}
+  [data-section="what"]{
+    background:radial-gradient(ellipse at 50% 0%,rgba(56,189,248,.025) 0%,transparent 55%);
+  }
+  [data-section="ranks"]{
+    background:radial-gradient(ellipse at 50% 20%,rgba(167,139,250,.02) 0%,transparent 55%);
+  }
+  [data-section="start"]{background:transparent}
+  [data-section="workflow"]{
+    background:radial-gradient(ellipse at 50% 30%,rgba(245,158,11,.018) 0%,transparent 50%);
+  }
+  [data-section="explorer"]{
+    max-width:none;
+    background:linear-gradient(180deg,#050a14 0%,#040810 100%);
+    border-top:1px solid rgba(239,68,68,.2);
+    padding:4rem 2rem 5rem;
+    margin:0;
+  }
+  [data-section="explorer"]::before{
+    content:'';position:absolute;top:0;left:0;right:0;height:120px;
+    background:radial-gradient(ellipse at 50% 0%,rgba(239,68,68,.04) 0%,transparent 70%);
+    pointer-events:none;
+  }
+  [data-section="explorer"] > *{
+    max-width:1000px;margin-left:auto;margin-right:auto;
+  }
+  [data-section="glossary"]{background:transparent}
+  /* ── SECTION SPACING VARIATION ── */
+  [data-section="what"],[data-section="ranks"]{padding:5rem 1.5rem}
+  [data-section="start"],[data-section="workflow"]{padding:6rem 1.5rem 5rem}
+  [data-section="glossary"]{padding:4rem 1.5rem 5rem}
+  /* ── HEADING COLOR PROGRESSION ── */
+  [data-section="ranks"] h2{
+    background:linear-gradient(90deg,var(--text) 40%,rgba(167,139,250,.7));
+    -webkit-background-clip:text;-webkit-text-fill-color:transparent;
+  }
+  [data-section="start"] h2{
+    background:linear-gradient(90deg,var(--text) 50%,rgba(56,189,248,.7));
+    -webkit-background-clip:text;-webkit-text-fill-color:transparent;
+  }
+  [data-section="workflow"] h2{
+    background:linear-gradient(90deg,var(--text) 45%,rgba(245,158,11,.7));
+    -webkit-background-clip:text;-webkit-text-fill-color:transparent;
+  }
+  /* ── FOOTER ENHANCEMENT ── */
+  footer{
+    text-align:center;padding:4rem 1.5rem;
+    border-top:none;color:var(--muted);font-size:.85rem;
+    background:linear-gradient(180deg,transparent 0%,rgba(15,23,42,.4) 100%);
+    position:relative;
+  }
+  footer::before{
+    content:'';position:absolute;top:0;left:50%;transform:translateX(-50%);
+    width:45%;height:1px;
+    background:linear-gradient(90deg,transparent,rgba(56,189,248,.3) 20%,rgba(192,132,252,.3) 50%,rgba(245,158,11,.3) 80%,transparent);
+  }
+  /* ── DIVIDER (legacy) ── */
+  .divider{border:none;border-top:1px solid var(--border);margin:0}
+  /* ── ANIMATE ON SCROLL ── */
+  .reveal{opacity:0;transform:translateY(28px);transition:opacity .55s ease,transform .55s ease}
+  .reveal.visible{opacity:1;transform:none}
+  /* ── REVEAL TIMING VARIATION ── */
+  [data-section="what"].reveal,
+  [data-section="glossary"].reveal{transition-duration:.45s}
+  [data-section="start"].reveal,
+  [data-section="workflow"].reveal{transition-duration:.65s}
+  [data-section="explorer"].reveal{transition-duration:.7s}
+
+  /* ── SKILL EXPLORER OVERLAY ── */
+  :root {
+    --glow-II:  0 0 8px #63cab7, 0 0 22px rgba(99,202,183,.35);
+    --glow-III: 0 0 10px #a78bfa, 0 0 26px rgba(167,139,250,.4);
+    --glow-IV:  0 0 14px #e879f9, 0 0 32px rgba(232,121,249,.45);
+    --glow-V:   0 0 18px #fbbf24, 0 0 40px rgba(251,191,36,.5);
+    --glow-VI:  0 0 20px #fbbf24, 0 0 50px rgba(251,191,36,.6), 0 0 80px rgba(56,189,248,.3);
+  }
+  .skill-explorer {
+    position:fixed;top:58px;left:0;right:0;bottom:0;z-index:99;
+    background:var(--bg);overflow-y:auto;
+    transform:translateX(100%);
+    transition:transform .34s cubic-bezier(.4,0,.2,1);
+    visibility:hidden;
+  }
+  .skill-explorer.open { transform:translateX(0);visibility:visible; }
+  .se-topbar {
+    position:sticky;top:0;z-index:10;
+    display:flex;align-items:center;gap:1rem;
+    padding:.85rem 2rem;
+    background:rgba(3,7,18,.88);backdrop-filter:blur(14px);
+    border-bottom:1px solid var(--border);
+  }
+  .se-topbar-actions { margin-left:auto;display:flex;gap:.6rem; }
+  .se-breadcrumb { font-size:.85rem;color:#ef4444;flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap; }
+  .se-btn-ghost {
+    background:transparent;border:1px solid var(--border);color:var(--text);
+    padding:.38rem .9rem;border-radius:6px;cursor:pointer;font-size:.82rem;
+    transition:border-color .2s,color .2s;
+  }
+  .se-btn-ghost:hover { border-color:var(--basic);color:var(--basic); }
+  .se-btn-action {
+    background:transparent;border:1px solid var(--border);color:var(--muted);
+    padding:.38rem .9rem;border-radius:6px;cursor:pointer;font-size:.82rem;
+    transition:border-color .2s,color .2s;
+  }
+  .se-btn-action:hover { border-color:var(--extra);color:var(--extra); }
+  .se-body { max-width:1100px;margin:0 auto;padding:2.5rem 2rem 5rem; }
+  .se-hero {
+    display:grid;grid-template-columns:1fr 1fr;gap:2rem;margin-bottom:2rem;
+  }
+  @media(max-width:700px){.se-hero{grid-template-columns:1fr;}}
+  .se-hero-card {
+    background:var(--surface);border:1px solid var(--border);
+    border-radius:14px;padding:1.8rem;
+    transition:box-shadow .3s;
+  }
+  .se-hero-card[data-level="II"]  { box-shadow:var(--glow-II);  }
+  .se-hero-card[data-level="III"] { box-shadow:var(--glow-III); }
+  .se-hero-card[data-level="IV"]  { box-shadow:var(--glow-IV);  }
+  .se-hero-card[data-level="V"]   { box-shadow:var(--glow-V); animation:se-pulse 2.4s ease-in-out infinite; }
+  .se-hero-card[data-level="VI"]  { animation:se-shimmer 3s linear infinite,se-pulse 2s ease-in-out infinite; }
+  @keyframes se-pulse {
+    0%,100%{box-shadow:var(--glow-V);}
+    50%{box-shadow:0 0 28px #fbbf24,0 0 60px rgba(251,191,36,.65);}
+  }
+  @keyframes se-shimmer {
+    0%{border-color:rgba(56,189,248,.6);}
+    25%{border-color:rgba(192,132,252,.6);}
+    50%{border-color:rgba(245,158,11,.6);}
+    75%{border-color:rgba(232,121,249,.6);}
+    100%{border-color:rgba(56,189,248,.6);}
+  }
+  .se-skill-name { font-size:1.7rem;font-weight:800;margin-bottom:.3rem; }
+  .se-contrib { font-size:.88rem;color:#ef4444;margin-bottom:1rem; }
+  .se-badges { display:flex;flex-wrap:wrap;gap:.45rem;margin-bottom:1.2rem; }
+  .se-badge {
+    display:inline-block;padding:.22rem .7rem;border-radius:20px;
+    font-size:.75rem;font-weight:600;border:1px solid;
+  }
+  .se-desc-panel { background:var(--surface);border:1px solid var(--border);border-radius:14px;padding:1.8rem; }
+  .se-desc-panel h3 { font-size:.82rem;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);margin-bottom:.8rem; }
+  .se-desc-text { line-height:1.75;color:var(--text); }
+  .se-tags { display:flex;flex-wrap:wrap;gap:.4rem;margin-top:1rem; }
+  .se-tag { background:rgba(56,189,248,.08);border:1px solid rgba(56,189,248,.18);color:var(--basic);padding:.18rem .6rem;border-radius:20px;font-size:.75rem; }
+  .se-btn-icon {
+    background:transparent;border:1px solid var(--border);color:var(--muted);
+    width:32px;height:32px;border-radius:7px;cursor:pointer;
+    display:inline-flex;align-items:center;justify-content:center;
+    transition:border-color .2s,color .2s;flex-shrink:0;
+  }
+  .se-btn-icon:hover { border-color:var(--basic);color:var(--basic); }
+  .se-btn-icon.copied { border-color:var(--basic);color:var(--basic); }
+  /* sequential flow sections — no tabs */
+  .se-flow { padding:0; }
+  .se-flow-section {
+    padding:2.2rem 0;
+    border-bottom:1px solid var(--border);
+  }
+  .se-flow-section:last-child { border-bottom:none; }
+  .se-flow-h {
+    font-size:.72rem;font-weight:700;text-transform:uppercase;letter-spacing:.12em;
+    color:var(--muted);margin-bottom:1.4rem;
+    display:flex;align-items:center;gap:.5rem;
+  }
+  .se-flow-h svg { opacity:.7; }
+  .se-install-block {
+    background:var(--surface);border:1px solid var(--border);border-radius:10px;
+    padding:1.2rem 1.4rem;margin-bottom:.9rem;
+    display:flex;align-items:center;gap:1rem;
+  }
+  .se-install-block.recommended { border-color:rgba(56,189,248,.35);box-shadow:0 0 0 1px rgba(56,189,248,.12); }
+  .se-install-label { font-size:.75rem;font-weight:700;text-transform:uppercase;letter-spacing:.07em;min-width:120px;color:var(--muted); }
+  .se-install-label span { display:block;font-size:.65rem;color:var(--basic);margin-top:.15rem; }
+  .se-install-cmd { font-family:'JetBrains Mono',monospace;font-size:.88rem;color:var(--text);flex:1;word-break:break-all; }
+  .se-copy-btn {
+    background:transparent;border:1px solid var(--border);color:var(--muted);
+    width:32px;height:32px;border-radius:7px;cursor:pointer;
+    display:inline-flex;align-items:center;justify-content:center;flex-shrink:0;
+    transition:border-color .2s,color .2s;
+  }
+  .se-copy-btn:hover,.se-copy-btn.copied { border-color:var(--basic);color:var(--basic); }
+  .se-docs-block { margin-bottom:2rem; }
+  .se-docs-block h4 { font-size:.88rem;font-weight:600;color:var(--muted);text-transform:uppercase;letter-spacing:.07em;margin-bottom:.8rem; }
+  .se-evidence-row { display:flex;gap:.7rem;align-items:flex-start;padding:.6rem 0;border-bottom:1px solid var(--border);font-size:.85rem; }
+  .se-ev-class { font-weight:700;min-width:28px;color:var(--ultimate); }
+  .se-ev-link { color:var(--basic);text-decoration:none;word-break:break-all; }
+  .se-ev-link:hover { text-decoration:underline; }
+  .se-ev-date { color:var(--muted);white-space:nowrap; }
+  .se-known-agent { display:inline-block;background:rgba(192,132,252,.1);border:1px solid rgba(192,132,252,.25);color:#c084fc;padding:.22rem .65rem;border-radius:20px;font-size:.78rem;margin:.2rem; }
+  /* FLOWCHART */
+  .se-flowchart-wrap { position:relative;overflow:auto;min-height:320px;padding:1.5rem 1rem; }
+  .se-flowchart-svg { position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none;overflow:visible; }
+  .se-flowchart-rows { display:flex;flex-direction:column;gap:48px;align-items:center; }
+  .se-flowchart-row { display:flex;gap:28px;justify-content:center;flex-wrap:wrap; }
+  .se-flowchart-row-label { text-align:center;font-size:.7rem;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);margin-bottom:6px; }
+  .flow-node {
+    background:var(--surface);border:1px solid var(--border);border-radius:10px;
+    padding:.8rem 1rem;min-width:140px;max-width:180px;cursor:pointer;
+    transition:transform .2s,box-shadow .2s;text-align:center;
+    position:relative;
+  }
+  .flow-node:hover { transform:translateY(-3px); }
+  .flow-node.current { border-color:var(--basic);outline:2px solid rgba(56,189,248,.3); }
+  .flow-node[data-level="II"]  { box-shadow:var(--glow-II); }
+  .flow-node[data-level="III"] { box-shadow:var(--glow-III); }
+  .flow-node[data-level="IV"]  { box-shadow:var(--glow-IV); }
+  .flow-node[data-level="V"]   { box-shadow:var(--glow-V);animation:flow-pulse-V 2.2s ease-in-out infinite; }
+  .flow-node[data-level="VI"]  { box-shadow:var(--glow-VI);animation:flow-shimmer-VI 3s linear infinite,flow-pulse-V 2s ease-in-out infinite; }
+  @keyframes flow-pulse-V {
+    0%,100%{box-shadow:var(--glow-V);}
+    50%{box-shadow:0 0 28px #fbbf24,0 0 55px rgba(251,191,36,.7);}
+  }
+  @keyframes flow-shimmer-VI {
+    0%,100%{border-color:rgba(56,189,248,.7);}
+    33%{border-color:rgba(192,132,252,.7);}
+    66%{border-color:rgba(245,158,11,.7);}
+  }
+  .fn-level { display:inline-block;font-size:.68rem;font-weight:700;margin-bottom:.3rem;padding:.12rem .5rem;border-radius:20px; }
+  .fn-name { display:block;font-size:.88rem;font-weight:700;margin-bottom:.2rem; }
+  .fn-contrib { display:block;font-size:.72rem;color:var(--muted); }
+  .fn-type { display:block;font-size:.7rem;color:var(--muted);margin-top:.25rem; }
+  /* TIMELINE */
+  .se-timeline { position:relative;padding-left:28px; }
+  .se-timeline::before { content:'';position:absolute;left:7px;top:0;bottom:0;width:2px;background:var(--border); }
+  .se-tl-event { position:relative;margin-bottom:1.4rem; }
+  .se-tl-dot { position:absolute;left:-24px;top:4px;width:10px;height:10px;border-radius:50%;background:var(--basic);border:2px solid var(--bg); }
+  .se-tl-date { font-size:.75rem;color:var(--muted);margin-bottom:.2rem; }
+  .se-tl-msg { font-size:.88rem;color:var(--text); }
+  .se-tl-sha { font-size:.72rem;color:var(--muted);font-family:monospace; }
+  .se-empty { color:var(--muted);font-size:.9rem;padding:1rem 0; }
+  .se-repo-row { display:flex;align-items:center;gap:.7rem;margin-top:1rem;padding:.8rem 1rem;background:rgba(56,189,248,.06);border:1px solid rgba(56,189,248,.15);border-radius:8px; }
+  .se-repo-url { font-size:.82rem;color:var(--basic);word-break:break-all; }
+</style>
 </head>
 <body>
 
@@ -50,7 +1081,7 @@
     <div class="graph-dialog-header">
       <div>
         <div id="skillGraphTitle" class="graph-dialog-title">Full Gaia Skill Graph</div>
-        <div class="graph-dialog-sub">Rendered from the canonical registry/gaia.json source.</div>
+        <div class="graph-dialog-sub">Rendered from the canonical graph/gaia.json registry.</div>
       </div>
       <div class="graph-dialog-actions">
         <a class="graph-download" href="graph/gaia.json" download>Download JSON</a>
@@ -192,11 +1223,13 @@
           <button class="os-tab" data-os="win" onclick="switchOsTab(this)">Windows</button>
         </div>
         <div class="os-panel active" data-os="mac">
-          <pre><span class="cmd">pip install</span> gaia-cli</pre>
-          <div class="qs-tip"><span class="qs-tip-icon">💡</span><span>Working in a registry clone? Use <code>pip install -e ".[embeddings]"</code> for an editable install with semantic search. The <code>[embeddings]</code> extra enables meaning-based matching in <code>gaia skills search</code>.</span></div>
+          <pre><span class="cmd">pip install</span> -e <span class="str">".[embeddings]"</span>
+<span class="cmd">gaia embed</span></pre>
+          <div class="qs-tip"><span class="qs-tip-icon">💡</span><span>Run <code>gaia embed</code> once after install (~30 sec). Skip the <code>[embeddings]</code> extra if you don't need semantic search — plain <code>pip install -e .</code> works fine.</span></div>
         </div>
         <div class="os-panel" data-os="win">
-          <pre><span class="cmd">pip install</span> gaia-cli</pre>
+          <pre><span class="cmd">pip install</span> -e <span class="str">".[embeddings]"</span>
+<span class="cmd">gaia embed</span></pre>
           <div class="qs-tip"><span class="qs-tip-icon">🪟</span><span>If <code>gaia</code> isn't recognized after install, run the command below in PowerShell, then restart your terminal.</span></div>
           <pre><span class="kw">$env:PATH</span> += <span class="str">";"</span> + (<span class="cmd">python</span> -c <span class="str">"import sysconfig; print(sysconfig.get_path('scripts', 'nt_user'))"</span>)</pre>
         </div>
@@ -207,7 +1240,7 @@
       <div class="step-num">3</div>
       <div>
         <h3>Initialize your project</h3>
-        <p>Inside the repo you want Gaia to track, run <code>gaia init</code>. It auto-detects your GitHub username and skill paths, then writes a <code>.gaia/config.toml</code>.</p>
+        <p>Inside the repo you want Gaia to track, run <code>gaia init</code>. It auto-detects your GitHub username and skill paths, then writes a <code>.gaia/config.json</code>.</p>
         <pre><span class="cmd">gaia init</span></pre>
         <div class="qs-tip"><span class="qs-tip-icon">💡</span><span>Username is read from <code>git remote</code> / <code>git config</code>. Scan paths are auto-detected from common locations (<code>.claude/skills/</code>, <code>AGENTS.md</code>, etc.). Pass <code>--user your-username</code> to override.</span></div>
       </div>
@@ -226,7 +1259,7 @@
       <div class="step-num">5</div>
       <div>
         <h3>Push your skills for review</h3>
-        <p>Writes a batch under <code>registry-for-review/skill-batches/</code> and opens a GitHub PR against the canonical graph for maintainer review.</p>
+        <p>Creates an intake record and opens a GitHub PR against the canonical graph for maintainer review.</p>
         <pre><span class="cmd">gaia push</span></pre>
         <div class="qs-tip"><span class="qs-tip-icon">💡</span><span>Run <code>gaia push --dry-run</code> first to preview the exact JSON that would be submitted — no files written, no PR opened.</span></div>
       </div>
@@ -246,7 +1279,7 @@
   <div class="flow">
     <div class="flow-node">🔍 <strong>gaia scan</strong><br><small style="color:var(--muted)">detect skills</small></div>
     <span class="flow-arrow">→</span>
-    <div class="flow-node">📦 <strong>gaia push</strong><br><small style="color:var(--muted)">review PR</small></div>
+    <div class="flow-node">📦 <strong>gaia push</strong><br><small style="color:var(--muted)">intake PR</small></div>
     <span class="flow-arrow">→</span>
     <div class="flow-node" style="border-color:var(--basic);color:var(--basic)">⚡ <strong>Pending</strong><br><small>under review</small></div>
     <span class="flow-arrow">→</span>
@@ -260,30 +1293,29 @@
       <div class="step-num" style="background:linear-gradient(135deg,var(--extra),var(--ultimate))">+</div>
       <div>
         <h3>Install a named skill</h3>
-        <p>Browse and install real contributor implementations directly into your repo. List what's available, then install by ID.</p>
-        <pre><span class="cmd">gaia skills list</span>
-<span class="cmd">gaia skills install</span> <span class="str">contributor/skill-name</span>
-<span class="cmd">gaia pull</span></pre>
-        <div class="qs-tip"><span class="qs-tip-icon">💡</span><span>Browse real skill IDs in the <a href="#named" style="color:var(--basic)">Named Skills Explorer</a> below. Run <code>gaia pull</code> periodically to refresh registry data from origin.</span></div>
+        <p>Browse and install real contributor implementations directly into your repo. Use <code>--list</code> to see what's available, then install by ID.</p>
+        <pre><span class="cmd">gaia install --list</span>
+<span class="cmd">gaia install</span> <span class="str">contributor/skill-name</span>
+<span class="cmd">gaia sync</span></pre>
+        <div class="qs-tip"><span class="qs-tip-icon">💡</span><span>Browse real skill IDs in the <a href="#named" style="color:var(--basic)">Named Skills Explorer</a> below. Run <code>gaia sync</code> periodically to pull the latest versions of all installed skills.</span></div>
       </div>
     </div>
     <div class="step">
       <div class="step-num" style="background:linear-gradient(135deg,var(--ultimate),#f97316)">★</div>
       <div>
-        <h3>Promote your scanned skill</h3>
-        <p>Promotion is scan-gated: appraise to see what the last <code>gaia scan</code> flagged, then promote. The CLI uses the level recommended by the most recent <code>generated-output/promotion-candidates.json</code>.</p>
-        <pre><span class="cmd">gaia appraise</span> <span class="str">your-skill</span>
-<span class="cmd">gaia promote</span> <span class="str">your-skill</span></pre>
-        <div class="qs-tip"><span class="qs-tip-icon">💡</span><span>Use <code>gaia promote --all</code> to promote every valid candidate from the last scan, or <code>--name yourname/my-skill</code> to claim it under a contributor handle in one shot.</span></div>
+        <h3>Name your awakened skill</h3>
+        <p>Once a maintainer marks your pushed skill as awakened, claim it under your GitHub username to make it installable by others.</p>
+        <pre><span class="cmd">gaia name</span> intake/skill-batches/batch-abc.json 0 <span class="str">yourname/my-skill</span></pre>
+        <div class="qs-tip"><span class="qs-tip-icon">💡</span><span>Syntax: <code>gaia name &lt;batch-file&gt; &lt;skill-index&gt; &lt;contributor/skill-name&gt;</code>. The skill-name becomes your permanent ID in the registry.</span></div>
       </div>
     </div>
     <div class="step">
       <div class="step-num" style="background:var(--ultimate);color:#000">◆</div>
       <div>
         <h3>Contribute at the Ultimate tier</h3>
-        <p>Five Ultimate skills in the registry are unclaimed — no contributor has built them yet. Build an implementation, push it through review, then promote it to become the origin contributor. New proposals require ≥3 prerequisites, ≥3 Class A/B evidence sources, and 2 Core Maintainer approvals.</p>
+        <p>Five Ultimate skills in the registry are unclaimed — no contributor has built them yet. Build an implementation, push it through intake review, then name it to become the origin contributor. New proposals require ≥3 prerequisites, ≥3 Class A/B evidence sources, and 2 Core Maintainer approvals.</p>
         <pre><span class="cmd">python scripts/validate.py</span></pre>
-        <div class="qs-tip"><span class="qs-tip-icon">💡</span><span>Find unclaimed slots with <code>[Unclaimed ✦]</code> in <code>registry/registry.md</code>. Use the <code>new_ultimate_skill</code> PR template. Set <code>"status": "provisional"</code> — maintainers flip it to <code>validated</code> at merge.</span></div>
+        <div class="qs-tip"><span class="qs-tip-icon">💡</span><span>Find unclaimed slots with <code>[Unclaimed ✦]</code> in <code>registry.md</code>. Use the <code>new_ultimate_skill</code> PR template. Set <code>"status": "provisional"</code> — maintainers flip it to <code>validated</code> at merge.</span></div>
       </div>
     </div>
   </div>
@@ -344,15 +1376,13 @@
   <p class="section-sub">Terms you'll see throughout the registry.</p>
   <div class="glossary">
     <div class="gloss-item"><div class="gloss-term">gaia.json</div><div class="gloss-def">The canonical source of truth. Every skill lives here.</div></div>
-    <div class="gloss-item"><div class="gloss-term">registry-for-review/</div><div class="gloss-def">Pending skill batch intake records, overlaid in <code>gaia skills</code> by default until promoted.</div></div>
-    <div class="gloss-item"><div class="gloss-term">registry/named/</div><div class="gloss-def">Curated named implementations attributed to contributors (e.g. karpathy/autoresearch).</div></div>
-    <div class="gloss-item"><div class="gloss-term">skill-trees/</div><div class="gloss-def">Per-user skill-tree.json files indexed by Gaia username.</div></div>
-    <div class="gloss-item"><div class="gloss-term">generated-output/</div><div class="gloss-def">Local scan and render output (<code>tree.html</code>, <code>tree.md</code>, <code>promotion-candidates.json</code>). Gitignored.</div></div>
+    <div class="gloss-item"><div class="gloss-term">intake/</div><div class="gloss-def">Staging area for proposed skills before they enter the graph.</div></div>
+    <div class="gloss-item"><div class="gloss-term">graph/named/</div><div class="gloss-def">Real implementations, attributed to contributors (e.g. karpathy/autoresearch).</div></div>
     <div class="gloss-item"><div class="gloss-term">prerequisites</div><div class="gloss-def">Skills that must be present before an extra or ultimate skill can emerge.</div></div>
     <div class="gloss-item"><div class="gloss-term">fusion</div><div class="gloss-def">When a set of prerequisites unlocks a higher-tier extra or ultimate skill.</div></div>
     <div class="gloss-item"><div class="gloss-term">evidence class</div><div class="gloss-def">A–C quality tiers for skill demonstrations. Class A = peer-reviewed.</div></div>
     <div class="gloss-item"><div class="gloss-term">origin: true</div><div class="gloss-def">Marks the first contributor to publish a named implementation of a skill.</div></div>
-    <div class="gloss-item"><div class="gloss-term">gaia skills search</div><div class="gloss-def">Semantic search over named skills — runs fully locally when the <code>[embeddings]</code> extra is installed.</div></div>
+    <div class="gloss-item"><div class="gloss-term">gaia embed</div><div class="gloss-def">Pre-computes local semantic vectors so `gaia search` works by meaning.</div></div>
     <div class="gloss-item"><div class="gloss-term">[Unclaimed ✦]</div><div class="gloss-def">An Ultimate skill with a hidden seed title but no contributor implementation yet — open for the taking.</div></div>
   </div>
 </section>
@@ -368,6 +1398,1527 @@
     MIT License
   </p>
 </footer>
+
+<!-- ─── FULL SKILL GRAPH ANIMATION (zero-dependency Canvas 2D + generated graph data) ─── -->
+<script>
+(function () {
+  const GRAPH_JSON_URL = 'graph/gaia.json';
+  const GRAPH_SCALE = 1.25;
+  const PALETTE = {
+    basic:    { rgb:'56,189,248',   hex:'#38bdf8' },
+    extra:    { rgb:'192,132,252',  hex:'#c084fc' },
+    ultimate: { rgb:'245,158,11',   hex:'#f59e0b' },
+  };
+  const TYPE_ORDER = { basic:0, extra:1, ultimate:2 };
+  const RANK_META = {
+    'I':  { name:'Awakened',       hex:'#38bdf8', bg:'rgba(56,189,248,.12)' },
+    'II': { name:'Named',          hex:'#63cab7', bg:'rgba(99,202,183,.12)' },
+    'III':{ name:'Evolved',        hex:'#a78bfa', bg:'rgba(167,139,250,.12)' },
+    'IV': { name:'Hardened',       hex:'#e879f9', bg:'rgba(232,121,249,.12)' },
+    'V':  { name:'Transcendent',   hex:'#fbbf24', bg:'rgba(251,191,36,.12)' },
+    'VI': { name:'Transcendent ★', hex:'#fbbf24', bg:'rgba(251,191,36,.20)' },
+  };
+  const FALLBACK_SKILLS = [
+    { id:'tokenize', type:'basic', name:'Tokenize', prerequisites:[] },
+    { id:'retrieve', type:'basic', name:'Retrieve', prerequisites:[] },
+    { id:'embed-text', type:'basic', name:'Embed Text', prerequisites:[] },
+    { id:'score-relevance', type:'basic', name:'Score Relevance', prerequisites:[] },
+    { id:'web-search', type:'basic', name:'Web Search', prerequisites:[] },
+    { id:'summarize', type:'basic', name:'Summarize', prerequisites:[] },
+    { id:'cite-sources', type:'basic', name:'Cite Sources', prerequisites:[] },
+    { id:'code-generation', type:'basic', name:'Code Generation', prerequisites:[] },
+    { id:'execute-bash', type:'basic', name:'Execute Bash', prerequisites:[] },
+    { id:'tool-select', type:'basic', name:'Tool Select', prerequisites:[] },
+    { id:'chunk-document', type:'basic', name:'Chunk Document', prerequisites:[] },
+    { id:'rank', type:'basic', name:'Rank', prerequisites:[] },
+    { id:'rag-pipeline', type:'extra', name:'RAG Pipeline', prerequisites:['retrieve','chunk-document','embed-text','score-relevance','tokenize','rank'] },
+    { id:'research', type:'extra', name:'Research', prerequisites:['web-search','summarize','cite-sources'] },
+    { id:'error-interpretation', type:'basic', name:'Error Interpretation', prerequisites:[] },
+    { id:'autonomous-debug', type:'extra', name:'Autonomous Debug', prerequisites:['code-generation','execute-bash','error-interpretation'] },
+    { id:'ghostwrite', type:'extra', name:'Ghostwrite', prerequisites:['research','write-report','audience-model'] },
+    { id:'knowledge-harvest', type:'extra', name:'Knowledge Harvest', prerequisites:['web-scrape','embed-text','extract-entities'] },
+    { id:'autonomous-research-agent', type:'ultimate', name:'Autonomous Research Agent', prerequisites:['research','ghostwrite','knowledge-harvest'] },
+  ];
+  const FALLBACK_NAMED_MAP = {
+    'automated-testing':           '0xdarkmatter/pytest-patterns',
+    'test-driven-development':     'addy-osmani/test-driven-development',
+    'document-editing':            'anthropic/pptx',
+    'tool-creation':               'anthropic/skill-creator',
+    'autonomous-debug':            'devin-ai/autonomous-swe',
+    'write-report':                'glincker/readme-generator',
+    'browser-automation':          'gooseworks/notte-browser',
+    'autonomous-research-agent':   'karpathy/autoresearch',
+    'framework-upgrade':           'laravel/upgrade-laravel-v13',
+    'ux-audit':                    'martin-stepanoski/nielsen-heuristics-audit',
+    'multi-agent-orchestration-v': 'ruvnet/flow-nexus-swarm',
+    'generate-test':               'upsonic/unittest-generator',
+    'skill-discovery':             'vercel/find-skills',
+    'rag-pipeline':                'yonatangross/orchestkit-rag',
+  };
+  const FALLBACK_TITLE_MAP = {
+    'automated-testing':           'The Quality Guardian',
+    'test-driven-development':     'The Red-Green Oath',
+    'document-editing':            'The Slide Artisan',
+    'tool-creation':               "The Skill Forger's Art",
+    'autonomous-debug':            "The Codebreaker's Will",
+    'write-report':                'The Document Weaver',
+    'browser-automation':          'The Digital Navigator',
+    'autonomous-research-agent':   "The Scholar's Compass",
+    'framework-upgrade':           "The Versionist's Trial",
+    'ux-audit':                    'The Ten Laws of Sight',
+    'multi-agent-orchestration-v': "The Grand Conductor's Blueprint",
+    'generate-test':               'The Test Weaver',
+    'skill-discovery':             'The Registry Scout',
+    'rag-pipeline':                'The Knowledge Architect',
+  };
+
+  function normalizeSkills(graph) {
+    const TYPE_ALIASES = { atomic: 'basic', composite: 'extra', legendary: 'ultimate' };
+    const skills = (graph && graph.skills) ? graph.skills : FALLBACK_SKILLS;
+    return skills.map(skill => ({
+      id: skill.id,
+      name: skill.name || skill.id,
+      type: TYPE_ALIASES[skill.type] || skill.type || 'basic',
+      level: skill.level || '',
+      rarity: skill.rarity || '',
+      prerequisites: Array.isArray(skill.prerequisites) ? skill.prerequisites : [],
+    })).filter(skill => skill.id);
+  }
+
+  function stableHash(str) {
+    let h = 2166136261;
+    for (let i = 0; i < str.length; i += 1) {
+      h ^= str.charCodeAt(i);
+      h = Math.imul(h, 16777619);
+    }
+    return Math.abs(h >>> 0);
+  }
+
+  function spherePoint(radius, seed, index, count) {
+    const golden = Math.PI * (3 - Math.sqrt(5));
+    const i = index + (seed % 17) / 17;
+    const y = 1 - (i / Math.max(count - 1, 1)) * 2;
+    const ring = Math.sqrt(Math.max(0, 1 - y * y));
+    const theta = golden * i + (seed % 360) * Math.PI / 180;
+    return {
+      x: Math.cos(theta) * ring * radius,
+      y: y * radius,
+      z: Math.sin(theta) * ring * radius,
+      phase: (seed % 628) / 100,
+    };
+  }
+
+  function buildPositions(skills, scale) {
+    const groups = { basic:[], extra:[], ultimate:[] };
+    skills.forEach(skill => (groups[skill.type] || groups.basic).push(skill));
+    Object.values(groups).forEach(group => group.sort((a,b) => (a.name || a.id).localeCompare(b.name || b.id)));
+    const positions = {};
+    const radii = { basic: 250 * scale, extra: 145 * scale, ultimate: 44 * scale };
+    Object.entries(groups).forEach(([type, group]) => {
+      group.forEach((skill, index) => {
+        positions[skill.id] = spherePoint(radii[type] || radii.basic, stableHash(skill.id), index, group.length);
+      });
+    });
+    return positions;
+  }
+
+  function createSkillGraph(canvas, options) {
+    const ctx = canvas.getContext('2d');
+    const DPR = Math.min(window.devicePixelRatio || 1, 2);
+    const NAMED_LEVELS = new Set(['II','III','IV','V','VI']);
+    const state = {
+      skills: FALLBACK_SKILLS,
+      positions: buildPositions(FALLBACK_SKILLS, GRAPH_SCALE),
+      stars: [],
+      width: 0,
+      height: 0,
+      t: 0,
+      mx: 0,
+      my: 0,
+      labelMode: options.labelMode || 'ultimate',
+      scale: options.scale || GRAPH_SCALE,
+      zoom: 1,
+      statusEl: options.statusEl || null,
+      running: options.autostart !== false,
+      frame: null,
+      orbitX: 0,
+      orbitY: 0,
+      dragging: false,
+      dragLastX: 0,
+      dragLastY: 0,
+      dragStartX: 0,
+      dragStartY: 0,
+      dragMoved: false,
+      hoveredId: null,
+      lastHoveredId: null,
+      projectedNodes: {},
+      tooltipEl: null,
+      nodeAlphas: {},
+      searchText: '',
+      legendFilterType: null,
+      legendFilterRank: null,
+      legendHoverType: null,
+      legendHoverRank: null,
+      legendEl: null,
+      showTitles: false,
+      redPillActive: false,
+      namedMap: FALLBACK_NAMED_MAP,
+      titleMap: FALLBACK_TITLE_MAP,
+    };
+
+    function resize() {
+      const parent = canvas.parentElement;
+      state.width = parent.clientWidth;
+      state.height = parent.clientHeight;
+      canvas.width = state.width * DPR;
+      canvas.height = state.height * DPR;
+      canvas.style.width = state.width + 'px';
+      canvas.style.height = state.height + 'px';
+      ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
+      state.stars = Array.from({ length: options.stars || 260 }, (_, i) => {
+        const seed = i * 7919 + 97;
+        const point = spherePoint((500 + (seed % 280)) * state.scale, seed, i, options.stars || 260);
+        return { ...point, size: 0.4 + (seed % 13) / 10, alpha: 0.22 + (seed % 55) / 100 };
+      });
+    }
+
+    function setSkills(skills) {
+      state.skills = skills;
+      state.positions = buildPositions(skills, state.scale);
+      const newAlphas = {};
+      skills.forEach(s => { newAlphas[s.id] = state.nodeAlphas[s.id] !== undefined ? state.nodeAlphas[s.id] : 1.0; });
+      state.nodeAlphas = newAlphas;
+      if (state.statusEl) {
+        const edgeCount = skills.reduce((sum, skill) => sum + skill.prerequisites.length, 0);
+        const zoomNote = options.zoomable ? ' · scroll to zoom' : '';
+        const dragNote = options.draggable ? ' · drag to orbit' : '';
+        state.statusEl.textContent = `${skills.length} skills · ${edgeCount} links${zoomNote}${dragNote}`;
+      }
+    }
+
+    function rotX(p, a) {
+      const c = Math.cos(a), s = Math.sin(a);
+      return { x: p.x, y: c*p.y - s*p.z, z: s*p.y + c*p.z, phase: p.phase };
+    }
+    function rotY(p, a) {
+      const c = Math.cos(a), s = Math.sin(a);
+      return { x: c*p.x + s*p.z, y: p.y, z: -s*p.x + c*p.z, phase: p.phase };
+    }
+    function project(p) {
+      const fov = Math.min(state.width, state.height) * 0.75;
+      const dist = fov / (fov + p.z + 360 * state.scale);
+      const z = state.zoom;
+      return { sx: state.width / 2 + p.x * dist * z, sy: state.height / 2 + p.y * dist * z, scale: dist * z };
+    }
+    function drawNode(sx, sy, r, color, alpha) {
+      const grad = ctx.createRadialGradient(sx, sy, 0, sx, sy, r * 3.9);
+      grad.addColorStop(0, `rgba(${color.rgb},${Math.min(alpha * 0.68, 1).toFixed(2)})`);
+      grad.addColorStop(0.42, `rgba(${color.rgb},${Math.min(alpha * 0.24, 1).toFixed(2)})`);
+      grad.addColorStop(1, `rgba(${color.rgb},0)`);
+      ctx.beginPath(); ctx.arc(sx, sy, r * 3.9, 0, Math.PI * 2); ctx.fillStyle = grad; ctx.fill();
+      ctx.beginPath(); ctx.arc(sx, sy, r, 0, Math.PI * 2); ctx.fillStyle = `rgba(${color.rgb},${Math.min(alpha * 1.18, 1).toFixed(2)})`; ctx.fill();
+      ctx.beginPath(); ctx.arc(sx - r * 0.28, sy - r * 0.28, r * 0.32, 0, Math.PI * 2); ctx.fillStyle = `rgba(255,255,255,${(alpha * 0.65).toFixed(2)})`; ctx.fill();
+    }
+    function drawNodeNamed(sx, sy, r, alpha) {
+      const glow = ctx.createRadialGradient(sx, sy, 0, sx, sy, r * 4.2);
+      glow.addColorStop(0,   `rgba(239,68,68,${Math.min(alpha * 0.7, 1).toFixed(2)})`);
+      glow.addColorStop(0.4, `rgba(239,68,68,${Math.min(alpha * 0.25, 1).toFixed(2)})`);
+      glow.addColorStop(1,   'rgba(239,68,68,0)');
+      ctx.beginPath(); ctx.arc(sx, sy, r * 4.2, 0, Math.PI * 2); ctx.fillStyle = glow; ctx.fill();
+      ctx.beginPath(); ctx.arc(sx, sy, r, 0, Math.PI * 2);
+      ctx.fillStyle = `rgba(239,68,68,${Math.min(alpha * 1.2, 1).toFixed(2)})`; ctx.fill();
+      ctx.beginPath(); ctx.arc(sx - r * 0.28, sy - r * 0.28, r * 0.32, 0, Math.PI * 2);
+      ctx.fillStyle = `rgba(255,255,255,${(alpha * 0.65).toFixed(2)})`; ctx.fill();
+    }
+    function drawNodeVI(sx, sy, r, alpha, t, p) {
+      const hue = (t * 45) % 360;
+      const glowPulse = 0.7 + 0.3 * Math.sin(t * 1.8 + (p.phase || 0));
+      const glowR = r * (4.8 + glowPulse);
+      const glow = ctx.createRadialGradient(sx, sy, r * 0.5, sx, sy, glowR);
+      glow.addColorStop(0,    `hsla(${hue},100%,72%,${(alpha * 0.55).toFixed(2)})`);
+      glow.addColorStop(0.35, `hsla(${(hue + 90) % 360},100%,65%,${(alpha * 0.32).toFixed(2)})`);
+      glow.addColorStop(0.65, `hsla(45,100%,58%,${(alpha * 0.18).toFixed(2)})`);
+      glow.addColorStop(1,    'hsla(45,100%,50%,0)');
+      ctx.beginPath(); ctx.arc(sx, sy, glowR, 0, Math.PI * 2); ctx.fillStyle = glow; ctx.fill();
+      const coreGrad = ctx.createRadialGradient(sx - r * 0.25, sy - r * 0.25, 0, sx, sy, r * 1.05);
+      coreGrad.addColorStop(0,    `hsla(${(hue + 200) % 360},100%,88%,${Math.min(alpha * 1.1, 1).toFixed(2)})`);
+      coreGrad.addColorStop(0.45, `hsla(${hue},100%,68%,${Math.min(alpha * 1.1, 1).toFixed(2)})`);
+      coreGrad.addColorStop(0.8,  `hsla(${(hue + 60) % 360},90%,55%,${alpha.toFixed(2)})`);
+      coreGrad.addColorStop(1,    `hsla(45,100%,45%,${alpha.toFixed(2)})`);
+      ctx.beginPath(); ctx.arc(sx, sy, r, 0, Math.PI * 2); ctx.fillStyle = coreGrad; ctx.fill();
+      for (let i = 0; i < 6; i++) {
+        const angle = (Math.PI * 2 * i / 6) + t * 0.4;
+        const dist = r * (1.65 + 0.35 * Math.sin(t * 2.1 + i));
+        const sAlpha = alpha * (0.5 + 0.5 * Math.sin(t * 3.0 + i * 1.05));
+        ctx.beginPath();
+        ctx.arc(sx + Math.cos(angle) * dist, sy + Math.sin(angle) * dist, r * 0.2, 0, Math.PI * 2);
+        ctx.fillStyle = `hsla(${(hue + i * 60) % 360},100%,82%,${sAlpha.toFixed(2)})`;
+        ctx.fill();
+      }
+      ctx.beginPath(); ctx.arc(sx - r * 0.28, sy - r * 0.28, r * 0.32, 0, Math.PI * 2);
+      ctx.fillStyle = `rgba(255,255,255,${(alpha * 0.85).toFixed(2)})`; ctx.fill();
+    }
+    function shouldLabel(skill) {
+      if (state.redPillActive && state.namedMap[skill.id]) return true;
+      if (state.labelMode === 'none') return false;
+      if (state.labelMode === 'all') return true;
+      if (state.labelMode === 'modal') return skill.type !== 'basic' || stableHash(skill.id) % 7 === 0;
+      return skill.type === 'ultimate';
+    }
+    function draw() {
+      if (!state.running) return;
+      state.t += 0.006;
+      ctx.clearRect(0, 0, state.width, state.height);
+      state.projectedNodes = {};
+      const ry = options.draggable
+        ? state.t * 0.16 + state.orbitY
+        : state.t * 0.16 + state.mx * 0.10;
+      const rx = options.draggable
+        ? Math.sin(state.t * 0.055) * 0.20 + state.orbitX
+        : Math.sin(state.t * 0.055) * 0.20 + state.my * 0.055;
+      const xf = {};
+      state.skills.forEach(skill => {
+        const p0 = state.positions[skill.id];
+        if (!p0) return;
+        xf[skill.id] = rotX(rotY(p0, ry), rx);
+      });
+      const neighborSet = new Set();
+      if (state.hoveredId) {
+        neighborSet.add(state.hoveredId);
+        const hoveredSkill = state.skills.find(s => s.id === state.hoveredId);
+        if (hoveredSkill) hoveredSkill.prerequisites.forEach(pid => neighborSet.add(pid));
+        state.skills.forEach(s => { if (s.prerequisites.includes(state.hoveredId)) neighborSet.add(s.id); });
+      }
+      const hovering = Boolean(state.hoveredId);
+      const isSearchActive = Boolean(state.searchText);
+      const searchQuery = isSearchActive ? state.searchText.toLowerCase() : '';
+      const legendHovering = Boolean(state.legendHoverType || state.legendHoverRank);
+      const legendFiltering = Boolean(state.legendFilterType || state.legendFilterRank);
+      state.skills.forEach(skill => {
+        let targetVis;
+        if (hovering) {
+          targetVis = skill.id === state.hoveredId ? 1.0 : neighborSet.has(skill.id) ? 0.88 : 0.12;
+        } else if (legendHovering) {
+          const mt = !state.legendHoverType || skill.type === state.legendHoverType;
+          const mr = !state.legendHoverRank || skill.level === state.legendHoverRank;
+          targetVis = (mt && mr) ? 1.0 : 0.12;
+        } else if (legendFiltering) {
+          const mt = !state.legendFilterType || skill.type === state.legendFilterType;
+          const mr = !state.legendFilterRank || skill.level === state.legendFilterRank;
+          const matchesLegend = mt && mr;
+          if (isSearchActive) {
+            const matchesSearch = (skill.name || skill.id).toLowerCase().includes(searchQuery);
+            targetVis = (matchesLegend && matchesSearch) ? 1.0 : 0.12;
+          } else {
+            targetVis = matchesLegend ? 1.0 : 0.12;
+          }
+        } else if (isSearchActive) {
+          targetVis = (skill.name || skill.id).toLowerCase().includes(searchQuery) ? 1.0 : 0.12;
+        } else {
+          targetVis = 1.0;
+        }
+        if (state.redPillActive && !state.namedMap[skill.id]) targetVis = Math.min(targetVis, 0.07);
+        if (state.nodeAlphas[skill.id] === undefined) state.nodeAlphas[skill.id] = targetVis;
+        state.nodeAlphas[skill.id] += (targetVis - state.nodeAlphas[skill.id]) * 0.15;
+      });
+      state.stars.forEach(star => {
+        const p = rotX(rotY(star, ry), rx);
+        const pr = project(p);
+        if (pr.scale < 0.01) return;
+        ctx.beginPath();
+        ctx.arc(pr.sx, pr.sy, star.size * pr.scale * 1.55, 0, Math.PI * 2);
+        ctx.fillStyle = `rgba(255,255,255,${(star.alpha * Math.min(pr.scale * 2, 1)).toFixed(2)})`;
+        ctx.fill();
+      });
+      const edges = [];
+      state.skills.forEach(skill => {
+        if (!xf[skill.id]) return;
+        skill.prerequisites.forEach(pid => {
+          if (!xf[pid]) return;
+          edges.push({ from: pid, to: skill.id, type: skill.type, avgZ: (xf[skill.id].z + xf[pid].z) / 2 });
+        });
+      });
+      edges.sort((a,b) => a.avgZ - b.avgZ);
+      edges.forEach(edge => {
+        const pa = project(xf[edge.from]), pb = project(xf[edge.to]);
+        const col = PALETTE[edge.type] || PALETTE.basic;
+        const depthAlpha = Math.min(Math.max((xf[edge.to].z + 430 * state.scale) / (860 * state.scale), 0.08), 1);
+        const isNeighborEdge = hovering && neighborSet.has(edge.from) && neighborSet.has(edge.to);
+        const fromVis = state.nodeAlphas[edge.from] !== undefined ? state.nodeAlphas[edge.from] : 1.0;
+        const toVis   = state.nodeAlphas[edge.to]   !== undefined ? state.nodeAlphas[edge.to]   : 1.0;
+        const edgeVis = (fromVis + toVis) / 2;
+        const baseEdgeAlpha = isNeighborEdge ? 0.72 : 0.31;
+        ctx.beginPath(); ctx.moveTo(pa.sx, pa.sy); ctx.lineTo(pb.sx, pb.sy);
+        ctx.strokeStyle = `rgba(${col.rgb},${(depthAlpha * baseEdgeAlpha * edgeVis).toFixed(2)})`;
+        ctx.lineWidth = isNeighborEdge ? (edge.type === 'ultimate' ? 2.2 : 1.4) : (edge.type === 'ultimate' ? 1.55 : 0.92);
+        ctx.stroke();
+      });
+      const nodes = state.skills.map(skill => ({ skill, z: xf[skill.id] ? xf[skill.id].z : -9999 })).sort((a,b) => a.z - b.z);
+      nodes.forEach(({ skill }) => {
+        const p = xf[skill.id]; if (!p) return;
+        const pr = project(p);
+        state.projectedNodes[skill.id] = pr;
+        const pulse = 0.84 + 0.16 * Math.sin(state.t * 2.2 + p.phase);
+        const depthAlpha = Math.min(Math.max((p.z + 430 * state.scale) / (860 * state.scale), 0.16), 1);
+        const col = PALETTE[skill.type] || PALETTE.basic;
+        const baseR = skill.type === 'ultimate' ? 12.5 : skill.type === 'extra' ? 6.9 : 3.5;
+        const vis = state.nodeAlphas[skill.id] !== undefined ? state.nodeAlphas[skill.id] : 1.0;
+        if (skill.level === 'VI') {
+          drawNodeVI(pr.sx, pr.sy, baseR * state.scale * pr.scale * pulse, depthAlpha * vis, state.t, p);
+        } else if (state.redPillActive && state.namedMap[skill.id]) {
+          drawNodeNamed(pr.sx, pr.sy, baseR * state.scale * pr.scale * pulse, depthAlpha * vis);
+        } else {
+          drawNode(pr.sx, pr.sy, baseR * state.scale * pr.scale * pulse, col, depthAlpha * vis);
+        }
+      });
+      const labelNodes = nodes.filter(({ skill }) => shouldLabel(skill));
+      function drawLabel(skill, highlighted) {
+        const p = xf[skill.id]; if (!p) return;
+        const pr = project(p);
+        const depthAlpha = Math.min(Math.max((p.z + 430 * state.scale) / (860 * state.scale), 0), 1);
+        if (!highlighted && depthAlpha < 0.22) return;
+        const vis = state.nodeAlphas[skill.id] !== undefined ? state.nodeAlphas[skill.id] : 1.0;
+        const labelAlpha = highlighted ? 1.0 : depthAlpha * Math.max(0.22, vis) * 0.9;
+        if (labelAlpha < 0.04) return;
+        const col = (state.redPillActive && state.namedMap[skill.id])
+          ? { rgb:'239,68,68' }
+          : (PALETTE[skill.type] || PALETTE.basic);
+        const size = skill.type === 'ultimate' ? 13 : skill.type === 'extra' ? 10 : 8;
+        ctx.font = `bold ${Math.max(6, Math.round(size * pr.scale * 1.16))}px Inter,system-ui,sans-serif`;
+        ctx.fillStyle = `rgba(${col.rgb},${labelAlpha.toFixed(2)})`;
+        ctx.textAlign = 'center';
+        const labelText = (state.redPillActive && state.namedMap && state.namedMap[skill.id])
+          ? state.namedMap[skill.id]
+          : state.showTitles
+            ? ((state.titleMap && state.titleMap[skill.id]) || skill.name)
+            : '/' + skill.id;
+        ctx.fillText(labelText, pr.sx, pr.sy + 18 * pr.scale);
+      }
+      labelNodes.forEach(({ skill }) => {
+        const vis = state.nodeAlphas[skill.id] !== undefined ? state.nodeAlphas[skill.id] : 1.0;
+        if (vis <= 0.95) drawLabel(skill, false);
+      });
+      labelNodes.forEach(({ skill }) => {
+        const vis = state.nodeAlphas[skill.id] !== undefined ? state.nodeAlphas[skill.id] : 1.0;
+        if (vis > 0.95) drawLabel(skill, true);
+      });
+      if (options.hoverable && state.tooltipEl) {
+        const pr = state.projectedNodes[state.hoveredId];
+        if (state.hoveredId && pr) {
+          if (state.hoveredId !== state.lastHoveredId) {
+            const skill = state.skills.find(s => s.id === state.hoveredId);
+            const col = PALETTE[skill.type] || PALETTE.basic;
+            const typeClass = `skill-tooltip-type-${skill.type}`;
+            const rm = skill.level ? RANK_META[skill.level] : null;
+            const rankPill = rm
+              ? `<span style="display:inline-block;padding:.12rem .42rem;border-radius:999px;font-size:.62rem;font-weight:700;background:${rm.bg};color:${rm.hex}">${skill.level}</span>`
+              : '';
+            state.tooltipEl.innerHTML =
+              `<div class="skill-tooltip-name" style="color:rgba(${col.rgb},1)">${skill.name}</div>` +
+              `<div style="color:#64748b;font-size:.68rem;font-weight:500;margin-bottom:.3rem;font-family:monospace">${skill.id}</div>` +
+              `<div class="skill-tooltip-row"><span class="skill-tooltip-badge ${typeClass}">${skill.type.toUpperCase()}</span>${rankPill}</div>`;
+            state.lastHoveredId = state.hoveredId;
+          }
+          let tx = pr.sx + 18, ty = pr.sy - 34;
+          tx = Math.min(tx, state.width - 240); ty = Math.max(ty, 8);
+          state.tooltipEl.style.left = tx + 'px';
+          state.tooltipEl.style.top  = ty + 'px';
+          state.tooltipEl.style.display = 'block';
+        } else {
+          state.tooltipEl.style.display = 'none';
+          state.lastHoveredId = null;
+        }
+      }
+      state.frame = requestAnimationFrame(draw);
+    }
+
+    function start() {
+      if (state.running) return;
+      state.running = true;
+      draw();
+    }
+
+    function stop() {
+      state.running = false;
+      if (state.frame) cancelAnimationFrame(state.frame);
+      state.frame = null;
+    }
+
+    resize();
+    if (options.hoverable) {
+      const tip = document.createElement('div');
+      tip.className = 'skill-tooltip';
+      canvas.parentElement.appendChild(tip);
+      state.tooltipEl = tip;
+      const searchWrap = document.createElement('div');
+      searchWrap.className = 'graph-search-wrap';
+      const searchInput = document.createElement('input');
+      searchInput.type = 'text';
+      searchInput.className = 'graph-search';
+      searchInput.placeholder = 'Search skills…';
+      searchInput.setAttribute('aria-label', 'Filter skill graph');
+      searchInput.addEventListener('input', () => { state.searchText = searchInput.value.trim(); });
+      searchInput.addEventListener('mousedown', e => e.stopPropagation());
+      searchWrap.appendChild(searchInput);
+      canvas.parentElement.appendChild(searchWrap);
+      state.searchInputEl = searchInput;
+
+      const legend = document.createElement('div');
+      legend.className = 'graph-legend';
+      legend.innerHTML =
+        '<div class="graph-legend-section"><div class="graph-legend-heading">Type</div>' +
+        '<div class="graph-legend-item" data-legend-type="basic"><span class="graph-legend-swatch" style="background:#38bdf8;width:7px;height:7px"></span>Basic</div>' +
+        '<div class="graph-legend-item" data-legend-type="extra"><span class="graph-legend-swatch" style="background:#c084fc;width:10px;height:10px"></span>Extra</div>' +
+        '<div class="graph-legend-item" data-legend-type="ultimate"><span class="graph-legend-swatch" style="background:#f59e0b;width:14px;height:14px"></span>Ultimate</div>' +
+        '</div><div class="graph-legend-section"><div class="graph-legend-heading">Rank</div>' +
+        '<div class="graph-legend-ranks">' +
+        '<span class="graph-legend-rank-pill" data-legend-rank="I" style="background:rgba(56,189,248,.12);color:#38bdf8">I</span>' +
+        '<span class="graph-legend-rank-pill" data-legend-rank="II" style="background:rgba(99,202,183,.12);color:#63cab7">II</span>' +
+        '<span class="graph-legend-rank-pill" data-legend-rank="III" style="background:rgba(167,139,250,.12);color:#a78bfa">III</span>' +
+        '<span class="graph-legend-rank-pill" data-legend-rank="IV" style="background:rgba(232,121,249,.12);color:#e879f9">IV</span>' +
+        '<span class="graph-legend-rank-pill" data-legend-rank="V" style="background:rgba(251,191,36,.12);color:#fbbf24">V</span>' +
+        '<span class="graph-legend-rank-pill" data-legend-rank="VI" style="background:rgba(251,191,36,.20);color:#fbbf24">VI</span>' +
+        '</div></div>';
+      legend.addEventListener('mousedown', e => e.stopPropagation());
+      legend.querySelectorAll('.graph-legend-item[data-legend-type]').forEach(item => {
+        item.addEventListener('mouseenter', () => { state.legendHoverType = item.dataset.legendType; });
+        item.addEventListener('mouseleave', () => { state.legendHoverType = null; });
+        item.addEventListener('click', () => {
+          const val = state.legendFilterType === item.dataset.legendType ? null : item.dataset.legendType;
+          state.legendFilterType = val;
+          legend.querySelectorAll('[data-legend-type]').forEach(el => el.classList.remove('active'));
+          if (val) item.classList.add('active');
+        });
+      });
+      legend.querySelectorAll('.graph-legend-rank-pill').forEach(pill => {
+        pill.addEventListener('mouseenter', () => { state.legendHoverRank = pill.dataset.legendRank; });
+        pill.addEventListener('mouseleave', () => { state.legendHoverRank = null; });
+        pill.addEventListener('click', () => {
+          const val = state.legendFilterRank === pill.dataset.legendRank ? null : pill.dataset.legendRank;
+          state.legendFilterRank = val;
+          legend.querySelectorAll('.graph-legend-rank-pill').forEach(el => el.classList.remove('active'));
+          if (val) pill.classList.add('active');
+        });
+      });
+      canvas.parentElement.appendChild(legend);
+      state.legendEl = legend;
+
+      const redPill = document.createElement('button');
+      redPill.type = 'button';
+      redPill.className = 'graph-redpill';
+      redPill.textContent = 'Named Skills';
+      redPill.title = 'Highlight Named skills (Level II+) with contributor attribution and red glow';
+      redPill.addEventListener('mousedown', e => e.stopPropagation());
+      redPill.addEventListener('click', () => {
+        state.redPillActive = !state.redPillActive;
+        redPill.classList.toggle('active', state.redPillActive);
+      });
+      canvas.parentElement.appendChild(redPill);
+      state.redPillEl = redPill;
+
+      const labelToggle = document.createElement('button');
+      labelToggle.type = 'button';
+      labelToggle.className = 'graph-label-toggle';
+      labelToggle.textContent = 'Show Title';
+      labelToggle.addEventListener('mousedown', e => e.stopPropagation());
+      labelToggle.addEventListener('click', () => {
+        state.showTitles = !state.showTitles;
+        labelToggle.classList.toggle('active', state.showTitles);
+      });
+      canvas.parentElement.appendChild(labelToggle);
+      state.labelToggleEl = labelToggle;
+    }
+    window.addEventListener('resize', resize);
+    const pointerTarget = options.pointerTarget || canvas;
+    pointerTarget.addEventListener('mousemove', event => {
+      const rect = canvas.getBoundingClientRect();
+      if (options.draggable && state.dragging) {
+        state.orbitY += (event.clientX - state.dragLastX) * 0.007;
+        state.orbitX += (event.clientY - state.dragLastY) * 0.007;
+        state.dragLastX = event.clientX;
+        state.dragLastY = event.clientY;
+        if (Math.hypot(event.clientX - state.dragStartX, event.clientY - state.dragStartY) > 5) state.dragMoved = true;
+        state.hoveredId = null;
+      } else {
+        state.mx = ((event.clientX - rect.left) / Math.max(rect.width, 1) - 0.5) * 2;
+        state.my = ((event.clientY - rect.top) / Math.max(rect.height, 1) - 0.5) * 2;
+        if (options.hoverable) {
+          const mx = event.clientX - rect.left;
+          const my = event.clientY - rect.top;
+          let closest = null, closestDist = 22;
+          Object.entries(state.projectedNodes).forEach(([id, pr]) => {
+            const d = Math.hypot(pr.sx - mx, pr.sy - my);
+            if (d < closestDist) { closestDist = d; closest = id; }
+          });
+          state.hoveredId = closest;
+          canvas.style.cursor = closest ? 'pointer' : (options.draggable ? 'grab' : 'default');
+        }
+      }
+    });
+    if (options.draggable) {
+      canvas.style.cursor = 'grab';
+      canvas.addEventListener('mouseleave', () => { if (!state.dragging) state.hoveredId = null; });
+      canvas.addEventListener('mousedown', e => {
+        e.preventDefault();
+        state.dragging = true;
+        state.dragMoved = false;
+        state.dragStartX = e.clientX;
+        state.dragStartY = e.clientY;
+        state.dragLastX = e.clientX;
+        state.dragLastY = e.clientY;
+        canvas.style.cursor = 'grabbing';
+      });
+      window.addEventListener('mouseup', e => {
+        if (!state.dragging) return;
+        const didClick = !state.dragMoved && state.hoveredId;
+        state.dragging = false;
+        state.dragMoved = false;
+        canvas.style.cursor = state.hoveredId ? 'pointer' : 'grab';
+        if (didClick && options.onNodeClick) options.onNodeClick(state.hoveredId);
+      });
+    }
+    if (options.zoomable) {
+      canvas.addEventListener('wheel', e => {
+        e.preventDefault();
+        state.zoom = Math.max(0.3, Math.min(3.0, state.zoom * (1 - e.deltaY * 0.001)));
+      }, { passive: false });
+    }
+    function resetFilters() {
+      state.legendFilterType = null;
+      state.legendFilterRank = null;
+      state.legendHoverType = null;
+      state.legendHoverRank = null;
+      state.showTitles = false;
+      state.searchText = '';
+      state.redPillActive = false;
+      if (state.redPillEl) state.redPillEl.classList.remove('active');
+      if (state.legendEl) {
+        state.legendEl.querySelectorAll('.active').forEach(el => el.classList.remove('active'));
+      }
+      if (state.searchInputEl) state.searchInputEl.value = '';
+      if (state.labelToggleEl) state.labelToggleEl.classList.remove('active');
+    }
+    if (state.running) draw();
+    function setNamedMap(map) { state.namedMap = map || {}; }
+    function setTitleMap(map) { state.titleMap = map || {}; }
+    return { setSkills, setNamedMap, setTitleMap, resize, start, stop, resetFilters };
+  }
+
+  const hero = document.getElementById('hero');
+  const trigger = document.querySelector('[data-graph-trigger]');
+  const dialog = document.getElementById('skillGraphDialog');
+  const closeBtn = document.querySelector('[data-graph-close]');
+  const heroGraph = createSkillGraph(document.getElementById('canvas3d'), { labelMode:'none', scale:GRAPH_SCALE, stars:280, pointerTarget:hero });
+  const modalGraph = createSkillGraph(document.getElementById('graphDialogCanvas'), {
+    labelMode:'all', scale:1.38, stars:320, statusEl:document.querySelector('[data-graph-status]'), autostart:false, zoomable:true, draggable:true, hoverable:true,
+    onNodeClick: function(id) {
+      var buckets = window._gaiaNamedBuckets || {};
+      if (buckets[id] && buckets[id].length) {
+        window.openSkillExplorer(buckets[id][0].id);
+      } else {
+        var skill = (window._gaiaSkillMap || {})[id] || { id: id, name: id, type: 'basic' };
+        window.openUnnamedPopup(skill);
+      }
+    }
+  });
+
+  function peek(on) { hero.classList.toggle('hero-graph-peek', Boolean(on)); }
+  trigger.addEventListener('mouseenter', () => peek(true));
+  trigger.addEventListener('mouseleave', () => peek(false));
+  trigger.addEventListener('focus', () => peek(true));
+  trigger.addEventListener('blur', () => peek(false));
+  trigger.addEventListener('click', () => {
+    if (typeof dialog.showModal === 'function') dialog.showModal();
+    else dialog.setAttribute('open', '');
+    modalGraph.resize();
+    modalGraph.start();
+    peek(false);
+  });
+  function closeDialog() {
+    if (dialog.close) dialog.close();
+    else dialog.removeAttribute('open');
+    modalGraph.resetFilters();
+    modalGraph.stop();
+  }
+  closeBtn.addEventListener('click', closeDialog);
+  dialog.addEventListener('click', event => {
+    if (event.target === dialog) closeDialog();
+  });
+  dialog.addEventListener('close', () => modalGraph.stop());
+
+  fetch(GRAPH_JSON_URL)
+    .then(response => {
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      return response.json();
+    })
+    .then(graph => normalizeSkills(graph))
+    .then(skills => { heroGraph.setSkills(skills); modalGraph.setSkills(skills); })
+    .catch(error => {
+      console.warn('Using embedded fallback skill graph:', error);
+      const status = document.querySelector('[data-graph-status]');
+      if (status) status.textContent = 'Using embedded preview graph. Run the page from docs/ to load the full graph.';
+    });
+
+  fetch('graph/named/index.json')
+    .then(r => r.ok ? r.json() : Promise.reject())
+    .then(indexData => {
+      const map = {};
+      const titleMap = {};
+      const buckets = indexData.buckets || {};
+      Object.entries(buckets).forEach(([skillId, arr]) => {
+        if (Array.isArray(arr) && arr.length) {
+          const origin = arr.find(e => e.origin) || arr[0];
+          if (origin && origin.id) map[skillId] = origin.id;
+          if (origin && origin.title) titleMap[skillId] = origin.title;
+        }
+      });
+      heroGraph.setNamedMap(map);
+      modalGraph.setNamedMap(map);
+      heroGraph.setTitleMap(titleMap);
+      modalGraph.setTitleMap(titleMap);
+    })
+    .catch(() => {});
+})();
+</script>
+
+<!-- ─── SCROLL REVEAL ─── -->
+<script>
+const obs = new IntersectionObserver(entries => {
+  entries.forEach(e => { if (e.isIntersecting) e.target.classList.add('visible'); });
+}, { threshold: 0.12 });
+document.querySelectorAll('.reveal').forEach(el => obs.observe(el));
+
+function revealHashTarget() {
+  if (!location.hash) return;
+  const target = document.querySelector(location.hash);
+  if (target && target.classList && target.classList.contains('reveal')) {
+    target.classList.add('visible');
+  }
+}
+window.addEventListener('hashchange', revealHashTarget);
+window.addEventListener('load', revealHashTarget);
+</script>
+
+<!-- ─── NAMED SKILLS DATA ─── -->
+<script>
+(function () {
+  function esc(str) {
+    return String(str == null ? '' : str)
+      .replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  }
+
+  function nsClick(id) { return 'onclick="openSkillExplorer(\''+id.replace(/'/g,"\\'")+'\')\"'; }
+  function nsDisplayName(ns) { return ns.name || ns.id.split('/')[1] || ns.id; }
+
+  // ── TAG COLORS (8-color hash wheel, matches DESIGN.md palette) ──
+  var TAG_PAL=[
+    {c:'#38bdf8',bg:'rgba(56,189,248,.12)',bd:'rgba(56,189,248,.3)'},
+    {c:'#c084fc',bg:'rgba(192,132,252,.12)',bd:'rgba(192,132,252,.3)'},
+    {c:'#63cab7',bg:'rgba(99,202,183,.12)',bd:'rgba(99,202,183,.3)'},
+    {c:'#a78bfa',bg:'rgba(167,139,250,.12)',bd:'rgba(167,139,250,.3)'},
+    {c:'#f59e0b',bg:'rgba(245,158,11,.12)',bd:'rgba(245,158,11,.3)'},
+    {c:'#e879f9',bg:'rgba(232,121,249,.12)',bd:'rgba(232,121,249,.3)'},
+    {c:'#fb923c',bg:'rgba(251,146,60,.12)',bd:'rgba(251,146,60,.3)'},
+    {c:'#4ade80',bg:'rgba(74,222,128,.12)',bd:'rgba(74,222,128,.3)'},
+  ];
+  function tagStyle(t){var h=0;for(var i=0;i<t.length;i++)h=(h*31+t.charCodeAt(i))%TAG_PAL.length;var p=TAG_PAL[h];return 'style="color:'+p.c+';background:'+p.bg+';border-color:'+p.bd+'"';}
+  function tagHtml(t){return '<span class="ns-tag" '+tagStyle(t)+'>'+esc(t)+'</span>';}
+
+  // ── TERMINAL INSTALL ROW ──
+  var CLIP_SM='<svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="5" width="9" height="9" rx="1.5"/><path d="M11 5V3a1 1 0 00-1-1H3a1 1 0 00-1 1v7a1 1 0 001 1h2"/></svg>';
+  var CHECK_SM='<svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="#4ade80" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 8l4 4 8-8"/></svg>';
+  function installRow(id){
+    var cmd='gaia install '+id;
+    return '<div class="ns-install-row"><span class="ns-install-prompt">$</span>'+
+      '<span class="ns-install-cmd-txt">'+esc(cmd)+'</span>'+
+      '<button class="ns-install-copy" title="Copy install command" data-cmd="'+esc(cmd)+'" onclick="event.stopPropagation();nsInstCopy(this)">'+CLIP_SM+'</button>'+
+    '</div>';
+  }
+  window.nsInstCopy = function(btn){
+    navigator.clipboard.writeText(btn.dataset.cmd).then(function(){
+      var prev=btn.innerHTML; btn.innerHTML=CHECK_SM;
+      setTimeout(function(){btn.innerHTML=prev;},1500);
+    }).catch(function(){});
+  };
+
+  function renderTile(ns, lm) {
+    var tags = (ns.tags||[]).slice(0,3).map(tagHtml).join('');
+    return '<article class="ns-tile" data-level="'+esc(ns.level)+'" data-type="'+esc(ns.type||'basic')+'" '+nsClick(ns.id)+'>' +
+      '<div class="ns-tile-head">' +
+        '<span class="ns-level-badge" style="color:'+lm.color+';background:'+lm.bg+';border-color:'+lm.border+'">'+esc(ns.level)+'</span>' +
+        (ns.origin ? '<span class="ns-origin">\u2605</span>' : '') +
+      '</div>' +
+      '<div class="ns-tile-name">' + esc(nsDisplayName(ns)) + '</div>' +
+      '<div class="ns-tile-id">' + esc(ns.id) + '</div>' +
+      (tags ? '<div class="ns-tile-tags">' + tags + '</div>' : '') +
+      installRow(ns.id) +
+    '</article>';
+  }
+
+  function renderListRow(ns, lm) {
+    var tags = (ns.tags||[]).slice(0,2).map(tagHtml).join('');
+    return '<article class="ns-list-row" data-level="'+esc(ns.level)+'" data-type="'+esc(ns.type||'basic')+'" '+nsClick(ns.id)+'>' +
+      '<span class="ns-level-badge" style="color:'+lm.color+';background:'+lm.bg+';border-color:'+lm.border+'">'+esc(ns.level)+'</span>' +
+      '<span class="ns-lr-name">' + esc(nsDisplayName(ns)) + '</span>' +
+      '<span class="ns-lr-id">' + esc(ns.id) + '</span>' +
+      '<span class="ns-lr-tags">' + tags + '</span>' +
+      '<span style="flex:1"></span>' +
+      installRow(ns.id) +
+      '<span class="ns-lr-arrow">\u203a</span>' +
+    '</article>';
+  }
+
+  function renderFlowchartView(allNamed, lm) {
+    var groups = {};
+    allNamed.forEach(function(ns) {
+      var ref = ns.genericSkillRef || 'other';
+      if (!groups[ref]) groups[ref] = [];
+      groups[ref].push(ns);
+    });
+    return Object.keys(groups).sort().map(function(ref) {
+      var cards = groups[ref].map(function(ns) {
+        var m = lm[ns.level] || lm['II'];
+        return '<div class="ns-fc-leaf-wrap">' +
+          '<article class="ns-fc-card" data-level="'+esc(ns.level)+'" data-type="'+esc(ns.type||'basic')+'" '+nsClick(ns.id)+'>' +
+            '<div style="margin-bottom:.3rem"><span class="ns-level-badge" style="color:'+m.color+';background:'+m.bg+';border-color:'+m.border+'">'+esc(ns.level)+'</span>' +
+            (ns.origin ? ' <span class="ns-origin">\u2605</span>' : '') + '</div>' +
+            '<div class="ns-fc-card-name">'+esc(nsDisplayName(ns))+'</div>' +
+            '<div class="ns-fc-card-id">'+esc(ns.id)+'</div>' +
+          '</article>' +
+        '</div>';
+      }).join('');
+      return '<div class="ns-fc-group">' +
+        '<div class="ns-fc-root"><span style="opacity:.5">&#9671;</span> '+esc(ref)+'</div>' +
+        '<div class="ns-fc-connector"></div>' +
+        '<div class="ns-fc-branches-wrap"><div class="ns-fc-hbar"></div>' +
+          '<div class="ns-fc-branches">'+cards+'</div>' +
+        '</div>' +
+      '</div>';
+    }).join('');
+  }
+
+  function initNamedSkills() {
+    var grid = document.getElementById('nsGrid');
+    var tabsEl = document.getElementById('nsLevelTabs');
+    var viewBtnsEl = document.getElementById('nsViewBtns');
+    var searchEl = document.getElementById('nsSearch');
+    var sortEl = document.getElementById('nsSort');
+    if (!grid) return;
+
+    var viewMode = 'tile';
+    var levelFilter = 'all';
+    var searchQuery = '';
+    var sortMode = 'level';
+    var FALLBACK_NAMED_INDEX = { buckets: {
+      'automated-testing':           [{ id:'0xdarkmatter/pytest-patterns',            name:'Pytest Patterns',               contributor:'0xdarkmatter',       origin:true,  genericSkillRef:'automated-testing',           status:'named', level:'III', description:'Comprehensive pytest skill covering modern patterns for Python test automation including fixtures, parametrize, async testing, mocking, coverage strategies, integration tests, and conftest organisation for pytest 7.0+ projects.',            title:'The Quality Guardian',           tags:['pytest','python','test-automation','fixtures','async-testing','coverage','mocking'],                   links:{ github:'https://github.com/aiskillstore/marketplace' } }],
+      'test-driven-development':     [{ id:'addy-osmani/test-driven-development',     name:'Test-Driven Development',       contributor:'addy-osmani',        origin:true,  genericSkillRef:'test-driven-development',     status:'named', level:'II',  description:'Forces the AI agent to follow a strict red-green-refactor TDD workflow — writing failing tests before any implementation code, blocking code generation that skips the test step, and enforcing coverage thresholds before completing a task.', title:'The Red-Green Oath',             tags:['tdd','testing','red-green-refactor','workflow-enforcement','software-quality'],              links:{ github:'https://github.com/addyosmani/agent-skills' } }],
+      'document-editing':            [{ id:'anthropic/pptx',                           name:'PPTX Editor',                   contributor:'anthropic',          origin:true,  genericSkillRef:'document-editing',            status:'named', level:'II',  description:'Extracts slide content from PowerPoint (.pptx) files using markitdown, applies edits or design principles in-place, and repacks the file — enabling agents to read, modify, and write structured presentation files without a GUI.',            title:'The Slide Artisan',              tags:['pptx','powerpoint','document-editing','markitdown','presentations'],                          links:{ github:'https://github.com/anthropics/skills/blob/main/skills/pptx/SKILL.md' } }],
+      'tool-creation':               [{ id:'anthropic/skill-creator',                 name:'Skill Creator',                 contributor:'anthropic',          origin:true,  genericSkillRef:'tool-creation',               status:'named', level:'II',  description:'Interviews the user through a structured dialogue to elicit the skill\'s purpose, trigger conditions, and step-by-step instructions, then programmatically writes a new SKILL.md file ready for use in a Claude Code or Codex CLI skills directory.', title:'The Skill Forger\'s Art',        tags:['skill-authoring','meta-agent','claude-code','tool-creation'],                                links:{ github:'https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md' } }],
+      'autonomous-debug':            [{ id:'devin-ai/autonomous-swe',                 name:'Autonomous SWE',                contributor:'devin-ai',           origin:true,  genericSkillRef:'autonomous-debug',            status:'named', level:'III', description:'Autonomous software engineering agent capable of end-to-end debugging, code generation, and self-correction across complex multi-file codebases.',                                                                                               title:'The Codebreaker\'s Will',        tags:['software-engineering','autonomous','debugging','code-generation','self-correction'],         links:{ github:'https://github.com/cognition-labs/devin' } }],
+      'write-report':                [{ id:'glincker/readme-generator',               name:'README Generator',              contributor:'glincker',           origin:true,  genericSkillRef:'write-report',                status:'named', level:'II',  description:'Analyzes a project\'s directory structure, dependency manifests, and configuration files to generate a professional README.md covering installation, usage, API reference, and contributing guidelines.',                                          title:'The Document Weaver',            tags:['documentation','readme','code-analysis','project-structure'],                                links:{ github:'https://github.com/GLINCKER/claude-code-marketplace/blob/main/skills/documentation/readme-generator/SKILL.md' } },
+                                      { id:'spring-ai/readme-generate',               name:'REST API README Generator',     contributor:'spring-ai',          origin:false, genericSkillRef:'write-report',                status:'named', level:'II',  description:'Scans a Java Spring project for controller annotations, extracts REST API endpoint definitions, and automatically generates structured API documentation in README format.',                                                                      title:'The Endpoint Scribe',            tags:['java','spring','rest-api','documentation','readme'],                                         links:{ github:'https://github.com/spring-ai-alibaba/examples/tree/main/.claude/skills' } }],
+      'browser-automation':          [{ id:'gooseworks/notte-browser',                name:'Notte Browser',                 contributor:'gooseworks',         origin:true,  genericSkillRef:'browser-automation',          status:'named', level:'III', description:'AI-first browser automation using the Notte Browser API to control browser sessions, scrape pages, fill forms, take screenshots, and run autonomous web agents with managed credential handling.',                                              title:'The Digital Navigator',          tags:['browser','automation','web-agent','scraping','notte'],                                       links:{ github:'https://github.com/gooseworks-ai/goose-skills' } }],
+      'autonomous-research-agent':   [{ id:'karpathy/autoresearch',                   name:'AutoResearch',                  contributor:'karpathy',           origin:true,  genericSkillRef:'autonomous-research-agent',   status:'named', level:'VI',  description:'Autonomous research agent that iteratively searches, reads, and synthesizes academic papers into structured summaries.',                                                                                                                           title:'The Scholar\'s Compass',         tags:['research','autonomous','paper-synthesis'],                                                   links:{ github:'https://github.com/karpathy/autoresearch' } }],
+      'framework-upgrade':           [{ id:'laravel/upgrade-laravel-v13',             name:'Upgrade Laravel v13',           contributor:'laravel',            origin:true,  genericSkillRef:'framework-upgrade',           status:'named', level:'II',  description:'Guides an AI agent through upgrading a Laravel 12 application to Laravel 13 safely, covering breaking changes, dependency updates, config migrations, and post-upgrade test validation.',                                                       title:'The Versionist\'s Trial',        tags:['laravel','php','framework-upgrade','migration'],                                             links:{ github:'https://github.com/laravel/boost/issues/698' } }],
+      'ux-audit':                    [{ id:'martin-stepanoski/nielsen-heuristics-audit',name:'Nielsen Heuristics Audit',    contributor:'martin-stepanoski',  origin:true,  genericSkillRef:'ux-audit',                    status:'named', level:'II',  description:'Audits a UI interface against Jakob Nielsen\'s 10 usability heuristics step-by-step, scoring each heuristic, surfacing violations, and producing a prioritized remediation report.',                                                             title:'The Ten Laws of Sight',          tags:['ux','usability','nielsen','heuristics','accessibility'],                                     links:{ npm:'https://classic.yarnpkg.com/en/package/@mastepanoski/claude-skills' } }],
+      'multi-agent-orchestration-v': [{ id:'ruvnet/flow-nexus-swarm',                 name:'Flow Nexus Swarm',              contributor:'ruvnet',             origin:true,  genericSkillRef:'multi-agent-orchestration-v', status:'named', level:'III', description:'Cloud-based AI swarm orchestration platform supporting hierarchical, mesh, ring, and star topologies with event-driven workflows, message queue processing, and intelligent agent assignment.',                                                  title:'The Grand Conductor\'s Blueprint',tags:['multi-agent','swarm','orchestration','event-driven','workflow'],                             links:{ github:'https://github.com/ruvnet/ruflo' } }],
+      'generate-test':               [{ id:'upsonic/unittest-generator',              name:'Unittest Generator',            contributor:'upsonic',            origin:true,  genericSkillRef:'generate-test',               status:'named', level:'II',  description:'Autonomous Claude agent that generates comprehensive unittest.TestCase suites from source code, organising tests into concept-based subfolders under a tests/ directory with proper imports, fixtures, and edge-case coverage.',                 title:'The Test Weaver',                tags:['unit-testing','unittest','test-generation','python','autonomous-agent'],                      links:{ github:'https://github.com/Upsonic/Upsonic' } }],
+      'skill-discovery':             [{ id:'vercel/find-skills',                      name:'Find Skills',                   contributor:'vercel',             origin:true,  genericSkillRef:'skill-discovery',             status:'named', level:'II',  description:'Searches the skills.sh registry by keyword or category, queries install counts to surface popular skills, and auto-installs the selected skill into the current project\'s skills directory.',                                                   title:'The Registry Scout',             tags:['skill-registry','discovery','skills-sh','auto-install'],                                     links:{ github:'https://github.com/vercel-labs/skills/blob/main/skills/find-skills/SKILL.md' } }],
+      'rag-pipeline':                [{ id:'yonatangross/orchestkit-rag',             name:'OrchestrKit RAG',               contributor:'yonatangross',       origin:true,  genericSkillRef:'rag-pipeline',                status:'named', level:'III', description:'Production-grade RAG retrieval skill covering 30+ patterns including core pipeline composition, HyDE query expansion, pgvector hybrid search, cross-encoder reranking, multimodal chunking, and agentic self-RAG and corrective-RAG loops.', title:'The Knowledge Architect',        tags:['rag','retrieval','hybrid-search','hyde','pgvector','reranking','agentic-rag'],               links:{ github:'https://github.com/yonatangross/orchestkit' } }],
+    }};
+
+    Promise.all([
+      fetch('graph/named/index.json').then(function(r){ if (!r.ok) throw r; return r.json(); }).catch(function(){ return FALLBACK_NAMED_INDEX; }),
+      fetch('graph/gaia.json').then(function(r){ if (!r.ok) throw r; return r.json(); }).catch(function(){ return { skills: [] }; }),
+    ]).then(function(results) {
+      var indexData = results[0], fullGraph = results[1];
+      var skillMap = {};
+      (fullGraph.skills || []).forEach(function(s){ skillMap[s.id] = s; });
+
+      var buckets = indexData.buckets || {};
+      var allNamed = [];
+      Object.values(buckets).forEach(function(arr){ if (Array.isArray(arr)) Array.prototype.push.apply(allNamed, arr); });
+
+      window._gaiaSkillMap = skillMap;
+      window._gaiaNamedBuckets = buckets;
+      window._gaiaNamedAll = allNamed;
+
+      // Augment each named skill with type + level from the generic skill in gaia.json
+      allNamed.forEach(function(ns) {
+        var g = skillMap[ns.genericSkillRef];
+        if (g) {
+          if (!ns.type) ns.type = g.type;
+          if (g.level) ns.level = g.level;
+        }
+      });
+
+      var levelOrder = ['II','III','IV','V','VI'];
+      allNamed.sort(function(a, b) {
+        var d = levelOrder.indexOf(a.level) - levelOrder.indexOf(b.level);
+        return d !== 0 ? d : String(a.id).localeCompare(String(b.id));
+      });
+
+      if (!allNamed.length) {
+        grid.innerHTML = '<div class="ns-empty">No named skills yet. Publish the first with <code>gaia name</code>.</div>';
+        return;
+      }
+
+      var LEVEL_META = {
+        'II':  { name:'Named',          color:'#63cab7', bg:'rgba(99,202,183,.15)',  border:'rgba(99,202,183,.4)'  },
+        'III': { name:'Evolved',        color:'#a78bfa', bg:'rgba(167,139,250,.15)', border:'rgba(167,139,250,.4)' },
+        'IV':  { name:'Hardened',       color:'#e879f9', bg:'rgba(232,121,249,.15)', border:'rgba(232,121,249,.4)' },
+        'V':   { name:'Transcendent',   color:'#fbbf24', bg:'rgba(251,191,36,.15)',  border:'rgba(251,191,36,.4)'  },
+        'VI':  { name:'Transcendent ★', color:'#fbbf24', bg:'rgba(251,191,36,.22)', border:'rgba(251,191,36,.55)' },
+      };
+
+      var TYPE_ORDER = ['ultimate','extra','basic'];
+      var TYPE_META_G = {
+        ultimate: { glyph:'◆', label:'Ultimate', color:'#f59e0b' },
+        extra:    { glyph:'◇', label:'Extra',    color:'#c084fc' },
+        basic:    { glyph:'○', label:'Basic',    color:'#38bdf8' },
+      };
+
+      function nsType(ns) { return ns.type || 'basic'; }
+
+      function groupHeader(type, id) {
+        var tm = TYPE_META_G[type]; if (!tm) return '';
+        return '<div class="ns-group-header" id="ns-group-'+id+'">' +
+          '<span class="ns-group-glyph" style="color:'+tm.color+'">'+tm.glyph+'</span>'+tm.label+
+        '</div>';
+      }
+
+      function renderCurrent() {
+        var q = searchQuery.toLowerCase();
+        var filtered = allNamed.filter(function(ns) {
+          if (levelFilter !== 'all' && ns.level !== levelFilter) return false;
+          if (q) {
+            var hay = (nsDisplayName(ns)+' '+ns.id+' '+(ns.tags||[]).join(' ')+' '+(ns.contributor||'')).toLowerCase();
+            if (hay.indexOf(q) === -1) return false;
+          }
+          return true;
+        });
+        if (sortMode === 'creator') filtered.sort(function(a,b){return (a.contributor||'').localeCompare(b.contributor||'');});
+        else if (sortMode === 'name') filtered.sort(function(a,b){return nsDisplayName(a).localeCompare(nsDisplayName(b));});
+        if (!filtered.length) { grid.innerHTML='<div class="ns-empty">No skills match.</div>'; return; }
+        function lm(ns) { return LEVEL_META[ns.level] || LEVEL_META['II']; }
+
+        if (viewMode === 'flow') {
+          grid.className = 'ns-grid-flow';
+          grid.innerHTML = renderFlowchartView(filtered, LEVEL_META);
+        } else {
+          // Group by type: ultimate → extra → basic
+          var groups = { ultimate:[], extra:[], basic:[] };
+          filtered.forEach(function(ns){ var t=nsType(ns); (groups[t]||(groups[t]=[])).push(ns); });
+          var html = '';
+          TYPE_ORDER.forEach(function(type) {
+            var items = groups[type]; if (!items || !items.length) return;
+            html += groupHeader(type, type);
+            if (viewMode === 'list') html += items.map(function(ns){ return renderListRow(ns, lm(ns)); }).join('');
+            else html += items.map(function(ns){ return renderTile(ns, lm(ns)); }).join('');
+          });
+          grid.className = viewMode === 'list' ? 'ns-grid-list' : 'ns-grid-tile';
+          grid.innerHTML = html;
+        }
+      }
+
+      if (tabsEl) {
+        tabsEl.addEventListener('click', function(e) {
+          var btn = e.target.closest('.ns-tab');
+          if (!btn) return;
+          tabsEl.querySelectorAll('.ns-tab').forEach(function(t){ t.classList.remove('active'); });
+          btn.classList.add('active');
+          levelFilter = btn.dataset.level || 'all';
+          renderCurrent();
+        });
+      }
+
+      if (viewBtnsEl) {
+        viewBtnsEl.addEventListener('click', function(e) {
+          var btn = e.target.closest('.ns-view-btn');
+          if (!btn) return;
+          viewBtnsEl.querySelectorAll('.ns-view-btn').forEach(function(b){ b.classList.remove('active'); });
+          btn.classList.add('active');
+          viewMode = btn.dataset.view || 'tile';
+          renderCurrent();
+        });
+      }
+
+      if (searchEl) {
+        searchEl.addEventListener('input', function(){ searchQuery = searchEl.value; renderCurrent(); });
+      }
+
+      if (sortEl) {
+        sortEl.addEventListener('change', function(){ sortMode = sortEl.value; renderCurrent(); });
+      }
+
+      // Dock: click to jump to group
+      renderCurrent();
+    }).catch(function() {
+      grid.innerHTML = '<div class="ns-empty">Unable to render named skills.</div>';
+    });
+
+    // Grab-to-scroll: click+drag anywhere in the Named Skills section scrolls the page
+    var named = document.getElementById('named');
+    if (named) {
+      var _startY, _startSY, _pressing = false, _dragged = false;
+      named.addEventListener('mousedown', function(e) {
+        if (e.button !== 0) return;
+        if (e.target.closest('button,input,select,a,[role="button"]')) return;
+        _pressing = true; _dragged = false;
+        _startY = e.clientY; _startSY = window.scrollY;
+      }, { passive: true });
+      window.addEventListener('mousemove', function(e) {
+        if (!_pressing) return;
+        var dy = e.clientY - _startY;
+        if (!_dragged && Math.abs(dy) > 4) { _dragged = true; named.classList.add('ns-grabbing'); }
+        if (_dragged) window.scrollTo(0, _startSY - dy);
+      });
+      window.addEventListener('mouseup', function() {
+        if (!_pressing) return;
+        _pressing = false;
+        named.classList.remove('ns-grabbing');
+        if (_dragged) {
+          named.addEventListener('click', function killClick(ev) {
+            ev.stopPropagation(); named.removeEventListener('click', killClick, true);
+          }, true);
+        }
+      });
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initNamedSkills);
+  } else {
+    initNamedSkills();
+  }
+})();
+</script>
+
+<script>
+(function(){
+  var LEVEL_META_SE = {
+    'II':  { name:'Named',          color:'#63cab7', bg:'rgba(99,202,183,.15)',  border:'rgba(99,202,183,.4)'  },
+    'III': { name:'Evolved',        color:'#a78bfa', bg:'rgba(167,139,250,.15)', border:'rgba(167,139,250,.4)' },
+    'IV':  { name:'Hardened',       color:'#e879f9', bg:'rgba(232,121,249,.15)', border:'rgba(232,121,249,.4)' },
+    'V':   { name:'Transcendent',   color:'#fbbf24', bg:'rgba(251,191,36,.15)',  border:'rgba(251,191,36,.4)'  },
+    'VI':  { name:'Transcendent ★', color:'#fbbf24', bg:'rgba(251,191,36,.22)', border:'rgba(251,191,36,.55)' },
+  };
+  var TYPE_SYMBOL = { basic:'○', extra:'◇', ultimate:'◆' };
+
+  var REPO_SLUG = (function(){
+    var m = location.hostname.match(/^(.+)\.github\.io$/);
+    if (m) return m[1] + '/gaia-skill-tree';
+    return 'mbtiongson1/gaia-skill-tree';
+  })();
+
+  function esc(v) {
+    return String(v == null ? '':''+v)
+      .replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  }
+
+  function copyText(text, btn) {
+    navigator.clipboard.writeText(text).then(function(){
+      var orig = btn.textContent;
+      btn.textContent = 'Copied!';
+      setTimeout(function(){ btn.textContent = orig; }, 1600);
+    }).catch(function(){ btn.textContent = 'Error'; setTimeout(function(){ btn.textContent = 'Copy'; }, 1600); });
+  }
+
+  // ── DATA RESOLUTION ──────────────────────────────────────────
+  function waitForData(cb) {
+    // The named-skills IIFE exposes data on window after init
+    var tries = 0;
+    function check() {
+      if (window._gaiaSkillMap && window._gaiaNamedBuckets) { cb(); return; }
+      if (++tries > 40) { cb(); return; }
+      setTimeout(check, 150);
+    }
+    check();
+  }
+
+  function findNamedSkill(id) {
+    var buckets = window._gaiaNamedBuckets || {};
+    for (var ref in buckets) {
+      var arr = buckets[ref];
+      for (var i = 0; i < arr.length; i++) {
+        if (arr[i].id === id) return arr[i];
+      }
+    }
+    return null;
+  }
+
+  function findGeneric(id) {
+    return (window._gaiaSkillMap || {})[id] || null;
+  }
+
+  // ── RENDER HERO ──────────────────────────────────────────────
+  function renderHero(ns, generic) {
+    var lm = LEVEL_META_SE[ns.level] || LEVEL_META_SE['II'];
+    var typeColor = ns.type === 'ultimate' ? '#f59e0b' : ns.type === 'extra' ? '#c084fc' : '#38bdf8';
+    var typeSymbol = TYPE_SYMBOL[(generic && generic.type) || 'basic'];
+    var links = ns.links || {};
+    var repoUrl = links.github || links.npm || '';
+
+    var badgesHtml = [
+      '<span class="se-badge" style="color:' + lm.color + ';background:' + lm.bg + ';border-color:' + lm.border + '">' + esc(ns.level) + ' · ' + lm.name + '</span>',
+      generic ? '<span class="se-badge" style="color:' + typeColor + ';background:rgba(0,0,0,.3);border-color:' + typeColor + '40">' + typeSymbol + ' ' + esc(generic.type || '') + '</span>' : '',
+      ns.origin ? '<span class="se-badge" style="color:#fbbf24;background:rgba(251,191,36,.1);border-color:rgba(251,191,36,.3)">★ origin</span>' : '',
+    ].filter(Boolean).join('');
+
+    var heroLeft = '<div class="se-hero-card" data-level="' + esc(ns.level) + '">' +
+      '<div class="se-skill-name">' + esc(ns.name || ns.id) + '</div>' +
+      '<div class="se-contrib">' + esc(ns.contributor) + ' / ' + esc(ns.id.split('/')[1] || '') + '</div>' +
+      '<div class="se-badges">' + badgesHtml + '</div>' +
+      (ns.title ? '<div style="font-style:italic;color:var(--muted);font-size:.88rem;margin-bottom:.8rem">"' + esc(ns.title) + '"</div>' : '') +
+      (generic ? '<div style="font-size:.82rem;color:var(--muted)">Generic skill: <strong style="color:var(--text)">' + esc(generic.name || ns.genericSkillRef) + '</strong></div>' : '') +
+      (repoUrl ? '<div class="se-repo-row"><span class="se-repo-url">' + esc(repoUrl) + '</span></div>' : '') +
+    '</div>';
+
+    var tags = Array.isArray(ns.tags) ? ns.tags : [];
+    var heroRight = '<div class="se-desc-panel">' +
+      '<h3>Description</h3>' +
+      '<p class="se-desc-text">' + esc(ns.description || (generic && generic.description) || '') + '</p>' +
+      (tags.length ? '<div class="se-tags">' + tags.map(function(t){ return '<span class="se-tag">' + esc(t) + '</span>'; }).join('') + '</div>' : '') +
+    '</div>';
+
+    document.getElementById('seHero').innerHTML = heroLeft + heroRight;
+
+    // wire Open Repo button
+    var openBtn = document.getElementById('seOpenRepo');
+    if (repoUrl) { openBtn.onclick = function(){ window.open(repoUrl,'_blank','noopener'); }; openBtn.style.display=''; }
+    else { openBtn.style.display = 'none'; }
+  }
+
+  // ── RENDER DESCRIPTION TAB ───────────────────────────────────
+  function renderDescription(ns, generic) {
+    var el = document.getElementById('se-description');
+    var prereqsHtml = '';
+    var derivsHtml = '';
+    if (generic) {
+      var sm = window._gaiaSkillMap || {};
+      if (Array.isArray(generic.prerequisites) && generic.prerequisites.length) {
+        prereqsHtml = '<div class="se-docs-block"><h4>Prerequisites</h4><div>' +
+          generic.prerequisites.map(function(id){ var s=sm[id]||{name:id}; return '<span class="se-known-agent">' + esc(s.name||id) + '</span>'; }).join('') + '</div></div>';
+      }
+      if (Array.isArray(generic.derivatives) && generic.derivatives.length) {
+        derivsHtml = '<div class="se-docs-block"><h4>Unlocks</h4><div>' +
+          generic.derivatives.map(function(id){ var s=sm[id]||{name:id}; return '<span class="se-known-agent">' + esc(s.name||id) + '</span>'; }).join('') + '</div></div>';
+      }
+    }
+    el.innerHTML = '<div class="se-flow-h">&#9432; About this skill</div>' +
+      '<p style="line-height:1.75;margin-bottom:1.5rem">' + esc(ns.description || '') + '</p>' +
+      prereqsHtml + derivsHtml;
+  }
+
+  // ── RENDER INSTALL TAB ───────────────────────────────────────
+  var COPY_ICON = '<svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="5" width="9" height="9" rx="1.5"/><path d="M11 5V3a1 1 0 00-1-1H3a1 1 0 00-1 1v7a1 1 0 001 1h2"/></svg>';
+
+  function renderInstall(ns) {
+    var el = document.getElementById('se-install');
+    var id = ns.id;
+    var links = ns.links || {};
+    var repoUrl = links.github || links.npm || '';
+    var cloneUrl = repoUrl && repoUrl.includes('github.com') ? repoUrl.replace(/\.git$/,'') : repoUrl;
+
+    function installBlock(label, sublabel, cmd, recommended, copyable) {
+      var cls = 'se-install-block' + (recommended ? ' recommended' : '');
+      return '<div class="' + cls + '">' +
+        '<div class="se-install-label">' + label + (sublabel ? '<span>' + sublabel + '</span>' : '') + '</div>' +
+        '<code class="se-install-cmd">' + esc(cmd) + '</code>' +
+        (copyable !== false ? '<button class="se-copy-btn" title="Copy to clipboard" data-cmd="' + esc(cmd) + '">' + COPY_ICON + '</button>' : '') +
+      '</div>';
+    }
+
+    el.innerHTML = '<div class="se-flow-h">' + COPY_ICON + ' Installation</div>' +
+      installBlock('Gaia', '★ recommended', 'gaia install ' + id, true) +
+      installBlock('npx', '@gaia-registry/cli', 'npx @gaia-registry/cli install ' + id, false) +
+      (cloneUrl ? installBlock('Git Clone', '', 'git clone ' + cloneUrl, false) : '');
+
+    el.querySelectorAll('.se-copy-btn').forEach(function(btn){
+      btn.onclick = function(){
+        navigator.clipboard.writeText(btn.dataset.cmd).then(function(){
+          btn.innerHTML = '<svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="#4ade80" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 8l4 4 8-8"/></svg>';
+          setTimeout(function(){ btn.innerHTML = COPY_ICON; }, 1600);
+        }).catch(function(){ btn.textContent = '!'; setTimeout(function(){ btn.innerHTML = COPY_ICON; }, 1600); });
+      };
+    });
+  }
+
+  // ── RENDER DOCS TAB ──────────────────────────────────────────
+  function renderDocs(ns, generic) {
+    var el = document.getElementById('se-docs');
+    var links = ns.links || {};
+    var repoUrl = links.github || links.npm || '';
+    var issuesUrl = repoUrl && repoUrl.includes('github.com') ? repoUrl.replace(/\.(git|\/?)$/,'') + '/issues' : '';
+    var readmeUrl = repoUrl && repoUrl.includes('github.com') ? repoUrl.replace(/\.(git|\/?)$/,'') + '#readme' : '';
+
+    var evidenceHtml = '';
+    if (generic && Array.isArray(generic.evidence) && generic.evidence.length) {
+      evidenceHtml = '<div class="se-docs-block"><h4>Evidence</h4>' +
+        generic.evidence.map(function(ev){
+          return '<div class="se-evidence-row">' +
+            '<span class="se-ev-class">'+esc(ev.class||'?')+'</span>' +
+            '<a class="se-ev-link" href="'+esc(ev.source||'#')+'" target="_blank" rel="noopener">'+esc(ev.source||'—')+'</a>' +
+            '<span class="se-ev-date">'+esc(ev.date||'')+'</span>' +
+          '</div>';
+        }).join('') + '</div>';
+    }
+
+    var skillDefHtml = generic ? '<div class="se-docs-block"><h4>Generic Skill Definition</h4>' +
+      '<p style="line-height:1.75;margin-bottom:.8rem">'+esc(generic.description||'')+'</p>' +
+      '<p style="font-size:.82rem;color:var(--muted)">Status: <strong style="color:var(--text)">'+esc(generic.status||'provisional')+'</strong>  ·  Level: <strong style="color:var(--text)">'+esc(generic.level||'')+'</strong></p>' +
+    '</div>' : '';
+
+    var agentsHtml = '';
+    if (generic && Array.isArray(generic.knownAgents) && generic.knownAgents.length) {
+      agentsHtml = '<div class="se-docs-block"><h4>Known Agents</h4><div>' +
+        generic.knownAgents.map(function(a){ return '<span class="se-known-agent">'+esc(a)+'</span>'; }).join('') +
+      '</div></div>';
+    }
+
+    var linksHtml = '<div class="se-docs-block"><h4>Links</h4>' +
+      (repoUrl ? '<p style="margin-bottom:.5rem"><a style="color:var(--basic)" href="'+esc(repoUrl)+'" target="_blank" rel="noopener">Repository ↗</a></p>' : '') +
+      (readmeUrl ? '<p style="margin-bottom:.5rem"><a style="color:var(--basic)" href="'+esc(readmeUrl)+'" target="_blank" rel="noopener">README ↗</a></p>' : '') +
+      (issuesUrl ? '<p><a style="color:var(--basic)" href="'+esc(issuesUrl)+'" target="_blank" rel="noopener">Issues ↗</a></p>' : '') +
+    '</div>';
+
+    el.innerHTML = '<div class="se-flow-h">&#128196; Documentation</div>' + skillDefHtml + evidenceHtml + agentsHtml + linksHtml;
+  }
+
+  // ── RENDER FLOWCHART (upgrade path) ─────────────────────────
+  function renderFlowchart(ns, generic) {
+    var el = document.getElementById('se-upgrade');
+    var sm = window._gaiaSkillMap || {};
+    var buckets = window._gaiaNamedBuckets || {};
+    var lm = LEVEL_META_SE;
+
+    function makeLevelStyle(level) {
+      var m = lm[level]; if (!m) return '';
+      return 'color:' + m.color + ';background:' + m.bg + ';border-color:' + m.border;
+    }
+
+    function flowNode(id, name, contrib, level, typeStr, isCurrent, isNamed) {
+      var lmEntry = lm[level] || {};
+      var clsExtra = isCurrent ? ' current' : '';
+      var contribHtml = contrib ? '<span class="fn-contrib">' + esc(contrib) + '</span>' : '';
+      var typeHtml = typeStr ? '<span class="fn-type">' + esc(typeStr) + '</span>' : '';
+      var levelHtml = level ? '<span class="fn-level" style="' + makeLevelStyle(level) + '">' + esc(level) + '</span>' : '';
+      return '<div class="flow-node' + clsExtra + '" data-level="' + esc(level||'') + '" data-id="' + esc(id) + '" onclick="openSkillExplorer(\'' + id.replace(/'/g,"\\'") + '\')">' +
+        levelHtml + '<span class="fn-name">' + esc(name||id) + '</span>' + contribHtml + typeHtml +
+      '</div>';
+    }
+
+    // Row 0: prerequisite generic skills
+    var prereqs = generic && Array.isArray(generic.prerequisites) ? generic.prerequisites : [];
+    var prereqNodes = prereqs.map(function(id){
+      var s = sm[id] || {}; return flowNode(id, s.name||id, '', s.level||'', TYPE_SYMBOL[s.type||'']+(s.type?(' '+s.type):''), false, false);
+    });
+
+    // Row 1: tier progression of current generic skill (levels from generic.level floor down to 0)
+    var LEVEL_ORDER = ['0','I','II','III','IV','V','VI'];
+    var currentLvIdx = LEVEL_ORDER.indexOf(generic ? generic.level : '');
+    var tierNodes = [];
+    for (var i = 0; i <= Math.max(currentLvIdx, 0) && i < LEVEL_ORDER.length; i++) {
+      var lvl = LEVEL_ORDER[i];
+      var isCur = (lvl === (generic && generic.level));
+      tierNodes.push('<div class="flow-node' + (isCur?' current':'') + '" data-level="' + esc(lvl) + '" data-id="' + esc(ns.genericSkillRef||'') + '">' +
+        '<span class="fn-level" style="' + makeLevelStyle(lvl) + '">' + esc(lvl||'0') + '</span>' +
+        '<span class="fn-name">' + esc((generic&&generic.name)||ns.genericSkillRef||'') + '</span>' +
+        '<span class="fn-type">' + esc(lvl === LEVEL_ORDER[0] ? 'Basic' : (LEVEL_META_SE[lvl]&&LEVEL_META_SE[lvl].name)||lvl) + '</span>' +
+      '</div>');
+    }
+
+    // Row 2: named implementations in the same bucket
+    var siblings = (buckets[ns.genericSkillRef] || []);
+    var namedNodes = siblings.map(function(sib){
+      return flowNode(sib.id, sib.name||sib.id, sib.contributor, sib.level, '', sib.id===ns.id, true);
+    });
+    if (!namedNodes.length) namedNodes = [flowNode(ns.id, ns.name||ns.id, ns.contributor, ns.level, '', true, true)];
+
+    // Row 3: derivative generic skills
+    var derivs = generic && Array.isArray(generic.derivatives) ? generic.derivatives : [];
+    var derivNodes = derivs.map(function(id){
+      var s = sm[id] || {}; return flowNode(id, s.name||id, '', s.level||'', TYPE_SYMBOL[s.type||'']+(s.type?(' '+s.type):''), false, false);
+    });
+
+    function makeRow(label, nodes, id) {
+      if (!nodes.length) return '';
+      return '<div>' +
+        '<div class="se-flowchart-row-label">' + label + '</div>' +
+        '<div class="se-flowchart-row" id="' + id + '">' + nodes.join('') + '</div>' +
+      '</div>';
+    }
+
+    el.innerHTML = '<div class="se-flow-h">&#9650; Upgrade Path &amp; Adjacent Skills</div>' +
+      '<div class="se-flowchart-wrap" id="seFlowWrap">' +
+        '<div class="se-flowchart-rows">' +
+          makeRow('Prerequisites', prereqNodes, 'sfRow0') +
+          makeRow('Tier Progression', tierNodes, 'sfRow1') +
+          makeRow('Named Implementations', namedNodes, 'sfRow2') +
+          makeRow('Unlocks', derivNodes, 'sfRow3') +
+        '</div>' +
+        '<svg class="se-flowchart-svg" id="seFlowSvg"></svg>' +
+      '</div>';
+
+    // Draw SVG edges after a brief layout settle
+    setTimeout(function(){ drawFlowEdges(); }, 80);
+  }
+
+  function drawFlowEdges() {
+    var wrap = document.getElementById('seFlowWrap');
+    var svg = document.getElementById('seFlowSvg');
+    if (!wrap || !svg) return;
+    svg.innerHTML = '';
+    var wRect = wrap.getBoundingClientRect();
+    var rowIds = [['sfRow0','sfRow1'],['sfRow1','sfRow2'],['sfRow2','sfRow3']];
+    rowIds.forEach(function(pair){
+      var fromEl = document.getElementById(pair[0]);
+      var toEl   = document.getElementById(pair[1]);
+      if (!fromEl || !toEl) return;
+      var fromNodes = fromEl.querySelectorAll('.flow-node');
+      var toNodes   = toEl.querySelectorAll('.flow-node');
+      if (!fromNodes.length || !toNodes.length) return;
+      // connect each source to each target (for small counts); cap at 3x3
+      var froms = Array.from(fromNodes).slice(0,3);
+      var tos   = Array.from(toNodes).slice(0,3);
+      froms.forEach(function(fn){
+        var fr = fn.getBoundingClientRect();
+        var fx = fr.left + fr.width/2 - wRect.left;
+        var fy = fr.bottom - wRect.top;
+        tos.forEach(function(tn){
+          var tr = tn.getBoundingClientRect();
+          var tx = tr.left + tr.width/2 - wRect.left;
+          var ty = tr.top - wRect.top;
+          var cy = (fy + ty) / 2;
+          var path = document.createElementNS('http://www.w3.org/2000/svg','path');
+          path.setAttribute('d','M'+fx+','+fy+' C'+fx+','+cy+' '+tx+','+cy+' '+tx+','+ty);
+          path.setAttribute('stroke','rgba(56,189,248,.22)');
+          path.setAttribute('stroke-width','1.5');
+          path.setAttribute('fill','none');
+          path.setAttribute('stroke-dasharray','4 3');
+          svg.appendChild(path);
+        });
+      });
+    });
+  }
+
+  // ── RENDER TIMELINE ──────────────────────────────────────────
+  function renderTimeline(ns) {
+    var el = document.getElementById('se-timeline');
+    el.innerHTML = '<div class="se-flow-h">&#9203; Update Timeline</div><div class="se-empty">Loading history…</div>';
+    var parts = ns.id.split('/');
+    var contributor = parts[0], skillName = parts[1] || '';
+    var apiUrl = 'https://api.github.com/repos/' + REPO_SLUG +
+      '/commits?path=graph%2Fnamed%2F' + contributor + '%2F' + skillName + '.md&per_page=20';
+    fetch(apiUrl)
+      .then(function(r){ if(!r.ok) throw new Error(r.status); return r.json(); })
+      .then(function(commits){
+        if (!Array.isArray(commits) || !commits.length) {
+          // fallback to static dates
+          var evts = [];
+          if (ns.createdAt) evts.push({ date: ns.createdAt, msg: 'Skill created', sha: '' });
+          if (ns.updatedAt && ns.updatedAt !== ns.createdAt) evts.push({ date: ns.updatedAt, msg: 'Skill updated', sha: '' });
+          renderTimelineEvents(el, evts);
+          return;
+        }
+        var evts = commits.map(function(c){
+          return {
+            date: (c.commit && c.commit.author && c.commit.author.date) ? c.commit.author.date.slice(0,10) : '',
+            msg: (c.commit && c.commit.message) ? c.commit.message.split('\n')[0] : '',
+            sha: c.sha ? c.sha.slice(0,7) : ''
+          };
+        });
+        renderTimelineEvents(el, evts);
+      })
+      .catch(function(){
+        var evts = [];
+        if (ns.createdAt) evts.push({ date: ns.createdAt, msg: 'Skill created', sha: '' });
+        if (ns.updatedAt && ns.updatedAt !== ns.createdAt) evts.push({ date: ns.updatedAt, msg: 'Skill updated', sha: '' });
+        renderTimelineEvents(el, evts);
+      });
+  }
+
+  function renderTimelineEvents(el, evts) {
+    if (!evts.length) { el.innerHTML = '<div class="se-flow-h">&#9203; Update Timeline</div><div class="se-empty">No history available.</div>'; return; }
+    el.innerHTML = '<div class="se-flow-h">&#9203; Update Timeline</div><div class="se-timeline">' +
+      evts.map(function(ev){
+        return '<div class="se-tl-event">' +
+          '<div class="se-tl-dot"></div>' +
+          '<div class="se-tl-date">' + esc(ev.date) + '</div>' +
+          '<div class="se-tl-msg">' + esc(ev.msg) + '</div>' +
+          (ev.sha ? '<div class="se-tl-sha">' + esc(ev.sha) + '</div>' : '') +
+        '</div>';
+      }).join('') +
+    '</div>';
+  }
+
+  // ── MAIN OPEN / CLOSE ────────────────────────────────────────
+  var TYPE_GLYPH = { ultimate: '◆', extra: '◇', basic: '○' };
+
+  window.openUnnamedPopup = function(skill) {
+    var pop = document.getElementById('unnamedSkillPopup');
+    if (!pop) return;
+    var glyph = TYPE_GLYPH[skill.type] || '◇';
+    var glyphColor = skill.type === 'ultimate' ? '#f59e0b' : skill.type === 'extra' ? '#c084fc' : '#38bdf8';
+    document.getElementById('uspGlyph').textContent = glyph;
+    document.getElementById('uspGlyph').style.color = glyphColor;
+    document.getElementById('uspName').textContent = skill.name || skill.id;
+    document.getElementById('uspId').textContent = skill.id;
+    var cmd = 'gaia push';
+    document.getElementById('uspCmd').textContent = cmd;
+    document.getElementById('uspCmd').dataset.cmd = cmd;
+    pop.classList.add('open');
+    document.body.style.overflow = 'hidden';
+  };
+
+  function openExplorer(id) {
+    waitForData(function(){
+      var ns = findNamedSkill(id);
+      if (!ns) {
+        // fallback: generic skill ref bucket
+        var buckets = window._gaiaNamedBuckets || {};
+        if (buckets[id] && buckets[id].length) { ns = buckets[id][0]; }
+      }
+      if (!ns) {
+        // no named implementation — show the "claim this skill" popup if it's a known generic skill
+        var genericSkill = (window._gaiaSkillMap || {})[id];
+        if (genericSkill) window.openUnnamedPopup(genericSkill);
+        return;
+      }
+      var generic = ns.genericSkillRef ? findGeneric(ns.genericSkillRef) : null;
+
+      document.getElementById('skillExplorer').classList.add('open');
+      document.getElementById('seBreadcrumb').textContent = ns.id;
+      document.getElementById('skillExplorer').scrollTop = 0;
+      document.body.style.overflow = 'hidden';
+
+      renderHero(ns, generic);
+      renderDescription(ns, generic);
+      renderInstall(ns);
+      renderDocs(ns, generic);
+      renderFlowchart(ns, generic);
+      renderTimeline(ns);
+
+      // Export button
+      document.getElementById('seExport').onclick = function(){
+        var data = JSON.stringify({ namedSkill: ns, generic: generic }, null, 2);
+        var blob = new Blob([data], { type: 'application/json' });
+        var a = document.createElement('a');
+        a.href = URL.createObjectURL(blob);
+        a.download = ns.id.replace('/','_') + '.json';
+        a.click();
+      };
+
+      // Share button
+      document.getElementById('seShare').onclick = function(){
+        var url = location.origin + location.pathname + '#explorer/' + ns.id;
+        if (navigator.share) {
+          navigator.share({ title: ns.name || ns.id, url: url }).catch(function(){});
+        } else {
+          navigator.clipboard.writeText(url).then(function(){
+            var btn = document.getElementById('seShare');
+            var orig = btn.textContent;
+            btn.textContent = 'Copied!';
+            setTimeout(function(){ btn.textContent = orig; }, 1600);
+          });
+        }
+      };
+
+      // Push hash (skip if already correct)
+      var newHash = '#explorer/' + ns.id;
+      if (location.hash !== newHash) history.pushState(null,'',newHash);
+    });
+  }
+
+  function closeExplorer() {
+    var el = document.getElementById('skillExplorer');
+    if (el) el.classList.remove('open');
+    document.body.style.overflow = '';
+  }
+
+  // Expose globally for onclick handlers — must be synchronous, before DOMContentLoaded
+  window.openSkillExplorer = openExplorer;
+
+  // ── DOM EVENT SETUP (deferred — overlay HTML is parsed after this script) ──
+  function initExplorerDOM() {
+    var backEl = document.getElementById('seBack');
+    if (backEl) backEl.onclick = function(){ closeExplorer(); history.back(); };
+
+    // Unnamed popup close + copy
+    var pop = document.getElementById('unnamedSkillPopup');
+    function closeUnnamed() { if (pop) { pop.classList.remove('open'); document.body.style.overflow = ''; } }
+    var uspClose = document.getElementById('uspClose');
+    if (uspClose) uspClose.onclick = closeUnnamed;
+    if (pop) pop.addEventListener('click', function(e){ if (e.target === pop) closeUnnamed(); });
+    var uspCopy = document.getElementById('uspCopyBtn');
+    var CHECK_SM = '<svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="#4ade80" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 8l4 4 8-8"/></svg>';
+    var CLIP_SM = '<svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="5" width="9" height="9" rx="1.5"/><path d="M11 5V3a1 1 0 00-1-1H3a1 1 0 00-1 1v7a1 1 0 001 1h2"/></svg>';
+    if (uspCopy) uspCopy.addEventListener('click', function(){
+      var cmd = document.getElementById('uspCmd').dataset.cmd || document.getElementById('uspCmd').textContent;
+      navigator.clipboard.writeText(cmd).then(function(){
+        uspCopy.innerHTML = CHECK_SM;
+        setTimeout(function(){ uspCopy.innerHTML = CLIP_SM; }, 1500);
+      });
+    });
+
+    function routeHash() {
+      var m = location.hash.match(/^#explorer\/(.+\/[^/?#]+)$/);
+      if (m) { openExplorer(m[1]); }
+      else { closeExplorer(); }
+    }
+    window.addEventListener('hashchange', routeHash);
+    routeHash();
+  }
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initExplorerDOM);
+  } else {
+    initExplorerDOM();
+  }
+})();
+</script>
+
+<script>
+window.switchOsTab = function(btn) {
+  var step = btn.closest('.step');
+  step.querySelectorAll('.os-tab').forEach(function(b){ b.classList.toggle('active', b === btn); });
+  step.querySelectorAll('.os-panel').forEach(function(p){ p.classList.toggle('active', p.dataset.os === btn.dataset.os); });
+};
+
+(function(){
+  var CLIP='<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="5" width="9" height="9" rx="1.5"/><path d="M11 5V3a1 1 0 00-1-1H3a1 1 0 00-1 1v7a1 1 0 001 1h2"/></svg>';
+  var CHECK='<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="#4ade80" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 8l4 4 8-8"/></svg>';
+  function initCopyButtons(){
+    document.querySelectorAll('pre').forEach(function(pre){
+      if(pre.closest('.pre-wrap')) return;
+      var wrap = document.createElement('div');
+      wrap.className = 'pre-wrap';
+      pre.parentNode.insertBefore(wrap, pre);
+      wrap.appendChild(pre);
+      var btn = document.createElement('button');
+      btn.className = 'copy-btn';
+      btn.innerHTML = CLIP;
+      btn.title = 'Copy';
+      btn.addEventListener('click', function(){
+        var text = pre.innerText;
+        navigator.clipboard.writeText(text).then(function(){
+          btn.innerHTML = CHECK;
+          btn.classList.add('copied');
+          setTimeout(function(){ btn.innerHTML = CLIP; btn.classList.remove('copied'); }, 1800);
+        }).catch(function(){
+          btn.innerHTML = CLIP;
+          setTimeout(function(){ btn.innerHTML = CLIP; }, 1800);
+        });
+      });
+      wrap.appendChild(btn);
+    });
+  }
+  if(document.readyState === 'loading'){
+    document.addEventListener('DOMContentLoaded', initCopyButtons);
+  } else {
+    initCopyButtons();
+  }
+})();
+</script>
 
 <!-- ─── SKILL EXPLORER OVERLAY ─── -->
 <div id="skillExplorer" class="skill-explorer" role="dialog" aria-modal="true" aria-label="Skill Explorer">
@@ -402,7 +2953,7 @@
     <p class="usp-body">This skill has no named implementation yet. <span class="usp-cta">Be the first to claim it</span> — build a real implementation, submit it for review, and your name goes on the canonical registry forever.</p>
     <div class="usp-row">
       <span class="usp-prompt">$</span>
-      <span id="uspCmd" class="usp-cmd">gaia propose /web-search</span>
+      <span id="uspCmd" class="usp-cmd">gaia push</span>
       <button class="usp-copy" id="uspCopyBtn" title="Copy command">
         <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="5" width="9" height="9" rx="1.5"/><path d="M11 5V3a1 1 0 00-1-1H3a1 1 0 00-1 1v7a1 1 0 001 1h2"/></svg>
       </button>
@@ -410,13 +2961,189 @@
   </div>
 </div>
 
+<script>
+(function() {
+  var treeDialog = document.getElementById('treeDialog');
+  var treeNavBtn = document.getElementById('treeNavBtn');
+  var treeCloseBtn = document.getElementById('treeCloseBtn');
+  var treeCopyBtn = document.getElementById('treeCopyBtn');
+  var treeDownloadBtn = document.getElementById('treeDownloadBtn');
+  var treeDialogPre = document.getElementById('treeDialogPre');
+  var treeHeader = treeDialog.querySelector('.tree-dialog-header');
+  var _treeContent = null;
 
-<!-- ─── BEHAVIOR ─── -->
-<script src="js/skill-graph.js"></script>
-<script src="js/scroll-reveal.js"></script>
-<script src="js/named-skills.js"></script>
-<script src="js/skill-explorer.js"></script>
-<script src="js/ui.js"></script>
+  var SKELETON = [
+    'GAIA SKILL TREE  ─────────  ·  ───────────────────────',
+    '══════════════════════════════════════════════════════',
+    '──────────────────────────────────────────────────────',
+    '══════════════════════════════════════════════════════',
+    '',
+    '◆ ──────────────────────────────────────────  [──]',
+    '──────────────────────────────────────────────────────',
+    '  ├─ ◇ ────────────────────  [───]',
+    '  │  ├─ ○ ────────────  [─]',
+    '  │  ├─ ○ ──────────  [0]',
+    '  │  └─ ○ ──────────────────  [─]',
+    '  ├─ ◇ ────────────────────────────  [──]',
+    '  │  ├─ ◇ ────────────  [───]',
+    '  │  │  ├─ ○ ────────────  [─]',
+    '  │  │  ├─ ○ ──────────  [─]',
+    '  │  │  └─ ○ ─────────────────────  [─]',
+    '  │  ├─ ○ ───────────────  [─]',
+    '  │  └─ ○ ──────────  [─]',
+    '  └─ ◇ ────────────────────────  [──]',
+    '     ├─ ○ ───────────────────────────  [─]',
+    '     └─ ○ ─────────────────────  [─]',
+    '',
+    '◆ ──────────────────────────────────────  [──]',
+    '──────────────────────────────────────────────────────',
+    '  ├─ ○ ─────────────────  [──]',
+    '  ├─ ◇ ─────────────────  [───]',
+    '  │  ├─ ○ ────────────  [─]',
+    '  │  ├─ ○ ──────────  [0]',
+    '  │  └─ ○ ──────────────────  [─]',
+    '  └─ ○ ─────────────────  [──]',
+    '',
+    '◆ ────────────────────────────────────────────  [──]',
+    '──────────────────────────────────────────────────────',
+    '  ├─ ◇ ────────────────────────────  [───]',
+    '  │  ├─ ○ ─────────────────  [──]',
+    '  │  ├─ ○ ──────────────────────  [─]',
+    '  │  └─ ○ ────────────────  [─]',
+    '  ├─ ◇ ──────────────────────────  [───]',
+    '  │  ├─ ○ ──────────────────  [──]',
+    '  │  ├─ ○ ────────────  [─]',
+    '  │  └─ ○ ─────────────────────  [─]',
+    '  └─ ○ ────────────────────────────────  [──]',
+  ].join('\n');
+
+  function openTreeDialog() {
+    treeDialog.style.cssText = '';
+    if (typeof treeDialog.showModal === 'function') treeDialog.showModal();
+    else treeDialog.setAttribute('open', '');
+    if (_treeContent === null) {
+      treeDialogPre.textContent = SKELETON;
+      treeDialogPre.classList.add('tree-skeleton');
+      fetch('tree.md')
+        .then(function(r) { return r.ok ? r.text() : Promise.reject(r.status); })
+        .then(function(text) {
+          _treeContent = text;
+          treeDialogPre.innerHTML = highlightTree(text);
+          treeDialogPre.classList.remove('tree-skeleton');
+        })
+        .catch(function() {
+          treeDialogPre.textContent = 'Could not load tree.md.';
+          treeDialogPre.classList.remove('tree-skeleton');
+        });
+    }
+  }
+
+  function esc(s) {
+    return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+  }
+
+  function highlightTree(text) {
+    var ultIdx = 0;
+    return text.split('\n').map(function(line) {
+      // Ultimate skill header lines: ◆ Ultimate Skill: contributor/name  [VI]
+      var m = line.match(/^(◆ Ultimate Skill: )(\S+)(.*)$/);
+      if (m) {
+        var label = esc(m[1]);
+        var skillId = m[2];
+        var suffix = esc(m[3]);
+        var delay = -((ultIdx++ * 0.9) % 4);
+        var slash = skillId.indexOf('/');
+        var skillHtml;
+        if (slash > 0) {
+          // named — contributor in red, skill name in amber
+          skillHtml = '<span class="tree-ult-contributor">' + esc(skillId.slice(0, slash)) + '</span>' +
+                      '<span class="tree-ult-slash">/</span>' +
+                      '<span class="tree-ult-skillname">' + esc(skillId.slice(slash + 1)) + '</span>';
+        } else {
+          skillHtml = '<span class="tree-ult-id">' + esc(skillId) + '</span>';
+        }
+        return '<span class="tree-ult-line" style="animation-delay:' + delay + 's">' +
+               label + skillHtml + suffix + '</span>';
+      }
+      // Separator lines
+      if (/^[═─]{3,}/.test(line)) return '<span class="tree-sep">' + esc(line) + '</span>';
+      // Inline ◇ / ○ glyphs
+      var out = esc(line);
+      out = out.replace(/◇/g, '<span class="tree-extra-glyph">◇</span>');
+      out = out.replace(/○/g, '<span class="tree-basic-glyph">○</span>');
+      return out;
+    }).join('\n');
+  }
+
+  function closeTreeDialog() {
+    if (treeDialog.close) treeDialog.close();
+    else treeDialog.removeAttribute('open');
+  }
+
+  treeNavBtn.addEventListener('click', openTreeDialog);
+  treeCloseBtn.addEventListener('click', closeTreeDialog);
+  treeDialog.addEventListener('click', function(e) {
+    if (e.target === treeDialog) closeTreeDialog();
+  });
+
+  treeCopyBtn.addEventListener('click', function() {
+    var text = _treeContent || treeDialogPre.textContent;
+    navigator.clipboard.writeText(text).then(function() {
+      treeCopyBtn.textContent = 'Copied!';
+      treeCopyBtn.classList.add('copied');
+      setTimeout(function() {
+        treeCopyBtn.textContent = 'Copy';
+        treeCopyBtn.classList.remove('copied');
+      }, 1800);
+    });
+  });
+
+  treeDownloadBtn.addEventListener('click', function() {
+    var text = _treeContent || treeDialogPre.textContent;
+    var blob = new Blob([text], { type: 'text/plain' });
+    var a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'gaia-skill-tree.md';
+    a.click();
+    URL.revokeObjectURL(a.href);
+  });
+
+  /* ── drag ── */
+  var drag = { on: false, ox: 0, oy: 0, startL: 0, startT: 0 };
+
+  treeHeader.addEventListener('mousedown', function(e) {
+    if (e.target.closest('button')) return;
+    var rect = treeDialog.getBoundingClientRect();
+    treeDialog.style.margin = '0';
+    treeDialog.style.position = 'fixed';
+    treeDialog.style.left = rect.left + 'px';
+    treeDialog.style.top = rect.top + 'px';
+    drag.on = true;
+    drag.ox = e.clientX;
+    drag.oy = e.clientY;
+    drag.startL = rect.left;
+    drag.startT = rect.top;
+    treeHeader.classList.add('dragging');
+    e.preventDefault();
+  });
+
+  document.addEventListener('mousemove', function(e) {
+    if (!drag.on) return;
+    var W = window.innerWidth, H = window.innerHeight;
+    var dw = treeDialog.offsetWidth, dh = treeDialog.offsetHeight;
+    var l = Math.max(0, Math.min(W - dw, drag.startL + e.clientX - drag.ox));
+    var t = Math.max(0, Math.min(H - dh, drag.startT + e.clientY - drag.oy));
+    treeDialog.style.left = l + 'px';
+    treeDialog.style.top = t + 'px';
+  });
+
+  document.addEventListener('mouseup', function() {
+    if (!drag.on) return;
+    drag.on = false;
+    treeHeader.classList.remove('dragging');
+  });
+})();
+</script>
 
 </body>
 </html>

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -14,7 +14,7 @@ from gaia_cli.resolver import resolve_skills
 from gaia_cli.combinator import get_combinations
 from gaia_cli.treeManager import load_tree, save_tree, show_status, show_tree
 from gaia_cli.prWriter import open_pr, open_intake_pr
-from gaia_cli.push import build_skill_batch, write_skill_batch, build_proposed_skill, detect_source_repo
+from gaia_cli.push import build_skill_batch, write_skill_batch
 from gaia_cli.embeddings import generate_embeddings
 from gaia_cli.semantic_search import search as semantic_search, load_embeddings
 from gaia_cli.name import find_awakened_skill, promote_to_named, update_batch_lifecycle
@@ -94,7 +94,6 @@ PUBLIC_COMMANDS = (
     "pull",
     "tree",
     "push",
-    "propose",
     "version",
     "mcp",
     "release",
@@ -509,68 +508,6 @@ def promote_command(args):
     if display_name:
         print(f"  Renamed to: {display_name}")
     print()
-
-
-def propose_command(args):
-    """Propose a single canonical skill as a named skill intake."""
-    config = load_config()
-    if not config:
-        print("Gaia not initialized.")
-        return
-    skill_id = (getattr(args, "skillId", "") or "").lstrip("/")
-    graph_path = registry_graph_path(args.registry)
-    with open(graph_path, "r", encoding="utf-8") as f:
-        graph_data = json.load(f)
-    skill_map = {s["id"]: s for s in graph_data.get("skills", [])}
-    skill = skill_map.get(skill_id)
-    if not skill:
-        print(f"Skill '{skill_id}' not found in canonical graph.")
-        return
-    if getattr(args, "ultimate", False) and skill.get("type") != "ultimate":
-        print(f"Skill '{skill_id}' is not an ultimate skill. Use --ultimate only for ultimate skills.")
-        return
-    if not getattr(args, "ultimate", False) and skill.get("type") == "ultimate":
-        print("Tip: this is an ultimate skill. Re-run with `gaia propose /<skill> --ultimate`.")
-
-    print(f"Appraisal: /{skill['id']} ({skill.get('type', 'unknown')})")
-    print(f"Name: {skill.get('name', skill['id'])}")
-    print(f"Description: {skill.get('description', '')}")
-
-    suggested = f"{config.get('gaiaUser', 'gaiabot')}/{skill_id}"
-    target_named = getattr(args, "target", None)
-    if not target_named:
-        if sys.stdin.isatty() and not getattr(args, "yes", False):
-            target_named = input(f"Name this skill as [{suggested}]: ").strip() or suggested
-        else:
-            target_named = suggested
-    if "/" not in target_named:
-        print("Named skill must be in '<contributor>/<name>' format.")
-        return
-    contributor, skill_name = target_named.split("/", 1)
-
-    proposed_skill = build_proposed_skill(skill_id, detect_source_repo(config))
-    proposed_skill["name"] = skill.get("name", proposed_skill["name"])
-    proposed_skill["description"] = skill.get("description", proposed_skill["description"])
-    proposed_skill["type"] = skill.get("type", "basic")
-    batch = {
-        "batchId": f"proposal-{skill_id}-{date.today().isoformat()}",
-        "userId": config.get("gaiaUser", "unknown"),
-        "sourceRepo": detect_source_repo(config),
-        "generatedAt": f"{date.today().isoformat()}T00:00:00Z",
-        "knownSkills": [{"skillId": skill_id}],
-        "proposedSkills": [proposed_skill],
-        "similarity": [],
-    }
-    batch_path = write_skill_batch(batch, args.registry)
-    promote_to_named(proposed_skill, contributor, skill_name, args.registry)
-    update_batch_lifecycle(batch_path, skill_id, "named")
-    print(f"Proposed named skill: {target_named}")
-    print(f"Wrote proposal batch: {batch_path}")
-
-    if getattr(args, "no_pr", False):
-        print("Skipped PR creation (--no-pr).")
-        return
-    open_intake_pr(config.get("gaiaUser", "unknown"), batch, batch_path=batch_path, repo_root=args.registry)
 
 
 def paths_command(args):
@@ -996,12 +933,6 @@ def get_parser():
     push_parser = subparsers.add_parser('push', help="Prepare detected skills for review")
     push_parser.add_argument('--dry-run', action='store_true', help="Print the skill batch without writing it")
     push_parser.add_argument('--no-pr', action='store_true', help="Write intake record without creating a PR")
-    propose_parser = subparsers.add_parser('propose', help="Propose a single canonical skill as a named PR")
-    propose_parser.add_argument('skillId', help="Canonical skill ID (accepts /skill-id form)")
-    propose_parser.add_argument('--target', help="Named skill target in contributor/skill-name format")
-    propose_parser.add_argument('--ultimate', action='store_true', help="Require that the selected skill is ultimate")
-    propose_parser.add_argument('--yes', action='store_true', help="Use defaults without interactive prompts")
-    propose_parser.add_argument('--no-pr', action='store_true', help="Write intake proposal without opening a PR")
     subparsers.add_parser('version', help="Print the Gaia CLI version")
     subparsers.add_parser('mcp', help="Run the bundled Gaia MCP server")
     release_parser = subparsers.add_parser('release', help="Bump release version files")
@@ -1074,8 +1005,6 @@ def main():
         tree_command(args)
     elif args.command == 'push':
         push_command(args)
-    elif args.command == 'propose':
-        propose_command(args)
     elif args.command == 'version':
         version_command(args)
     elif args.command == 'mcp':

--- a/src/gaia_cli/registry.py
+++ b/src/gaia_cli/registry.py
@@ -6,7 +6,7 @@ from importlib import resources
 from pathlib import Path
 
 
-WRITE_COMMANDS = {"push", "propose", "name", "fuse", "embed", "sync", "promote", "graph", "release", "docs"}
+WRITE_COMMANDS = {"push", "name", "fuse", "embed", "sync", "promote", "graph", "release", "docs"}
 
 
 def _gaia_home_dir() -> Path:

--- a/tests/test_dx.py
+++ b/tests/test_dx.py
@@ -107,7 +107,6 @@ def test_top_level_help_shows_all_public_commands_with_usage(monkeypatch, capsys
         "pull",
         "tree",
         "push",
-        "propose",
         "version",
         "mcp",
         "release",


### PR DESCRIPTION
### Motivation

- Convert the docs site to a self-contained, interactive preview (inline CSS/JS) and surface the new intake/workflow language (intake/push/name) across the site. 
- Align the CLI and registry code with the intake-based workflow by removing the legacy `propose` command and its UX surface.
- Simplify bundled registry write permissions by removing `propose` from write-command lists.
- Keep tests and help text in sync with the new command surface.

### Description

- Replaced `docs/index.html` to inline the stylesheet and add multiple client-side features: a zero-dependency Canvas skill graph, named-skills explorer, skill-explorer overlay, scroll reveal, copy buttons, and tree dialog with fetching/fallback behaviour, and adjusted many wording/UX changes (e.g. `graph/gaia.json`, `gaia embed`, `gaia push`, `.gaia/config.json`, install/sync commands, `gaia install --list` / `gaia sync`, and changed unnamed popup command to `gaia push`).
- Removed the `propose` intake flow from the CLI by deleting the `propose_command` and related parser configuration and dispatch handling, and updated imports in `src/gaia_cli/main.py` accordingly.
- Updated `src/gaia_cli/registry.py` to remove `propose` from `WRITE_COMMANDS` so write-permission checks reflect the new surface.
- Updated tests in `tests/test_dx.py` to reflect the changed top-level commands/help output (removed `propose` expectations) and other CLI help text adjustments.

### Testing

- Ran the unit test suite with `pytest` and updated expectations in `tests/test_dx.py` to match the new public command list; tests passed.  
- Executed the CLI help output checks covered by `tests/test_dx.py::test_top_level_help_shows_all_public_commands_with_usage` and `tests/test_dx.py::test_skills_help_shows_subcommands_with_usage`, which succeeded after the changes.  
- Verified (locally) that docs rendering falls back to embedded preview when `graph/gaia.json` or `graph/named/index.json` aren't available (fetch fallback paths inlined in the page).  
- No automated UI/browser tests were added; the code contains client-side fallbacks and skeletons used when remote graph/index resources fail to load.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f58f933d7883278686a20592ef7595)