### PR TITLE
Add Hermes-derived skills (wiki-search, architecture-diagram, humanize-prose, prediction-market-analysis, feed-monitoring) and update registry

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -454,5 +454,5 @@
 </html>
 
 <!-- gaia:stats-start -->
-<!-- skills=123; namedSkills=32; version=3.0.1 -->
+<!-- skills=128; namedSkills=32; version=3.0.1 -->
 <!-- gaia:stats-end -->

--- a/registry/combinations.md
+++ b/registry/combinations.md
@@ -3,6 +3,7 @@
 | Skill | Class | Prerequisites | Level Floor | Conditions |
 |---|---|---|---|---|
 | ◇ Extra Skill: /agent-eval | Extra Skill | Evaluate Output, Score Relevance | III |  |
+| ◇ Extra Skill: /architecture-diagram | Extra Skill | Data Visualize, Format Output, Write Report | IV | Requires enough system context to identify components, relationships, boundaries, and rendering constraints. |
 | ◇ Extra Skill: 0xdarkmatter/pytest-patterns | Extra Skill | Generate Test, Execute Bash, Error Interpretation | III |  |
 | ◆ Ultimate Skill: /autonomous-data-scientist [Unclaimed ✦] | Ultimate Skill | Data Analysis, Math Reason, Research | V | Requires dataset access and compute environment. Minimum 3 Class A/B evidence sources. |
 | ◇ Extra Skill: devin-ai/autonomous-swe | Extra Skill | Code Generation, Execute Bash, Error Interpretation | IV |  |
@@ -24,6 +25,7 @@
 | ◇ Extra Skill: /ghostwrite | Extra Skill | Research, Write Report, Audience Model | IV | Requires research output as input context. |
 | ◇ Extra Skill: /grounding | Extra Skill | Retrieve, Cite Sources, Evaluate Output | III |  |
 | ◇ Extra Skill: /guardrails | Extra Skill | Evaluate Output, Classify, Structured Output Generation | III | Requires a defined policy schema and an evaluation loop. |
+| ◇ Extra Skill: /humanize-prose | Extra Skill | Document Editing, Audience Model, Format Output | IV | Requires explicit user permission to revise voice, tone, and stylistic markers without changing factual claims. |
 | ◇ Extra Skill: /knowledge-graph-build | Extra Skill | Extract Entities, Logical Inference | III |  |
 | ◇ Extra Skill: /knowledge-harvest | Extra Skill | Web Scrape, Extract Entities, Embed Text | IV |  |
 | ◇ Extra Skill: huggingface/huggingface-papers | Extra Skill | Research, Cite Sources, Summarize | IV | Requires access to academic databases (PubMed, bioRxiv, ChEMBL, or equivalent). |
@@ -33,6 +35,7 @@
 | ◇ Extra Skill: huggingface/transformers-js | Extra Skill | Image Caption, Question Answer, Logical Inference | III | Requires vision-language model capability. |
 | ◇ Extra Skill: /plan-and-execute | Extra Skill | Route Intent, Plan and Decompose, Tool Select | IV |  |
 | ◇ Extra Skill: mattpocock/to-prd | Extra Skill | Write Report, Plan and Decompose | IV |  |
+| ◇ Extra Skill: /prediction-market-analysis | Extra Skill | Data Analysis, Web Search, Statistical Analysis | IV | Requires read-only market data sources and clear separation between analysis output and financial advice or trade execution. |
 | ◇ Extra Skill: /prompt-optimization | Extra Skill | Evaluate Output, Generate Text | IV |  |
 | ◇ Extra Skill: yonatangross/orchestkit-rag | Extra Skill | Retrieve, Chunk Document, Embed Text, Score Relevance, Tokenize, Rank | III |  |
 | ◇ Extra Skill: /re-act-reasoning | Extra Skill | Plan and Decompose, Tool Use | III |  |
@@ -52,4 +55,5 @@
 | ◇ Extra Skill: mattpocock/to-issues | Extra Skill | Plan and Decompose, Route Intent | III |  |
 | ◇ Extra Skill: /voice-agent | Extra Skill | Speech to Text, Question Answer, Text to Speech | III | Requires real-time audio I/O or audio file access. |
 | ◇ Extra Skill: /web-scrape | Extra Skill | Web Search, Parse HTML, Extract Entities | III | Structured output mode required. |
+| ◇ Extra Skill: /wiki-search | Extra Skill | Retrieve, Embed Text, Summarize | IV | Requires an accessible local wiki or markdown knowledge-base directory and a consistent linking or indexing convention. |
 | ◇ Extra Skill: /workflow-automation | Extra Skill | Plan and Decompose, Tool Use, API Call | IV |  |

--- a/registry/gaia.gexf
+++ b/registry/gaia.gexf
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <gexf xmlns="http://www.gexf.net/1.2draft" version="1.2">
-  <meta lastmodifieddate="2026-04-30">
+  <meta lastmodifieddate="2026-05-06">
     <creator>Gaia</creator>
     <description>Gaia Skill Registry Graph</description>
   </meta>
@@ -26,6 +26,14 @@
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="basic" />
+        </attvalues>
+      </node>
+      <node id="architecture-diagram" label="Architecture Diagram">
+        <attvalues>
+          <attvalue for="level" value="IV" />
+          <attvalue for="rarity" value="uncommon" />
+          <attvalue for="status" value="provisional" />
+          <attvalue for="type" value="extra" />
         </attvalues>
       </node>
       <node id="audience-model" label="Audience Model">
@@ -292,6 +300,14 @@
           <attvalue for="type" value="basic" />
         </attvalues>
       </node>
+      <node id="feed-monitoring" label="Feed Monitoring">
+        <attvalues>
+          <attvalue for="level" value="IV" />
+          <attvalue for="rarity" value="common" />
+          <attvalue for="status" value="provisional" />
+          <attvalue for="type" value="basic" />
+        </attvalues>
+      </node>
       <node id="few-shot-learning" label="Few-Shot Learning">
         <attvalues>
           <attvalue for="level" value="IV" />
@@ -399,6 +415,14 @@
       <node id="guardrails" label="Guardrails">
         <attvalues>
           <attvalue for="level" value="III" />
+          <attvalue for="rarity" value="uncommon" />
+          <attvalue for="status" value="provisional" />
+          <attvalue for="type" value="extra" />
+        </attvalues>
+      </node>
+      <node id="humanize-prose" label="Humanize Prose">
+        <attvalues>
+          <attvalue for="level" value="IV" />
           <attvalue for="rarity" value="uncommon" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="extra" />
@@ -592,6 +616,14 @@
         <attvalues>
           <attvalue for="level" value="IV" />
           <attvalue for="rarity" value="uncommon" />
+          <attvalue for="status" value="provisional" />
+          <attvalue for="type" value="extra" />
+        </attvalues>
+      </node>
+      <node id="prediction-market-analysis" label="Prediction Market Analysis">
+        <attvalues>
+          <attvalue for="level" value="IV" />
+          <attvalue for="rarity" value="rare" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="extra" />
         </attvalues>
@@ -980,6 +1012,14 @@
           <attvalue for="type" value="basic" />
         </attvalues>
       </node>
+      <node id="wiki-search" label="Wiki Search">
+        <attvalues>
+          <attvalue for="level" value="IV" />
+          <attvalue for="rarity" value="uncommon" />
+          <attvalue for="status" value="provisional" />
+          <attvalue for="type" value="extra" />
+        </attvalues>
+      </node>
       <node id="workflow-automation" label="Workflow Automation">
         <attvalues>
           <attvalue for="level" value="IV" />
@@ -1000,147 +1040,159 @@
     <edges>
       <edge id="e0" source="evaluate-output" target="agent-eval" />
       <edge id="e1" source="score-relevance" target="agent-eval" />
