### PR TITLE
design(docs): UX batch — popup unification, DAG view, stacked cards

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -814,12 +814,6 @@
   .ns-fc-card[data-type="ultimate"][data-level="VI"],.ns-fc-card[data-type="extra"][data-level="VI"]  {box-shadow:0 0 16px rgba(var(--ns-gc),.5),0 0 36px rgba(var(--ct),.35),0 0 72px rgba(var(--ct),.15)}
   .ns-fc-card-name { font-size:.83rem;font-weight:700;color:var(--text);margin-bottom:.25rem; }
   .ns-fc-card-id   { font-family:'JetBrains Mono',monospace;font-size:.68rem;color:#ef4444; }
-  .ns-tile[data-type="ultimate"] .ns-tile-name,
-  .ns-list-row[data-type="ultimate"] .ns-lr-name,
-  .ns-fc-card[data-type="ultimate"] .ns-fc-card-name{animation:tree-rainbow-glow 4s linear infinite}
-  .ns-tile[data-type="extra"] .ns-tile-name,
-  .ns-list-row[data-type="extra"] .ns-lr-name,
-  .ns-fc-card[data-type="extra"] .ns-fc-card-name{animation:tree-extra-glow 4s linear infinite}
   .ns-none{color:var(--muted);font-size:.78rem;font-style:italic}
   .ns-links{display:flex;gap:.5rem;flex-wrap:wrap;margin-top:.9rem}
   /* ── GROUP LAYOUT ── */
@@ -841,6 +835,63 @@
     border:1px solid rgba(56,189,248,.22);text-decoration:none;transition:background .15s,border-color .15s;
   }
   .ns-link-btn:hover{background:rgba(56,189,248,.16);border-color:rgba(56,189,248,.45)}
