### PR TITLE
design: Fix mobile Named Skills explorer visibility

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -551,7 +551,7 @@
   }
 
   /* -- NAMED SKILLS -- */
-  #named { min-height:100vh; padding-top:4rem; scroll-margin-top:0; max-width:none; }
+  #named { min-height:100vh; padding-top:4rem; scroll-margin-top:5rem; max-width:none; }
   .ns-controls {
     display:flex;flex-direction:column;gap:.7rem;margin-bottom:1.6rem;
   }
@@ -1162,8 +1162,14 @@
     table{font-size:.85rem}
     pre,code{font-size:.82rem}
     pre{padding:.75rem}
-    /* Named Skills: don't reserve a full viewport when contents are short */
-    #named{min-height:auto;padding-top:3rem;padding-bottom:1.5rem}
+    /* Named Skills: keep the full explorer visible and usable on narrow screens. */
+    #named{min-height:auto;padding:3rem 1rem 1.5rem;scroll-margin-top:7rem}
+    .ns-filter-row{align-items:stretch}
+    .ns-level-tabs{flex-wrap:nowrap;overflow-x:auto;padding-bottom:.2rem;-webkit-overflow-scrolling:touch}
+    .ns-level-tabs .ns-tab{flex:0 0 auto}
+    .ns-view-btns,.ns-sort-sel{width:100%}
+    .ns-view-btns{justify-content:space-between}
+    .ns-sort-sel{min-height:2.35rem}
     .ns-grid-tile{grid-template-columns:repeat(auto-fill,minmax(160px,1fr))}
     .flow{flex-direction:column;align-items:stretch}
     .flow-arrow{transform:rotate(90deg);align-self:center}
@@ -1180,8 +1186,10 @@
     .step-num{margin-bottom:.25rem}
     .btn{width:100%;text-align:center}
     .ns-grid-tile{grid-template-columns:1fr}
+    #named{padding-left:.9rem;padding-right:.9rem}
     .ns-controls{gap:.55rem}
     .ns-search{font-size:.85rem}
+    .ns-view-btn{flex:1;justify-content:center;padding:.35rem .45rem}
     /* Always keep loading/empty state visible above the fold */
     .ns-loading,.ns-empty{padding:2rem 1rem;font-size:.88rem}
   }

--- a/docs/js/scroll-reveal.js
+++ b/docs/js/scroll-reveal.js
@@ -1,4 +1,29 @@
-const obs = new IntersectionObserver(entries => {
-  entries.forEach(e => { if (e.isIntersecting) e.target.classList.add('visible'); });
-}, { threshold: 0.12 });
-document.querySelectorAll('.reveal').forEach(el => obs.observe(el));
+(function () {
+  var revealEls = Array.prototype.slice.call(document.querySelectorAll('.reveal'));
+  if (!revealEls.length) return;
+
+  function show(el) {
+    el.classList.add('visible');
+  }
+
+  if (!('IntersectionObserver' in window)) {
+    revealEls.forEach(show);
+    return;
+  }
+
+  var obs = new IntersectionObserver(function (entries) {
+    entries.forEach(function (entry) {
+      if (entry.isIntersecting || entry.intersectionRatio > 0) {
+        show(entry.target);
+        obs.unobserve(entry.target);
+      }
+    });
+  }, {
+    threshold: 0,
+    rootMargin: '0px 0px -10% 0px'
+  });
+
+  revealEls.forEach(function (el) {
+    obs.observe(el);
+  });
+})();


### PR DESCRIPTION
### Motivation
- The Named Skills explorer was being hidden or not revealed correctly on narrow/mobile viewports and the index section could land under the fixed nav when deep-linked, so the page needed layout and reveal-behavior fixes to make the section visible and usable on phones.
- Improve level-tab affordance and control layout on small screens so the Named Skills UI remains navigable with limited horizontal space.
- Use the `design/...` branch prefix to match the project `CONTRIBUTING.md` convention for UI/website changes.

### Description
- Replace the simple observer in `docs/js/scroll-reveal.js` with a small IIFE that gracefully falls back when `IntersectionObserver` is unavailable and uses `threshold: 0` plus `rootMargin: '0px 0px -10% 0px'` so tall sections become visible as soon as any part enters the viewport and are unobserved after reveal.  (`docs/js/scroll-reveal.js`)
- Add a fixed-nav-safe anchor offset and various mobile layout tweaks for the Named Skills explorer including `scroll-margin-top` for `#named`, horizontally scrollable level tabs, full-width view/sort controls, adjusted padding and button sizing, and tightened phone breakpoints. (`docs/css/styles.css`)
- Changes touch only the site assets; the modified files are `docs/js/scroll-reveal.js` and `docs/css/styles.css` on branch `design/fix-mobile-index-named-skills`.

### Testing
- Ran JavaScript sanity checks with `node --check docs/js/scroll-reveal.js` and `node --check docs/js/named-skills.js`, both succeeded. 
- Ran `git diff --check` to validate no whitespace/patch issues, which succeeded. 
- Verified the mobile behavior end-to-end by launching a static server and using Playwright to capture a mobile viewport screenshot with `--viewport-size=390,844` and waiting for `#named.visible .ns-tile`, which succeeded and produced the screenshot. 
- Playwright required installing browsers and native deps during the run (`npx playwright install chromium` / `npx playwright install-deps chromium`), and the screenshot test passed after those installs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fafc4c62188327965c3eda6f40ecb4)