-      <edge id="e2" source="generate-test" target="automated-testing" />
-      <edge id="e3" source="execute-bash" target="automated-testing" />
-      <edge id="e4" source="error-interpretation" target="automated-testing" />
-      <edge id="e5" source="data-analysis" target="autonomous-data-scientist" />
-      <edge id="e6" source="math-reason" target="autonomous-data-scientist" />
-      <edge id="e7" source="research" target="autonomous-data-scientist" />
-      <edge id="e8" source="code-generation" target="autonomous-debug" />
-      <edge id="e9" source="execute-bash" target="autonomous-debug" />
-      <edge id="e10" source="error-interpretation" target="autonomous-debug" />
-      <edge id="e11" source="research" target="autonomous-research-agent" />
-      <edge id="e12" source="knowledge-harvest" target="autonomous-research-agent" />
-      <edge id="e13" source="ghostwrite" target="autonomous-research-agent" />
-      <edge id="e14" source="web-search" target="browser-automation" />
-      <edge id="e15" source="computer-use" target="browser-automation" />
-      <edge id="e16" source="code-generation" target="code-review-pipeline" />
-      <edge id="e17" source="diff-content" target="code-review-pipeline" />
-      <edge id="e18" source="evaluate-output" target="code-review-pipeline" />
-      <edge id="e19" source="classify" target="content-moderation" />
-      <edge id="e20" source="sentiment-analysis" target="content-moderation" />
-      <edge id="e21" source="extract-entities" target="content-moderation" />
-      <edge id="e22" source="question-answer" target="conversational-agent" />
-      <edge id="e23" source="memory-manage" target="conversational-agent" />
-      <edge id="e24" source="route-intent" target="conversational-agent" />
-      <edge id="e25" source="generate-sql" target="data-analysis" />
-      <edge id="e26" source="data-visualize" target="data-analysis" />
-      <edge id="e27" source="summarize" target="data-analysis" />
-      <edge id="e28" source="workflow-automation" target="deployment-automation" />
-      <edge id="e29" source="execute-bash" target="deployment-automation" />
-      <edge id="e30" source="evaluate-output" target="design-review" />
-      <edge id="e31" source="plan-decompose" target="design-review" />
-      <edge id="e32" source="parse-json" target="document-analyst" />
-      <edge id="e33" source="extract-entities" target="document-analyst" />
-      <edge id="e34" source="summarize" target="document-analyst" />
-      <edge id="e35" source="format-output" target="document-analyst" />
-      <edge id="e36" source="parse-pdf" target="document-digitization" />
-      <edge id="e37" source="extract-entities" target="document-digitization" />
-      <edge id="e38" source="format-output" target="document-digitization" />
-      <edge id="e39" source="browser-automation" target="e2e-testing" />
-      <edge id="e40" source="automated-testing" target="e2e-testing" />
-      <edge id="e41" source="code-review-pipeline" target="full-stack-developer" />
-      <edge id="e42" source="automated-testing" target="full-stack-developer" />
-      <edge id="e43" source="refactor-code" target="full-stack-developer" />
-      <edge id="e44" source="structured-output" target="function-calling" />
-      <edge id="e45" source="api-call" target="function-calling" />
-      <edge id="e46" source="tool-select" target="function-calling" />
-      <edge id="e47" source="retrieve" target="gaia-audit" />
-      <edge id="e48" source="cite-sources" target="gaia-audit" />
-      <edge id="e49" source="evaluate-output" target="gaia-audit" />
-      <edge id="e50" source="gaia-audit" target="gaia-meta-audit" />
-      <edge id="e51" source="registry-curation" target="gaia-meta-audit" />
-      <edge id="e52" source="detect-anomaly" target="gaia-meta-audit" />
-      <edge id="e53" source="research" target="ghostwrite" />
-      <edge id="e54" source="write-report" target="ghostwrite" />
-      <edge id="e55" source="audience-model" target="ghostwrite" />
-      <edge id="e56" source="retrieve" target="grounding" />
-      <edge id="e57" source="cite-sources" target="grounding" />
-      <edge id="e58" source="evaluate-output" target="grounding" />
-      <edge id="e59" source="evaluate-output" target="guardrails" />
-      <edge id="e60" source="classify" target="guardrails" />
-      <edge id="e61" source="structured-output" target="guardrails" />
-      <edge id="e62" source="extract-entities" target="knowledge-graph-build" />
-      <edge id="e63" source="logical-inference" target="knowledge-graph-build" />
-      <edge id="e64" source="web-scrape" target="knowledge-harvest" />
-      <edge id="e65" source="extract-entities" target="knowledge-harvest" />
-      <edge id="e66" source="embed-text" target="knowledge-harvest" />
-      <edge id="e67" source="research" target="literature-review" />
-      <edge id="e68" source="cite-sources" target="literature-review" />
-      <edge id="e69" source="summarize" target="literature-review" />
-      <edge id="e70" source="data-analysis" target="ml-pipeline" />
-      <edge id="e71" source="automated-testing" target="ml-pipeline" />
-      <edge id="e72" source="code-generation" target="ml-pipeline" />
-      <edge id="e73" source="self-critique" target="multi-agent-debate" />
-      <edge id="e74" source="evaluate-output" target="multi-agent-debate" />
-      <edge id="e75" source="chain-of-thought" target="multi-agent-debate" />
-      <edge id="e76" source="plan-and-execute" target="multi-agent-orchestration-v" />
-      <edge id="e77" source="route-intent" target="multi-agent-orchestration-v" />
-      <edge id="e78" source="tool-select" target="multi-agent-orchestration-v" />
-      <edge id="e79" source="image-caption" target="multimodal-reasoning" />
-      <edge id="e80" source="question-answer" target="multimodal-reasoning" />
-      <edge id="e81" source="logical-inference" target="multimodal-reasoning" />
-      <edge id="e82" source="route-intent" target="plan-and-execute" />
-      <edge id="e83" source="plan-decompose" target="plan-and-execute" />
-      <edge id="e84" source="tool-select" target="plan-and-execute" />
-      <edge id="e85" source="write-report" target="prd-generation" />
-      <edge id="e86" source="plan-decompose" target="prd-generation" />
-      <edge id="e87" source="evaluate-output" target="prompt-optimization" />
-      <edge id="e88" source="generate-text" target="prompt-optimization" />
-      <edge id="e89" source="retrieve" target="rag-pipeline" />
-      <edge id="e90" source="chunk-document" target="rag-pipeline" />
-      <edge id="e91" source="embed-text" target="rag-pipeline" />
-      <edge id="e92" source="score-relevance" target="rag-pipeline" />
-      <edge id="e93" source="tokenize" target="rag-pipeline" />
-      <edge id="e94" source="rank" target="rag-pipeline" />
-      <edge id="e95" source="plan-decompose" target="re-act-reasoning" />
-      <edge id="e96" source="tool-use" target="re-act-reasoning" />
-      <edge id="e97" source="voice-agent" target="real-time-voice-assistant" />
-      <edge id="e98" source="memory-manage" target="real-time-voice-assistant" />
-      <edge id="e99" source="plan-and-execute" target="real-time-voice-assistant" />
-      <edge id="e100" source="autonomous-debug" target="recursive-self-improvement" />
-      <edge id="e101" source="evaluate-output" target="recursive-self-improvement" />
-      <edge id="e102" source="plan-and-execute" target="recursive-self-improvement" />
-      <edge id="e103" source="research" target="registry-curation" />
-      <edge id="e104" source="code-generation" target="registry-curation" />
-      <edge id="e105" source="execute-bash" target="registry-curation" />
-      <edge id="e106" source="workflow-automation" target="release-automation" />
-      <edge id="e107" source="execute-bash" target="release-automation" />
-      <edge id="e108" source="generate-text" target="release-automation" />
-      <edge id="e109" source="web-search" target="research" />
-      <edge id="e110" source="summarize" target="research" />
-      <edge id="e111" source="cite-sources" target="research" />
-      <edge id="e112" source="hypothesis-generate" target="scientific-discovery" />
-      <edge id="e113" source="research" target="scientific-discovery" />
-      <edge id="e114" source="math-reason" target="scientific-discovery" />
-      <edge id="e115" source="write-report" target="scientific-writing" />
-      <edge id="e116" source="cite-sources" target="scientific-writing" />
-      <edge id="e117" source="scientific-visualization" target="scientific-writing" />
-      <edge id="e118" source="code-review-pipeline" target="security-audit" />
-      <edge id="e119" source="evaluate-output" target="security-audit" />
-      <edge id="e120" source="generate-sql" target="text-to-sql-pipeline" />
-      <edge id="e121" source="parse-json" target="text-to-sql-pipeline" />
-      <edge id="e122" source="format-output" target="text-to-sql-pipeline" />
-      <edge id="e123" source="tool-use" target="tool-chaining" />
-      <edge id="e124" source="tool-select" target="tool-chaining" />
-      <edge id="e125" source="code-generation" target="tool-creation" />
-      <edge id="e126" source="tool-use" target="tool-creation" />
-      <edge id="e127" source="translate" target="translation-pipeline" />
-      <edge id="e128" source="sentiment-analysis" target="translation-pipeline" />
-      <edge id="e129" source="audience-model" target="translation-pipeline" />
-      <edge id="e130" source="chain-of-thought" target="tree-of-thought" />
-      <edge id="e131" source="plan-decompose" target="tree-of-thought" />
-      <edge id="e132" source="plan-decompose" target="vertical-slice-planning" />
-      <edge id="e133" source="route-intent" target="vertical-slice-planning" />
-      <edge id="e134" source="speech-to-text" target="voice-agent" />
-      <edge id="e135" source="question-answer" target="voice-agent" />
-      <edge id="e136" source="text-to-speech" target="voice-agent" />
-      <edge id="e137" source="web-search" target="web-scrape" />
-      <edge id="e138" source="parse-html" target="web-scrape" />
-      <edge id="e139" source="extract-entities" target="web-scrape" />
-      <edge id="e140" source="plan-decompose" target="workflow-automation" />
-      <edge id="e141" source="tool-use" target="workflow-automation" />
-      <edge id="e142" source="api-call" target="workflow-automation" />
+      <edge id="e2" source="data-visualize" target="architecture-diagram" />
+      <edge id="e3" source="format-output" target="architecture-diagram" />
+      <edge id="e4" source="write-report" target="architecture-diagram" />
+      <edge id="e5" source="generate-test" target="automated-testing" />
+      <edge id="e6" source="execute-bash" target="automated-testing" />
+      <edge id="e7" source="error-interpretation" target="automated-testing" />
+      <edge id="e8" source="data-analysis" target="autonomous-data-scientist" />
+      <edge id="e9" source="math-reason" target="autonomous-data-scientist" />
+      <edge id="e10" source="research" target="autonomous-data-scientist" />
+      <edge id="e11" source="code-generation" target="autonomous-debug" />
+      <edge id="e12" source="execute-bash" target="autonomous-debug" />
+      <edge id="e13" source="error-interpretation" target="autonomous-debug" />
+      <edge id="e14" source="research" target="autonomous-research-agent" />
+      <edge id="e15" source="knowledge-harvest" target="autonomous-research-agent" />
+      <edge id="e16" source="ghostwrite" target="autonomous-research-agent" />
+      <edge id="e17" source="web-search" target="browser-automation" />
+      <edge id="e18" source="computer-use" target="browser-automation" />
+      <edge id="e19" source="code-generation" target="code-review-pipeline" />
+      <edge id="e20" source="diff-content" target="code-review-pipeline" />
+      <edge id="e21" source="evaluate-output" target="code-review-pipeline" />
+      <edge id="e22" source="classify" target="content-moderation" />
+      <edge id="e23" source="sentiment-analysis" target="content-moderation" />
+      <edge id="e24" source="extract-entities" target="content-moderation" />
+      <edge id="e25" source="question-answer" target="conversational-agent" />
+      <edge id="e26" source="memory-manage" target="conversational-agent" />
+      <edge id="e27" source="route-intent" target="conversational-agent" />
+      <edge id="e28" source="generate-sql" target="data-analysis" />
+      <edge id="e29" source="data-visualize" target="data-analysis" />
+      <edge id="e30" source="summarize" target="data-analysis" />
+      <edge id="e31" source="workflow-automation" target="deployment-automation" />
+      <edge id="e32" source="execute-bash" target="deployment-automation" />
+      <edge id="e33" source="evaluate-output" target="design-review" />
+      <edge id="e34" source="plan-decompose" target="design-review" />
+      <edge id="e35" source="parse-json" target="document-analyst" />
+      <edge id="e36" source="extract-entities" target="document-analyst" />
+      <edge id="e37" source="summarize" target="document-analyst" />
+      <edge id="e38" source="format-output" target="document-analyst" />
+      <edge id="e39" source="parse-pdf" target="document-digitization" />
+      <edge id="e40" source="extract-entities" target="document-digitization" />
+      <edge id="e41" source="format-output" target="document-digitization" />
+      <edge id="e42" source="browser-automation" target="e2e-testing" />
+      <edge id="e43" source="automated-testing" target="e2e-testing" />
+      <edge id="e44" source="code-review-pipeline" target="full-stack-developer" />
+      <edge id="e45" source="automated-testing" target="full-stack-developer" />
+      <edge id="e46" source="refactor-code" target="full-stack-developer" />
+      <edge id="e47" source="structured-output" target="function-calling" />
+      <edge id="e48" source="api-call" target="function-calling" />
+      <edge id="e49" source="tool-select" target="function-calling" />
+      <edge id="e50" source="retrieve" target="gaia-audit" />
+      <edge id="e51" source="cite-sources" target="gaia-audit" />
+      <edge id="e52" source="evaluate-output" target="gaia-audit" />
+      <edge id="e53" source="gaia-audit" target="gaia-meta-audit" />
+      <edge id="e54" source="registry-curation" target="gaia-meta-audit" />
+      <edge id="e55" source="detect-anomaly" target="gaia-meta-audit" />
+      <edge id="e56" source="research" target="ghostwrite" />
+      <edge id="e57" source="write-report" target="ghostwrite" />
+      <edge id="e58" source="audience-model" target="ghostwrite" />
+      <edge id="e59" source="retrieve" target="grounding" />
+      <edge id="e60" source="cite-sources" target="grounding" />
+      <edge id="e61" source="evaluate-output" target="grounding" />
+      <edge id="e62" source="evaluate-output" target="guardrails" />
+      <edge id="e63" source="classify" target="guardrails" />
+      <edge id="e64" source="structured-output" target="guardrails" />
+      <edge id="e65" source="document-editing" target="humanize-prose" />
+      <edge id="e66" source="audience-model" target="humanize-prose" />
+      <edge id="e67" source="format-output" target="humanize-prose" />
+      <edge id="e68" source="extract-entities" target="knowledge-graph-build" />
+      <edge id="e69" source="logical-inference" target="knowledge-graph-build" />
+      <edge id="e70" source="web-scrape" target="knowledge-harvest" />
+      <edge id="e71" source="extract-entities" target="knowledge-harvest" />
+      <edge id="e72" source="embed-text" target="knowledge-harvest" />
+      <edge id="e73" source="research" target="literature-review" />
+      <edge id="e74" source="cite-sources" target="literature-review" />
+      <edge id="e75" source="summarize" target="literature-review" />
+      <edge id="e76" source="data-analysis" target="ml-pipeline" />
+      <edge id="e77" source="automated-testing" target="ml-pipeline" />
+      <edge id="e78" source="code-generation" target="ml-pipeline" />
+      <edge id="e79" source="self-critique" target="multi-agent-debate" />
+      <edge id="e80" source="evaluate-output" target="multi-agent-debate" />
+      <edge id="e81" source="chain-of-thought" target="multi-agent-debate" />
+      <edge id="e82" source="plan-and-execute" target="multi-agent-orchestration-v" />
+      <edge id="e83" source="route-intent" target="multi-agent-orchestration-v" />
+      <edge id="e84" source="tool-select" target="multi-agent-orchestration-v" />
+      <edge id="e85" source="image-caption" target="multimodal-reasoning" />
+      <edge id="e86" source="question-answer" target="multimodal-reasoning" />
+      <edge id="e87" source="logical-inference" target="multimodal-reasoning" />
+      <edge id="e88" source="route-intent" target="plan-and-execute" />
+      <edge id="e89" source="plan-decompose" target="plan-and-execute" />
+      <edge id="e90" source="tool-select" target="plan-and-execute" />
+      <edge id="e91" source="write-report" target="prd-generation" />
+      <edge id="e92" source="plan-decompose" target="prd-generation" />
+      <edge id="e93" source="data-analysis" target="prediction-market-analysis" />
+      <edge id="e94" source="web-search" target="prediction-market-analysis" />
+      <edge id="e95" source="statistical-analysis" target="prediction-market-analysis" />
+      <edge id="e96" source="evaluate-output" target="prompt-optimization" />
+      <edge id="e97" source="generate-text" target="prompt-optimization" />
+      <edge id="e98" source="retrieve" target="rag-pipeline" />
+      <edge id="e99" source="chunk-document" target="rag-pipeline" />
+      <edge id="e100" source="embed-text" target="rag-pipeline" />
+      <edge id="e101" source="score-relevance" target="rag-pipeline" />
+      <edge id="e102" source="tokenize" target="rag-pipeline" />
+      <edge id="e103" source="rank" target="rag-pipeline" />
+      <edge id="e104" source="plan-decompose" target="re-act-reasoning" />
+      <edge id="e105" source="tool-use" target="re-act-reasoning" />
+      <edge id="e106" source="voice-agent" target="real-time-voice-assistant" />
+      <edge id="e107" source="memory-manage" target="real-time-voice-assistant" />
+      <edge id="e108" source="plan-and-execute" target="real-time-voice-assistant" />
+      <edge id="e109" source="autonomous-debug" target="recursive-self-improvement" />
+      <edge id="e110" source="evaluate-output" target="recursive-self-improvement" />
+      <edge id="e111" source="plan-and-execute" target="recursive-self-improvement" />
+      <edge id="e112" source="research" target="registry-curation" />
+      <edge id="e113" source="code-generation" target="registry-curation" />
+      <edge id="e114" source="execute-bash" target="registry-curation" />
+      <edge id="e115" source="workflow-automation" target="release-automation" />
+      <edge id="e116" source="execute-bash" target="release-automation" />
+      <edge id="e117" source="generate-text" target="release-automation" />
+      <edge id="e118" source="web-search" target="research" />
+      <edge id="e119" source="summarize" target="research" />
+      <edge id="e120" source="cite-sources" target="research" />
+      <edge id="e121" source="hypothesis-generate" target="scientific-discovery" />
+      <edge id="e122" source="research" target="scientific-discovery" />
+      <edge id="e123" source="math-reason" target="scientific-discovery" />
+      <edge id="e124" source="write-report" target="scientific-writing" />
+      <edge id="e125" source="cite-sources" target="scientific-writing" />
+      <edge id="e126" source="scientific-visualization" target="scientific-writing" />
+      <edge id="e127" source="code-review-pipeline" target="security-audit" />
+      <edge id="e128" source="evaluate-output" target="security-audit" />
+      <edge id="e129" source="generate-sql" target="text-to-sql-pipeline" />
+      <edge id="e130" source="parse-json" target="text-to-sql-pipeline" />
+      <edge id="e131" source="format-output" target="text-to-sql-pipeline" />
+      <edge id="e132" source="tool-use" target="tool-chaining" />
+      <edge id="e133" source="tool-select" target="tool-chaining" />
+      <edge id="e134" source="code-generation" target="tool-creation" />
+      <edge id="e135" source="tool-use" target="tool-creation" />
+      <edge id="e136" source="translate" target="translation-pipeline" />
+      <edge id="e137" source="sentiment-analysis" target="translation-pipeline" />
+      <edge id="e138" source="audience-model" target="translation-pipeline" />
+      <edge id="e139" source="chain-of-thought" target="tree-of-thought" />
+      <edge id="e140" source="plan-decompose" target="tree-of-thought" />
+      <edge id="e141" source="plan-decompose" target="vertical-slice-planning" />
+      <edge id="e142" source="route-intent" target="vertical-slice-planning" />
+      <edge id="e143" source="speech-to-text" target="voice-agent" />
+      <edge id="e144" source="question-answer" target="voice-agent" />
+      <edge id="e145" source="text-to-speech" target="voice-agent" />
+      <edge id="e146" source="web-search" target="web-scrape" />
+      <edge id="e147" source="parse-html" target="web-scrape" />
+      <edge id="e148" source="extract-entities" target="web-scrape" />
+      <edge id="e149" source="retrieve" target="wiki-search" />
+      <edge id="e150" source="embed-text" target="wiki-search" />
+      <edge id="e151" source="summarize" target="wiki-search" />
+      <edge id="e152" source="plan-decompose" target="workflow-automation" />
+      <edge id="e153" source="tool-use" target="workflow-automation" />
+      <edge id="e154" source="api-call" target="workflow-automation" />
     </edges>
   </graph>
 </gexf>

--- a/registry/gaia.json
+++ b/registry/gaia.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/skill.schema.json",
   "version": "3.0.1",
