### PR TITLE
Add `gaia stats` command to show registry health and wire into CLI, docs, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,13 +222,13 @@ Use this catalog to bucket popular named skills from sources such as VoltAgent's
 <!-- gaia:cli-start -->
 ```text
 usage: gaia [-h] [--registry REGISTRY] [--global] [--version]
-            {help,init,scan,pull,tree,push,propose,version,mcp,release,graph,appraise,promote,fuse,docs,skills}
+            {help,init,scan,pull,tree,push,propose,version,mcp,release,graph,stats,appraise,promote,fuse,docs,skills}
             ...
 
 Gaia Registry CLI
 
 positional arguments:
-  {help,init,scan,pull,tree,push,propose,version,mcp,release,graph,appraise,promote,fuse,docs,skills}
+  {help,init,scan,pull,tree,push,propose,version,mcp,release,graph,stats,appraise,promote,fuse,docs,skills}
     help                Show command help
     init                Create or update local Gaia config
     scan                Scan configured paths for skill evidence
@@ -240,6 +240,7 @@ positional arguments:
     mcp                 Run the bundled Gaia MCP server
     release             Bump release version files
     graph               Generate and open the Gaia skill graph
+    stats               Show registry health at a glance
     appraise            Inspect a skill card with status and actions
     promote             Promote a skill eligible for level-up
     fuse                Confirm a skill combination or promotion candidate
@@ -267,6 +268,7 @@ Quick usage:
   gaia appraise [<skillId>]
   gaia promote [<skillId>] [--all] [--name <name>]
   gaia fuse <skillId> [--name <name>]
+  gaia stats
   gaia docs build [--check]
   gaia skills <list|search|info|install|uninstall>
   gaia skills list [--exclude-pending]

--- a/docs/index.html
+++ b/docs/index.html
@@ -454,5 +454,5 @@
 </html>
 
 <!-- gaia:stats-start -->
-<!-- skills=123; namedSkills=32; version=3.0.1 -->
+<!-- skills=128; namedSkills=32; version=3.0.1 -->
 <!-- gaia:stats-end -->

--- a/src/gaia_cli/commands/__init__.py
+++ b/src/gaia_cli/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Subcommands for the Gaia CLI."""

--- a/src/gaia_cli/commands/stats.py
+++ b/src/gaia_cli/commands/stats.py
@@ -1,0 +1,192 @@
+"""Registry health summary for ``gaia stats``."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Iterable
+
+from gaia_cli.registry import named_skills_dir, registry_graph_path
+
+TYPE_LABELS = {
+    "basic": "Atomic",
+    "extra": "Composite",
+    "ultimate": "Legendary",
+}
+
+LEVEL_LABELS = {
+    "0": "Basic",
+    "I": "Awakened",
+    "II": "Named",
+    "III": "Evolved",
+    "IV": "Hardened",
+    "V": "Transcendent",
+    "VI": "Transcendent★",
+}
+
+LEVEL_ORDER = ("0", "I", "II", "III", "IV", "V", "VI")
+TYPE_ORDER = ("basic", "extra", "ultimate")
+EVIDENCE_ORDER = ("A", "B", "C")
+_EVIDENCE_RANK = {klass: rank for rank, klass in enumerate(reversed(EVIDENCE_ORDER), start=1)}
+
+
+def _load_json(path: str | Path) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _graph_path(registry_path: str | Path) -> Path:
+    root = Path(registry_path)
+    current = Path(registry_graph_path(root))
+    if current.exists():
+        return current
+    return root / "graph" / "gaia.json"
+
+
+def _named_dir(registry_path: str | Path) -> Path:
+    root = Path(registry_path)
+    current = Path(named_skills_dir(root))
+    if current.is_dir():
+        return current
+    return root / "graph" / "named"
+
+
+def _parse_frontmatter(text: str) -> dict[str, str]:
+    if not text.startswith("---\n"):
+        return {}
+    frontmatter, sep, _body = text[4:].partition("\n---")
+    if not sep:
+        return {}
+    data: dict[str, str] = {}
+    for line in frontmatter.splitlines():
+        if not line.strip() or line.lstrip().startswith("#") or ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        data[key.strip()] = value.strip().strip('"').strip("'")
+    return data
+
+
+def _iter_named_skill_metadata(registry_path: str | Path) -> Iterable[dict[str, str]]:
+    root = _named_dir(registry_path)
+    if not root.is_dir():
+        return []
+    items = []
+    for path in sorted(root.glob("*/*.md")):
+        try:
+            items.append(_parse_frontmatter(path.read_text(encoding="utf-8")))
+        except OSError:
+            continue
+    return items
+
+
+def _best_evidence_class(skill: dict) -> str | None:
+    best: str | None = None
+    for evidence in skill.get("evidence", []) or []:
+        klass = str(evidence.get("class", "")).upper()
+        if klass not in _EVIDENCE_RANK:
+            continue
+        if best is None or _EVIDENCE_RANK[klass] > _EVIDENCE_RANK[best]:
+            best = klass
+    return best
+
+
+def collect_stats(registry_path: str | Path) -> dict:
+    """Collect registry counts used by the stats command."""
+    graph = _load_json(_graph_path(registry_path))
+    skills = graph.get("skills", [])
+    edges = graph.get("edges")
+    if edges is None:
+        edges = [
+            {"source": prereq, "target": skill.get("id")}
+            for skill in skills
+            for prereq in (skill.get("prerequisites", []) or [])
+        ]
+
+    type_counts = Counter(skill.get("type", "unknown") for skill in skills)
+    level_counts = Counter(skill.get("level", "?") for skill in skills)
+
+    best_evidence_counts: Counter[str] = Counter()
+    for skill in skills:
+        best = _best_evidence_class(skill)
+        if best:
+            best_evidence_counts[best] += 1
+
+    named_items = [
+        item for item in _iter_named_skill_metadata(registry_path)
+        if item.get("id") and item.get("genericSkillRef") and item.get("status", "named") == "named"
+    ]
+    named_slots = {item["genericSkillRef"] for item in named_items}
+    eligible_slots = {
+        skill["id"]
+        for skill in skills
+        if skill.get("id") and skill.get("level") != "0"
+    }
+
+    return {
+        "total_skills": len(skills),
+        "total_edges": len(edges),
+        "type_counts": dict(type_counts),
+        "level_counts": dict(level_counts),
+        "evidence_counts": {klass: best_evidence_counts.get(klass, 0) for klass in EVIDENCE_ORDER},
+        "skills_with_evidence": sum(best_evidence_counts.values()),
+        "named_implemented": len(named_items),
+        "named_slots": len(named_slots),
+        "named_eligible": len(eligible_slots),
+        "named_unclaimed": max(len(eligible_slots - named_slots), 0),
+    }
+
+
+def _bar(count: int, total: int, width: int = 25) -> str:
+    if total <= 0:
+        filled = 0
+    else:
+        filled = round((count / total) * width)
+    filled = max(0, min(width, filled))
+    return "█" * filled + "░" * (width - filled)
+
+
+def _percent(count: int, total: int) -> int:
+    return round((count / total) * 100) if total else 0
+
+
+def render_stats(stats: dict) -> str:
+    """Render a human-readable stats report."""
+    total = stats["total_skills"]
+    lines = [f"Gaia Registry — {total} skills  {stats['total_edges']} edges", ""]
+
+    lines.append("Type breakdown")
+    for skill_type in TYPE_ORDER:
+        label = TYPE_LABELS[skill_type]
+        count = stats["type_counts"].get(skill_type, 0)
+        lines.append(f"  {label:<9} {count:>4}  {_bar(count, total)}  {_percent(count, total):>3}%")
+    for skill_type, count in sorted(stats["type_counts"].items()):
+        if skill_type not in TYPE_LABELS:
+            lines.append(f"  {skill_type:<9} {count:>4}  {_bar(count, total)}  {_percent(count, total):>3}%")
+
+    lines.extend(["", "Level breakdown"])
+    for level in LEVEL_ORDER:
+        label = LEVEL_LABELS[level]
+        count = stats["level_counts"].get(level, 0)
+        suffix = ""
+        if level == "II" and stats.get("named_unclaimed", 0):
+            suffix = f"  ({stats['named_unclaimed']} slots unclaimed)"
+        lines.append(f"  {level:<3} {label:<14} {count:>4}{suffix}")
+    for level, count in sorted(stats["level_counts"].items()):
+        if level not in LEVEL_LABELS:
+            lines.append(f"  {level:<3} {'Unknown':<14} {count:>4}")
+
+    lines.extend(["", "Evidence coverage"])
+    lines.append(f"  With evidence {stats['skills_with_evidence']:>4} / {total}")
+    for klass in EVIDENCE_ORDER:
+        lines.append(f"  Class {klass:<7} {stats['evidence_counts'].get(klass, 0):>4}")
+
+    eligible = stats.get("named_eligible", 0)
+    implemented = stats.get("named_implemented", 0)
+    lines.extend(["", "Named skills"])
+    lines.append(f"  Implemented  {implemented:>4} / {eligible} eligible ({_percent(implemented, eligible)}%)")
+    return "\n".join(lines) + "\n"
+
+
+def stats_command(args) -> None:
+    print(render_stats(collect_stats(args.registry)), end="")

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -20,6 +20,7 @@ from gaia_cli.semantic_search import search as semantic_search, load_embeddings
 from gaia_cli.name import find_awakened_skill, promote_to_named, update_batch_lifecycle
 from gaia_cli.install import install_skill, sync_skills, uninstall_skill, list_installed, interactive_install, list_available
 from gaia_cli.graph import graph_command
+from gaia_cli.commands.stats import stats_command
 from gaia_cli.registry import (
     generated_output_dir,
     embeddings_path,
@@ -71,6 +72,7 @@ Quick usage:
   gaia appraise [<skillId>]
   gaia promote [<skillId>] [--all] [--name <name>]
   gaia fuse <skillId> [--name <name>]
+  gaia stats
   gaia docs build [--check]
   gaia skills <list|search|info|install|uninstall>
   gaia skills list [--exclude-pending]
@@ -101,6 +103,7 @@ PUBLIC_COMMANDS = (
     "mcp",
     "release",
     "graph",
+    "stats",
     "appraise",
     "promote",
     "fuse",
@@ -1031,6 +1034,7 @@ def get_parser():
     graph_parser.add_argument('-o', '--output', help="Output path (default: registry/render/gaia.html)")
     graph_parser.add_argument('--open', dest='open', action='store_true', default=True, help="Open the generated graph (default)")
     graph_parser.add_argument('--no-open', dest='open', action='store_false', help="Do not open the generated graph")
+    subparsers.add_parser('stats', help="Show registry health at a glance")
     appraise_parser = subparsers.add_parser('appraise', help="Inspect a skill card with status and actions")
     appraise_parser.add_argument('skillId', nargs='?', default=None, help="Skill ID to appraise (default: most recent)")
     promote_parser = subparsers.add_parser('promote', help="Promote a skill eligible for level-up")
@@ -1107,6 +1111,8 @@ def main():
         release_command(args)
     elif args.command == 'graph':
         graph_command(args)
+    elif args.command == 'stats':
+        stats_command(args)
     elif args.command == 'appraise':
         appraise_command(args)
     elif args.command == 'promote':

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,103 @@
+import json
+import sys
+from pathlib import Path
+
+
+from gaia_cli.commands.stats import collect_stats, render_stats
+from gaia_cli.main import main
+
+
+def write_fixture_registry(root: Path) -> None:
+    registry = root / "registry"
+    named = registry / "named" / "alice"
+    named.mkdir(parents=True)
+    (registry / "gaia.json").write_text(
+        json.dumps(
+            {
+                "skills": [
+                    {"id": "tokenize", "type": "basic", "level": "0", "evidence": []},
+                    {"id": "web-search", "type": "basic", "level": "I", "evidence": [{"class": "C"}]},
+                    {"id": "automated-testing", "type": "extra", "level": "II", "evidence": [{"class": "B"}]},
+                    {"id": "autonomous-swe", "type": "ultimate", "level": "V", "evidence": [{"class": "B"}, {"class": "A"}]},
+                ],
+                "edges": [{"source": "web-search", "target": "automated-testing"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (named / "pytest-patterns.md").write_text(
+        "---\n"
+        "id: alice/pytest-patterns\n"
+        "genericSkillRef: automated-testing\n"
+        "status: named\n"
+        "---\n",
+        encoding="utf-8",
+    )
+
+
+def test_collect_stats_matches_fixture_graph(tmp_path):
+    write_fixture_registry(tmp_path)
+
+    stats = collect_stats(tmp_path)
+
+    assert stats["total_skills"] == 4
+    assert stats["total_edges"] == 1
+    assert stats["type_counts"] == {"basic": 2, "extra": 1, "ultimate": 1}
+    assert stats["level_counts"] == {"0": 1, "I": 1, "II": 1, "V": 1}
+    assert stats["skills_with_evidence"] == 3
+    assert stats["evidence_counts"] == {"A": 1, "B": 1, "C": 1}
+    assert stats["named_implemented"] == 1
+    assert stats["named_eligible"] == 3
+
+
+def test_collect_stats_supports_legacy_graph_layout(tmp_path):
+    graph = tmp_path / "graph"
+    named = graph / "named" / "alice"
+    named.mkdir(parents=True)
+    (graph / "gaia.json").write_text(
+        json.dumps(
+            {
+                "skills": [
+                    {"id": "plan", "type": "basic", "level": "I", "prerequisites": [], "evidence": [{"class": "C"}]},
+                    {"id": "execute", "type": "extra", "level": "II", "prerequisites": ["plan"], "evidence": []},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (named / "execute.md").write_text(
+        "---\nid: alice/execute\ngenericSkillRef: execute\nstatus: named\n---\n",
+        encoding="utf-8",
+    )
+
+    stats = collect_stats(tmp_path)
+
+    assert stats["total_skills"] == 2
+    assert stats["total_edges"] == 1
+    assert stats["named_implemented"] == 1
+
+
+def test_render_stats_includes_registry_health_sections(tmp_path):
+    write_fixture_registry(tmp_path)
+
+    output = render_stats(collect_stats(tmp_path))
+
+    assert "Gaia Registry — 4 skills  1 edges" in output
+    assert "Type breakdown" in output
+    assert "Atomic" in output
+    assert "Level breakdown" in output
+    assert "Evidence coverage" in output
+    assert "With evidence    3 / 4" in output
+    assert "Named skills" in output
+    assert "Implemented     1 / 3 eligible (33%)" in output
+
+
+def test_stats_cli_prints_summary(tmp_path, monkeypatch, capsys):
+    write_fixture_registry(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["gaia", "--registry", str(tmp_path), "stats"])
+
+    main()
+
+    output = capsys.readouterr().out
+    assert "Gaia Registry — 4 skills  1 edges" in output
+    assert "Class A" in output


### PR DESCRIPTION
### Motivation

- Provide a quick, human-readable health summary of the Gaia registry from the CLI. 
- Make stats discoverable via `gaia stats` and surface counts useful for maintainers and contributors.
- Keep documentation and the demo site in sync with the new command and registry metrics.

### Description

- Add a new subcommand implementation in `src/gaia_cli/commands/stats.py` including `collect_stats`, `render_stats`, and `stats_command` to compute and render registry metrics. 
- Wire the command into the CLI by importing and registering `stats_command` in `src/gaia_cli/main.py` and adding `stats` to the public command list and argument parsing. 
- Add package marker `src/gaia_cli/commands/__init__.py` and unit tests in `tests/test_stats.py` that validate graph parsing, legacy layout support, rendering, and CLI output. 
- Update `README.md` and `docs/index.html` to include `stats` in the usage text and bump the embedded site stats comment.

### Testing

- Ran the new unit tests in `tests/test_stats.py` (via `pytest`), exercising `collect_stats`, `render_stats`, and a CLI invocation, and they passed. 
- The CLI dispatch path for `gaia stats` was exercised by a test that calls `main()` with `--registry` and `stats` and asserted expected output, and it succeeded. 
- Rendering and legacy-graph layout parsing behavior are covered by the tests and returned the expected summaries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fb7a9defa883278fef676e670d2e78)