### PR TITLE
Fix docs build registry auto-resolution

### DIFF
--- a/src/gaia_cli/registry.py
+++ b/src/gaia_cli/registry.py
@@ -135,8 +135,16 @@ def write_global_registry(path: str) -> None:
         json.dump(existing, f, indent=2)
 
 
+def read_cwd_registry() -> str | None:
+    """Return CWD when it looks like a Gaia registry checkout."""
+    cwd = Path.cwd()
+    if (cwd / "registry" / "gaia.json").exists():
+        return str(cwd)
+    return None
+
+
 def resolve_registry_path(explicit_registry=None, global_flag=False):
-    """Resolve the registry path: explicit → --global → local .gaia → global config → bundled."""
+    """Resolve the registry path: explicit → --global → local .gaia → CWD clone → global config → bundled."""
     if explicit_registry:
         return os.path.abspath(os.path.expanduser(explicit_registry))
     if global_flag:
@@ -145,6 +153,9 @@ def resolve_registry_path(explicit_registry=None, global_flag=False):
     local_reg = read_local_registry()
     if local_reg:
         return local_reg
+    cwd_reg = read_cwd_registry()
+    if cwd_reg:
+        return cwd_reg
     global_reg = read_global_registry()
     if global_reg:
         return global_reg

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -199,6 +199,33 @@ def test_local_registry_fallback_to_cwd_when_no_localRegistryPath(tmp_path):
         os.chdir(orig_cwd)
 
 
+def test_registry_clone_auto_resolves_without_gaia_config(tmp_path):
+    registry = tmp_path / "registry"
+    registry.mkdir()
+    (registry / "registry").mkdir()
+    (registry / "registry" / "gaia.json").write_text(json.dumps({"skills": [], "edges": []}))
+
+    from gaia_cli.registry import resolve_registry_path
+
+    orig_cwd = os.getcwd()
+    try:
+        os.chdir(registry)
+        result = resolve_registry_path()
+        assert result == str(registry)
+    finally:
+        os.chdir(orig_cwd)
+
+
+def test_docs_build_can_run_from_registry_clone_without_registry_flag(tmp_path):
+    result = run_python(
+        ["-m", "gaia_cli", "docs", "build", "--check"],
+        cwd=REPO_ROOT,
+        env={"GAIA_HOME": str(tmp_path / "home")},
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
 def test_init_writes_local_registry_path(tmp_path):
     result = run_python(
         ["-m", "gaia_cli", "init", "--user", "testuser", "--yes"],


### PR DESCRIPTION
### Motivation
- `gaia docs build` required an explicit `--registry` or `.gaia` config when run from a registry clone, causing a poor UX and CI friction (covers #134).

### Description
- Add `read_cwd_registry()` to detect a local registry checkout when CWD contains `registry/gaia.json`.
- Update `resolve_registry_path()` to check the CWD clone before falling back to the global config or bundled registry.
- Add regression tests `test_registry_clone_auto_resolves_without_gaia_config` and `test_docs_build_can_run_from_registry_clone_without_registry_flag` in `tests/test_packaging.py`.
- Modified files: `src/gaia_cli/registry.py` and `tests/test_packaging.py`.

### Testing
- Ran `PYTHONPATH=src python -m gaia_cli docs build --check` and it succeeded with "Documentation is up to date.".
- Ran the two new tests directly with `PYTHONPATH=src python -m pytest tests/test_packaging.py::test_registry_clone_auto_resolves_without_gaia_config tests/test_packaging.py::test_docs_build_can_run_from_registry_clone_without_registry_flag -q` and both passed.
- Ran the broader test set with `PYTHONPATH=src python -m pytest -q -m 'not packaging'` which reported `275 passed, 2 deselected`.
- Running full packaging tests in this environment shows two packaging failures unrelated to this change due to the environment missing the `build` module (`No module named build`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fb0931ae18832790f7930df07b192b)