-  "generatedAt": "2026-04-30T00:00:00Z",
+  "generatedAt": "2026-05-06T00:00:00Z",
   "meta": {
     "typeLabels": {
       "basic": "Basic Skill",
@@ -15,7 +15,7 @@
       "III": "Evolved",
       "IV": "Hardened",
       "V": "Transcendent",
-      "VI": "Transcendent \u2605"
+      "VI": "Transcendent ★"
     },
     "rarityLabels": {
       "legendary": "Divine"
@@ -72,9 +72,9 @@
       }
     },
     "typeSymbols": {
-      "basic": "\u25cb",
-      "extra": "\u25c7",
-      "ultimate": "\u25c6"
+      "basic": "○",
+      "extra": "◇",
+      "ultimate": "◆"
     }
   },
   "skills": [
@@ -144,7 +144,8 @@
       "derivatives": [
         "gaia-audit",
         "grounding",
-        "rag-pipeline"
+        "rag-pipeline",
+        "wiki-search"
       ],
       "conditions": "",
       "evidence": [
@@ -159,7 +160,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-26",
-      "updatedAt": "2026-04-30",
+      "updatedAt": "2026-05-06",
       "version": "0.1.0"
     },
     {
@@ -315,7 +316,8 @@
         "research",
         "document-analyst",
         "data-analysis",
-        "literature-review"
+        "literature-review",
+        "wiki-search"
       ],
       "conditions": "",
       "evidence": [
@@ -330,7 +332,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-26",
-      "updatedAt": "2026-04-30",
+      "updatedAt": "2026-05-06",
       "version": "0.1.0"
     },
     {
@@ -470,7 +472,8 @@
       "prerequisites": [],
       "derivatives": [
         "rag-pipeline",
-        "knowledge-harvest"
+        "knowledge-harvest",
+        "wiki-search"
       ],
       "conditions": "",
       "evidence": [
@@ -485,7 +488,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-26",
-      "updatedAt": "2026-04-26",
+      "updatedAt": "2026-05-06",
       "version": "0.1.0"
     },
     {
@@ -559,7 +562,8 @@
       "derivatives": [
         "ghostwrite",
         "prd-generation",
-        "scientific-writing"
+        "scientific-writing",
+        "architecture-diagram"
       ],
       "conditions": "",
       "evidence": [
@@ -574,7 +578,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-26",
-      "updatedAt": "2026-04-30",
+      "updatedAt": "2026-05-06",
       "version": "0.1.0"
     },
     {
@@ -587,7 +591,8 @@
       "prerequisites": [],
       "derivatives": [
         "ghostwrite",
-        "translation-pipeline"
+        "translation-pipeline",
+        "humanize-prose"
       ],
       "conditions": "",
       "evidence": [
@@ -602,7 +607,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-26",
-      "updatedAt": "2026-04-26",
+      "updatedAt": "2026-05-06",
       "version": "0.1.0"
     },
     {
@@ -704,7 +709,8 @@
       "derivatives": [
         "browser-automation",
         "research",
-        "web-scrape"
+        "web-scrape",
+        "prediction-market-analysis"
       ],
       "conditions": "",
       "evidence": [
@@ -719,7 +725,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-26",
-      "updatedAt": "2026-04-28",
+      "updatedAt": "2026-05-06",
       "version": "0.1.0"
     },
     {
@@ -761,7 +767,9 @@
       "derivatives": [
         "document-analyst",
         "document-digitization",
-        "text-to-sql-pipeline"
+        "text-to-sql-pipeline",
+        "humanize-prose",
+        "architecture-diagram"
       ],
       "conditions": "",
       "evidence": [
@@ -776,7 +784,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-26",
-      "updatedAt": "2026-04-28",
+      "updatedAt": "2026-05-06",
       "version": "0.1.0"
     },
     {
@@ -1079,7 +1087,7 @@
           "source": "https://github.com/gaia-registry/gaia/blob/main/docs/evidence/seed.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Seed evidence \u00e2\u20ac\u201d structural validation placeholder."
+          "notes": "Seed evidence â€” structural validation placeholder."
         }
       ],
       "knownAgents": [],
@@ -1109,7 +1117,7 @@
           "source": "https://github.com/gaia-registry/gaia/blob/main/docs/evidence/seed.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Seed evidence \u00e2\u20ac\u201d structural validation placeholder."
+          "notes": "Seed evidence â€” structural validation placeholder."
         }
       ],
       "knownAgents": [],
@@ -1139,7 +1147,7 @@
           "source": "https://github.com/gaia-registry/gaia/blob/main/docs/evidence/seed.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Seed evidence \u00e2\u20ac\u201d apex tier structural validation placeholder."
+          "notes": "Seed evidence â€” apex tier structural validation placeholder."
         },
         {
           "class": "B",
@@ -1174,7 +1182,7 @@
           "source": "https://arxiv.org/abs/2207.04672",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "NLLB (No Language Left Behind) \u00e2\u20ac\u201d Meta AI paper demonstrating 200-language translation at human-level quality on FLORES-200 benchmark."
+          "notes": "NLLB (No Language Left Behind) â€” Meta AI paper demonstrating 200-language translation at human-level quality on FLORES-200 benchmark."
         }
       ],
       "knownAgents": [],
@@ -1202,7 +1210,7 @@
           "source": "https://arxiv.org/abs/1810.04805",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "BERT paper \u00e2\u20ac\u201d achieves SOTA on SST-2 sentiment benchmark (93.5% accuracy), foundational evidence for LLM-based sentiment analysis."
+          "notes": "BERT paper â€” achieves SOTA on SST-2 sentiment benchmark (93.5% accuracy), foundational evidence for LLM-based sentiment analysis."
         }
       ],
       "knownAgents": [],
@@ -1229,7 +1237,7 @@
           "source": "https://arxiv.org/abs/2301.12597",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "BLIP-2 \u00e2\u20ac\u201d bootstrapped language-image pre-training achieving SOTA on COCO Captions (CIDEr 145.8) and NoCaps benchmarks."
+          "notes": "BLIP-2 â€” bootstrapped language-image pre-training achieving SOTA on COCO Captions (CIDEr 145.8) and NoCaps benchmarks."
         }
       ],
       "knownAgents": [],
@@ -1256,7 +1264,7 @@
           "source": "https://arxiv.org/abs/2212.04356",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Whisper (OpenAI) \u00e2\u20ac\u201d large-scale weak supervision across 680K hours of audio achieves near-human WER on LibriSpeech and multilingual benchmarks."
+          "notes": "Whisper (OpenAI) â€” large-scale weak supervision across 680K hours of audio achieves near-human WER on LibriSpeech and multilingual benchmarks."
         }
       ],
       "knownAgents": [],
@@ -1283,7 +1291,7 @@
           "source": "https://arxiv.org/abs/2301.02111",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "VALL-E (Microsoft) \u00e2\u20ac\u201d neural codec language model achieving SOTA speech synthesis with 3-second voice cloning on LibriSpeech."
+          "notes": "VALL-E (Microsoft) â€” neural codec language model achieving SOTA speech synthesis with 3-second voice cloning on LibriSpeech."
         }
       ],
       "knownAgents": [],
@@ -1311,7 +1319,7 @@
           "source": "https://arxiv.org/abs/1809.08887",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Spider benchmark \u00e2\u20ac\u201d cross-domain text-to-SQL dataset; LLM baselines reach >85% exact match, establishing reproducible evaluation methodology."
+          "notes": "Spider benchmark â€” cross-domain text-to-SQL dataset; LLM baselines reach >85% exact match, establishing reproducible evaluation methodology."
         }
       ],
       "knownAgents": [],
@@ -1340,7 +1348,7 @@
           "source": "https://arxiv.org/abs/1806.03822",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SQuAD 2.0 \u00e2\u20ac\u201d reading comprehension benchmark with 150K questions; modern LLMs exceed human F1 (90.9), providing rigorous reproducible evaluation."
+          "notes": "SQuAD 2.0 â€” reading comprehension benchmark with 150K questions; modern LLMs exceed human F1 (90.9), providing rigorous reproducible evaluation."
         }
       ],
       "knownAgents": [],
@@ -1365,7 +1373,7 @@
           "source": "https://arxiv.org/abs/2112.10752",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Latent Diffusion Models (Rombach et al.) \u00e2\u20ac\u201d foundational paper for Stable Diffusion; achieves FID 5.11 on LSUN-Beds at 200\u00c3\u2014 less compute than pixel-space diffusion."
+          "notes": "Latent Diffusion Models (Rombach et al.) â€” foundational paper for Stable Diffusion; achieves FID 5.11 on LSUN-Beds at 200Ã— less compute than pixel-space diffusion."
         }
       ],
       "knownAgents": [],
@@ -1393,7 +1401,7 @@
           "source": "https://arxiv.org/abs/2206.14858",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Minerva (Google) \u00e2\u20ac\u201d 50.3% on MATH and 78.5% on MMLU-STEM benchmarks using chain-of-thought over scientific literature."
+          "notes": "Minerva (Google) â€” 50.3% on MATH and 78.5% on MMLU-STEM benchmarks using chain-of-thought over scientific literature."
         }
       ],
       "knownAgents": [],
@@ -1421,7 +1429,7 @@
           "source": "https://arxiv.org/abs/2201.11903",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Chain-of-Thought prompting (Wei et al.) \u00e2\u20ac\u201d few-shot CoT elicits multi-step reasoning; +18% on GSM8K and +15% on SVAMP over standard prompting."
+          "notes": "Chain-of-Thought prompting (Wei et al.) â€” few-shot CoT elicits multi-step reasoning; +18% on GSM8K and +15% on SVAMP over standard prompting."
         }
       ],
       "knownAgents": [],
@@ -1449,7 +1457,7 @@
           "source": "https://arxiv.org/abs/2310.08560",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "MemGPT \u00e2\u20ac\u201d virtual context management system enabling LLMs to handle unbounded memory; benchmarked on multi-session dialogue and document QA."
+          "notes": "MemGPT â€” virtual context management system enabling LLMs to handle unbounded memory; benchmarked on multi-session dialogue and document QA."
         }
       ],
       "knownAgents": [],
@@ -1477,7 +1485,7 @@
           "source": "https://arxiv.org/abs/2305.15334",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Gorilla (Patil et al.) \u00e2\u20ac\u201d LLM that generates accurate API calls across TorchHub, TensorFlow Hub, and HuggingFace; 20.43% AST accuracy improvement over GPT-4."
+          "notes": "Gorilla (Patil et al.) â€” LLM that generates accurate API calls across TorchHub, TensorFlow Hub, and HuggingFace; 20.43% AST accuracy improvement over GPT-4."
         }
       ],
       "knownAgents": [],
@@ -1504,7 +1512,7 @@
           "source": "https://arxiv.org/abs/2310.06770",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SWE-bench \u00e2\u20ac\u201d 2294 real GitHub issues benchmark; agents that resolve issues must safely refactor code while passing existing test suites."
+          "notes": "SWE-bench â€” 2294 real GitHub issues benchmark; agents that resolve issues must safely refactor code while passing existing test suites."
         }
       ],
       "knownAgents": [],
@@ -1531,7 +1539,7 @@
           "source": "https://arxiv.org/abs/2107.03374",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Codex/HumanEval (Chen et al.) \u00e2\u20ac\u201d evaluates LLMs on writing Python functions that pass hand-crafted unit tests; pass@1 72.0% for GPT-4."
+          "notes": "Codex/HumanEval (Chen et al.) â€” evaluates LLMs on writing Python functions that pass hand-crafted unit tests; pass@1 72.0% for GPT-4."
         }
       ],
       "knownAgents": [],
@@ -1558,7 +1566,7 @@
           "source": "https://arxiv.org/abs/2308.13418",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Nougat (Meta AI) \u00e2\u20ac\u201d visual transformer for scientific PDF parsing; 7.6% edit distance on arXiv papers, handling LaTeX, tables, and equations."
+          "notes": "Nougat (Meta AI) â€” visual transformer for scientific PDF parsing; 7.6% edit distance on arXiv papers, handling LaTeX, tables, and equations."
         }
       ],
       "knownAgents": [],
@@ -1585,7 +1593,7 @@
           "source": "https://arxiv.org/abs/2007.02500",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Deep Learning for Anomaly Detection survey (Pang et al., ACM CSUR) \u00e2\u20ac\u201d comprehensive benchmark of 30+ methods across fraud, intrusion, and medical anomaly detection."
+          "notes": "Deep Learning for Anomaly Detection survey (Pang et al., ACM CSUR) â€” comprehensive benchmark of 30+ methods across fraud, intrusion, and medical anomaly detection."
         }
       ],
       "knownAgents": [],
@@ -1603,7 +1611,8 @@
       "description": "Generates charts, graphs, and visual summaries from datasets by selecting appropriate visualization types and mapping data dimensions.",
       "prerequisites": [],
       "derivatives": [
-        "data-analysis"
+        "data-analysis",
+        "architecture-diagram"
       ],
       "conditions": "",
       "evidence": [
@@ -1612,13 +1621,13 @@
           "source": "https://github.com/microsoft/lida",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "LIDA (Microsoft) \u00e2\u20ac\u201d open-source LLM-based data visualization tool with reproducible generation pipeline; evaluated on diverse real-world datasets."
+          "notes": "LIDA (Microsoft) â€” open-source LLM-based data visualization tool with reproducible generation pipeline; evaluated on diverse real-world datasets."
         }
       ],
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-28",
-      "updatedAt": "2026-04-28",
+      "updatedAt": "2026-05-06",
       "version": "0.2.0"
     },
     {
@@ -1641,7 +1650,7 @@
           "source": "https://github.com/langchain-ai/langchain/tree/master/libs/langchain/langchain/chains/conversation",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "LangChain ConversationChain \u00e2\u20ac\u201d reproducible open-source multi-turn conversational agent with buffer and summary memory backends."
+          "notes": "LangChain ConversationChain â€” reproducible open-source multi-turn conversational agent with buffer and summary memory backends."
         }
       ],
       "knownAgents": [],
@@ -1670,7 +1679,7 @@
           "source": "https://arxiv.org/abs/2304.11015",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "DIN-SQL \u00e2\u20ac\u201d decomposed in-context learning for text-to-SQL; 82.8% execution accuracy on Spider dev, demonstrating end-to-end pipeline."
+          "notes": "DIN-SQL â€” decomposed in-context learning for text-to-SQL; 82.8% execution accuracy on Spider dev, demonstrating end-to-end pipeline."
         }
       ],
       "knownAgents": [],
@@ -1702,7 +1711,7 @@
           "source": "https://arxiv.org/abs/2203.09095",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "CodeReviewer (Microsoft) \u00e2\u20ac\u201d pre-trained model for code review tasks; 28.7% BLEU improvement on comment generation and change quality prediction."
+          "notes": "CodeReviewer (Microsoft) â€” pre-trained model for code review tasks; 28.7% BLEU improvement on comment generation and change quality prediction."
         }
       ],
       "knownAgents": [],
@@ -1725,7 +1734,8 @@
       ],
       "derivatives": [
         "autonomous-data-scientist",
-        "ml-pipeline"
+        "ml-pipeline",
+        "prediction-market-analysis"
       ],
       "conditions": "",
       "evidence": [
@@ -1734,13 +1744,13 @@
           "source": "https://github.com/Sinaptik-AI/pandas-ai",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "pandas-ai \u00e2\u20ac\u201d open-source agent for natural-language data analysis over pandas DataFrames; reproducible demos with logging and output artifacts."
+          "notes": "pandas-ai â€” open-source agent for natural-language data analysis over pandas DataFrames; reproducible demos with logging and output artifacts."
         }
       ],
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-28",
-      "updatedAt": "2026-04-30",
+      "updatedAt": "2026-05-06",
       "version": "0.2.0"
     },
     {
@@ -1765,7 +1775,7 @@
           "source": "https://github.com/rasa/rasa",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Rasa Open Source \u00e2\u20ac\u201d production voice agent framework with ASR/TTS integrations; reproducible pipeline with test suite and documented benchmarks."
+          "notes": "Rasa Open Source â€” production voice agent framework with ASR/TTS integrations; reproducible pipeline with test suite and documented benchmarks."
         }
       ],
       "knownAgents": [],
@@ -1798,7 +1808,7 @@
           "source": "https://github.com/princeton-nlp/SWE-bench",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SWE-bench Verified \u00e2\u20ac\u201d open-source evaluation harness where agents fix GitHub issues by generating and passing test suites; full execution logs archived."
+          "notes": "SWE-bench Verified â€” open-source evaluation harness where agents fix GitHub issues by generating and passing test suites; full execution logs archived."
         }
       ],
       "knownAgents": [],
