### PR TITLE
docs: add README and CONTRIBUTING tables of contents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,24 @@ This page is now a **contributor quickstart**. Detailed policy, reviewer playboo
 
 ---
 
+## Table of Contents
+
+- [1) Pick your workflow](#1-pick-your-workflow)
+  - [A) Submit discovered skills (recommended)](#a-submit-discovered-skills-recommended)
+  - [B) Update the canonical graph directly](#b-update-the-canonical-graph-directly)
+- [2) What files are source-of-truth?](#2-what-files-are-source-of-truth)
+- [3) Branch naming (copy/paste)](#3-branch-naming-copypaste)
+- [4) Naming + evidence minimums](#4-naming--evidence-minimums)
+  - [Naming](#naming)
+  - [Evidence by level](#evidence-by-level)
+  - [Ultimate (`ultimate`) requirements](#ultimate-ultimate-requirements)
+- [5) PR checklist (copy/paste)](#5-pr-checklist-copypaste)
+- [6) FAQ](#6-faq)
+- [7) Helpful links](#7-helpful-links)
+- [8) Demotion and Reclassification Criteria](#8-demotion-and-reclassification-criteria)
+
+---
+
 ## 1) Pick your workflow
 
 ### A) Submit discovered skills (recommended)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,32 @@
 
 ---
 
+## Table of Contents
+
+- [The Tree](#the-tree)
+- [What This Means for You](#what-this-means-for-you)
+- [Tutorial](#tutorial)
+- [The Hierarchy](#the-hierarchy)
+- [Rank System: The Transcendent Line](#rank-system-the-transcendent-line)
+- [Install](#install)
+- [Quickstart](#quickstart)
+- [Push](#push)
+  - [Github CLI issues](#github-cli-issues)
+- [Named Skills Browser](#named-skills-browser)
+- [Real Skill Catalog](#real-skill-catalog)
+- [CLI Usage](#cli-usage)
+  - [Command Reference](#command-reference)
+  - [Commands](#commands)
+  - [Typical Workflow](#typical-workflow)
+- [MCP Server (Agent-Native Integration)](#mcp-server-agent-native-integration)
+- [Repository Structure](#repository-structure)
+- [Maintainer Hooks](#maintainer-hooks)
+- [Contributing](#contributing)
+- [Contributors](#contributors)
+- [License](#license)
+
+---
+
 ## The Tree
 
 Every AI agent capability exists somewhere on this graph. Skills start at the foundation tier, awaken through evidence, evolve through use, and fuse into things greater than the sum of their parts.


### PR DESCRIPTION
### Motivation

- Improve documentation navigation by adding a linked Table of Contents to the top of `README.md` and `CONTRIBUTING.md` so readers can quickly jump to major sections.

### Description

- Inserted a `## Table of Contents` block near the top of `README.md` linking to major headings including `CLI Usage`, `Push`, and `Repository Structure`.
- Inserted a `## Table of Contents` block near the top of `CONTRIBUTING.md` linking contributor-focused headings such as workflows, naming/evidence rules, and the PR checklist.
- Ensured the TOC entries use local anchors that resolve to existing headings in each file.

### Testing

- Ran the anchor-resolution check script (`python3 - <<'PY' ... PY`) which verified that all local TOC anchors resolve and it passed.
- Ran quick assertions (`python3 -c "from pathlib import Path; ..."`) to confirm the TOC link presence and they passed.
- Ran `git diff --check` to verify there are no whitespace errors and it returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fafca86918832784d680ce4e6a18bd)