### PR TITLE
[codex] Fix docs skill npx install command

### DIFF
--- a/docs/js/skill-explorer.js
+++ b/docs/js/skill-explorer.js
@@ -122,6 +122,13 @@
     var links = ns.links || {};
     var repoUrl = links.github || links.npm || '';
     var cloneUrl = repoUrl && repoUrl.includes('github.com') ? repoUrl.replace(/\.git$/,'') : repoUrl;
+    var skillsAddRef = repoUrl || id;
+    if (repoUrl && repoUrl.includes('github.com')) {
+      skillsAddRef = repoUrl
+        .replace('/blob/', '/tree/')
+        .replace(/\/SKILL\.md$/i, '')
+        .replace(/\.git$/, '');
+    }
 
     function installBlock(label, sublabel, cmd, recommended, copyable) {
       var cls = 'se-install-block' + (recommended ? ' recommended' : '');
@@ -134,7 +141,7 @@
 
     el.innerHTML = '<div class="se-flow-h">' + COPY_ICON + ' Installation</div>' +
       installBlock('Gaia', '★ recommended', 'gaia install ' + id, true) +
-      installBlock('npx', '@gaia-registry/cli', 'npx @gaia-registry/cli install ' + id, false) +
+      installBlock('npx', 'skills package', 'npx skills add ' + skillsAddRef, false) +
       (cloneUrl ? installBlock('Git Clone', '', 'git clone ' + cloneUrl, false) : '');
 
     el.querySelectorAll('.se-copy-btn').forEach(function(btn){

--- a/tests/test_docs_skill_explorer.py
+++ b/tests/test_docs_skill_explorer.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_skill_explorer_uses_open_source_skills_npx_install():
+    js = (ROOT / "docs" / "js" / "skill-explorer.js").read_text(encoding="utf-8")
+
+    assert "npx skills add " in js
+    assert "skills package" in js
+    assert "npx @gaia-registry/cli install " not in js
+    assert "@gaia-registry/cli" not in js
+
+
+def test_skill_explorer_normalizes_github_skill_file_urls_for_skills_add():
+    js = (ROOT / "docs" / "js" / "skill-explorer.js").read_text(encoding="utf-8")
+
+    assert ".replace('/blob/', '/tree/')" in js
+    assert ".replace(/\\/SKILL\\.md$/i, '')" in js


### PR DESCRIPTION
## Summary
- Replaces the docs skill explorer alternate npx command with `npx skills add`.
- Normalizes GitHub `blob/.../SKILL.md` links into installable `tree/...` skill directory refs.
- Adds a regression test to prevent the old `npx @gaia-registry/cli install` command from returning.

Closes #136.

## Validation
- `.venv/bin/python -m pytest tests/test_docs_skill_explorer.py tests/test_graph.py`
- `.venv/bin/python -m pytest`

Note: `scripts/build_docs.py --check` still reports a pre-existing stale README CLI help region unrelated to this issue.