### PR TITLE
[codex] Fix gaia push hook imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ $env:PATH += ";" + (python -c "import sysconfig; print(sysconfig.get_path('scrip
 ```
 
 <!-- gaia:version-start -->
-Current Gaia CLI version: `2.4.5`.
+Current Gaia CLI version: `2.4.6`.
 
 Python install:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -424,5 +424,5 @@
 </html>
 
 <!-- gaia:stats-start -->
-<!-- skills=123; namedSkills=34; version=2.4.5 -->
+<!-- skills=123; namedSkills=34; version=2.4.6 -->
 <!-- gaia:stats-end -->

--- a/packages/cli-npm/package.json
+++ b/packages/cli-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia-registry/cli",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "description": "Gaia CLI - Integrate your AI agent skills with the Gaia registry",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia-registry/mcp-server",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "description": "MCP server for the Gaia Skill Registry \u2014 agent-native skill detection, fusion, and progression",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gaia-cli"
-version = "2.4.5"
+version = "2.4.6"
 description = "Gaia AI Agent Skill Registry CLI"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/registry/gaia.json
+++ b/registry/gaia.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./schema/skill.schema.json",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "generatedAt": "2026-04-30T00:00:00Z",
   "meta": {
     "typeLabels": {

--- a/src/gaia_cli/prWriter.py
+++ b/src/gaia_cli/prWriter.py
@@ -2,6 +2,7 @@ import os
 import re
 import shutil
 import subprocess
+from pathlib import Path
 
 
 def open_pr(username, tree_data, candidate_result=None):
@@ -98,8 +99,26 @@ def build_intake_pr_body(batch_data):
     return "\n".join(lines)
 
 
+def _subprocess_env():
+    env = os.environ.copy()
+    package_parent = str(Path(__file__).resolve().parent.parent)
+    pythonpath = [package_parent]
+    existing = env.get("PYTHONPATH")
+    if existing:
+        pythonpath.extend(existing.split(os.pathsep))
+    env["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(path for path in pythonpath if path))
+    return env
+
+
 def _run(cmd, cwd):
-    return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, check=False)
+    return subprocess.run(
+        cmd,
+        cwd=cwd,
+        env=_subprocess_env(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
 
 
 def _gh_ready(cwd):

--- a/tests/test_pr_writer.py
+++ b/tests/test_pr_writer.py
@@ -1,12 +1,14 @@
 import os
 import sys
+import tempfile
 import unittest
+from unittest.mock import patch
 
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, REPO_ROOT)
 
-from gaia_cli.prWriter import build_intake_pr_body
+from gaia_cli.prWriter import _run, build_intake_pr_body
 
 
 class TestPrWriter(unittest.TestCase):
@@ -40,6 +42,22 @@ class TestPrWriter(unittest.TestCase):
         self.assertIn("`web-search` (0.730)", body)
         self.assertIn("### Reviewer Checklist", body)
         self.assertIn("### Maintainer Promotion Checklist", body)
+
+    def test_run_exposes_gaia_cli_to_subprocesses_outside_repo_root(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(os.environ, {}, clear=True):
+                result = _run(
+                    [
+                        sys.executable,
+                        "-S",
+                        "-c",
+                        "import gaia_cli; print(gaia_cli.__name__)",
+                    ],
+                    cwd=tmp,
+                )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("gaia_cli", result.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fixes intake PR subprocesses so git hooks can import `gaia_cli` even when the child process runs outside the package checkout
- adds a regression test for hook-like subprocess imports with site-packages disabled
- includes the pre-commit patch version bump to 2.4.6 and regenerated docs-owned regions

Fixes #120.

## Verification
- `uv run --frozen --extra dev python -m pytest -q` (272 passed)
- `uv run --frozen gaia --registry . docs build --check`