+  /* ── DAG flow view ── */
+  .ns-dag-container{position:relative;overflow-x:auto;overflow-y:visible;padding:2rem 1rem}
+  .ns-dag-rank{display:flex;justify-content:center;gap:1.2rem;margin-bottom:3.5rem;position:relative;z-index:1;flex-wrap:wrap}
+  .ns-dag-card{
+    position:relative;padding:.6rem .9rem;border-radius:10px;
+    background:var(--surface);border:1px solid var(--border);
+    cursor:pointer;min-width:110px;max-width:160px;text-align:center;
+    transition:border-color .2s,box-shadow .2s;
+  }
+  .ns-dag-card:hover{border-color:var(--basic);box-shadow:0 0 12px rgba(56,189,248,.2)}
+  .ns-dag-card[data-type="ultimate"]{border-color:rgba(245,158,11,.4)}
+  .ns-dag-card[data-type="extra"]{border-color:rgba(192,132,252,.3)}
+  .ns-dag-card-name{font-weight:600;font-size:.78rem;margin:.25rem 0}
+  .ns-dag-glyph{font-size:.9rem}
+  .ns-dag-ghost{opacity:.45;border-style:dashed}
+  .ns-dag-svg{position:absolute;top:0;left:0;pointer-events:none;z-index:0}
+  .ns-tile[data-type="ultimate"] .ns-tile-name,
+  .ns-list-row[data-type="ultimate"] .ns-lr-name,
+  .ns-dag-card[data-type="ultimate"] .ns-dag-card-name{animation:tree-rainbow-glow 4s linear infinite}
+  .ns-tile[data-type="extra"] .ns-tile-name,
+  .ns-list-row[data-type="extra"] .ns-lr-name,
+  .ns-dag-card[data-type="extra"] .ns-dag-card-name{animation:tree-extra-glow 4s linear infinite}
+  .ns-dag-arrow{stroke:var(--muted);stroke-width:1.5;fill:none;marker-end:url(#ns-arrowhead)}
+  /* ── flow-node ghost + stacked cards + close button ── */
+  .flow-node-ghost{opacity:.5;border-style:dashed}
+  .fn-contrib{color:#ef4444!important;font-weight:700}
+  .se-close-x{margin-left:auto;font-size:1.2rem;font-weight:700;padding:.3rem .6rem;border-radius:6px}
+  .se-stack-deck{position:relative;display:inline-flex;align-items:center;justify-content:center;min-height:90px;min-width:150px}
+  .se-stack-card{
+    position:absolute;padding:.6rem .9rem;border-radius:10px;
+    background:var(--surface);border:1px solid var(--border);
+    text-align:center;transition:transform .3s,z-index .3s,box-shadow .3s;
+    min-width:120px;cursor:pointer;
+  }
+  .se-stack-card:hover{transform:rotate(0deg)!important;z-index:100!important;box-shadow:0 4px 20px rgba(56,189,248,.3)}
+  .se-stack-current{transform:rotate(0deg)!important;border-color:rgba(56,189,248,.5);box-shadow:0 0 12px rgba(56,189,248,.2)}
+  .usp-details-link{margin-top:.8rem;text-align:center}
+  .usp-details-link a{color:var(--basic);text-decoration:none;font-size:.85rem;font-weight:600}
+  .usp-details-link a:hover{text-decoration:underline}
+  /* ── hero install terminal ── */
+  .se-hero-card{position:relative}
+  .se-github-link{position:absolute;top:.6rem;right:.6rem;color:var(--basic);font-size:.75rem;font-weight:600;text-decoration:none;opacity:.7;transition:opacity .2s}
+  .se-github-link:hover{opacity:1;text-decoration:underline}
+  .se-hero-install{margin-top:.8rem;display:flex;align-items:center;gap:.5rem;background:rgba(0,0,0,.4);border:1px solid var(--border);border-radius:8px;padding:.45rem .7rem;font-family:'JetBrains Mono','Fira Code',monospace;font-size:.78rem}
+  .se-hero-prompt{color:var(--muted);user-select:none}
+  .se-hero-cmd{color:var(--basic);flex:1}
+  .se-hero-copy{background:transparent;border:1px solid var(--border);color:var(--muted);border-radius:4px;padding:.2rem .5rem;font-size:.7rem;cursor:pointer;font-family:inherit;transition:border-color .2s,color .2s}
+  .se-hero-copy:hover{border-color:var(--basic);color:var(--basic)}
+  /* ── fusion + lock + GitHub link on cards ── */
+  .se-fusion-label{color:var(--muted);font-size:.8rem;margin-bottom:.8rem;padding-left:.2rem}
+  .fn-lock{font-size:.7rem;margin-right:.3rem;opacity:.6}
+  .flow-node-locked{border-color:rgba(100,116,139,.3)}
+  .ns-gh-link{position:absolute;top:.45rem;right:.5rem;color:var(--basic);font-size:.68rem;font-weight:600;text-decoration:none;opacity:.6;transition:opacity .2s;z-index:2}
+  .ns-gh-link:hover{opacity:1;text-decoration:underline}
+  .ns-tile{position:relative}
+  .ns-list-row .ns-gh-link{position:static;margin-right:.5rem;white-space:nowrap}
+  .ns-dag-card .ns-gh-link{position:absolute;top:.3rem;right:.3rem;font-size:.6rem}
   /* ── FOOTER ── */
   footer a{color:var(--basic);text-decoration:none}
   /* ── SECTION DIVIDERS (redesigned) ── */

--- a/docs/index.html
+++ b/docs/index.html
@@ -380,6 +380,7 @@
       <button id="seOpenRepo" class="se-btn-action"><svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 3H3a1 1 0 00-1 1v9a1 1 0 001 1h9a1 1 0 001-1V9"/><path d="M13 3h-4m4 0v4m0-4L7 9"/></svg> Repository</button>
       <button id="seExport"   class="se-btn-action"><svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 2v8m-3-3l3 3 3-3"/><rect x="2" y="11" width="12" height="3" rx="1"/></svg> Export</button>
       <button id="seShare"    class="se-btn-action"><svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="3" r="1.5"/><circle cx="12" cy="13" r="1.5"/><circle cx="3" cy="8" r="1.5"/><path d="M10.5 4l-6 3m6 3l-6-3"/></svg> Share</button>
+      <button id="seClose" class="se-btn-ghost se-close-x" aria-label="Close">&#x2715;</button>
     </div>
   </div>
   <div class="se-body">

--- a/docs/js/named-skills.js
+++ b/docs/js/named-skills.js
@@ -38,6 +38,13 @@
     }).catch(function(){});
   };
 