@@ -1827,7 +1837,7 @@
           "source": "https://platform.openai.com/docs/guides/moderation",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "OpenAI Moderation API \u00e2\u20ac\u201d publicly documented multi-category content classifier with reproducible API calls, category scores, and evaluation methodology."
+          "notes": "OpenAI Moderation API â€” publicly documented multi-category content classifier with reproducible API calls, category scores, and evaluation methodology."
         }
       ],
       "knownAgents": [],
@@ -1856,7 +1866,7 @@
           "source": "https://arxiv.org/abs/2304.08485",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "LLaVA \u00e2\u20ac\u201d large language and vision assistant; 85.1% on ScienceQA and 64.3% on TextVQA, establishing reproducible multimodal reasoning benchmark."
+          "notes": "LLaVA â€” large language and vision assistant; 85.1% on ScienceQA and 64.3% on TextVQA, establishing reproducible multimodal reasoning benchmark."
         }
       ],
       "knownAgents": [],
@@ -1885,7 +1895,7 @@
           "source": "https://arxiv.org/abs/2308.11596",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SeamlessM4T (Meta AI) \u00e2\u20ac\u201d unified speech and text translation model with tone and register control; BLEU +3.3 over NLLB on FLORES-200."
+          "notes": "SeamlessM4T (Meta AI) â€” unified speech and text translation model with tone and register control; BLEU +3.3 over NLLB on FLORES-200."
         }
       ],
       "knownAgents": [],
@@ -1914,7 +1924,7 @@
           "source": "https://github.com/VikParuchuri/marker",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Marker \u00e2\u20ac\u201d open-source PDF-to-markdown pipeline with reproducible benchmarks; outperforms Nougat on edit distance across 1000+ arXiv PDFs."
+          "notes": "Marker â€” open-source PDF-to-markdown pipeline with reproducible benchmarks; outperforms Nougat on edit distance across 1000+ arXiv PDFs."
         }
       ],
       "knownAgents": [],
@@ -1943,21 +1953,21 @@
           "source": "https://arxiv.org/abs/2310.06770",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SWE-bench \u00e2\u20ac\u201d 2294 real GitHub issues; Claude 3.5 Sonnet (Cognition) resolves 49% on Verified, demonstrating full-cycle autonomous development."
+          "notes": "SWE-bench â€” 2294 real GitHub issues; Claude 3.5 Sonnet (Cognition) resolves 49% on Verified, demonstrating full-cycle autonomous development."
         },
         {
           "class": "B",
           "source": "https://github.com/princeton-nlp/SWE-agent",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SWE-agent \u00e2\u20ac\u201d open-source agent with AgentComputer Interface; reproducible harness achieving 12.5% on SWE-bench full with logs and eval scripts."
+          "notes": "SWE-agent â€” open-source agent with AgentComputer Interface; reproducible harness achieving 12.5% on SWE-bench full with logs and eval scripts."
         },
         {
           "class": "A",
           "source": "https://arxiv.org/abs/2402.01030",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "CodeAct \u00e2\u20ac\u201d executable code action space for LLM agents; +20% task completion vs JSON/text-based actions across 17 programming benchmarks."
+          "notes": "CodeAct â€” executable code action space for LLM agents; +20% task completion vs JSON/text-based actions across 17 programming benchmarks."
         }
       ],
       "knownAgents": [],
@@ -1987,21 +1997,21 @@
           "source": "https://arxiv.org/abs/2210.12641",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "DS-1000 \u00e2\u20ac\u201d benchmark of 1000 data science problems across NumPy/Pandas/Scikit-learn; GPT-4 achieves 43.3% pass@1, establishing reproducible DS evaluation."
+          "notes": "DS-1000 â€” benchmark of 1000 data science problems across NumPy/Pandas/Scikit-learn; GPT-4 achieves 43.3% pass@1, establishing reproducible DS evaluation."
         },
         {
           "class": "A",
           "source": "https://arxiv.org/abs/2208.01756",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "AutoML Survey (He et al., ACM CSUR) \u00e2\u20ac\u201d systematic review of autonomous ML pipeline search; demonstrates automated feature engineering, model selection, and HPO."
+          "notes": "AutoML Survey (He et al., ACM CSUR) â€” systematic review of autonomous ML pipeline search; demonstrates automated feature engineering, model selection, and HPO."
         },
         {
           "class": "B",
           "source": "https://github.com/microsoft/autogen",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "AutoGen (Microsoft) \u00e2\u20ac\u201d multi-agent framework with reproducible data science notebooks; science agent achieves 44.3% on DS-1000 with full execution logs."
+          "notes": "AutoGen (Microsoft) â€” multi-agent framework with reproducible data science notebooks; science agent achieves 44.3% on DS-1000 with full execution logs."
         }
       ],
       "knownAgents": [],
@@ -2031,21 +2041,21 @@
           "source": "https://arxiv.org/abs/2312.11805",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "AudioPaLM (Google) \u00e2\u20ac\u201d unified audio language model supporting real-time spoken dialogue; SOTA on ASR and speech translation, demonstrating end-to-end voice assistant capability."
+          "notes": "AudioPaLM (Google) â€” unified audio language model supporting real-time spoken dialogue; SOTA on ASR and speech translation, demonstrating end-to-end voice assistant capability."
         },
         {
           "class": "A",
           "source": "https://arxiv.org/abs/2305.11206",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "VoiceBox (Meta AI) \u00e2\u20ac\u201d generative speech model with zero-shot TTS; enables real-time voice assistants with <100ms synthesis latency benchmarked on VCTK."
+          "notes": "VoiceBox (Meta AI) â€” generative speech model with zero-shot TTS; enables real-time voice assistants with <100ms synthesis latency benchmarked on VCTK."
         },
         {
           "class": "B",
           "source": "https://github.com/openai/whisper",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Whisper + LLM integration demos \u00e2\u20ac\u201d open-source real-time voice assistant pipelines combining Whisper STT, LLM reasoning, and TTS with documented latency benchmarks."
+          "notes": "Whisper + LLM integration demos â€” open-source real-time voice assistant pipelines combining Whisper STT, LLM reasoning, and TTS with documented latency benchmarks."
         }
       ],
       "knownAgents": [],
@@ -2077,7 +2087,7 @@
           "source": "https://github.com/mbtiongson1/gaia-skill-tree/pull/2",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Reproducible demonstration: Claude Code agent researched 30 popular AI skills, sourced 22 peer-reviewed papers, generated gaia.json via script, passed all 6 validator checks, and submitted PR \u00e2\u20ac\u201d full inputs/outputs archived in the PR diff."
+          "notes": "Reproducible demonstration: Claude Code agent researched 30 popular AI skills, sourced 22 peer-reviewed papers, generated gaia.json via script, passed all 6 validator checks, and submitted PR â€” full inputs/outputs archived in the PR diff."
         },
         {
           "class": "B",
@@ -2091,7 +2101,7 @@
           "source": "https://github.com/mbtiongson1/gaia-skill-tree",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Batch 3 curation: 5 skills added (2 atomic, 3 composite) \u00e2\u20ac\u201d self-consistency, few-shot-learning, tree-of-thought, prompt-optimization, tool-creation."
+          "notes": "Batch 3 curation: 5 skills added (2 atomic, 3 composite) â€” self-consistency, few-shot-learning, tree-of-thought, prompt-optimization, tool-creation."
         },
         {
           "class": "B",
@@ -2195,14 +2205,14 @@
           "source": "https://arxiv.org/abs/2302.04761",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Toolformer (Schick et al., 2023) \u00e2\u20ac\u201d self-supervised method teaching LLMs to call APIs; zero-shot tool use surpasses GPT-3 175B on several benchmarks."
+          "notes": "Toolformer (Schick et al., 2023) â€” self-supervised method teaching LLMs to call APIs; zero-shot tool use surpasses GPT-3 175B on several benchmarks."
         },
         {
           "class": "B",
           "source": "https://github.com/OpenBMB/ToolBench",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "ToolBench \u00e2\u20ac\u201d open benchmark with 16,000+ real-world APIs; end-to-end tool-use training and evaluation harness."
+          "notes": "ToolBench â€” open benchmark with 16,000+ real-world APIs; end-to-end tool-use training and evaluation harness."
         }
       ],
       "knownAgents": [],
@@ -2268,14 +2278,14 @@
           "source": "https://arxiv.org/abs/2201.11903",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Wei et al. (2022) \u00e2\u20ac\u201d Chain-of-Thought Prompting; +18% on GSM8K and +14% on MATH with PaLM 540B vs standard prompting."
+          "notes": "Wei et al. (2022) â€” Chain-of-Thought Prompting; +18% on GSM8K and +14% on MATH with PaLM 540B vs standard prompting."
         },
         {
           "class": "B",
           "source": "https://github.com/princeton-nlp/chain-of-thought-hub",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Chain-of-Thought Hub \u00e2\u20ac\u201d reproducible evaluation suite covering 10+ reasoning benchmarks with CoT prompts and baselines."
+          "notes": "Chain-of-Thought Hub â€” reproducible evaluation suite covering 10+ reasoning benchmarks with CoT prompts and baselines."
         }
       ],
       "knownAgents": [],
@@ -2303,14 +2313,14 @@
           "source": "https://arxiv.org/abs/2303.17651",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Self-Refine (Madaan et al., 2023) \u00e2\u20ac\u201d iterative self-feedback loop; +20% on code generation and +13% on math reasoning vs single-pass generation."
+          "notes": "Self-Refine (Madaan et al., 2023) â€” iterative self-feedback loop; +20% on code generation and +13% on math reasoning vs single-pass generation."
         },
         {
           "class": "B",
           "source": "https://github.com/madaan/self-refine",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Self-Refine repo \u00e2\u20ac\u201d reproducible demos across 7 tasks (code, math, dialogue, sentiment reversal) with evaluation scripts."
+          "notes": "Self-Refine repo â€” reproducible demos across 7 tasks (code, math, dialogue, sentiment reversal) with evaluation scripts."
         }
       ],
       "knownAgents": [],
@@ -2340,14 +2350,14 @@
           "source": "https://arxiv.org/abs/2307.09702",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Willard & Louf (2023) \u00e2\u20ac\u201d Efficient Guided Generation for LLMs; finite-state machine approach guarantees schema-valid output with <1% throughput overhead."
+          "notes": "Willard & Louf (2023) â€” Efficient Guided Generation for LLMs; finite-state machine approach guarantees schema-valid output with <1% throughput overhead."
         },
         {
           "class": "B",
           "source": "https://github.com/outlines-dev/outlines",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Outlines library \u00e2\u20ac\u201d production-grade constrained decoding supporting JSON Schema, regex, and CFG grammars; 2k+ GitHub stars."
+          "notes": "Outlines library â€” production-grade constrained decoding supporting JSON Schema, regex, and CFG grammars; 2k+ GitHub stars."
         }
       ],
       "knownAgents": [],
@@ -2376,14 +2386,14 @@
           "source": "https://arxiv.org/abs/2211.10435",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "PAL (Gao et al., 2023) \u00e2\u20ac\u201d Program-Aided Language Models; delegates computation to Python interpreter, achieving +7% on GSM8K over direct CoT."
+          "notes": "PAL (Gao et al., 2023) â€” Program-Aided Language Models; delegates computation to Python interpreter, achieving +7% on GSM8K over direct CoT."
         },
         {
           "class": "B",
           "source": "https://github.com/reasoning-machines/pal",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "PAL repo \u00e2\u20ac\u201d reproducible harness across 13 reasoning benchmarks; evaluation scripts and baseline comparisons included."
+          "notes": "PAL repo â€” reproducible harness across 13 reasoning benchmarks; evaluation scripts and baseline comparisons included."
         }
       ],
       "knownAgents": [],
@@ -2410,14 +2420,14 @@
           "source": "https://arxiv.org/abs/2307.13854",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "WebArena (Zhou et al., 2023) \u00e2\u20ac\u201d realistic 812-task benchmark for autonomous web agents; establishes controlled eval for GUI-based computer use."
+          "notes": "WebArena (Zhou et al., 2023) â€” realistic 812-task benchmark for autonomous web agents; establishes controlled eval for GUI-based computer use."
         },
         {
           "class": "B",
           "source": "https://github.com/xlang-ai/OSWorld",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "OSWorld \u00e2\u20ac\u201d 369 computer tasks across real OS environments (Windows, macOS, Ubuntu); reproducible VM-based evaluation harness."
+          "notes": "OSWorld â€” 369 computer tasks across real OS environments (Windows, macOS, Ubuntu); reproducible VM-based evaluation harness."
         }
       ],
       "knownAgents": [],
@@ -2444,21 +2454,21 @@
           "source": "https://arxiv.org/abs/2304.05376",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "ChemCrow (Bran et al., 2023) \u00e2\u20ac\u201d LLM augmented with 18 chemistry tools autonomously proposes and validates synthesis routes; GPT-4 outperforms on Chem. benchmark."
+          "notes": "ChemCrow (Bran et al., 2023) â€” LLM augmented with 18 chemistry tools autonomously proposes and validates synthesis routes; GPT-4 outperforms on Chem. benchmark."
         },
         {
           "class": "A",
           "source": "https://arxiv.org/abs/2304.05332",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Coscientist (Boiko et al., 2023) \u00e2\u20ac\u201d autonomous LLM system designs and executes chemistry experiments; independently re-derived Suzuki coupling conditions."
+          "notes": "Coscientist (Boiko et al., 2023) â€” autonomous LLM system designs and executes chemistry experiments; independently re-derived Suzuki coupling conditions."
         },
         {
           "class": "B",
           "source": "https://github.com/SakanaAI/AI-Scientist",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "The AI Scientist (Sakana AI) \u00e2\u20ac\u201d end-to-end pipeline generating ideas, running experiments, and writing ML papers; 50+ auto-generated manuscripts reviewed."
+          "notes": "The AI Scientist (Sakana AI) â€” end-to-end pipeline generating ideas, running experiments, and writing ML papers; 50+ auto-generated manuscripts reviewed."
         }
       ],
       "knownAgents": [],
@@ -2489,14 +2499,14 @@
           "source": "https://arxiv.org/abs/2210.03629",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "ReAct (Yao et al., 2023) \u00e2\u20ac\u201d reasoning+acting paradigm; +34% on HotpotQA and +10% on ALFWorld vs chain-of-thought-only baselines."
+          "notes": "ReAct (Yao et al., 2023) â€” reasoning+acting paradigm; +34% on HotpotQA and +10% on ALFWorld vs chain-of-thought-only baselines."
         },
         {
           "class": "B",
           "source": "https://github.com/ysymyth/ReAct",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "ReAct repo \u00e2\u20ac\u201d reproducible prompts and evaluation harness for HotpotQA, FEVER, ALFWorld, and WebShop benchmarks."
+          "notes": "ReAct repo â€” reproducible prompts and evaluation harness for HotpotQA, FEVER, ALFWorld, and WebShop benchmarks."
         }
       ],
       "knownAgents": [],
@@ -2527,14 +2537,14 @@
           "source": "https://arxiv.org/abs/2401.13919",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "WebVoyager (He et al., 2024) \u00e2\u20ac\u201d end-to-end web agent with GPT-4V; 59.1% task success on real-world web tasks across 15 popular websites."
