### PR TITLE
docs: sync wiki graph artifacts to v2.5.0

### DIFF
--- a/docs/graph/gaia.json
+++ b/docs/graph/gaia.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./schema/skill.schema.json",
-  "version": "2.4.8",
+  "version": "2.5.0",
   "generatedAt": "2026-04-30T00:00:00Z",
   "meta": {
     "typeLabels": {

--- a/docs/tree.md
+++ b/docs/tree.md
@@ -1,7 +1,7 @@
 # Gaia Skill Tree
 
 ```
-GAIA SKILL TREE  v2.4.8  ·  generated 2026-04-30
+GAIA SKILL TREE  v2.5.0  ·  generated 2026-04-30
 ══════════════════════════════════════════════════════════════════════
 Upgrade paths — each legendary shows its full prerequisite chain.
 Shared prerequisites marked (↑ see above) on second occurrence.


### PR DESCRIPTION
### Motivation
- Sync generated wiki-facing graph artifacts so the `docs/` site reflects the current registry/CLI version (`2.5.0`) and remove stale version metadata.

### Description
- Updated `docs/tree.md` banner from `v2.4.8` to `v2.5.0` and updated the top-level `version` in `docs/graph/gaia.json` to `2.5.0`, and refreshed the generated projections and synced the docs-facing artifacts.

### Testing
- Ran `python3 scripts/generateProjections.py`, `PYTHONPATH=src python3 scripts/renderGraphSvg.py --format svg --output registry/gaia.svg`, `python3 scripts/syncDocsGraphAssets.py`, and `pytest -q tests/test_docs_site.py tests/test_registry_layout.py`, and the automated steps/tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7cd0d53408327b706c70dc0756c1e)