+  function ghLink(ns) {
+    var links = ns.links || {};
+    var url = links.github || links.npm || '';
+    if (!url) return '';
+    return '<a class="ns-gh-link" href="' + esc(url) + '" target="_blank" rel="noopener" onclick="event.stopPropagation()" title="View on GitHub"><svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>';
+  }
+
   function renderTile(ns, lm, idx) {
     var tags = (ns.tags||[]).slice(0,3).map(tagHtml).join('');
     var animStyle = (ns.type === 'ultimate' || ns.type === 'extra') ? ' style="animation-delay:-' + ((idx * 0.4) % 4).toFixed(1) + 's"' : '';
@@ -45,6 +52,7 @@
       '<div class="ns-tile-head">' +
         '<span class="ns-level-badge" style="color:'+lm.color+';background:'+lm.bg+';border-color:'+lm.border+'">'+esc(ns.level)+'</span>' +
         (ns.origin ? '<span class="ns-origin">\u2605</span>' : '') +
+        ghLink(ns) +
       '</div>' +
       '<div class="ns-tile-name"' + animStyle + '>' + esc(nsDisplayName(ns)) + '</div>' +
       '<div class="ns-tile-id">' + esc(ns.id) + '</div>' +
@@ -62,41 +70,107 @@
       '<span class="ns-lr-id">' + esc(ns.id) + '</span>' +
       '<span class="ns-lr-tags">' + tags + '</span>' +
       '<span style="flex:1"></span>' +
+      ghLink(ns) +
       installRow(ns.id) +
       '<span class="ns-lr-arrow">\u203a</span>' +
     '</article>';
   }
 