+          "notes": "WebVoyager (He et al., 2024) â€” end-to-end web agent with GPT-4V; 59.1% task success on real-world web tasks across 15 popular websites."
         },
         {
           "class": "B",
           "source": "https://github.com/web-arena-x/webarena",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "WebArena \u00e2\u20ac\u201d self-hosted web environment with 812 realistic tasks; reproducible benchmark with ground-truth evaluation scripts."
+          "notes": "WebArena â€” self-hosted web environment with 812 realistic tasks; reproducible benchmark with ground-truth evaluation scripts."
         }
       ],
       "knownAgents": [],
@@ -2565,14 +2575,14 @@
           "source": "https://arxiv.org/abs/2306.08302",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Pan et al. (2024) \u00e2\u20ac\u201d Unifying Large Language Models and Knowledge Graphs: A Roadmap; comprehensive survey showing LLM-KG synergy improves downstream tasks by 5-15%."
+          "notes": "Pan et al. (2024) â€” Unifying Large Language Models and Knowledge Graphs: A Roadmap; comprehensive survey showing LLM-KG synergy improves downstream tasks by 5-15%."
         },
         {
           "class": "B",
           "source": "https://github.com/microsoft/graphrag",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Microsoft GraphRAG \u00e2\u20ac\u201d production KG construction pipeline; extracts community summaries and entity graphs from corpora, enabling global sensemaking queries."
+          "notes": "Microsoft GraphRAG â€” production KG construction pipeline; extracts community summaries and entity graphs from corpora, enabling global sensemaking queries."
         }
       ],
       "knownAgents": [],
@@ -2587,7 +2597,7 @@
       "type": "ultimate",
       "level": "V",
       "rarity": "legendary",
-      "description": "Autonomously generates novel scientific hypotheses, designs and executes experiments, analyses results, and produces a written report \u00e2\u20ac\u201d completing a full research cycle without human intervention.",
+      "description": "Autonomously generates novel scientific hypotheses, designs and executes experiments, analyses results, and produces a written report â€” completing a full research cycle without human intervention.",
       "prerequisites": [
         "hypothesis-generate",
         "research",
@@ -2601,21 +2611,21 @@
           "source": "https://arxiv.org/abs/2304.05376",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "ChemCrow (Bran et al., 2023) \u00e2\u20ac\u201d autonomous chemistry agent completes synthesis planning and molecular design tasks rated expert-level by human chemists."
+          "notes": "ChemCrow (Bran et al., 2023) â€” autonomous chemistry agent completes synthesis planning and molecular design tasks rated expert-level by human chemists."
         },
         {
           "class": "A",
           "source": "https://arxiv.org/abs/2304.05332",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Coscientist (Boiko et al., 2023) \u00e2\u20ac\u201d autonomously planned and executed real wet-lab chemistry experiments, confirmed by GC-MS analysis."
+          "notes": "Coscientist (Boiko et al., 2023) â€” autonomously planned and executed real wet-lab chemistry experiments, confirmed by GC-MS analysis."
         },
         {
           "class": "B",
           "source": "https://github.com/SakanaAI/AI-Scientist",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "AI Scientist (Lu et al., 2024) \u00e2\u20ac\u201d generates idea, writes code, runs experiments, and produces a full NeurIPS-style paper; 50+ manuscripts auto-generated."
+          "notes": "AI Scientist (Lu et al., 2024) â€” generates idea, writes code, runs experiments, and produces a full NeurIPS-style paper; 50+ manuscripts auto-generated."
         }
       ],
       "knownAgents": [],
@@ -2644,7 +2654,7 @@
           "source": "https://arxiv.org/abs/2203.11171",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Wang et al. (2022) \u00e2\u20ac\u201d Self-Consistency Improves Chain of Thought Reasoning in Language Models; +17.9% on GSM8K and +11.0% on MATH over greedy CoT decoding."
+          "notes": "Wang et al. (2022) â€” Self-Consistency Improves Chain of Thought Reasoning in Language Models; +17.9% on GSM8K and +11.0% on MATH over greedy CoT decoding."
         }
       ],
       "knownAgents": [],
@@ -2672,7 +2682,7 @@
           "source": "https://arxiv.org/abs/2005.14165",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Brown et al. (2020) \u00e2\u20ac\u201d Language Models are Few-Shot Learners (GPT-3); in-context learning from 1-100 examples achieves near-SOTA on SuperGLUE, translation, and QA benchmarks."
+          "notes": "Brown et al. (2020) â€” Language Models are Few-Shot Learners (GPT-3); in-context learning from 1-100 examples achieves near-SOTA on SuperGLUE, translation, and QA benchmarks."
         }
       ],
       "knownAgents": [],
@@ -2702,14 +2712,14 @@
           "source": "https://arxiv.org/abs/2305.10601",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Yao et al. (2023) \u00e2\u20ac\u201d Tree of Thoughts: Deliberate Problem Solving with LLMs; +74% on Game of 24 and +4% on Creative Writing vs chain-of-thought baseline."
+          "notes": "Yao et al. (2023) â€” Tree of Thoughts: Deliberate Problem Solving with LLMs; +74% on Game of 24 and +4% on Creative Writing vs chain-of-thought baseline."
         },
         {
           "class": "B",
           "source": "https://github.com/princeton-nlp/tree-of-thought-llm",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Princeton-NLP ToT repo \u00e2\u20ac\u201d reproducible breadth-first and depth-first tree search implementations with evaluation scripts for Game of 24 and Mini Crosswords."
+          "notes": "Princeton-NLP ToT repo â€” reproducible breadth-first and depth-first tree search implementations with evaluation scripts for Game of 24 and Mini Crosswords."
         }
       ],
       "knownAgents": [],
@@ -2739,14 +2749,14 @@
           "source": "https://arxiv.org/abs/2310.03714",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Khattab et al. (2023) \u00e2\u20ac\u201d DSPy: Compiling Declarative Language Model Calls into Self-Improving Pipelines; automated prompt tuning matches or exceeds hand-crafted prompts on GSM8K, HotPotQA, and FEVER."
+          "notes": "Khattab et al. (2023) â€” DSPy: Compiling Declarative Language Model Calls into Self-Improving Pipelines; automated prompt tuning matches or exceeds hand-crafted prompts on GSM8K, HotPotQA, and FEVER."
         },
         {
           "class": "B",
           "source": "https://github.com/stanfordnlp/dspy",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "DSPy \u00e2\u20ac\u201d Stanford NLP library for programmable LM pipelines; 18k+ GitHub stars, supports multiple optimizers (BootstrapFewShot, MIPRO, COPRO) across any LM."
+          "notes": "DSPy â€” Stanford NLP library for programmable LM pipelines; 18k+ GitHub stars, supports multiple optimizers (BootstrapFewShot, MIPRO, COPRO) across any LM."
         }
       ],
       "knownAgents": [],
@@ -2777,14 +2787,14 @@
           "source": "https://arxiv.org/abs/2305.17126",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Cai et al. (2023) \u00e2\u20ac\u201d Large Language Models as Tool Makers (LATM); LLM-generated tools reused across problem instances achieve +8.7% on BigBench Hard vs per-instance CoT."
+          "notes": "Cai et al. (2023) â€” Large Language Models as Tool Makers (LATM); LLM-generated tools reused across problem instances achieve +8.7% on BigBench Hard vs per-instance CoT."
         },
         {
           "class": "B",
           "source": "https://github.com/ctlllll/LLM-ToolMaker",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "LATM repo \u00e2\u20ac\u201d reproducible tool-maker/tool-user pipeline with evaluation on BigBench Hard tasks and tool reuse across problem batches."
+          "notes": "LATM repo â€” reproducible tool-maker/tool-user pipeline with evaluation on BigBench Hard tasks and tool reuse across problem batches."
         }
       ],
       "knownAgents": [],
@@ -3264,7 +3274,9 @@
       "rarity": "common",
       "description": "Reads, edits, repacks, and applies styling or design principles to structured binary document formats such as PPTX, DOCX, and XLSX.",
       "prerequisites": [],
-      "derivatives": [],
+      "derivatives": [
+        "humanize-prose"
+      ],
       "conditions": "",
       "evidence": [
         {
@@ -3278,7 +3290,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-30",
-      "updatedAt": "2026-04-30",
+      "updatedAt": "2026-05-06",
       "version": "0.1.0"
     },
     {
@@ -3347,14 +3359,14 @@
           "source": "https://arxiv.org/abs/2403.12968",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "LLMLingua-2 (ACL 2024 Findings) \u2014 data-distillation for efficient task-agnostic prompt compression; 3x-6x speed-up, BERT-base token classifier; demonstrates measurable perplexity-based faithfulness."
+          "notes": "LLMLingua-2 (ACL 2024 Findings) — data-distillation for efficient task-agnostic prompt compression; 3x-6x speed-up, BERT-base token classifier; demonstrates measurable perplexity-based faithfulness."
         },
         {
           "class": "B",
           "source": "https://github.com/microsoft/LLMLingua",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "Microsoft LLMLingua \u2014 reproducible open-source implementation of LLMLingua-1/2/LongLLMLingua; CI, README, Apache-2.0 license."
+          "notes": "Microsoft LLMLingua — reproducible open-source implementation of LLMLingua-1/2/LongLLMLingua; CI, README, Apache-2.0 license."
         },
         {
           "class": "C",
@@ -3386,21 +3398,21 @@
           "source": "https://arxiv.org/abs/2604.10134",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "PlanGuard (2026) \u2014 training-free indirect prompt injection defense; planning-based consistency verification reduces InjecAgent attack success rate from 72.8% to 0%."
+          "notes": "PlanGuard (2026) — training-free indirect prompt injection defense; planning-based consistency verification reduces InjecAgent attack success rate from 72.8% to 0%."
         },
         {
           "class": "B",
           "source": "https://github.com/tldrsec/prompt-injection-defenses",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "tldrsec/prompt-injection-defenses (682 stars) \u2014 curated, reproducible catalog of defense techniques with implementation references; actively maintained."
+          "notes": "tldrsec/prompt-injection-defenses (682 stars) — curated, reproducible catalog of defense techniques with implementation references; actively maintained."
         },
         {
           "class": "C",
           "source": "https://skillsmp.com/api/v1/skills/search?q=prompt-injection-defense",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "SkillsMP top hit: openclaw/prompt-injection-defense (4,419 stars) \u2014 'Harden agent sessions against prompt injection from untrusted content'; references CaMeL benchmark."
+          "notes": "SkillsMP top hit: openclaw/prompt-injection-defense (4,419 stars) — 'Harden agent sessions against prompt injection from untrusted content'; references CaMeL benchmark."
         }
       ],
       "knownAgents": [],
@@ -3425,7 +3437,7 @@
           "source": "https://arxiv.org/abs/2604.17488",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "AutoVQA-G (ICASSP 2026) \u2014 self-improving agentic framework for automated VQA and grounding annotation; uses Chain-of-Thought verification + prompt optimization to generate high-quality VQA-G datasets."
+          "notes": "AutoVQA-G (ICASSP 2026) — self-improving agentic framework for automated VQA and grounding annotation; uses Chain-of-Thought verification + prompt optimization to generate high-quality VQA-G datasets."
         },
         {
           "class": "C",
@@ -3460,7 +3472,7 @@
           "source": "https://arxiv.org/abs/2604.07223",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "TraceSafe (2026) \u2014 first benchmark with 1,000+ instances explicitly evaluating sequential multi-step tool-calling trajectories across 12 risk categories; establishes tool-chaining as a distinct, measurable capability surface."
+          "notes": "TraceSafe (2026) — first benchmark with 1,000+ instances explicitly evaluating sequential multi-step tool-calling trajectories across 12 risk categories; establishes tool-chaining as a distinct, measurable capability surface."
         },
         {
           "class": "C",
@@ -3584,7 +3596,7 @@
       "type": "extra",
       "level": "III",
       "rarity": "rare",
-      "description": "Stress-tests a plan or design through relentless targeted questioning, walking the decision tree branch-by-branch, resolving concept dependencies, surfacing contradictions against the existing codebase, and crystallising ubiquitous language \u2014 optionally persisting resolved decisions to CONTEXT.md and ADRs.",
+      "description": "Stress-tests a plan or design through relentless targeted questioning, walking the decision tree branch-by-branch, resolving concept dependencies, surfacing contradictions against the existing codebase, and crystallising ubiquitous language — optionally persisting resolved decisions to CONTEXT.md and ADRs.",
       "prerequisites": [
         "evaluate-output",
         "plan-decompose"
@@ -3621,7 +3633,9 @@
       "rarity": "uncommon",
       "description": "Performs hypothesis testing, regression analysis, and Bayesian modelling with effect size calculation and APA-formatted statistical reporting using scipy, statsmodels, and PyMC.",
       "prerequisites": [],
-      "derivatives": [],
+      "derivatives": [
+        "prediction-market-analysis"
+      ],
       "conditions": "",
       "evidence": [
         {
@@ -3629,20 +3643,20 @@
           "source": "https://arxiv.org/abs/2511.06701",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "Sargsyan (2025) \u2014 Structural Enforcement of Statistical Rigor in AI-Driven Discovery; monadic architecture achieves 1.1% false discovery rate vs 41% for naive LLM approaches across automated hypothesis-testing pipelines."
+          "notes": "Sargsyan (2025) — Structural Enforcement of Statistical Rigor in AI-Driven Discovery; monadic architecture achieves 1.1% false discovery rate vs 41% for naive LLM approaches across automated hypothesis-testing pipelines."
         },
         {
           "class": "B",
           "source": "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/scientific-skills/statistical-analysis/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "K-Dense-AI scientific-agent-skills \u2014 reproducible statistical-analysis skill covering parametric, non-parametric, and Bayesian workflows with scipy/statsmodels/pingouin/PyMC and APA-formatted output."
+          "notes": "K-Dense-AI scientific-agent-skills — reproducible statistical-analysis skill covering parametric, non-parametric, and Bayesian workflows with scipy/statsmodels/pingouin/PyMC and APA-formatted output."
         }
       ],
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-30",
-      "updatedAt": "2026-04-30",
+      "updatedAt": "2026-05-06",
       "version": "0.1.0"
     },
     {
@@ -3663,7 +3677,7 @@
           "source": "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/scientific-skills/scientific-visualization/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "K-Dense-AI scientific-agent-skills \u2014 reproducible scientific-visualization skill orchestrating matplotlib, seaborn, and plotly for journal-quality multi-panel figures with PDF/EPS/TIFF/PNG export and accessibility annotations."
+          "notes": "K-Dense-AI scientific-agent-skills — reproducible scientific-visualization skill orchestrating matplotlib, seaborn, and plotly for journal-quality multi-panel figures with PDF/EPS/TIFF/PNG export and accessibility annotations."
         }
       ],
       "knownAgents": [],
@@ -3692,14 +3706,14 @@
           "source": "https://arxiv.org/abs/2501.05468",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "Rouzrokh et al. (2025) \u2014 LatteReview: multi-agent framework for systematic review automation; modular agents for title/abstract screening, relevance scoring, and structured data extraction with RAG and multimodal support."
