### PR TITLE
docs: simplify MCP install guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,19 +321,15 @@ Intake PRs are draft review artifacts. Accepted candidates are promoted later in
 
 ## MCP Server (Agent-Native Integration)
 
-`@gaia-registry/mcp-server` connects Gaia directly to MCP-compatible agents such as Claude Code, Cursor, VS Code, and others:
+`@gaia-registry/mcp-server` connects Gaia directly to MCP-compatible agents such as Claude Code, Cursor, VS Code, and others. The README intentionally keeps this to install methods only; copy the command for your agent and use [`packages/mcp/`](packages/mcp/) for agent-specific config-file examples.
 
-```json
-{
-  "mcpServers": {
-    "gaia": {
-      "command": "npx",
-      "args": ["@gaia-registry/mcp-server"],
-      "env": { "GAIA_USER": "your-github-username" }
-    }
-  }
-}
-```
+| Agent | Install method |
+|---|---|
+| Claude Code | `claude mcp add gaia -- npx @gaia-registry/mcp-server` |
+| Any MCP client with a command picker | Command: `npx`; args: `@gaia-registry/mcp-server` |
+| Local smoke test | `npx @gaia-registry/mcp-server` |
+
+Optional environment variables: set `GAIA_USER=your-github-username` to load your tree by default and `GITHUB_TOKEN` if you want proposal tools to open PRs.
 
 Once connected, your agent gets these tools:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -15,6 +15,7 @@
     <li><a href="#what">What</a></li>
     <li><a href="#ranks">Ranks</a></li>
     <li><a href="#start">Start</a></li>
+    <li><a href="#mcp">Agent MCP</a></li>
     <li><a href="#workflow">Flow</a></li>
     <li><a href="how-we-do-things.html">How We Work</a></li>
     <li><a href="#named" class="nav-named-explorer">Named Skills</a></li>
@@ -235,6 +236,34 @@
 
   </div>
 
+</section>
+
+<div class="section-divider"></div>
+
+<!-- ─── MCP ─── -->
+<section id="mcp" class="reveal" data-section="mcp">
+  <h2>Connect Gaia to Your Agent</h2>
+  <p class="section-sub">Install the MCP server with copy-paste commands; keep agent-specific JSON in the MCP package docs.</p>
+
+  <div class="steps">
+    <div class="step">
+      <div class="step-num" style="background:linear-gradient(135deg,var(--basic),var(--extra))">M</div>
+      <div>
+        <h3>Claude Code</h3>
+        <p>Add Gaia as an MCP server from the CLI.</p>
+        <pre><span class="cmd">claude mcp add</span> <span class="str">gaia</span> -- <span class="cmd">npx</span> <span class="str">@gaia-registry/mcp-server</span></pre>
+      </div>
+    </div>
+    <div class="step">
+      <div class="step-num" style="background:linear-gradient(135deg,var(--extra),var(--ultimate))">*</div>
+      <div>
+        <h3>Any MCP-compatible agent</h3>
+        <p>Use command <code>npx</code> with argument <code>@gaia-registry/mcp-server</code>. Set <code>GAIA_USER</code> to your GitHub username if your client supports environment variables.</p>
+        <pre><span class="cmd">npx</span> <span class="str">@gaia-registry/mcp-server</span></pre>
+        <div class="qs-tip"><span class="qs-tip-icon">💡</span><span>Need Claude Desktop, Cursor, VS Code, Codex CLI, Gemini, or OpenClaw config-file examples? Open <a href="https://github.com/mbtiongson1/gaia-skill-tree/tree/main/packages/mcp" target="_blank" style="color:var(--basic)">packages/mcp</a>.</span></div>
+      </div>
+    </div>
+  </div>
 </section>
 
 <div class="section-divider"></div>


### PR DESCRIPTION
### Motivation
- Clarify MCP installation instructions by replacing a verbose inline JSON snippet with concise, copy-paste install commands and a pointer to the MCP package for agent-specific examples to address a docs usability issue (referenced by the open MCP/docs issue). 

### Description
- Replace the README inline MCP config JSON block with a short install-method table and notes about optional `GAIA_USER`/`GITHUB_TOKEN` environment variables. 
- Add a new "Agent MCP" section to `docs/index.html` with copy-paste commands for Claude Code and a generic MCP-compatible agent workflow and add a navigation link. 
- Direct readers to `packages/mcp/` for full, agent-specific configuration examples and keep the docs site self-contained for quick start guidance. 
- Changes were implemented on a docs feature branch following the repository's branch naming guidance.

### Testing
- Ran `PYTHONPATH=src python3 scripts/build_docs.py --check` which reported the generated docs are up to date (success). 
- Ran `python3 scripts/validate.py` which completed all schema and integrity checks (success). 
- Performed a visual smoke-check by serving the docs (`python3 -m http.server 8080`) and capturing a page screenshot via `npx playwright` which completed and produced a screenshot (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69faff9d94808327ab36b086bc24c6e2)