-  function renderFlowchartView(allNamed, lm) {
-    var groups = {};
-    var fcIdx = 0;
-    allNamed.forEach(function(ns) {
-      var ref = ns.genericSkillRef || 'other';
-      if (!groups[ref]) groups[ref] = [];
-      groups[ref].push(ns);
+  function renderFlowchartView(filteredNamed, LEVEL_META) {
+    var skillMap = window._gaiaSkillMap || {};
+    var namedIds = {};
+    filteredNamed.forEach(function(ns) { namedIds[ns.genericSkillRef || ns.id] = ns; });
+
+    var dagNodes = {};
+    Object.values(skillMap).forEach(function(s) {
+      if (s.type === 'extra' || s.type === 'ultimate') dagNodes[s.id] = s;
     });
-    return Object.keys(groups).sort().map(function(ref) {
-      var cards = groups[ref].map(function(ns) {
-        var m = lm[ns.level] || lm['II'];
-        var animStyle = (ns.type === 'ultimate' || ns.type === 'extra') ? ' style="animation-delay:-' + ((fcIdx * 0.4) % 4).toFixed(1) + 's"' : '';
+
+    var edges = [];
+    Object.values(dagNodes).forEach(function(s) {
+      (s.prerequisites || []).forEach(function(pid) {
+        if (dagNodes[pid]) edges.push({from: pid, to: s.id});
+      });
+    });
+
+    var depth = {};
+    function getDepth(id) {
+      if (depth[id] !== undefined) return depth[id];
+      depth[id] = -1;
+      var maxPre = 0;
+      (dagNodes[id].prerequisites || []).forEach(function(pid) {
+        if (dagNodes[pid]) maxPre = Math.max(maxPre, getDepth(pid) + 1);
+      });
+      depth[id] = maxPre;
+      return maxPre;
+    }
+    Object.keys(dagNodes).forEach(getDepth);
+
+    var maxD = 0;
+    Object.values(depth).forEach(function(d) { if (d > maxD) maxD = d; });
+    var ranks = [];
+    for (var r = 0; r <= maxD; r++) ranks.push([]);
+    Object.keys(dagNodes).forEach(function(id) { if (depth[id] >= 0) ranks[depth[id]].push(id); });
+
+    var fcIdx = 0;
+    var html = '<div class="ns-dag-container" id="nsDag">';
+    html += '<svg class="ns-dag-svg" id="nsDagSvg"><defs>' +
+      '<marker id="ns-arrowhead" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">' +
+      '<polygon points="0 0, 8 3, 0 6" fill="currentColor" style="color:var(--muted)"/></marker></defs></svg>';
+
+    ranks.forEach(function(rank, ri) {
+      html += '<div class="ns-dag-rank" data-rank="' + ri + '">';
+      rank.sort(function(a,b){ return (dagNodes[a].name||a).localeCompare(dagNodes[b].name||b); });
+      rank.forEach(function(id) {
+        var s = dagNodes[id];
+        var ns = namedIds[id];
+        var isGhost = !ns;
+        var lm = LEVEL_META[s.level] || LEVEL_META['II'];
+        var glyph = s.type === 'ultimate' ? '\u25c6' : '\u25c7';
+        var clickAttr = ns ? nsClick(ns.id) : 'onclick="openSkillExplorer(\'' + id.replace(/'/g, "\\'") + '\')"';
+        var animStyle = (s.type === 'ultimate' || s.type === 'extra') ? ' style="animation-delay:-' + ((fcIdx * 0.4) % 4).toFixed(1) + 's"' : '';
         fcIdx++;
-        return '<div class="ns-fc-leaf-wrap">' +
-          '<article class="ns-fc-card" data-level="'+esc(ns.level)+'" data-type="'+esc(ns.type||'basic')+'" '+nsClick(ns.id)+'>' +
-            '<div style="margin-bottom:.3rem"><span class="ns-level-badge" style="color:'+m.color+';background:'+m.bg+';border-color:'+m.border+'">'+esc(ns.level)+'</span>' +
-            (ns.origin ? ' <span class="ns-origin">\u2605</span>' : '') + '</div>' +
-            '<div class="ns-fc-card-name"' + animStyle + '>'+esc(nsDisplayName(ns))+'</div>' +
-            '<div class="ns-fc-card-id">'+esc(ns.id)+'</div>' +
-          '</article>' +
+        html += '<div class="ns-dag-card' + (isGhost ? ' ns-dag-ghost' : '') +
+          '" data-id="' + esc(id) + '" data-type="' + esc(s.type) + '" ' +
+          clickAttr + '>' +
+          (ns ? ghLink(ns) : '') +
+          '<span class="ns-dag-glyph" style="color:' + lm.color + '">' + glyph + '</span>' +
+          '<div class="ns-dag-card-name"' + animStyle + '>' + esc(s.name || id) + '</div>' +
+          '<span class="ns-level-badge" style="color:' + lm.color + ';background:' + lm.bg +
+          ';border-color:' + lm.border + '">' + esc(s.level) + '</span>' +
         '</div>';
-      }).join('');
-      return '<div class="ns-fc-group">' +
-        '<div class="ns-fc-root"><span style="opacity:.5">&#9671;</span> '+esc(ref)+'</div>' +
-        '<div class="ns-fc-connector"></div>' +
-        '<div class="ns-fc-branches-wrap"><div class="ns-fc-hbar"></div>' +
-          '<div class="ns-fc-branches">'+cards+'</div>' +
-        '</div>' +
-      '</div>';
-    }).join('');
+      });
+      html += '</div>';
+    });
+    html += '</div>';
+
+    setTimeout(function() {
+      var container = document.getElementById('nsDag');
+      var svg = document.getElementById('nsDagSvg');
+      if (!container || !svg) return;
+      var cRect = container.getBoundingClientRect();
+      svg.style.width = container.scrollWidth + 'px';
+      svg.style.height = container.scrollHeight + 'px';
+      var paths = '';
+      edges.forEach(function(e) {
+        var fromEl = container.querySelector('[data-id="' + e.from + '"]');
+        var toEl = container.querySelector('[data-id="' + e.to + '"]');
+        if (!fromEl || !toEl) return;
+        var fr = fromEl.getBoundingClientRect();
+        var tr = toEl.getBoundingClientRect();
+        var x1 = fr.left + fr.width / 2 - cRect.left + container.scrollLeft;
+        var y1 = fr.top + fr.height - cRect.top + container.scrollTop;
+        var x2 = tr.left + tr.width / 2 - cRect.left + container.scrollLeft;
+        var y2 = tr.top - cRect.top + container.scrollTop;
+        var cy1 = y1 + (y2 - y1) * 0.35;
+        var cy2 = y1 + (y2 - y1) * 0.65;
+        paths += '<path class="ns-dag-arrow" d="M' + x1 + ' ' + y1 + ' C' + x1 + ' ' + cy1 + ' ' + x2 + ' ' + cy2 + ' ' + x2 + ' ' + y2 + '"/>';
+      });
+      var defs = svg.querySelector('defs');
+      if (defs) defs.insertAdjacentHTML('afterend', paths);
+    }, 60);
+
+    return html;
   }
 
   function initNamedSkills() {
@@ -156,7 +230,7 @@
 
       var levelOrder = ['II','III','IV','V','VI'];
       allNamed.sort(function(a, b) {
-        var d = levelOrder.indexOf(a.level) - levelOrder.indexOf(b.level);
+        var d = levelOrder.indexOf(b.level) - levelOrder.indexOf(a.level);
         return d !== 0 ? d : String(a.id).localeCompare(String(b.id));
       });
 

--- a/docs/js/skill-explorer.js
+++ b/docs/js/skill-explorer.js
@@ -74,13 +74,15 @@
       ns.origin ? '<span class="se-badge" style="color:#fbbf24;background:rgba(251,191,36,.1);border-color:rgba(251,191,36,.3)">★ origin</span>' : '',
     ].filter(Boolean).join('');
 
+    var installCmd = 'gaia install ' + ns.id;
     var heroLeft = '<div class="se-hero-card" data-level="' + esc(ns.level) + '">' +
+      (repoUrl ? '<a class="se-github-link" href="' + esc(repoUrl) + '" target="_blank" rel="noopener">Show in GitHub ↗</a>' : '') +
       '<div class="se-skill-name">' + esc(ns.name || ns.id) + '</div>' +
-      '<div class="se-contrib">' + esc(ns.contributor) + ' / ' + esc(ns.id.split('/')[1] || '') + '</div>' +
+      '<div class="se-contrib"><span style="color:#ef4444;font-weight:700">' + esc(ns.contributor) + '</span> / ' + esc(ns.id.split('/')[1] || '') + '</div>' +
       '<div class="se-badges">' + badgesHtml + '</div>' +
       (ns.title ? '<div style="font-style:italic;color:var(--muted);font-size:.88rem;margin-bottom:.8rem">"' + esc(ns.title) + '"</div>' : '') +
       (generic ? '<div style="font-size:.82rem;color:var(--muted)">Generic skill: <strong style="color:var(--text)">' + esc(generic.name || ns.genericSkillRef) + '</strong></div>' : '') +
-      (repoUrl ? '<div class="se-repo-row"><span class="se-repo-url">' + esc(repoUrl) + '</span></div>' : '') +
+      '<div class="se-hero-install"><span class="se-hero-prompt">$</span><span class="se-hero-cmd">' + esc(installCmd) + '</span><button class="se-hero-copy" data-cmd="' + esc(installCmd) + '" onclick="event.stopPropagation();navigator.clipboard.writeText(this.dataset.cmd).then(function(){})">Copy</button></div>' +
     '</div>';
 
     var tags = Array.isArray(ns.tags) ? ns.tags : [];
@@ -216,46 +218,68 @@
     function flowNode(id, name, contrib, level, typeStr, isCurrent, isNamed) {
       var lmEntry = lm[level] || {};
       var clsExtra = isCurrent ? ' current' : '';
-      var contribHtml = contrib ? '<span class="fn-contrib">' + esc(contrib) + '</span>' : '';
-      var typeHtml = typeStr ? '<span class="fn-type">' + esc(typeStr) + '</span>' : '';
+      var ghostCls = isNamed ? '' : ' flow-node-ghost';
+      var contribHtml = contrib ? '<span class="fn-contrib" style="color:#ef4444">' + esc(contrib) + '</span>' : '';
       var levelHtml = level ? '<span class="fn-level" style="' + makeLevelStyle(level) + '">' + esc(level) + '</span>' : '';
-      return '<div class="flow-node' + clsExtra + '" data-level="' + esc(level||'') + '" data-id="' + esc(id) + '" onclick="openSkillExplorer(\'' + id.replace(/'/g,"\\'") + '\')">' +
-        levelHtml + '<span class="fn-name">' + esc(name||id) + '</span>' + contribHtml + typeHtml +
+      return '<div class="flow-node' + clsExtra + ghostCls + '" data-level="' + esc(level||'') + '" data-id="' + esc(id) + '" onclick="openSkillExplorer(\'' + id.replace(/'/g,"\\'") + '\')">' +
+        levelHtml + '<span class="fn-name">' + esc(name||id) + '</span>' + contribHtml +
       '</div>';
     }
 
-    // Row 0: prerequisite generic skills
+    // Row 0: prerequisite generic skills (show named if available)
     var prereqs = generic && Array.isArray(generic.prerequisites) ? generic.prerequisites : [];
     var prereqNodes = prereqs.map(function(id){
-      var s = sm[id] || {}; return flowNode(id, s.name||id, '', s.level||'', TYPE_SYMBOL[s.type||'']+(s.type?(' '+s.type):''), false, false);
+      var s = sm[id] || {};
+      var namedBucket = buckets[id];
+      if (namedBucket && namedBucket.length) {
+        var nb = namedBucket[0];
+        return flowNode(nb.id, nb.name||nb.id, nb.contributor, nb.level, '', false, true);
+      }
+      return flowNode(id, s.name||id, '', s.level||'', '', false, false);
     });
 
-    // Row 1: tier progression of current generic skill (levels from generic.level floor down to 0)
-    var LEVEL_ORDER = ['0','I','II','III','IV','V','VI'];
-    var currentLvIdx = LEVEL_ORDER.indexOf(generic ? generic.level : '');
-    var tierNodes = [];
-    for (var i = 0; i <= Math.max(currentLvIdx, 0) && i < LEVEL_ORDER.length; i++) {
-      var lvl = LEVEL_ORDER[i];
-      var isCur = (lvl === (generic && generic.level));
-      tierNodes.push('<div class="flow-node' + (isCur?' current':'') + '" data-level="' + esc(lvl) + '" data-id="' + esc(ns.genericSkillRef||'') + '">' +
-        '<span class="fn-level" style="' + makeLevelStyle(lvl) + '">' + esc(lvl||'0') + '</span>' +
-        '<span class="fn-name">' + esc((generic&&generic.name)||ns.genericSkillRef||'') + '</span>' +
-        '<span class="fn-type">' + esc(lvl === LEVEL_ORDER[0] ? 'Basic' : (LEVEL_META_SE[lvl]&&LEVEL_META_SE[lvl].name)||lvl) + '</span>' +
-      '</div>');
+    // Row 1: named implementations — stacked card deck
+    var siblings = (buckets[ns.genericSkillRef] || []);
+    var namedHtml = '';
+    if (siblings.length > 1) {
+      namedHtml = '<div class="se-stack-deck" data-count="' + siblings.length + '">';
+      siblings.forEach(function(sib, idx) {
+        var isCur = sib.id === ns.id;
+        var zIdx = isCur ? siblings.length : siblings.length - idx;
+        var rot = isCur ? 0 : (idx % 2 === 0 ? -3 : 3) * (idx + 1) * 0.5;
+        namedHtml += '<div class="se-stack-card' + (isCur ? ' se-stack-current' : '') +
+          '" style="z-index:' + zIdx + ';transform:rotate(' + rot + 'deg)" ' +
+          'onclick="openSkillExplorer(\'' + sib.id.replace(/'/g,"\\'") + '\')">' +
+          '<span class="fn-level" style="' + makeLevelStyle(sib.level) + '">' + esc(sib.level) + '</span>' +
+          '<span class="fn-name">' + esc(sib.name || sib.id) + '</span>' +
+          '<span class="fn-contrib" style="color:#ef4444">' + esc(sib.contributor) + '</span>' +
+        '</div>';
+      });
+      namedHtml += '</div>';
+    } else {
+      namedHtml = flowNode(ns.id, ns.name||ns.id, ns.contributor, ns.level, '', true, true);
     }
 
-    // Row 2: named implementations in the same bucket
-    var siblings = (buckets[ns.genericSkillRef] || []);
-    var namedNodes = siblings.map(function(sib){
-      return flowNode(sib.id, sib.name||sib.id, sib.contributor, sib.level, '', sib.id===ns.id, true);
-    });
-    if (!namedNodes.length) namedNodes = [flowNode(ns.id, ns.name||ns.id, ns.contributor, ns.level, '', true, true)];
-
-    // Row 3: derivative generic skills
+    // Row 2: derivative generic skills (show named if available, with lock icon for unnamed)
     var derivs = generic && Array.isArray(generic.derivatives) ? generic.derivatives : [];
     var derivNodes = derivs.map(function(id){
-      var s = sm[id] || {}; return flowNode(id, s.name||id, '', s.level||'', TYPE_SYMBOL[s.type||'']+(s.type?(' '+s.type):''), false, false);
+      var s = sm[id] || {};
+      var namedBucket = buckets[id];
+      if (namedBucket && namedBucket.length) {
+        var nb = namedBucket[0];
+        return flowNode(nb.id, nb.name||nb.id, nb.contributor, nb.level, '', false, true);
+      }
+      return '<div class="flow-node flow-node-ghost flow-node-locked" data-level="' + esc(s.level||'') + '" data-id="' + esc(id) + '" onclick="openSkillExplorer(\'' + id.replace(/'/g,"\\'") + '\')">' +
+        '<span class="fn-lock">&#x1F512;</span>' +
+        '<span class="fn-name">' + esc(s.name||id) + '</span>' +
+      '</div>';
     });
+
+    // Fusion requirements label
+    var fusionHtml = '';
+    if (prereqs.length >= 2) {
+      fusionHtml = '<div class="se-fusion-label">&#x2728; Fuses from ' + prereqs.length + ' prerequisites</div>';
+    }
 
     function makeRow(label, nodes, id) {
       if (!nodes.length) return '';
@@ -265,13 +289,21 @@
       '</div>';
     }
 
+    function makeRowHtml(label, html, id) {
+      if (!html) return '';
+      return '<div>' +
+        '<div class="se-flowchart-row-label">' + label + '</div>' +
+        '<div class="se-flowchart-row" id="' + id + '">' + html + '</div>' +
+      '</div>';
+    }
+
     el.innerHTML = '<div class="se-flow-h">&#9650; Upgrade Path &amp; Adjacent Skills</div>' +
+      fusionHtml +
       '<div class="se-flowchart-wrap" id="seFlowWrap">' +
         '<div class="se-flowchart-rows">' +
           makeRow('Prerequisites', prereqNodes, 'sfRow0') +
-          makeRow('Tier Progression', tierNodes, 'sfRow1') +
-          makeRow('Named Implementations', namedNodes, 'sfRow2') +
-          makeRow('Unlocks', derivNodes, 'sfRow3') +
+          makeRowHtml('Named Implementations', namedHtml, 'sfRow1') +
+          makeRow('Unlocks', derivNodes, 'sfRow2') +
         '</div>' +
         '<svg class="se-flowchart-svg" id="seFlowSvg"></svg>' +
       '</div>';
@@ -286,7 +318,7 @@
     if (!wrap || !svg) return;
     svg.innerHTML = '';
     var wRect = wrap.getBoundingClientRect();
-    var rowIds = [['sfRow0','sfRow1'],['sfRow1','sfRow2'],['sfRow2','sfRow3']];
+    var rowIds = [['sfRow0','sfRow1'],['sfRow1','sfRow2']];
     rowIds.forEach(function(pair){
       var fromEl = document.getElementById(pair[0]);
       var toEl   = document.getElementById(pair[1]);
@@ -383,6 +415,36 @@
     var cmd = 'gaia propose /' + skill.id + (skill.type === 'ultimate' ? ' --ultimate' : '');
     document.getElementById('uspCmd').textContent = cmd;
     document.getElementById('uspCmd').dataset.cmd = cmd;
+    var bodyEl = pop.querySelector('.usp-body');
+    if (bodyEl) bodyEl.innerHTML = 'This skill has no named implementation yet. <span class="usp-cta">Be the first to claim it</span> — build a real implementation, submit it for review, and your name goes on the canonical registry forever.';
+    var existingLink = pop.querySelector('.usp-details-link');
+    if (existingLink) existingLink.remove();
+    pop.classList.add('open');
+    document.body.style.overflow = 'hidden';
+  };
+
+  window.openNamedPopup = function(ns) {
+    var pop = document.getElementById('unnamedSkillPopup');
+    if (!pop) return;
+    var lmEntry = (LEVEL_META_SE && LEVEL_META_SE[ns.level]) || {};
+    document.getElementById('uspGlyph').textContent = TYPE_GLYPH[ns.type] || '◇';
+    document.getElementById('uspGlyph').style.color = lmEntry.color || '#38bdf8';
+    document.getElementById('uspName').innerHTML = '<span style="color:#ef4444;font-weight:700">' + esc(ns.contributor || '') + '</span> / ' + esc(ns.name || ns.id.split('/')[1] || ns.id);
+    document.getElementById('uspId').textContent = ns.id;
+    var bodyEl = pop.querySelector('.usp-body');
+    if (bodyEl) bodyEl.innerHTML = 'Named implementation by <span style="color:#ef4444;font-weight:700">' + esc(ns.contributor || '') + '</span>. Select an install method:';
+    var cmd = 'gaia install ' + ns.id;
+    document.getElementById('uspCmd').textContent = cmd;
+    document.getElementById('uspCmd').dataset.cmd = cmd;
+    var existingLink = pop.querySelector('.usp-details-link');
+    if (!existingLink) {
+      var link = document.createElement('div');
+      link.className = 'usp-details-link';
+      link.innerHTML = '<a href="#" onclick="document.getElementById(\'unnamedSkillPopup\').classList.remove(\'open\');document.body.style.overflow=\'\';openSkillExplorer(\'' + ns.id.replace(/'/g,"\\'") + '\');return false;">View full details →</a>';
+      pop.querySelector('.usp-card').appendChild(link);
+    } else {
+      existingLink.innerHTML = '<a href="#" onclick="document.getElementById(\'unnamedSkillPopup\').classList.remove(\'open\');document.body.style.overflow=\'\';openSkillExplorer(\'' + ns.id.replace(/'/g,"\\'") + '\');return false;">View full details →</a>';
+    }
     pop.classList.add('open');
     document.body.style.overflow = 'hidden';
   };
@@ -475,6 +537,9 @@
   function initExplorerDOM() {
     var backEl = document.getElementById('seBack');
     if (backEl) backEl.onclick = function(){ closeExplorer(); history.back(); };
+
+    var closeEl = document.getElementById('seClose');
+    if (closeEl) closeEl.onclick = function(){ closeExplorer(); history.pushState(null, '', location.pathname); };
 
     // Unnamed popup close + copy
     var pop = document.getElementById('unnamedSkillPopup');

--- a/docs/js/skill-graph.js
+++ b/docs/js/skill-graph.js
@@ -658,7 +658,8 @@
     onNodeClick: function(id) {
       var buckets = window._gaiaNamedBuckets || {};
       if (buckets[id] && buckets[id].length) {
-        window.openSkillExplorer(buckets[id][0].id);
+        if (window.openNamedPopup) window.openNamedPopup(buckets[id][0]);
+        else window.openSkillExplorer(buckets[id][0].id);
       } else {
         var skill = (window._gaiaSkillMap || {})[id] || { id: id, name: id, type: 'basic' };
         window.openUnnamedPopup(skill);


### PR DESCRIPTION
## Summary
- **Ghost DAG nodes** click → opens `openUnnamedPopup` (gaia propose prompt)
- **Tier Progression removed** from skill explorer flowchart
- **Unnamed flow-nodes greyed out** with `.flow-node-ghost` (opacity + dashed border)
- **Contributor names always red** (`#ef4444`) in hero, flow-nodes, popups
- **Stacked card deck** for multiple named implementations (rotatable, hover-to-fan)
- **Graph HUD popup only** — `onNodeClick` uses `openNamedPopup` (install options) for named, `openUnnamedPopup` for unnamed
- **X close button** on skill explorer top-right
- **Hero card**: terminal install row + "Show in GitHub" link
- **Named prereqs/unlocks** show contributor (red) with skill name; unnamed get lock icon
- **Fusion requirements label** in upgrade path
- **GitHub SVG icon** on tiles, list rows, and DAG cards
- **Color-cycling animation-delay** preserved for DAG/tile/list card names

## Test plan
- [ ] Open Named Skills section → verify DAG view renders with SVG arrows and color-cycling names
- [ ] Click a ghost (unnamed) DAG node → "gaia propose" popup appears
- [ ] Click a named DAG node → skill explorer opens with no tier progression row
- [ ] Verify stacked cards appear when multiple named implementations exist
- [ ] Click graph HUD node → popup only (named = install, unnamed = propose)
- [ ] Verify X button closes skill explorer
- [ ] Verify contributor names are red everywhere
- [ ] Verify GitHub icon appears on tiles/list/DAG cards
- [ ] Run `python scripts/build_docs.py --check` → passes