+          "notes": "Rouzrokh et al. (2025) — LatteReview: multi-agent framework for systematic review automation; modular agents for title/abstract screening, relevance scoring, and structured data extraction with RAG and multimodal support."
         },
         {
           "class": "B",
           "source": "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/scientific-skills/literature-review/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "K-Dense-AI scientific-agent-skills \u2014 reproducible literature-review skill: seven-phase workflow from research-question planning through multi-database search, screening, extraction, synthesis, citation verification to final PDF output."
+          "notes": "K-Dense-AI scientific-agent-skills — reproducible literature-review skill: seven-phase workflow from research-question planning through multi-database search, screening, extraction, synthesis, citation verification to final PDF output."
         }
       ],
       "knownAgents": [],
@@ -3728,14 +3742,14 @@
           "source": "https://arxiv.org/abs/2405.20477",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "Chamoun et al. (ACL 2024 Findings) \u2014 SWIFT: automated focused feedback for scientific writing; multi-component LLM system (planner, investigator, reviewer, controller) rated more specific and helpful than human reviewers on 300 peer-reviewed manuscripts."
+          "notes": "Chamoun et al. (ACL 2024 Findings) — SWIFT: automated focused feedback for scientific writing; multi-component LLM system (planner, investigator, reviewer, controller) rated more specific and helpful than human reviewers on 300 peer-reviewed manuscripts."
         },
         {
           "class": "B",
           "source": "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/scientific-skills/scientific-writing/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "K-Dense-AI scientific-agent-skills \u2014 reproducible scientific-writing skill: two-stage outline-to-prose pipeline with IMRAD structure, multi-style citation management, and reporting-guideline validation (CONSORT, STROBE, PRISMA, STARD, TRIPOD)."
+          "notes": "K-Dense-AI scientific-agent-skills — reproducible scientific-writing skill: two-stage outline-to-prose pipeline with IMRAD structure, multi-style citation management, and reporting-guideline validation (CONSORT, STROBE, PRISMA, STARD, TRIPOD)."
         }
       ],
       "knownAgents": [],
@@ -3764,14 +3778,14 @@
           "source": "https://arxiv.org/abs/2502.18530",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "Xue et al. (2025) \u2014 IMPROVE: Iterative Model Pipeline Refinement and Optimization Leveraging LLM Experts; iterative component-level refinement consistently outperforms single-step zero-shot LLM-based ML pipeline optimization with theoretical convergence guarantees."
+          "notes": "Xue et al. (2025) — IMPROVE: Iterative Model Pipeline Refinement and Optimization Leveraging LLM Experts; iterative component-level refinement consistently outperforms single-step zero-shot LLM-based ML pipeline optimization with theoretical convergence guarantees."
         },
         {
           "class": "B",
           "source": "https://github.com/Jeffallan/claude-skills/blob/main/skills/ml-pipeline/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "Jeffallan/claude-skills \u2014 reproducible ml-pipeline skill: full lifecycle from data validation and feature engineering through distributed training, experiment tracking, model evaluation gates, A/B testing, and automated retraining with DVC/Feast/MLflow/Kubeflow."
+          "notes": "Jeffallan/claude-skills — reproducible ml-pipeline skill: full lifecycle from data validation and feature engineering through distributed training, experiment tracking, model evaluation gates, A/B testing, and automated retraining with DVC/Feast/MLflow/Kubeflow."
         }
       ],
       "knownAgents": [],
@@ -3786,7 +3800,7 @@
       "type": "basic",
       "level": "III",
       "rarity": "uncommon",
-      "description": "Connect to and invoke tools exposed by Model Context Protocol (MCP) servers \u2014 enumerate available tools, execute calls, and handle responses across any MCP-compatible backend.",
+      "description": "Connect to and invoke tools exposed by Model Context Protocol (MCP) servers — enumerate available tools, execute calls, and handle responses across any MCP-compatible backend.",
       "prerequisites": [],
       "derivatives": [],
       "conditions": "",
@@ -3810,7 +3824,7 @@
           "source": "https://github.com/intelligentcode-ai/skills/blob/main/skills/mcp-client/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "intelligentcode-ai/skills mcp-client \u2014 portable CLI MCP client with server enumeration, tool display, and on-demand execution."
+          "notes": "intelligentcode-ai/skills mcp-client — portable CLI MCP client with server enumeration, tool display, and on-demand execution."
         }
       ],
       "knownAgents": [],
@@ -3835,7 +3849,7 @@
           "source": "https://github.com/intelligentcode-ai/skills/blob/main/skills/parallel-execution/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "intelligentcode-ai/skills parallel-execution \u2014 concurrent work item execution with independence verification and configurable concurrency (default 5)."
+          "notes": "intelligentcode-ai/skills parallel-execution — concurrent work item execution with independence verification and configurable concurrency (default 5)."
         }
       ],
       "knownAgents": [],
@@ -3850,7 +3864,7 @@
       "type": "basic",
       "level": "II",
       "rarity": "common",
-      "description": "Elicit and structure requirements from stakeholder inputs into formal specifications \u2014 user stories, acceptance criteria, and traceability matrices.",
+      "description": "Elicit and structure requirements from stakeholder inputs into formal specifications — user stories, acceptance criteria, and traceability matrices.",
       "prerequisites": [],
       "derivatives": [],
       "conditions": "",
@@ -3860,7 +3874,7 @@
           "source": "https://github.com/intelligentcode-ai/skills/blob/main/skills/requirements-engineer/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "intelligentcode-ai/skills requirements-engineer \u2014 business analysis specialist bridging stakeholders and technical teams for full requirements lifecycle."
+          "notes": "intelligentcode-ai/skills requirements-engineer — business analysis specialist bridging stakeholders and technical teams for full requirements lifecycle."
         }
       ],
       "knownAgents": [],
@@ -3875,7 +3889,7 @@
       "type": "basic",
       "level": "II",
       "rarity": "common",
-      "description": "Design database schemas across relational, NoSQL, graph, and time-series stores \u2014 entity modelling, normalization, indexing strategies, and migration planning.",
+      "description": "Design database schemas across relational, NoSQL, graph, and time-series stores — entity modelling, normalization, indexing strategies, and migration planning.",
       "prerequisites": [],
       "derivatives": [],
       "conditions": "",
@@ -3885,7 +3899,7 @@
           "source": "https://github.com/intelligentcode-ai/skills/blob/main/skills/database-engineer/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "intelligentcode-ai/skills database-engineer \u2014 schema design and query optimization expert across relational, NoSQL, graph, time-series, and data warehouses."
+          "notes": "intelligentcode-ai/skills database-engineer — schema design and query optimization expert across relational, NoSQL, graph, time-series, and data warehouses."
         }
       ],
       "knownAgents": [],
@@ -3913,14 +3927,14 @@
           "source": "https://github.com/zachblume/autospec",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "autospec \u2014 AI agent that takes a web app URL and autonomously QAs it, saving passing specs as E2E test code (59 stars, active)."
+          "notes": "autospec — AI agent that takes a web app URL and autonomously QAs it, saving passing specs as E2E test code (59 stars, active)."
         },
         {
           "class": "C",
           "source": "https://github.com/intelligentcode-ai/skills/blob/main/skills/user-tester/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "intelligentcode-ai/skills user-tester \u2014 E2E testing specialist with Puppeteer/Playwright automation and cross-browser user journey validation."
+          "notes": "intelligentcode-ai/skills user-tester — E2E testing specialist with Puppeteer/Playwright automation and cross-browser user journey validation."
         }
       ],
       "knownAgents": [],
@@ -3948,14 +3962,14 @@
           "source": "https://github.com/intelligentcode-ai/skills/blob/main/skills/security-engineer/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "intelligentcode-ai/skills security-engineer \u2014 vulnerability assessment and security architecture with zero-trust principles and compliance management."
+          "notes": "intelligentcode-ai/skills security-engineer — vulnerability assessment and security architecture with zero-trust principles and compliance management."
         },
         {
           "class": "C",
           "source": "https://github.com/microsoft/PromptKit",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "microsoft/PromptKit (42 stars) \u2014 composable prompt components for security audits, code review, and bug investigation with any LLM."
+          "notes": "microsoft/PromptKit (42 stars) — composable prompt components for security audits, code review, and bug investigation with any LLM."
         }
       ],
       "knownAgents": [],
@@ -3984,7 +3998,7 @@
           "source": "https://github.com/intelligentcode-ai/skills/blob/main/skills/release/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "intelligentcode-ai/skills release \u2014 automates semantic versioning, CHANGELOG updates, PR merging, git tagging, and GitHub release creation with verification gates."
+          "notes": "intelligentcode-ai/skills release — automates semantic versioning, CHANGELOG updates, PR merging, git tagging, and GitHub release creation with verification gates."
         }
       ],
       "knownAgents": [],
@@ -3999,7 +4013,7 @@
       "type": "extra",
       "level": "II",
       "rarity": "uncommon",
-      "description": "Automate CI/CD pipeline execution and deployment to target environments \u2014 build, test, artifact publishing, environment promotion, and rollback strategies.",
+      "description": "Automate CI/CD pipeline execution and deployment to target environments — build, test, artifact publishing, environment promotion, and rollback strategies.",
       "prerequisites": [
         "workflow-automation",
         "execute-bash"
@@ -4012,7 +4026,7 @@
           "source": "https://github.com/intelligentcode-ai/skills/blob/main/skills/devops-engineer/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "intelligentcode-ai/skills devops-engineer \u2014 CI/CD pipeline design and deployment automation with build systems and release management."
+          "notes": "intelligentcode-ai/skills devops-engineer — CI/CD pipeline design and deployment automation with build systems and release management."
         }
       ],
       "knownAgents": [],
@@ -4020,6 +4034,157 @@
       "createdAt": "2026-04-30",
       "updatedAt": "2026-04-30",
       "version": "0.2.0"
+    },
+    {
+      "id": "feed-monitoring",
+      "name": "Feed Monitoring",
+      "type": "basic",
+      "level": "IV",
+      "rarity": "common",
+      "description": "Monitors RSS, Atom, blog, or other recurring content feeds, discovers updates, tracks read state, and surfaces new signals for downstream agent workflows.",
+      "prerequisites": [],
+      "derivatives": [],
+      "conditions": "Requires configured feed sources and a repeatable polling or discovery mechanism.",
+      "evidence": [
+        {
+          "class": "B",
+          "source": "https://github.com/NousResearch/hermes-agent/blob/main/skills/research/blogwatcher/SKILL.md",
+          "evaluator": "openai-codex",
+          "date": "2026-05-06",
+          "notes": "Hermes Agent blogwatcher skill monitors blogs and RSS/Atom feeds with feed discovery, scraping fallback, OPML import, and read/unread article management."
+        }
+      ],
+      "knownAgents": [
+        "NousResearch/hermes-agent"
+      ],
+      "status": "provisional",
+      "createdAt": "2026-05-06",
+      "updatedAt": "2026-05-06",
+      "version": "0.1.0"
+    },
+    {
+      "id": "wiki-search",
+      "name": "Wiki Search",
+      "type": "extra",
+      "level": "IV",
+      "rarity": "uncommon",
+      "description": "Builds, maintains, and queries an interlinked markdown or wiki-style knowledge base so an agent can retrieve durable local context across research sessions.",
+      "prerequisites": [
+        "retrieve",
+        "embed-text",
+        "summarize"
+      ],
+      "derivatives": [],
+      "conditions": "Requires an accessible local wiki or markdown knowledge-base directory and a consistent linking or indexing convention.",
+      "evidence": [
+        {
+          "class": "B",
+          "source": "https://github.com/NousResearch/hermes-agent/blob/main/skills/research/llm-wiki/SKILL.md",
+          "evaluator": "openai-codex",
+          "date": "2026-05-06",
+          "notes": "Hermes Agent llm-wiki skill documents a persistent interlinked markdown knowledge base pattern for compounding research notes and retrieval."
+        }
+      ],
+      "knownAgents": [
+        "NousResearch/hermes-agent"
+      ],
+      "status": "provisional",
+      "createdAt": "2026-05-06",
+      "updatedAt": "2026-05-06",
+      "version": "0.1.0"
+    },
+    {
+      "id": "prediction-market-analysis",
+      "name": "Prediction Market Analysis",
+      "type": "extra",
+      "level": "IV",
+      "rarity": "rare",
+      "description": "Queries prediction-market data, compares market probabilities and price history, and summarizes probabilistic signals for forecasting or decision-support workflows.",
+      "prerequisites": [
+        "data-analysis",
+        "web-search",
+        "statistical-analysis"
+      ],
+      "derivatives": [],
+      "conditions": "Requires read-only market data sources and clear separation between analysis output and financial advice or trade execution.",
+      "evidence": [
+        {
+          "class": "B",
+          "source": "https://github.com/NousResearch/hermes-agent/blob/main/skills/research/polymarket/SKILL.md",
+          "evaluator": "openai-codex",
+          "date": "2026-05-06",
+          "notes": "Hermes Agent polymarket skill queries markets, prices, order books, and historical prediction-market data through public read-only APIs."
+        }
+      ],
+      "knownAgents": [
+        "NousResearch/hermes-agent"
+      ],
+      "status": "provisional",
+      "createdAt": "2026-05-06",
+      "updatedAt": "2026-05-06",
+      "version": "0.1.0"
+    },
+    {
+      "id": "humanize-prose",
+      "name": "Humanize Prose",
+      "type": "extra",
+      "level": "IV",
+      "rarity": "uncommon",
+      "description": "Audits and rewrites prose to remove generic AI-writing patterns, preserve author intent, and adapt tone toward a more natural human voice.",
+      "prerequisites": [
+        "document-editing",
+        "audience-model",
+        "format-output"
+      ],
+      "derivatives": [],
+      "conditions": "Requires explicit user permission to revise voice, tone, and stylistic markers without changing factual claims.",
+      "evidence": [
+        {
+          "class": "B",
+          "source": "https://github.com/NousResearch/hermes-agent/blob/main/skills/creative/humanizer/SKILL.md",
+          "evaluator": "openai-codex",
+          "date": "2026-05-06",
+          "notes": "Hermes Agent humanizer skill identifies AI-generated writing patterns and rewrites text to sound more natural while retaining meaning."
+        }
+      ],
+      "knownAgents": [
+        "NousResearch/hermes-agent"
+      ],
+      "status": "provisional",
+      "createdAt": "2026-05-06",
+      "updatedAt": "2026-05-06",
+      "version": "0.1.0"
+    },
+    {
+      "id": "architecture-diagram",
+      "name": "Architecture Diagram",
+      "type": "extra",
+      "level": "IV",
+      "rarity": "uncommon",
+      "description": "Generates technical architecture, infrastructure, or cloud diagrams as structured visual artifacts from natural-language system descriptions.",
+      "prerequisites": [
+        "data-visualize",
+        "format-output",
+        "write-report"
+      ],
+      "derivatives": [],
+      "conditions": "Requires enough system context to identify components, relationships, boundaries, and rendering constraints.",
+      "evidence": [
+        {
+          "class": "B",
+          "source": "https://github.com/NousResearch/hermes-agent/blob/main/skills/creative/architecture-diagram/SKILL.md",
+          "evaluator": "openai-codex",
+          "date": "2026-05-06",
+          "notes": "Hermes Agent architecture-diagram skill generates standalone HTML files with inline SVG architecture diagrams from system descriptions."
+        }
+      ],
+      "knownAgents": [
+        "NousResearch/hermes-agent"
+      ],
+      "status": "provisional",
+      "createdAt": "2026-05-06",
+      "updatedAt": "2026-05-06",
+      "version": "0.1.0"
     }
   ],
   "edges": [
@@ -5591,6 +5756,126 @@
       "levelFloor": "II",
       "evidenceRefs": [
         "gaia-meta-audit#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "retrieve",
+      "targetSkillId": "wiki-search",
+      "edgeType": "prerequisite",
+      "condition": "Requires an accessible local wiki or markdown knowledge-base directory and a consistent linking or indexing convention.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "wiki-search#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "embed-text",
+      "targetSkillId": "wiki-search",
+      "edgeType": "prerequisite",
+      "condition": "Requires an accessible local wiki or markdown knowledge-base directory and a consistent linking or indexing convention.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "wiki-search#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "summarize",
+      "targetSkillId": "wiki-search",
+      "edgeType": "prerequisite",
+      "condition": "Requires an accessible local wiki or markdown knowledge-base directory and a consistent linking or indexing convention.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "wiki-search#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "data-analysis",
+      "targetSkillId": "prediction-market-analysis",
+      "edgeType": "prerequisite",
+      "condition": "Requires read-only market data sources and clear separation between analysis output and financial advice or trade execution.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "prediction-market-analysis#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "web-search",
+      "targetSkillId": "prediction-market-analysis",
+      "edgeType": "prerequisite",
+      "condition": "Requires read-only market data sources and clear separation between analysis output and financial advice or trade execution.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "prediction-market-analysis#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "statistical-analysis",
+      "targetSkillId": "prediction-market-analysis",
+      "edgeType": "prerequisite",
+      "condition": "Requires read-only market data sources and clear separation between analysis output and financial advice or trade execution.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "prediction-market-analysis#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "document-editing",
+      "targetSkillId": "humanize-prose",
+      "edgeType": "prerequisite",
+      "condition": "Requires explicit user permission to revise voice, tone, and stylistic markers without changing factual claims.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "humanize-prose#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "audience-model",
+      "targetSkillId": "humanize-prose",
+      "edgeType": "prerequisite",
+      "condition": "Requires explicit user permission to revise voice, tone, and stylistic markers without changing factual claims.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "humanize-prose#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "format-output",
+      "targetSkillId": "humanize-prose",
+      "edgeType": "prerequisite",
+      "condition": "Requires explicit user permission to revise voice, tone, and stylistic markers without changing factual claims.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "humanize-prose#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "data-visualize",
+      "targetSkillId": "architecture-diagram",
+      "edgeType": "prerequisite",
+      "condition": "Requires enough system context to identify components, relationships, boundaries, and rendering constraints.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "architecture-diagram#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "format-output",
+      "targetSkillId": "architecture-diagram",
+      "edgeType": "prerequisite",
+      "condition": "Requires enough system context to identify components, relationships, boundaries, and rendering constraints.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "architecture-diagram#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "write-report",
+      "targetSkillId": "architecture-diagram",
+      "edgeType": "prerequisite",
+      "condition": "Requires enough system context to identify components, relationships, boundaries, and rendering constraints.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "architecture-diagram#evidence[0]"
       ]
     }
   ]

