### PR TITLE
design: skill type color cycling across all views

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ $env:PATH += ";" + (python -c "import sysconfig; print(sysconfig.get_path('scrip
 ```
 
 <!-- gaia:version-start -->
-Current Gaia CLI version: `2.13.1`.
+Current Gaia CLI version: `3.0.0`.
 
 Python install:
 

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -400,10 +400,21 @@
     90% {color:#34d399;text-shadow:0 0 10px rgba(52,211,153,.8),0 0 22px rgba(52,211,153,.4)}
     100%{color:#38bdf8;text-shadow:0 0 10px rgba(56,189,248,.8),0 0 22px rgba(56,189,248,.4)}
   }
+  @keyframes tree-extra-glow{
+    0%,100%{color:#38bdf8;text-shadow:0 0 8px rgba(56,189,248,.7),0 0 18px rgba(56,189,248,.35)}
+    20%{color:#a78bfa;text-shadow:0 0 8px rgba(167,139,250,.7),0 0 18px rgba(167,139,250,.35)}
+    40%{color:#ef4444;text-shadow:0 0 8px rgba(239,68,68,.7),0 0 18px rgba(239,68,68,.35)}
+    60%{color:#c084fc;text-shadow:0 0 8px rgba(192,132,252,.7),0 0 18px rgba(192,132,252,.35)}
+    80%{color:#34d399;text-shadow:0 0 8px rgba(52,211,153,.7),0 0 18px rgba(52,211,153,.35)}
+  }
   .tree-ult-line{font-weight:700;animation:tree-rainbow-glow 4s linear infinite}
   .tree-ult-contributor{color:#ef4444;font-weight:800;text-shadow:0 0 8px rgba(239,68,68,.6)}
   .tree-ult-slash{color:var(--muted)}
   .tree-ult-skillname,.tree-ult-id{color:#f59e0b}
+  .tree-extra-line{font-weight:600;animation:tree-extra-glow 4s linear infinite}
+  .tree-extra-contributor{color:#ef4444;font-weight:700;text-shadow:0 0 6px rgba(239,68,68,.5)}
+  .tree-extra-slash{color:var(--muted)}
+  .tree-extra-skillname,.tree-extra-id{color:var(--extra)}
   .tree-extra-glyph{color:var(--extra)}
   .tree-basic-glyph{color:var(--basic)}
   .tree-sep{color:rgba(56,189,248,.2)}
@@ -803,6 +814,12 @@
   .ns-fc-card[data-type="ultimate"][data-level="VI"],.ns-fc-card[data-type="extra"][data-level="VI"]  {box-shadow:0 0 16px rgba(var(--ns-gc),.5),0 0 36px rgba(var(--ct),.35),0 0 72px rgba(var(--ct),.15)}
   .ns-fc-card-name { font-size:.83rem;font-weight:700;color:var(--text);margin-bottom:.25rem; }
   .ns-fc-card-id   { font-family:'JetBrains Mono',monospace;font-size:.68rem;color:#ef4444; }
+  .ns-tile[data-type="ultimate"] .ns-tile-name,
+  .ns-list-row[data-type="ultimate"] .ns-lr-name,
+  .ns-fc-card[data-type="ultimate"] .ns-fc-card-name{animation:tree-rainbow-glow 4s linear infinite}
+  .ns-tile[data-type="extra"] .ns-tile-name,
+  .ns-list-row[data-type="extra"] .ns-lr-name,
+  .ns-fc-card[data-type="extra"] .ns-fc-card-name{animation:tree-extra-glow 4s linear infinite}
   .ns-none{color:var(--muted);font-size:.78rem;font-style:italic}
   .ns-links{display:flex;gap:.5rem;flex-wrap:wrap;margin-top:.9rem}
   /* ── GROUP LAYOUT ── */

--- a/docs/index.html
+++ b/docs/index.html
@@ -424,5 +424,5 @@
 </html>
 
 <!-- gaia:stats-start -->
-<!-- skills=123; namedSkills=40; version=2.13.1 -->
+<!-- skills=123; namedSkills=40; version=3.0.0 -->
 <!-- gaia:stats-end -->

--- a/docs/js/named-skills.js
+++ b/docs/js/named-skills.js
@@ -38,25 +38,27 @@
     }).catch(function(){});
   };
 
-  function renderTile(ns, lm) {
+  function renderTile(ns, lm, idx) {
     var tags = (ns.tags||[]).slice(0,3).map(tagHtml).join('');
+    var animStyle = (ns.type === 'ultimate' || ns.type === 'extra') ? ' style="animation-delay:-' + ((idx * 0.4) % 4).toFixed(1) + 's"' : '';
     return '<article class="ns-tile" data-level="'+esc(ns.level)+'" data-type="'+esc(ns.type||'basic')+'" '+nsClick(ns.id)+'>' +
       '<div class="ns-tile-head">' +
         '<span class="ns-level-badge" style="color:'+lm.color+';background:'+lm.bg+';border-color:'+lm.border+'">'+esc(ns.level)+'</span>' +
         (ns.origin ? '<span class="ns-origin">\u2605</span>' : '') +
       '</div>' +
-      '<div class="ns-tile-name">' + esc(nsDisplayName(ns)) + '</div>' +
+      '<div class="ns-tile-name"' + animStyle + '>' + esc(nsDisplayName(ns)) + '</div>' +
       '<div class="ns-tile-id">' + esc(ns.id) + '</div>' +
       (tags ? '<div class="ns-tile-tags">' + tags + '</div>' : '') +
       installRow(ns.id) +
     '</article>';
   }
 
-  function renderListRow(ns, lm) {
+  function renderListRow(ns, lm, idx) {
     var tags = (ns.tags||[]).slice(0,2).map(tagHtml).join('');
+    var animStyle = (ns.type === 'ultimate' || ns.type === 'extra') ? ' style="animation-delay:-' + ((idx * 0.4) % 4).toFixed(1) + 's"' : '';
     return '<article class="ns-list-row" data-level="'+esc(ns.level)+'" data-type="'+esc(ns.type||'basic')+'" '+nsClick(ns.id)+'>' +
       '<span class="ns-level-badge" style="color:'+lm.color+';background:'+lm.bg+';border-color:'+lm.border+'">'+esc(ns.level)+'</span>' +
-      '<span class="ns-lr-name">' + esc(nsDisplayName(ns)) + '</span>' +
+      '<span class="ns-lr-name"' + animStyle + '>' + esc(nsDisplayName(ns)) + '</span>' +
       '<span class="ns-lr-id">' + esc(ns.id) + '</span>' +
       '<span class="ns-lr-tags">' + tags + '</span>' +
       '<span style="flex:1"></span>' +
@@ -67,6 +69,7 @@
 
   function renderFlowchartView(allNamed, lm) {
     var groups = {};
+    var fcIdx = 0;
     allNamed.forEach(function(ns) {
       var ref = ns.genericSkillRef || 'other';
       if (!groups[ref]) groups[ref] = [];
@@ -75,11 +78,13 @@
     return Object.keys(groups).sort().map(function(ref) {
       var cards = groups[ref].map(function(ns) {
         var m = lm[ns.level] || lm['II'];
+        var animStyle = (ns.type === 'ultimate' || ns.type === 'extra') ? ' style="animation-delay:-' + ((fcIdx * 0.4) % 4).toFixed(1) + 's"' : '';
+        fcIdx++;
         return '<div class="ns-fc-leaf-wrap">' +
           '<article class="ns-fc-card" data-level="'+esc(ns.level)+'" data-type="'+esc(ns.type||'basic')+'" '+nsClick(ns.id)+'>' +
             '<div style="margin-bottom:.3rem"><span class="ns-level-badge" style="color:'+m.color+';background:'+m.bg+';border-color:'+m.border+'">'+esc(ns.level)+'</span>' +
             (ns.origin ? ' <span class="ns-origin">\u2605</span>' : '') + '</div>' +
-            '<div class="ns-fc-card-name">'+esc(nsDisplayName(ns))+'</div>' +
+            '<div class="ns-fc-card-name"' + animStyle + '>'+esc(nsDisplayName(ns))+'</div>' +
             '<div class="ns-fc-card-id">'+esc(ns.id)+'</div>' +
           '</article>' +
         '</div>';
@@ -245,8 +250,8 @@
           TYPE_ORDER.forEach(function(type) {
             var items = groups[type]; if (!items || !items.length) return;
             html += groupHeader(type, type);
-            if (viewMode === 'list') html += items.map(function(ns){ return renderListRow(ns, lm(ns)); }).join('');
-            else html += items.map(function(ns){ return renderTile(ns, lm(ns)); }).join('');
+            if (viewMode === 'list') html += items.map(function(ns, i){ return renderListRow(ns, lm(ns), i); }).join('');
+            else html += items.map(function(ns, i){ return renderTile(ns, lm(ns), i); }).join('');
           });
           grid.className = viewMode === 'list' ? 'ns-grid-list' : 'ns-grid-tile';
           grid.innerHTML = html;

--- a/docs/js/skill-explorer.js
+++ b/docs/js/skill-explorer.js
@@ -591,6 +591,7 @@
 
   function highlightTree(text) {
     var ultIdx = 0;
+    var extIdx = 0;
     return text.split('\n').map(function(line) {
       // Ultimate skill header lines: ◆ Ultimate Skill: contributor/name  [VI]
       var m = line.match(/^(◆ Ultimate Skill: )(\S+)(.*)$/);
@@ -602,7 +603,6 @@
         var slash = skillId.indexOf('/');
         var skillHtml;
         if (slash > 0) {
-          // named — contributor in red, skill name in amber
           skillHtml = '<span class="tree-ult-contributor">' + esc(skillId.slice(0, slash)) + '</span>' +
                       '<span class="tree-ult-slash">/</span>' +
                       '<span class="tree-ult-skillname">' + esc(skillId.slice(slash + 1)) + '</span>';
@@ -611,6 +611,27 @@
         }
         return '<span class="tree-ult-line" style="animation-delay:' + delay + 's">' +
                label + skillHtml + suffix + '</span>';
+      }
+      // Extra skill lines: ◇ Extra Skill: skillId  [level]
+      var e = line.match(/^(.*)(◇ Extra Skill: )(\S+)(.*)$/);
+      if (e) {
+        var prefix = esc(e[1]);
+        var eLabel = esc(e[2]);
+        var eSkillId = e[3];
+        var eSuffix = esc(e[4]);
+        var eDelay = -((extIdx++ * 0.7) % 4);
+        var eSlash = eSkillId.indexOf('/');
+        var eSkillHtml;
+        if (eSlash > 0) {
+          eSkillHtml = '<span class="tree-extra-contributor">' + esc(eSkillId.slice(0, eSlash)) + '</span>' +
+                       '<span class="tree-extra-slash">/</span>' +
+                       '<span class="tree-extra-skillname">' + esc(eSkillId.slice(eSlash + 1)) + '</span>';
+        } else {
+          eSkillHtml = '<span class="tree-extra-id">' + esc(eSkillId) + '</span>';
+        }
+        return prefix +
+               '<span class="tree-extra-line" style="animation-delay:' + eDelay + 's">' +
+               eLabel + eSkillHtml + eSuffix + '</span>';
       }
       // Separator lines
       if (/^[═─]{3,}/.test(line)) return '<span class="tree-sep">' + esc(line) + '</span>';

--- a/docs/js/skill-graph.js
+++ b/docs/js/skill-graph.js
@@ -35,6 +35,20 @@
     }
   }
 
+  // Color cycling for canvas labels
+  const ULT_STOPS = [[56,189,248],[167,139,250],[245,158,11],[239,68,68],[192,132,252],[52,211,153]];
+  const EXTRA_STOPS = [[56,189,248],[167,139,250],[239,68,68],[192,132,252],[52,211,153]];
+  function cycleColor(stops, t) {
+    var progress = ((t * 0.25) % 1 + 1) % 1;
+    var seg = progress * stops.length;
+    var i = Math.floor(seg) % stops.length;
+    var next = (i + 1) % stops.length;
+    var f = seg - Math.floor(seg);
+    return Math.round(stops[i][0]+(stops[next][0]-stops[i][0])*f)+','+
+           Math.round(stops[i][1]+(stops[next][1]-stops[i][1])*f)+','+
+           Math.round(stops[i][2]+(stops[next][2]-stops[i][2])*f);
+  }
+
   const FALLBACK_SKILLS = [
     { id:'tokenize', type:'basic', name:'Tokenize', prerequisites:[] },
     { id:'retrieve', type:'basic', name:'Retrieve', prerequisites:[] },
@@ -397,11 +411,22 @@
         const vis = state.nodeAlphas[skill.id] !== undefined ? state.nodeAlphas[skill.id] : 1.0;
         const labelAlpha = highlighted ? 1.0 : depthAlpha * Math.max(0.22, vis) * 0.9;
         if (labelAlpha < 0.04) return;
-        const col = (state.redPillActive && state.namedMap[skill.id])
-          ? { rgb:'239,68,68' }
-          : (PALETTE[skill.type] || PALETTE.basic);
+        let col;
+        if (state.redPillActive && state.namedMap[skill.id]) {
+          col = { rgb:'239,68,68' };
+        } else if (skill.type === 'ultimate') {
+          col = { rgb: cycleColor(ULT_STOPS, state.t + (p.phase || 0)) };
+        } else if (skill.type === 'extra') {
+          col = { rgb: cycleColor(EXTRA_STOPS, state.t + (p.phase || 0)) };
+        } else {
+          col = PALETTE[skill.type] || PALETTE.basic;
+        }
         const size = skill.type === 'ultimate' ? 13 : skill.type === 'extra' ? 10 : 8;
         ctx.font = `bold ${Math.max(6, Math.round(size * pr.scale * 1.16))}px Inter,system-ui,sans-serif`;
+        if (skill.type === 'ultimate' || skill.type === 'extra') {
+          ctx.shadowColor = `rgba(${col.rgb},0.5)`;
+          ctx.shadowBlur = 8;
+        }
         ctx.fillStyle = `rgba(${col.rgb},${labelAlpha.toFixed(2)})`;
         ctx.textAlign = 'center';
         const labelText = (state.redPillActive && state.namedMap && state.namedMap[skill.id])
@@ -410,6 +435,8 @@
             ? ((state.titleMap && state.titleMap[skill.id]) || skill.name)
             : '/' + skill.id;
         ctx.fillText(labelText, pr.sx, pr.sy + 18 * pr.scale);
+        ctx.shadowColor = 'transparent';
+        ctx.shadowBlur = 0;
       }
       labelNodes.forEach(({ skill }) => {
         const vis = state.nodeAlphas[skill.id] !== undefined ? state.nodeAlphas[skill.id] : 1.0;


### PR DESCRIPTION
## Summary

- Ultimate skills get rainbow color-cycling (blue→purple→gold→red→purple→green) in the Tree dialog, Named Skills cards, and Skill Graph canvas labels
- Extra skills get their own cycle (blue→purple→red→purple→green — no gold) in the same three views
- Contributor names always render red; skill IDs keep their type color
- Named Skills cards get staggered `animation-delay` so they don't cycle in lockstep
- Skill Graph labels use a new `cycleColor()` utility with `ctx.shadowBlur` glow

## Files Changed

| File | Change |
|------|--------|
| `docs/css/styles.css` | `@keyframes tree-extra-glow`, `.tree-extra-*` classes, `[data-type]` animation rules |
| `docs/js/skill-explorer.js` | `highlightTree()` expanded with Extra Skill regex |
| `docs/js/skill-graph.js` | `cycleColor()`, `ULT_STOPS`/`EXTRA_STOPS`, label glow |
| `docs/js/named-skills.js` | `animation-delay` stagger on tile/list/flow names |

## Test plan

- [ ] Click Tree nav → Ultimate lines cycle rainbow, Extra lines cycle blue-purple-red-purple-green
- [ ] Named Skills tiles: ultimate/extra names cycle with stagger, basic names static
- [ ] Switch to list and flow views → same cycling behavior
- [ ] Open Skill Graph → ultimate/extra labels cycle colors with glow, named stays red
- [ ] Basic skill nodes/labels remain static cyan