--- a/registry/named-skills.json
+++ b/registry/named-skills.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-30",
+  "generatedAt": "2026-05-06",
   "buckets": {
     "automated-testing": [
       {

--- a/registry/registry.md
+++ b/registry/registry.md
@@ -4,6 +4,7 @@
 |---|---|---|---|---|
 | ◇ Extra Skill: /agent-eval | Extra Skill | III | Evolved | `/agent-eval` |
 | ○ huggingface/hf-cli | Basic Skill | II | Named | `/api-call` |
+| ◇ Extra Skill: /architecture-diagram | Extra Skill | IV | Hardened | `/architecture-diagram` |
 | ○ /audience-model | Basic Skill | I | Awakened | `/audience-model` |
 | ◇ Extra Skill: 0xdarkmatter/pytest-patterns | Extra Skill | III | Evolved | `/automated-testing` |
 | ◆ Ultimate Skill: /autonomous-data-scientist [Unclaimed ✦] | Ultimate Skill | V | Transcendent | `/autonomous-data-scientist` |
@@ -27,6 +28,7 @@
 | ○ /diff-content | Basic Skill | I | Awakened | `/diff-content` |
 | ◇ Extra Skill: /document-analyst | Extra Skill | III | Evolved | `/document-analyst` |
 | ◇ Extra Skill: /document-digitization | Extra Skill | III | Evolved | `/document-digitization` |
+| ○ anthropic/pptx | Basic Skill | 0 | Basic | `/document-editing` |
 | ◇ Extra Skill: /e2e-testing | Extra Skill | III | Evolved | `/e2e-testing` |
 | ○ /embed-text | Basic Skill | I | Awakened | `/embed-text` |
 | ○ /error-interpretation | Basic Skill | I | Awakened | `/error-interpretation` |
@@ -44,6 +46,7 @@
 | ◇ Extra Skill: /ghostwrite | Extra Skill | IV | Hardened | `/ghostwrite` |
 | ◇ Extra Skill: /grounding | Extra Skill | III | Evolved | `/grounding` |
 | ◇ Extra Skill: /guardrails | Extra Skill | III | Evolved | `/guardrails` |
+| ◇ Extra Skill: /humanize-prose | Extra Skill | IV | Hardened | `/humanize-prose` |
 | ○ /hypothesis-generate | Basic Skill | II | Named | `/hypothesis-generate` |
 | ○ /image-caption | Basic Skill | II | Named | `/image-caption` |
 | ◇ Extra Skill: /knowledge-graph-build | Extra Skill | III | Evolved | `/knowledge-graph-build` |
@@ -62,6 +65,7 @@
 | ◇ Extra Skill: /plan-and-execute | Extra Skill | IV | Hardened | `/plan-and-execute` |
 | ○ /plan-decompose | Basic Skill | I | Awakened | `/plan-decompose` |
 | ◇ Extra Skill: mattpocock/to-prd | Extra Skill | IV | Hardened | `/prd-generation` |
+| ◇ Extra Skill: /prediction-market-analysis | Extra Skill | IV | Hardened | `/prediction-market-analysis` |
 | ◇ Extra Skill: /prompt-optimization | Extra Skill | IV | Hardened | `/prompt-optimization` |
 | ○ /question-answer | Basic Skill | 0 | Basic | `/question-answer` |
 | ◇ Extra Skill: yonatangross/orchestkit-rag | Extra Skill | III | Evolved | `/rag-pipeline` |
@@ -83,6 +87,7 @@
 | ○ /self-critique | Basic Skill | I | Awakened | `/self-critique` |
 | ○ /sentiment-analysis | Basic Skill | 0 | Basic | `/sentiment-analysis` |
 | ○ /speech-to-text | Basic Skill | II | Named | `/speech-to-text` |
+| ○ /statistical-analysis | Basic Skill | III | Evolved | `/statistical-analysis` |
 | ○ /structured-output | Basic Skill | I | Awakened | `/structured-output` |
 | ○ /summarize | Basic Skill | 0 | Basic | `/summarize` |
 | ○ /text-to-speech | Basic Skill | II | Named | `/text-to-speech` |
@@ -99,6 +104,7 @@
 | ◇ Extra Skill: /voice-agent | Extra Skill | III | Evolved | `/voice-agent` |
 | ◇ Extra Skill: /web-scrape | Extra Skill | III | Evolved | `/web-scrape` |
 | ○ /web-search | Basic Skill | I | Awakened | `/web-search` |
+| ◇ Extra Skill: /wiki-search | Extra Skill | IV | Hardened | `/wiki-search` |
 | ◇ Extra Skill: /workflow-automation | Extra Skill | IV | Hardened | `/workflow-automation` |
 | ○ glincker/readme-generator | Basic Skill | I | Awakened | `/write-report` |
 
@@ -111,7 +117,7 @@
 | ○ Code Execution | Intrinsic Skill | II | Named | `/code-execution` |
 | ○ Code Explain | Intrinsic Skill | II | Named | `/code-explain` |
 | ○ Context Compression | Intrinsic Skill | III | Evolved | `/context-compression` |
-| ○ Document Editing | Intrinsic Skill | 0 | Basic | `/document-editing` |
+| ○ Feed Monitoring | Intrinsic Skill | IV | Hardened | `/feed-monitoring` |
 | ○ Few-Shot Learning | Intrinsic Skill | IV | Hardened | `/few-shot-learning` |
 | ○ Fine-Tune | Intrinsic Skill | IV | Hardened | `/fine-tune` |
 | ○ Framework Upgrade | Intrinsic Skill | 0 | Basic | `/framework-upgrade` |
@@ -128,7 +134,6 @@
 | ○ Self-Consistency | Intrinsic Skill | IV | Hardened | `/self-consistency` |
 | ○ Semantic Cache | Intrinsic Skill | IV | Hardened | `/semantic-cache` |
 | ○ Skill Discovery | Intrinsic Skill | 0 | Basic | `/skill-discovery` |
-| ○ Statistical Analysis | Intrinsic Skill | III | Evolved | `/statistical-analysis` |
 | ○ Test-Driven Development | Intrinsic Skill | 0 | Basic | `/test-driven-development` |
 | ○ UX Audit | Intrinsic Skill | 0 | Basic | `/ux-audit` |
 | ○ Visual Question Answering | Intrinsic Skill | III | Evolved | `/vision-qa` |

--- a/registry/skill-sources.md
+++ b/registry/skill-sources.md
@@ -25,6 +25,7 @@ Authoritative list of known skill sources and marketplaces. `gaia-curate` agents
 | karpathy/autoresearch | https://github.com/karpathy/autoresearch | github-repo | origin implementation of autonomous-research-agent |
 | spring-ai-alibaba/examples | https://github.com/spring-ai-alibaba/examples | github-repo | `gh api repos/spring-ai-alibaba/examples/contents/.claude/skills` |
 | balukosuri/Andrej-Karpathy-s-Autoresearch-As-a-Universal-Skill | https://github.com/balukosuri/Andrej-Karpathy-s-Autoresearch-As-a-Universal-Skill | github-repo | community reproduction of autoresearch as a general agent skill |
+| NousResearch/hermes-agent | https://github.com/NousResearch/hermes-agent | github-repo | `gh api repos/NousResearch/hermes-agent/contents/skills` and `gh api repos/NousResearch/hermes-agent/contents/optional-skills` |
 
 ## Academic / Evidence Sources
 

--- a/registry/skills/basic/audience-model.md
+++ b/registry/skills/basic/audience-model.md
@@ -16,6 +16,7 @@ _None._
 ## Unlocks
 - [Ghostwrite](../extra/ghostwrite.md)
 - [Translation Pipeline](../extra/translation-pipeline.md)
+- [Humanize Prose](../extra/humanize-prose.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/registry/skills/basic/data-visualize.md
+++ b/registry/skills/basic/data-visualize.md
@@ -15,6 +15,7 @@ _None._
 
 ## Unlocks
 - [Data Analysis](../extra/data-analysis.md)
+- [Architecture Diagram](../extra/architecture-diagram.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/registry/skills/basic/document-editing.md
+++ b/registry/skills/basic/document-editing.md
@@ -14,7 +14,7 @@ Reads, edits, repacks, and applies styling or design principles to structured bi
 _None._
 
 ## Unlocks
-_None._
+- [Humanize Prose](../extra/humanize-prose.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/registry/skills/basic/embed-text.md
+++ b/registry/skills/basic/embed-text.md
@@ -16,6 +16,7 @@ _None._
 ## Unlocks
 - [RAG Pipeline](../extra/rag-pipeline.md)
 - [Knowledge Harvest](../extra/knowledge-harvest.md)
+- [Wiki Search](../extra/wiki-search.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/registry/skills/basic/feed-monitoring.md
+++ b/registry/skills/basic/feed-monitoring.md
@@ -1,0 +1,27 @@
+# /feed-monitoring  [IV · Hardened]
+**ID:** feed-monitoring  
+**Type:** Basic Skill  
+**Level:** IV  
+**Tier:** Hardened  
+**Skill Call:** `/feed-monitoring`
+
+---
+
+## Description
+Monitors RSS, Atom, blog, or other recurring content feeds, discovers updates, tracks read state, and surfaces new signals for downstream agent workflows.
+
+## Prerequisites
+_None._
+
+## Unlocks
+_None._
+
+## Evidence
+| Class | Source | Evaluator | Date |
+|---|---|---|---|
+| B | https://github.com/NousResearch/hermes-agent/blob/main/skills/research/blogwatcher/SKILL.md | openai-codex | 2026-05-06 |
+
+## Known Agents
+- NousResearch/hermes-agent
+
+---

--- a/registry/skills/basic/format-output.md
+++ b/registry/skills/basic/format-output.md
@@ -17,6 +17,8 @@ _None._
 - [Document Analyst](../extra/document-analyst.md)
 - [Document Digitization](../extra/document-digitization.md)
 - [Text-to-SQL Pipeline](../extra/text-to-sql-pipeline.md)
+- [Humanize Prose](../extra/humanize-prose.md)
+- [Architecture Diagram](../extra/architecture-diagram.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/registry/skills/basic/retrieve.md
+++ b/registry/skills/basic/retrieve.md
@@ -17,6 +17,7 @@ _None._
 - [Gaia Audit](../extra/gaia-audit.md)
 - [Grounding](../extra/grounding.md)
 - [RAG Pipeline](../extra/rag-pipeline.md)
+- [Wiki Search](../extra/wiki-search.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/registry/skills/basic/statistical-analysis.md
+++ b/registry/skills/basic/statistical-analysis.md
@@ -14,7 +14,7 @@ Performs hypothesis testing, regression analysis, and Bayesian modelling with ef
 _None._
 
 ## Unlocks
-_None._
+- [Prediction Market Analysis](../extra/prediction-market-analysis.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/registry/skills/basic/summarize.md
+++ b/registry/skills/basic/summarize.md
@@ -18,6 +18,7 @@ _None._
 - [Document Analyst](../extra/document-analyst.md)
 - [Data Analysis](../extra/data-analysis.md)
 - [Literature Review](../extra/literature-review.md)
+- [Wiki Search](../extra/wiki-search.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/registry/skills/basic/web-search.md
+++ b/registry/skills/basic/web-search.md
@@ -17,6 +17,7 @@ _None._
 - [Browser Automation](../extra/browser-automation.md)
 - [Research](../extra/research.md)
 - [Web Scrape](../extra/web-scrape.md)
+- [Prediction Market Analysis](../extra/prediction-market-analysis.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/registry/skills/basic/write-report.md
+++ b/registry/skills/basic/write-report.md
@@ -17,6 +17,7 @@ _None._
 - [Ghostwrite](../extra/ghostwrite.md)
 - [PRD Generation](../extra/prd-generation.md)
 - [Scientific Writing](../extra/scientific-writing.md)
+- [Architecture Diagram](../extra/architecture-diagram.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/registry/skills/extra/architecture-diagram.md
+++ b/registry/skills/extra/architecture-diagram.md
@@ -1,0 +1,32 @@
+# Extra Skill: /architecture-diagram  [IV · Hardened]
+**ID:** architecture-diagram  
+**Type:** Extra Skill  
+**Level:** IV  
+**Tier:** Hardened  
+**Skill Call:** `/architecture-diagram`
+
+---
+
+## Description
+Generates technical architecture, infrastructure, or cloud diagrams as structured visual artifacts from natural-language system descriptions.
+
+## Prerequisites
+- [Data Visualize](../basic/data-visualize.md)
+- [Format Output](../basic/format-output.md)
+- [Write Report](../basic/write-report.md)
+
+## Unlocks
+_None._
+
+## Fusion Condition
+Requires enough system context to identify components, relationships, boundaries, and rendering constraints.
+
+## Evidence
+| Class | Source | Evaluator | Date |
+|---|---|---|---|
+| B | https://github.com/NousResearch/hermes-agent/blob/main/skills/creative/architecture-diagram/SKILL.md | openai-codex | 2026-05-06 |
+
+## Known Agents
+- NousResearch/hermes-agent
+
+---

--- a/registry/skills/extra/data-analysis.md
+++ b/registry/skills/extra/data-analysis.md
@@ -18,6 +18,7 @@ Conducts end-to-end quantitative analysis: queries data via SQL, computes statis
 ## Unlocks
 - [Autonomous Data Scientist](../ultimate/autonomous-data-scientist.md)
 - [ML Pipeline](../extra/ml-pipeline.md)
+- [Prediction Market Analysis](../extra/prediction-market-analysis.md)
 
 ## Fusion Condition
 _None specified._

--- a/registry/skills/extra/humanize-prose.md
+++ b/registry/skills/extra/humanize-prose.md
@@ -1,0 +1,32 @@
+# Extra Skill: /humanize-prose  [IV · Hardened]
+**ID:** humanize-prose  
+**Type:** Extra Skill  
+**Level:** IV  
+**Tier:** Hardened  
+**Skill Call:** `/humanize-prose`
+
+---
+
+## Description
+Audits and rewrites prose to remove generic AI-writing patterns, preserve author intent, and adapt tone toward a more natural human voice.
+
+## Prerequisites
+- [Document Editing](../basic/document-editing.md)
+- [Audience Model](../basic/audience-model.md)
+- [Format Output](../basic/format-output.md)
+
+## Unlocks
+_None._
+
+## Fusion Condition
+Requires explicit user permission to revise voice, tone, and stylistic markers without changing factual claims.
+
+## Evidence
+| Class | Source | Evaluator | Date |
+|---|---|---|---|
+| B | https://github.com/NousResearch/hermes-agent/blob/main/skills/creative/humanizer/SKILL.md | openai-codex | 2026-05-06 |
+
+## Known Agents
+- NousResearch/hermes-agent
+
+---

--- a/registry/skills/extra/prediction-market-analysis.md
+++ b/registry/skills/extra/prediction-market-analysis.md
@@ -1,0 +1,32 @@
+# Extra Skill: /prediction-market-analysis  [IV · Hardened]
+**ID:** prediction-market-analysis  
+**Type:** Extra Skill  
+**Level:** IV  
+**Tier:** Hardened  
+**Skill Call:** `/prediction-market-analysis`
+
+---
+
+## Description
+Queries prediction-market data, compares market probabilities and price history, and summarizes probabilistic signals for forecasting or decision-support workflows.
+
+## Prerequisites
+- [Data Analysis](../extra/data-analysis.md)
+- [Web Search](../basic/web-search.md)
+- [Statistical Analysis](../basic/statistical-analysis.md)
+
+## Unlocks
+_None._
+
+## Fusion Condition
+Requires read-only market data sources and clear separation between analysis output and financial advice or trade execution.
+
+## Evidence
+| Class | Source | Evaluator | Date |
+|---|---|---|---|
+| B | https://github.com/NousResearch/hermes-agent/blob/main/skills/research/polymarket/SKILL.md | openai-codex | 2026-05-06 |
+
+## Known Agents
+- NousResearch/hermes-agent
+
+---

--- a/registry/skills/extra/wiki-search.md
+++ b/registry/skills/extra/wiki-search.md
@@ -1,0 +1,32 @@
+# Extra Skill: /wiki-search  [IV · Hardened]
+**ID:** wiki-search  
+**Type:** Extra Skill  
+**Level:** IV  
+**Tier:** Hardened  
+**Skill Call:** `/wiki-search`
+
+---
+
+## Description
+Builds, maintains, and queries an interlinked markdown or wiki-style knowledge base so an agent can retrieve durable local context across research sessions.
+
+## Prerequisites
+- [Retrieve](../basic/retrieve.md)
+- [Embed Text](../basic/embed-text.md)
+- [Summarize](../basic/summarize.md)
+
+## Unlocks
+_None._
+
+## Fusion Condition
+Requires an accessible local wiki or markdown knowledge-base directory and a consistent linking or indexing convention.
+
+## Evidence
+| Class | Source | Evaluator | Date |
+|---|---|---|---|
+| B | https://github.com/NousResearch/hermes-agent/blob/main/skills/research/llm-wiki/SKILL.md | openai-codex | 2026-05-06 |
+
+## Known Agents
+- NousResearch/hermes-agent
+
+---

--- a/scripts/add_hermes_skills.py
+++ b/scripts/add_hermes_skills.py
@@ -1,0 +1,205 @@
+"""Add reviewed Hermes Agent skills to the Gaia registry."""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+
+REGISTRY_PATH = Path("registry/gaia.json")
+TODAY = "2026-05-06"
+EVALUATOR = "openai-codex"
+VERSION = "0.1.0"
+
+NEW_SKILLS = [
+    {
+        "id": "feed-monitoring",
+        "name": "Feed Monitoring",
+        "type": "basic",
+        "level": "IV",
+        "rarity": "common",
+        "description": "Monitors RSS, Atom, blog, or other recurring content feeds, discovers updates, tracks read state, and surfaces new signals for downstream agent workflows.",
+        "prerequisites": [],
+        "derivatives": [],
+        "conditions": "Requires configured feed sources and a repeatable polling or discovery mechanism.",
+        "evidence": [
+            {
+                "class": "B",
+                "source": "https://github.com/NousResearch/hermes-agent/blob/main/skills/research/blogwatcher/SKILL.md",
+                "evaluator": EVALUATOR,
+                "date": TODAY,
+                "notes": "Hermes Agent blogwatcher skill monitors blogs and RSS/Atom feeds with feed discovery, scraping fallback, OPML import, and read/unread article management.",
+            }
+        ],
+        "knownAgents": ["NousResearch/hermes-agent"],
+        "status": "provisional",
+        "createdAt": TODAY,
+        "updatedAt": TODAY,
+        "version": VERSION,
+    },
+    {
+        "id": "wiki-search",
+        "name": "Wiki Search",
+        "type": "extra",
+        "level": "IV",
+        "rarity": "uncommon",
+        "description": "Builds, maintains, and queries an interlinked markdown or wiki-style knowledge base so an agent can retrieve durable local context across research sessions.",
+        "prerequisites": ["retrieve", "embed-text", "summarize"],
+        "derivatives": [],
+        "conditions": "Requires an accessible local wiki or markdown knowledge-base directory and a consistent linking or indexing convention.",
+        "evidence": [
+            {
+                "class": "B",
+                "source": "https://github.com/NousResearch/hermes-agent/blob/main/skills/research/llm-wiki/SKILL.md",
+                "evaluator": EVALUATOR,
+                "date": TODAY,
+                "notes": "Hermes Agent llm-wiki skill documents a persistent interlinked markdown knowledge base pattern for compounding research notes and retrieval.",
+            }
+        ],
+        "knownAgents": ["NousResearch/hermes-agent"],
+        "status": "provisional",
+        "createdAt": TODAY,
+        "updatedAt": TODAY,
+        "version": VERSION,
+    },
+    {
+        "id": "prediction-market-analysis",
+        "name": "Prediction Market Analysis",
+        "type": "extra",
+        "level": "IV",
+        "rarity": "rare",
+        "description": "Queries prediction-market data, compares market probabilities and price history, and summarizes probabilistic signals for forecasting or decision-support workflows.",
+        "prerequisites": ["data-analysis", "web-search", "statistical-analysis"],
+        "derivatives": [],
+        "conditions": "Requires read-only market data sources and clear separation between analysis output and financial advice or trade execution.",
+        "evidence": [
+            {
+                "class": "B",
+                "source": "https://github.com/NousResearch/hermes-agent/blob/main/skills/research/polymarket/SKILL.md",
+                "evaluator": EVALUATOR,
+                "date": TODAY,
+                "notes": "Hermes Agent polymarket skill queries markets, prices, order books, and historical prediction-market data through public read-only APIs.",
+            }
+        ],
+        "knownAgents": ["NousResearch/hermes-agent"],
+        "status": "provisional",
+        "createdAt": TODAY,
+        "updatedAt": TODAY,
+        "version": VERSION,
+    },
+    {
+        "id": "humanize-prose",
+        "name": "Humanize Prose",
+        "type": "extra",
+        "level": "IV",
+        "rarity": "uncommon",
+        "description": "Audits and rewrites prose to remove generic AI-writing patterns, preserve author intent, and adapt tone toward a more natural human voice.",
+        "prerequisites": ["document-editing", "audience-model", "format-output"],
+        "derivatives": [],
+        "conditions": "Requires explicit user permission to revise voice, tone, and stylistic markers without changing factual claims.",
+        "evidence": [
+            {
+                "class": "B",
+                "source": "https://github.com/NousResearch/hermes-agent/blob/main/skills/creative/humanizer/SKILL.md",
+                "evaluator": EVALUATOR,
+                "date": TODAY,
+                "notes": "Hermes Agent humanizer skill identifies AI-generated writing patterns and rewrites text to sound more natural while retaining meaning.",
+            }
+        ],
+        "knownAgents": ["NousResearch/hermes-agent"],
+        "status": "provisional",
+        "createdAt": TODAY,
+        "updatedAt": TODAY,
+        "version": VERSION,
+    },
+    {
+        "id": "architecture-diagram",
+        "name": "Architecture Diagram",
+        "type": "extra",
+        "level": "IV",
+        "rarity": "uncommon",
+        "description": "Generates technical architecture, infrastructure, or cloud diagrams as structured visual artifacts from natural-language system descriptions.",
+        "prerequisites": ["data-visualize", "format-output", "write-report"],
+        "derivatives": [],
+        "conditions": "Requires enough system context to identify components, relationships, boundaries, and rendering constraints.",
+        "evidence": [
+            {
+                "class": "B",
+                "source": "https://github.com/NousResearch/hermes-agent/blob/main/skills/creative/architecture-diagram/SKILL.md",
+                "evaluator": EVALUATOR,
+                "date": TODAY,
+                "notes": "Hermes Agent architecture-diagram skill generates standalone HTML files with inline SVG architecture diagrams from system descriptions.",
+            }
+        ],
+        "knownAgents": ["NousResearch/hermes-agent"],
+        "status": "provisional",
+        "createdAt": TODAY,
+        "updatedAt": TODAY,
+        "version": VERSION,
+    },
+]
+
+NEW_EDGES = []
+for skill in NEW_SKILLS:
+    for prereq in skill["prerequisites"]:
+        NEW_EDGES.append(
+            {
+                "sourceSkillId": prereq,
+                "targetSkillId": skill["id"],
+                "edgeType": "prerequisite",
+                "condition": skill["conditions"],
+                "levelFloor": "II",
+                "evidenceRefs": [f"{skill['id']}#evidence[0]"],
+            }
+        )
+    for derivative in skill["derivatives"]:
+        NEW_EDGES.append(
+            {
+                "sourceSkillId": skill["id"],
+                "targetSkillId": derivative,
+                "edgeType": "enhances",
+                "condition": "",
+                "levelFloor": skill["level"],
+                "evidenceRefs": [f"{skill['id']}#evidence[0]"],
+            }
+        )
+
+
+def main() -> None:
+    with REGISTRY_PATH.open(encoding="utf-8") as fh:
+        registry = json.load(fh)
+
+    existing_ids = {skill["id"] for skill in registry["skills"]}
+    duplicate_ids = existing_ids.intersection(skill["id"] for skill in NEW_SKILLS)
+    if duplicate_ids:
+        raise SystemExit(f"Refusing to add duplicate skills: {sorted(duplicate_ids)}")
+
+    skill_by_id = {skill["id"]: skill for skill in registry["skills"]}
+    for skill in NEW_SKILLS:
+        registry["skills"].append(skill)
+        for prereq in skill["prerequisites"]:
+            parent = skill_by_id[prereq]
+            if skill["id"] not in parent["derivatives"]:
+                parent["derivatives"].append(skill["id"])
+                parent["updatedAt"] = TODAY
+        skill_by_id[skill["id"]] = skill
+
+    existing_edges = {
+        (edge["sourceSkillId"], edge["targetSkillId"], edge["edgeType"])
+        for edge in registry.get("edges", [])
+    }
+    for edge in NEW_EDGES:
+        key = (edge["sourceSkillId"], edge["targetSkillId"], edge["edgeType"])
+        if key not in existing_edges:
+            registry.setdefault("edges", []).append(edge)
+            existing_edges.add(key)
+
+    registry["generatedAt"] = f"{TODAY}T00:00:00Z"
+
+    with REGISTRY_PATH.open("w", encoding="utf-8") as fh:
+        json.dump(registry, fh, indent=2, ensure_ascii=False)
+        fh.write("\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Ingest reviewed Hermes Agent capabilities into the Gaia skill registry so they are represented as named/basic/extra skills with proper metadata, prerequisites, derivatives, and evidence. 
- Ensure the registry graph, docs, and visual exports are updated to reflect the new skills and relationships and to keep generated timestamps in sync.

### Description
- Added five new skills and documentation pages: `architecture-diagram`, `humanize-prose`, `wiki-search`, `prediction-market-analysis`, and `feed-monitoring`, each with metadata, evidence, known agents, and fusion/conditions files under `registry/skills/*`.
- Updated canonical registry artifacts (`registry/gaia.json`, `registry/gaia.gexf`, `registry/registry.md`, `registry/named-skills.json`) to include new nodes, edges, prerequisites, derivatives, and bumped `generatedAt`/`lastmodifieddate` timestamps and `updatedAt` fields where applicable.
- Propagated unlocks/derivatives across many basic/extra skill markdown files (for example `retrieve`, `embed-text`, `summarize`, `data-visualize`, `format-output`, `write-report`, `document-editing`, `audience-model`, `statistical-analysis`) to reference the new skills; also normalized some typographic escapes and replaced `typeSymbols` with visible characters in `gaia.json`.
- Added `scripts/add_hermes_skills.py`, a script to programmatically append the new Hermes-derived skills and their prerequisite edges to `registry/gaia.json` and update `generatedAt`.
- Incremented the public docs count in `docs/index.html` (skills counter) to reflect the additions.

### Testing
- No automated test suite was executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fb12af83a083279f2da8d97201deb4)