### PR TITLE
cli: local-first upgrade with slash-naming and fusion diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ options:
                         global registry.
   --global, -g          Use global GAIA_HOME registry, ignoring any local .gaia/ config.
   --version, -v         Print the Gaia CLI version and exit.
+  --canon               Show canonical registry data instead of local-first view.
 
 Quick usage:
   gaia init [--user <name>] [--scan <path>] [--yes]

--- a/registry/render/gaia.html
+++ b/registry/render/gaia.html
@@ -125,10 +125,11 @@
 </div>
 <script type="application/json" id="gaia-graph-data">{
   "$schema": "./schema/skill.schema.json",
-  "version": "2.13.0",
-  "generatedAt": "2026-04-30T00:00:00Z",
+  "version": "3.0.1",
+  "generatedAt": "2026-05-06T00:00:00Z",
   "meta": {
     "typeLabels": {
+      "basic": "Basic Skill",
       "extra": "Extra Skill",
       "ultimate": "Ultimate Skill"
     },
@@ -139,10 +140,66 @@
       "III": "Evolved",
       "IV": "Hardened",
       "V": "Transcendent",
-      "VI": "Transcendent â˜…"
+      "VI": "Transcendent ★"
     },
     "rarityLabels": {
       "legendary": "Divine"
+    },
+    "levelColors": {
+      "0": {
+        "hex": "#94a3b8",
+        "bg": "rgba(148,163,184,.12)",
+        "border": "rgba(148,163,184,.4)"
+      },
+      "I": {
+        "hex": "#38bdf8",
+        "bg": "rgba(56,189,248,.12)",
+        "border": "rgba(56,189,248,.4)"
+      },
+      "II": {
+        "hex": "#63cab7",
+        "bg": "rgba(99,202,183,.15)",
+        "border": "rgba(99,202,183,.4)"
+      },
+      "III": {
+        "hex": "#a78bfa",
+        "bg": "rgba(167,139,250,.15)",
+        "border": "rgba(167,139,250,.4)"
+      },
+      "IV": {
+        "hex": "#e879f9",
+        "bg": "rgba(232,121,249,.15)",
+        "border": "rgba(232,121,249,.4)"
+      },
+      "V": {
+        "hex": "#fbbf24",
+        "bg": "rgba(251,191,36,.15)",
+        "border": "rgba(251,191,36,.4)"
+      },
+      "VI": {
+        "hex": "#fbbf24",
+        "bg": "rgba(251,191,36,.22)",
+        "border": "rgba(251,191,36,.55)"
+      }
+    },
+    "typeColors": {
+      "basic": {
+        "hex": "#38bdf8",
+        "rgb": "56,189,248"
+      },
+      "extra": {
+        "hex": "#c084fc",
+        "rgb": "192,132,252"
+      },
+      "ultimate": {
+        "hex": "#f59e0b",
+        "rgb": "245,158,11"
+      }
+    },
+    "typeSymbols": {
+      "basic": "○",
+      "extra": "◇",
+      "ultimate": "◆"
     }
   },
   "skills": [
@@ -212,7 +269,8 @@
       "derivatives": [
         "gaia-audit",
         "grounding",
-        "rag-pipeline"
+        "rag-pipeline",
+        "wiki-search"
       ],
       "conditions": "",
       "evidence": [
@@ -227,7 +285,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-26",
-      "updatedAt": "2026-04-30",
+      "updatedAt": "2026-05-06",
       "version": "0.1.0"
     },
     {
@@ -383,7 +441,8 @@
         "research",
         "document-analyst",
         "data-analysis",
-        "literature-review"
+        "literature-review",
+        "wiki-search"
       ],
       "conditions": "",
       "evidence": [
@@ -398,7 +457,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-26",
-      "updatedAt": "2026-04-30",
+      "updatedAt": "2026-05-06",
       "version": "0.1.0"
     },
     {
@@ -538,7 +597,8 @@
       "prerequisites": [],
       "derivatives": [
         "rag-pipeline",
-        "knowledge-harvest"
+        "knowledge-harvest",
+        "wiki-search"
       ],
       "conditions": "",
       "evidence": [
@@ -553,7 +613,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-26",
-      "updatedAt": "2026-04-26",
+      "updatedAt": "2026-05-06",
       "version": "0.1.0"
     },
     {
@@ -627,7 +687,8 @@
       "derivatives": [
         "ghostwrite",
         "prd-generation",
-        "scientific-writing"
+        "scientific-writing",
+        "architecture-diagram"
       ],
       "conditions": "",
       "evidence": [
@@ -642,7 +703,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-26",
-      "updatedAt": "2026-04-30",
+      "updatedAt": "2026-05-06",
       "version": "0.1.0"
     },
     {
@@ -655,7 +716,8 @@
       "prerequisites": [],
       "derivatives": [
         "ghostwrite",
-        "translation-pipeline"
+        "translation-pipeline",
+        "humanize-prose"
       ],
       "conditions": "",
       "evidence": [
@@ -670,7 +732,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-26",
-      "updatedAt": "2026-04-26",
+      "updatedAt": "2026-05-06",
       "version": "0.1.0"
     },
     {
@@ -772,7 +834,8 @@
       "derivatives": [
         "browser-automation",
         "research",
-        "web-scrape"
+        "web-scrape",
+        "prediction-market-analysis"
       ],
       "conditions": "",
       "evidence": [
@@ -787,7 +850,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-26",
-      "updatedAt": "2026-04-28",
+      "updatedAt": "2026-05-06",
       "version": "0.1.0"
     },
     {
@@ -829,7 +892,9 @@
       "derivatives": [
         "document-analyst",
         "document-digitization",
-        "text-to-sql-pipeline"
+        "text-to-sql-pipeline",
+        "humanize-prose",
+        "architecture-diagram"
       ],
       "conditions": "",
       "evidence": [
@@ -844,7 +909,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-26",
-      "updatedAt": "2026-04-28",
+      "updatedAt": "2026-05-06",
       "version": "0.1.0"
     },
     {
@@ -1671,7 +1736,8 @@
       "description": "Generates charts, graphs, and visual summaries from datasets by selecting appropriate visualization types and mapping data dimensions.",
       "prerequisites": [],
       "derivatives": [
-        "data-analysis"
+        "data-analysis",
+        "architecture-diagram"
       ],
       "conditions": "",
       "evidence": [
@@ -1686,7 +1752,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-28",
-      "updatedAt": "2026-04-28",
+      "updatedAt": "2026-05-06",
       "version": "0.2.0"
     },
     {
@@ -1793,7 +1859,8 @@
       ],
       "derivatives": [
         "autonomous-data-scientist",
-        "ml-pipeline"
+        "ml-pipeline",
+        "prediction-market-analysis"
       ],
       "conditions": "",
       "evidence": [
@@ -1808,7 +1875,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-28",
-      "updatedAt": "2026-04-30",
+      "updatedAt": "2026-05-06",
       "version": "0.2.0"
     },
     {
@@ -3332,7 +3399,9 @@
       "rarity": "common",
       "description": "Reads, edits, repacks, and applies styling or design principles to structured binary document formats such as PPTX, DOCX, and XLSX.",
       "prerequisites": [],
-      "derivatives": [],
+      "derivatives": [
+        "humanize-prose"
+      ],
       "conditions": "",
       "evidence": [
         {
@@ -3346,7 +3415,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-30",
-      "updatedAt": "2026-04-30",
+      "updatedAt": "2026-05-06",
       "version": "0.1.0"
     },
     {
@@ -3689,7 +3758,9 @@
       "rarity": "uncommon",
       "description": "Performs hypothesis testing, regression analysis, and Bayesian modelling with effect size calculation and APA-formatted statistical reporting using scipy, statsmodels, and PyMC.",
       "prerequisites": [],
-      "derivatives": [],
+      "derivatives": [
+        "prediction-market-analysis"
+      ],
       "conditions": "",
       "evidence": [
         {
@@ -3710,7 +3781,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-30",
-      "updatedAt": "2026-04-30",
+      "updatedAt": "2026-05-06",
       "version": "0.1.0"
     },
     {
@@ -4088,6 +4159,157 @@
       "createdAt": "2026-04-30",
       "updatedAt": "2026-04-30",
       "version": "0.2.0"
+    },
+    {
+      "id": "feed-monitoring",
+      "name": "Feed Monitoring",
+      "type": "basic",
+      "level": "IV",
+      "rarity": "common",
+      "description": "Monitors RSS, Atom, blog, or other recurring content feeds, discovers updates, tracks read state, and surfaces new signals for downstream agent workflows.",
+      "prerequisites": [],
+      "derivatives": [],
+      "conditions": "Requires configured feed sources and a repeatable polling or discovery mechanism.",
+      "evidence": [
+        {
+          "class": "B",
+          "source": "https://github.com/NousResearch/hermes-agent/blob/main/skills/research/blogwatcher/SKILL.md",
+          "evaluator": "openai-codex",
+          "date": "2026-05-06",
+          "notes": "Hermes Agent blogwatcher skill monitors blogs and RSS/Atom feeds with feed discovery, scraping fallback, OPML import, and read/unread article management."
+        }
+      ],
+      "knownAgents": [
+        "NousResearch/hermes-agent"
+      ],
+      "status": "provisional",
+      "createdAt": "2026-05-06",
+      "updatedAt": "2026-05-06",
+      "version": "0.1.0"
+    },
+    {
+      "id": "wiki-search",
+      "name": "Wiki Search",
+      "type": "extra",
+      "level": "IV",
+      "rarity": "uncommon",
+      "description": "Builds, maintains, and queries an interlinked markdown or wiki-style knowledge base so an agent can retrieve durable local context across research sessions.",
+      "prerequisites": [
+        "retrieve",
+        "embed-text",
+        "summarize"
+      ],
+      "derivatives": [],
+      "conditions": "Requires an accessible local wiki or markdown knowledge-base directory and a consistent linking or indexing convention.",
+      "evidence": [
+        {
+          "class": "B",
+          "source": "https://github.com/NousResearch/hermes-agent/blob/main/skills/research/llm-wiki/SKILL.md",
+          "evaluator": "openai-codex",
+          "date": "2026-05-06",
+          "notes": "Hermes Agent llm-wiki skill documents a persistent interlinked markdown knowledge base pattern for compounding research notes and retrieval."
+        }
+      ],
+      "knownAgents": [
+        "NousResearch/hermes-agent"
+      ],
+      "status": "provisional",
+      "createdAt": "2026-05-06",
+      "updatedAt": "2026-05-06",
+      "version": "0.1.0"
+    },
+    {
+      "id": "prediction-market-analysis",
+      "name": "Prediction Market Analysis",
+      "type": "extra",
+      "level": "IV",
+      "rarity": "rare",
+      "description": "Queries prediction-market data, compares market probabilities and price history, and summarizes probabilistic signals for forecasting or decision-support workflows.",
+      "prerequisites": [
+        "data-analysis",
+        "web-search",
+        "statistical-analysis"
+      ],
+      "derivatives": [],
+      "conditions": "Requires read-only market data sources and clear separation between analysis output and financial advice or trade execution.",
+      "evidence": [
+        {
+          "class": "B",
+          "source": "https://github.com/NousResearch/hermes-agent/blob/main/skills/research/polymarket/SKILL.md",
+          "evaluator": "openai-codex",
+          "date": "2026-05-06",
+          "notes": "Hermes Agent polymarket skill queries markets, prices, order books, and historical prediction-market data through public read-only APIs."
+        }
+      ],
+      "knownAgents": [
+        "NousResearch/hermes-agent"
+      ],
+      "status": "provisional",
+      "createdAt": "2026-05-06",
+      "updatedAt": "2026-05-06",
+      "version": "0.1.0"
+    },
+    {
+      "id": "humanize-prose",
+      "name": "Humanize Prose",
+      "type": "extra",
+      "level": "IV",
+      "rarity": "uncommon",
+      "description": "Audits and rewrites prose to remove generic AI-writing patterns, preserve author intent, and adapt tone toward a more natural human voice.",
+      "prerequisites": [
+        "document-editing",
+        "audience-model",
+        "format-output"
+      ],
+      "derivatives": [],
+      "conditions": "Requires explicit user permission to revise voice, tone, and stylistic markers without changing factual claims.",
+      "evidence": [
+        {
+          "class": "B",
+          "source": "https://github.com/NousResearch/hermes-agent/blob/main/skills/creative/humanizer/SKILL.md",
+          "evaluator": "openai-codex",
+          "date": "2026-05-06",
+          "notes": "Hermes Agent humanizer skill identifies AI-generated writing patterns and rewrites text to sound more natural while retaining meaning."
+        }
+      ],
+      "knownAgents": [
+        "NousResearch/hermes-agent"
+      ],
+      "status": "provisional",
+      "createdAt": "2026-05-06",
+      "updatedAt": "2026-05-06",
+      "version": "0.1.0"
+    },
+    {
+      "id": "architecture-diagram",
+      "name": "Architecture Diagram",
+      "type": "extra",
+      "level": "IV",
+      "rarity": "uncommon",
+      "description": "Generates technical architecture, infrastructure, or cloud diagrams as structured visual artifacts from natural-language system descriptions.",
+      "prerequisites": [
+        "data-visualize",
+        "format-output",
+        "write-report"
+      ],
+      "derivatives": [],
+      "conditions": "Requires enough system context to identify components, relationships, boundaries, and rendering constraints.",
+      "evidence": [
+        {
+          "class": "B",
+          "source": "https://github.com/NousResearch/hermes-agent/blob/main/skills/creative/architecture-diagram/SKILL.md",
+          "evaluator": "openai-codex",
+          "date": "2026-05-06",
+          "notes": "Hermes Agent architecture-diagram skill generates standalone HTML files with inline SVG architecture diagrams from system descriptions."
+        }
+      ],
+      "knownAgents": [
+        "NousResearch/hermes-agent"
+      ],
+      "status": "provisional",
+      "createdAt": "2026-05-06",
+      "updatedAt": "2026-05-06",
+      "version": "0.1.0"
     }
   ],
   "edges": [
@@ -5660,11 +5882,131 @@
       "evidenceRefs": [
         "gaia-meta-audit#evidence[0]"
       ]
+    },
+    {
+      "sourceSkillId": "retrieve",
+      "targetSkillId": "wiki-search",
+      "edgeType": "prerequisite",
+      "condition": "Requires an accessible local wiki or markdown knowledge-base directory and a consistent linking or indexing convention.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "wiki-search#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "embed-text",
+      "targetSkillId": "wiki-search",
+      "edgeType": "prerequisite",
+      "condition": "Requires an accessible local wiki or markdown knowledge-base directory and a consistent linking or indexing convention.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "wiki-search#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "summarize",
+      "targetSkillId": "wiki-search",
+      "edgeType": "prerequisite",
+      "condition": "Requires an accessible local wiki or markdown knowledge-base directory and a consistent linking or indexing convention.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "wiki-search#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "data-analysis",
+      "targetSkillId": "prediction-market-analysis",
+      "edgeType": "prerequisite",
+      "condition": "Requires read-only market data sources and clear separation between analysis output and financial advice or trade execution.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "prediction-market-analysis#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "web-search",
+      "targetSkillId": "prediction-market-analysis",
+      "edgeType": "prerequisite",
+      "condition": "Requires read-only market data sources and clear separation between analysis output and financial advice or trade execution.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "prediction-market-analysis#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "statistical-analysis",
+      "targetSkillId": "prediction-market-analysis",
+      "edgeType": "prerequisite",
+      "condition": "Requires read-only market data sources and clear separation between analysis output and financial advice or trade execution.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "prediction-market-analysis#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "document-editing",
+      "targetSkillId": "humanize-prose",
+      "edgeType": "prerequisite",
+      "condition": "Requires explicit user permission to revise voice, tone, and stylistic markers without changing factual claims.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "humanize-prose#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "audience-model",
+      "targetSkillId": "humanize-prose",
+      "edgeType": "prerequisite",
+      "condition": "Requires explicit user permission to revise voice, tone, and stylistic markers without changing factual claims.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "humanize-prose#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "format-output",
+      "targetSkillId": "humanize-prose",
+      "edgeType": "prerequisite",
+      "condition": "Requires explicit user permission to revise voice, tone, and stylistic markers without changing factual claims.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "humanize-prose#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "data-visualize",
+      "targetSkillId": "architecture-diagram",
+      "edgeType": "prerequisite",
+      "condition": "Requires enough system context to identify components, relationships, boundaries, and rendering constraints.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "architecture-diagram#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "format-output",
+      "targetSkillId": "architecture-diagram",
+      "edgeType": "prerequisite",
+      "condition": "Requires enough system context to identify components, relationships, boundaries, and rendering constraints.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "architecture-diagram#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "write-report",
+      "targetSkillId": "architecture-diagram",
+      "edgeType": "prerequisite",
+      "condition": "Requires enough system context to identify components, relationships, boundaries, and rendering constraints.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "architecture-diagram#evidence[0]"
+      ]
     }
   ]
 }</script>
 <script type="application/json" id="gaia-named-skills">{
-  "generatedAt": "2026-04-30",
+  "generatedAt": "2026-05-06",
   "buckets": {
     "automated-testing": [
       {
@@ -6326,189 +6668,6 @@
         }
       }
     ],
-    "error-interpretation": [
-      {
-        "id": "openai/gh-fix-ci",
-        "name": "GH Fix CI",
-        "contributor": "openai",
-        "origin": false,
-        "genericSkillRef": "error-interpretation",
-        "status": "named",
-        "level": "II",
-        "description": "Debugs failing GitHub Actions checks on pull requests using GitHub CLI evidence, logs, and focused remediation steps.",
-        "title": "The Checkrunner Surgeon",
-        "catalogRef": "openai-gh-fix-ci",
-        "tags": [
-          "github-actions",
-          "ci",
-          "debugging",
-          "pull-requests"
-        ],
-        "links": {
-          "docs": "https://officialskills.sh/openai/skills/gh-fix-ci"
-        }
-      }
-    ],
-    "cite-sources": [
-      {
-        "id": "openai/openai-docs",
-        "name": "OpenAI Docs",
-        "contributor": "openai",
-        "origin": false,
-        "genericSkillRef": "cite-sources",
-        "status": "named",
-        "level": "II",
-        "description": "Fetches current OpenAI developer documentation for API and SDK implementation work, grounding code changes in official reference material.",
-        "title": "The Living API Codex",
-        "catalogRef": "openai-openai-docs",
-        "tags": [
-          "openai",
-          "docs",
-          "api-reference",
-          "sdk",
-          "citation"
-        ],
-        "links": {
-          "docs": "https://officialskills.sh/openai/skills/openai-docs"
-        }
-      }
-    ],
-    "computer-use": [
-      {
-        "id": "openai/playwright",
-        "name": "Playwright",
-        "contributor": "openai",
-        "origin": false,
-        "genericSkillRef": "computer-use",
-        "status": "named",
-        "level": "II",
-        "description": "Automates real-browser testing from the terminal with Playwright, collecting screenshots, DOM state, and interaction evidence.",
-        "title": "The Browser Witness",
-        "catalogRef": "openai-playwright",
-        "tags": [
-          "playwright",
-          "browser-testing",
-          "automation",
-          "screenshots"
-        ],
-        "links": {
-          "docs": "https://officialskills.sh/openai/skills/playwright"
-        }
-      }
-    ],
-    "code-review-pipeline": [
-      {
-        "id": "openai/security-best-practices",
-        "name": "Security Best Practices",
-        "contributor": "openai",
-        "origin": false,
-        "genericSkillRef": "code-review-pipeline",
-        "status": "named",
-        "level": "III",
-        "description": "Reviews Python, JavaScript, TypeScript, and Go code for language-specific security vulnerabilities and hardening opportunities.",
-        "title": "The Secure Code Sentinel",
-        "catalogRef": "openai-security-best-practices",
-        "tags": [
-          "security",
-          "secure-coding",
-          "code-review",
-          "vulnerability-analysis"
-        ],
-        "links": {
-          "docs": "https://officialskills.sh/openai/skills/security-best-practices"
-        }
-      },
-      {
-        "id": "openai/security-threat-model",
-        "name": "Security Threat Model",
-        "contributor": "openai",
-        "origin": false,
-        "genericSkillRef": "code-review-pipeline",
-        "status": "named",
-        "level": "III",
-        "description": "Performs application security threat modeling for specific repositories, flows, and code paths, producing prioritized risk findings.",
-        "title": "The Threat Cartographer",
-        "catalogRef": "openai-security-threat-model",
-        "tags": [
-          "security",
-          "threat-modeling",
-          "risk-analysis",
-          "code-review"
-        ],
-        "links": {
-          "docs": "https://officialskills.sh/openai/skills/security-threat-model"
-        }
-      }
-    ],
-    "knowledge-graph-build": [
-      {
-        "id": "openai/security-ownership-map",
-        "name": "Security Ownership Map",
-        "contributor": "openai",
-        "origin": false,
-        "genericSkillRef": "knowledge-graph-build",
-        "status": "named",
-        "level": "III",
-        "description": "Analyzes repository history to map ownership, bus factor, and sensitive-code clusters for security review planning.",
-        "title": "The Ownership Mapper",
-        "catalogRef": "openai-security-ownership-map",
-        "tags": [
-          "security",
-          "ownership",
-          "bus-factor",
-          "repository-analysis"
-        ],
-        "links": {
-          "docs": "https://officialskills.sh/openai/skills/security-ownership-map"
-        }
-      }
-    ],
-    "detect-anomaly": [
-      {
-        "id": "openai/sentry",
-        "name": "Sentry",
-        "contributor": "openai",
-        "origin": false,
-        "genericSkillRef": "detect-anomaly",
-        "status": "named",
-        "level": "II",
-        "description": "Connects to Sentry production error data for incident triage, regression investigation, and release-health analysis.",
-        "title": "The Incident Lens",
-        "catalogRef": "openai-sentry",
-        "tags": [
-          "sentry",
-          "incident-response",
-          "observability",
-          "errors"
-        ],
-        "links": {
-          "docs": "https://officialskills.sh/openai/skills/sentry"
-        }
-      }
-    ],
-    "diff-content": [
-      {
-        "id": "openai/yeet",
-        "name": "Yeet",
-        "contributor": "openai",
-        "origin": false,
-        "genericSkillRef": "diff-content",
-        "status": "named",
-        "level": "II",
-        "description": "Automates a guarded Git workflow from scoped diffs through staging, committing, pushing, and pull request creation.",
-        "title": "The Guarded Shipwright",
-        "catalogRef": "openai-yeet",
-        "tags": [
-          "git",
-          "pull-requests",
-          "commit-workflow",
-          "release-flow"
-        ],
-        "links": {
-          "docs": "https://officialskills.sh/openai/skills/yeet"
-        }
-      }
-    ],
     "multi-agent-orchestration-v": [
       {
         "id": "ruvnet/flow-nexus-swarm",
@@ -6832,16 +6991,6 @@
       "mattpocock/triage",
       "mattpocock/write-a-skill",
       "mattpocock/zoom-out"
-    ],
-    "openai": [
-      "openai/gh-fix-ci",
-      "openai/openai-docs",
-      "openai/playwright",
-      "openai/security-best-practices",
-      "openai/security-ownership-map",
-      "openai/security-threat-model",
-      "openai/sentry",
-      "openai/yeet"
     ],
     "ruvnet": [
       "ruvnet/flow-nexus-swarm"

--- a/scripts/detectCombinations.py
+++ b/scripts/detectCombinations.py
@@ -15,7 +15,7 @@ def detect_combinations(graph_data, owned_skills, detected_skills):
     combined_available = owned_skill_ids.union(set(detected_skills))
     
     for skill in graph_data.get('skills', []):
-        if skill.get('type') in ['composite', 'legendary']:
+        if skill.get('type') in ['extra', 'ultimate']:
             prereqs = skill.get('prerequisites', [])
             if not prereqs:
                 continue

--- a/src/gaia_cli/cardRenderer.py
+++ b/src/gaia_cli/cardRenderer.py
@@ -78,11 +78,22 @@ TIER_COLORS = {
     "extra": (192, 132, 252),
     "ultimate": (245, 158, 11),
 }
+RANK_COLORS = {
+    "0":  (148, 163, 184),   # Slate
+    "I":  (56, 189, 248),    # Sky
+    "II": (99, 202, 183),    # Teal
+    "III": (167, 139, 250),  # Violet
+    "IV": (232, 121, 249),   # Fuchsia
+    "V":  (251, 191, 36),    # Amber
+    "VI": (251, 191, 36),    # Amber bright
+}
 COLOR_SUCCESS = (134, 239, 172)
 COLOR_MISSING = (100, 116, 139)
 COLOR_TEXT = (226, 232, 240)
 COLOR_MUTED = (148, 163, 184)
 COLOR_GOLD = (251, 191, 36)
+COLOR_CONTRIBUTOR = (239, 68, 68)    # Red for named skill contributors
+COLOR_LOCAL_USER = (134, 239, 172)   # Bright green for local/user skills
 
 
 # ─── Style constants ────────────────────────────────────────────────────────
@@ -244,7 +255,8 @@ def render_card(skill: dict, *, width: int = CARD_WIDTH) -> str:
 
     tier = skill.get("type", "basic")
     glyph = TIER_GLYPHS.get(tier, "○")
-    name = skill.get("name", skill.get("id", "Unknown"))
+    skill_id = skill.get("id", "unknown")
+    name = f"/{skill_id}"
     rarity = skill.get("rarity", "common")
     rarity_label = RARITY_LABELS.get(rarity, rarity.capitalize())
     level = skill.get("level", "0")
@@ -254,7 +266,6 @@ def render_card(skill: dict, *, width: int = CARD_WIDTH) -> str:
     derivatives = skill.get("derivatives", [])
     status = skill.get("status", "provisional")
     evidence_count = len(skill.get("evidence", []))
-    skill_id = skill.get("id", "unknown")
 
     lines: list[str] = []
 
@@ -289,16 +300,18 @@ def render_card(skill: dict, *, width: int = CARD_WIDTH) -> str:
     # Separator
     lines.append(_separator(width))
 
-    # Prerequisites
+    # Prerequisites (slash-named)
     if prereqs:
-        prereq_str = _fit_list(prereqs, inner, prefix="Prereqs: ")
+        prereq_list = [f"/{p}" for p in prereqs]
+        prereq_str = _fit_list(prereq_list, inner, prefix="Prereqs: ")
         lines.append(_line(prereq_str, width))
     else:
         lines.append(_line("Prereqs: (none)", width))
 
-    # Derivatives
+    # Derivatives (slash-named)
     if derivatives:
-        deriv_str = _fit_list(derivatives, inner, prefix="Unlocks: ")
+        deriv_list = [f"/{d}" for d in derivatives]
+        deriv_str = _fit_list(deriv_list, inner, prefix="Unlocks: ")
         lines.append(_line(deriv_str, width))
     else:
         lines.append(_line("Unlocks: (none)", width))
@@ -322,11 +335,12 @@ def render_card_compact(skill: dict) -> str:
     """
     Render a compact single-line card summary.
 
-    Format: [glyph] name (level) [rarity] — first 60 chars of description
+    Format: [glyph] /skill-id (level) [rarity] — first 60 chars of description
     """
     tier = skill.get("type", "basic")
     glyph = TIER_GLYPHS.get(tier, "○")
-    name = skill.get("name", skill.get("id", "Unknown"))
+    skill_id = skill.get("id", skill.get("name", "unknown"))
+    name = f"/{skill_id}"
     level = skill.get("level", "0")
     rarity = skill.get("rarity", "common")
     desc = skill.get("description", "")
@@ -412,8 +426,10 @@ def render_appraise_card(
 
     tier = skill_data.get("type", "basic")
     tc = TIER_COLORS.get(tier, (56, 189, 248))
+    rc = RANK_COLORS.get(skill_data.get("level", "0"), (148, 163, 184))
     glyph = TIER_GLYPHS.get(tier, "○")
-    name = skill_data.get("name", skill_data.get("id", "?"))
+    skill_id = skill_data.get("id", "?")
+    name = f"/{skill_id}"
     level = skill_data.get("level", "0")
     rarity = skill_data.get("rarity", "common")
     desc = skill_data.get("description", "")
@@ -426,20 +442,21 @@ def render_appraise_card(
     # Top border
     lines.append(f"{bc}{TL}{H * (width - 2)}{TR}{r}")
 
-    # Header line: glyph + name + level
+    # Header line: glyph + name + level (rank-colored)
     level_str = f"Level {level}"
     header_left = f"{glyph} {name}"
     space = inner - len(header_left) - len(level_str)
     if space < 1:
         header_left = header_left[: inner - len(level_str) - 2] + "…"
         space = 1
-    lines.append(f"{bc}{V}{r} {bold()}{fg(*tc)}{header_left}{r}{' ' * space}{dim()}{level_str}{r} {bc}{V}{r}")
+    lines.append(f"{bc}{V}{r} {bold()}{fg(*tc)}{header_left}{r}{' ' * space}{fg(*rc)}{level_str}{r} {bc}{V}{r}")
 
     # Thin divider
     lines.append(f"{bc}{V}{r} {fg(*COLOR_MUTED)}{H * inner}{r} {bc}{V}{r}")
 
-    # Type + rarity
-    type_str = f"Type: {tier.capitalize()}"
+    # Type + rarity (using proper type labels)
+    type_labels = {"basic": "Basic Skill", "extra": "Extra Skill", "ultimate": "Ultimate Skill"}
+    type_str = f"Type: {type_labels.get(tier, tier.capitalize())}"
     rarity_str = f"Rarity: {rarity}"
     meta = f"{type_str}    {rarity_str}"
     lines.append(f"{bc}{V}{r} {fg(*COLOR_MUTED)}{_pad(meta, inner)}{r} {bc}{V}{r}")
@@ -460,7 +477,7 @@ def render_appraise_card(
         prereq_items = []
         for pid, has in prereq_status.items():
             icon = f"{fg(*COLOR_SUCCESS)}✓{r}" if has else f"{fg(*COLOR_MISSING)}○{r}"
-            prereq_items.append(f"  {icon} {pid}")
+            prereq_items.append(f"  {icon} /{pid}")
         # Two-column layout
         col_w = inner // 2
         for i in range(0, len(prereq_items), 2):
@@ -479,9 +496,9 @@ def render_appraise_card(
     # Blank
     lines.append(f"{bc}{V}{r} {' ' * inner} {bc}{V}{r}")
 
-    # Derivatives (unlocks)
+    # Derivatives (unlocks) — slash-named
     if derivatives:
-        deriv_line = "Unlocks: " + ", ".join(d.get("id", d) if isinstance(d, dict) else d for d in derivatives[:4])
+        deriv_line = "Unlocks: " + ", ".join("/" + (d.get("id", d) if isinstance(d, dict) else d) for d in derivatives[:4])
         if len(derivatives) > 4:
             deriv_line += f" +{len(derivatives) - 4} more"
         lines.append(f"{bc}{V}{r} {fg(*COLOR_MUTED)}{_pad(deriv_line, inner)}{r} {bc}{V}{r}")
@@ -515,7 +532,8 @@ def render_unlock_card(skill_data: dict, new_paths: list) -> str:
     """Celebratory unlock card with ASCII art."""
     tier = skill_data.get("type", "basic")
     tc = TIER_COLORS.get(tier, (56, 189, 248))
-    name = skill_data.get("name", skill_data.get("id", "?"))
+    skill_id = skill_data.get("id", "?")
+    name = f"/{skill_id}"
     glyph = TIER_GLYPHS.get(tier, "○")
     level = skill_data.get("level", "0")
     rarity = skill_data.get("rarity", "common")
@@ -582,22 +600,82 @@ def render_path_summary(paths: dict) -> str:
 
 def render_promotion_prompt(skill_data: dict, proposed_level: str) -> str:
     """Prompt shown when a skill is eligible for promotion."""
-    name = skill_data.get("name", skill_data.get("id", "?"))
     skill_id = skill_data.get("id", "?")
-    suggested_name = _name_from_slug(skill_id) or name
+    skill_type = skill_data.get("type", "extra")
+    prereqs = skill_data.get("prerequisites", [])
     gc = fg(*COLOR_GOLD)
+    tc = fg(*TIER_COLORS.get(skill_type, COLOR_GOLD))
     r = reset()
     b = bold()
 
     from gaia_cli.promotion import LEVEL_NAMES
     level_name = LEVEL_NAMES.get(proposed_level, proposed_level)
 
-    return "\n".join([
-        f"",
-        f"  {gc}┌─ Fusion Ready ─────────────────────┐{r}",
-        f"  {gc}│{r}  {b}{name}{r} can advance to {b}Level {proposed_level}{r} ({level_name})",
+    lines = [""]
+    # Show fusion diagram if skill has prerequisites
+    if prereqs:
+        lines.append(render_fusion_diagram(prereqs, skill_id, skill_type))
+    lines.extend([
+        f"  {gc}┌─ Fusion ──────────────────────────────┐{r}",
+        f"  {gc}│{r}  {tc}{b}/{skill_id}{r} can advance to {b}Level {proposed_level}{r} ({level_name})",
         f"  {gc}│{r}  Run: {b}gaia fuse {skill_id}{r}",
-        f"  {gc}│{r}  Rename? {dim()}gaia fuse {skill_id} --name \"{suggested_name}\"{r}",
         f"  {gc}└───────────────────────────────────────────┘{r}",
-        f"",
+        "",
     ])
+    return "\n".join(lines)
+
+
+# ─── Fusion diagram ───────────────────────────────────────────────────────
+
+
+def render_fusion_diagram(prereqs: list[str], result: str, result_type: str = "extra") -> str:
+    """Render a Unicode fusion flow diagram showing skill combination."""
+    tier_color = TIER_COLORS.get(result_type, TIER_COLORS["extra"])
+    glyph = TIER_GLYPHS.get(result_type, "◇")
+
+    mc = fg(*COLOR_MUTED)
+    tc = fg(*tier_color)
+    tb = bold() + fg(*tier_color)
+    r = reset()
+
+    # Format skill names with slash prefix
+    prereq_names = [f"/{p}" for p in prereqs]
+    result_name = f"/{result}"
+
+    # Single prereq: simple arrow
+    if len(prereqs) == 1:
+        return f"  {mc}{prereq_names[0]} ────▶{r} {tb}{result_name} {glyph}{r}"
+
+    # Pad prereq names to equal width
+    max_len = max(len(n) for n in prereq_names)
+    padded = [n.ljust(max_len) for n in prereq_names]
+
+    n = len(padded)
+    lines = []
+
+    if n == 2:
+        # Two prereqs: bracket rows with a connector row in between
+        padding = " " * max_len
+        lines.append(f"  {mc}{padded[0]} ─┐{r}")
+        lines.append(f"  {mc}{padding}  {r}{tc}├──▶{r} {tb}{result_name} {glyph}{r}")
+        lines.append(f"  {mc}{padded[1]} ─┘{r}")
+    else:
+        # 3+ prereqs: arrow on the vertical midpoint row
+        mid = n // 2
+        for i, name in enumerate(padded):
+            if i == 0:
+                bracket = "─┐"
+            elif i == n - 1:
+                bracket = "─┘"
+            elif i == mid:
+                bracket = "─┼──▶"
+            else:
+                bracket = "─┤"
+
+            if i == mid:
+                line = f"  {mc}{name} {r}{tc}─┼──▶{r} {tb}{result_name} {glyph}{r}"
+            else:
+                line = f"  {mc}{name} {bracket}{r}"
+            lines.append(line)
+
+    return "\n".join(lines)

--- a/src/gaia_cli/commands/stats.py
+++ b/src/gaia_cli/commands/stats.py
@@ -7,12 +7,13 @@ from collections import Counter
 from pathlib import Path
 from typing import Iterable
 
+from gaia_cli.formatting import TIER_COLORS, RANK_COLORS, TYPE_SYMBOLS, _use_color, _fg, _reset
 from gaia_cli.registry import named_skills_dir, registry_graph_path
 
 TYPE_LABELS = {
-    "basic": "Atomic",
-    "extra": "Composite",
-    "ultimate": "Legendary",
+    "basic": "Basic Skill",
+    "extra": "Extra Skill",
+    "ultimate": "Ultimate Skill",
 }
 
 LEVEL_LABELS = {
@@ -153,16 +154,24 @@ def _percent(count: int, total: int) -> int:
 def render_stats(stats: dict) -> str:
     """Render a human-readable stats report."""
     total = stats["total_skills"]
+    use_color = _use_color()
+    rst = _reset() if use_color else ""
     lines = [f"Gaia Registry — {total} skills  {stats['total_edges']} edges", ""]
 
     lines.append("Type breakdown")
     for skill_type in TYPE_ORDER:
         label = TYPE_LABELS[skill_type]
+        glyph = TYPE_SYMBOLS.get(skill_type, " ")
         count = stats["type_counts"].get(skill_type, 0)
-        lines.append(f"  {label:<9} {count:>4}  {_bar(count, total)}  {_percent(count, total):>3}%")
+        bar = _bar(count, total)
+        if use_color:
+            color = _fg(*TIER_COLORS[skill_type])
+            lines.append(f"  {color}{glyph} {label:<14}{rst} {count:>4}  {color}{bar}{rst}  {_percent(count, total):>3}%")
+        else:
+            lines.append(f"  {glyph} {label:<14} {count:>4}  {bar}  {_percent(count, total):>3}%")
     for skill_type, count in sorted(stats["type_counts"].items()):
         if skill_type not in TYPE_LABELS:
-            lines.append(f"  {skill_type:<9} {count:>4}  {_bar(count, total)}  {_percent(count, total):>3}%")
+            lines.append(f"  {skill_type:<14} {count:>4}  {_bar(count, total)}  {_percent(count, total):>3}%")
 
     lines.extend(["", "Level breakdown"])
     for level in LEVEL_ORDER:
@@ -171,7 +180,11 @@ def render_stats(stats: dict) -> str:
         suffix = ""
         if level == "II" and stats.get("named_unclaimed", 0):
             suffix = f"  ({stats['named_unclaimed']} slots unclaimed)"
-        lines.append(f"  {level:<3} {label:<14} {count:>4}{suffix}")
+        if use_color:
+            color = _fg(*RANK_COLORS.get(level, RANK_COLORS["0"]))
+            lines.append(f"  {color}{level:<3} {label:<14}{rst} {count:>4}{suffix}")
+        else:
+            lines.append(f"  {level:<3} {label:<14} {count:>4}{suffix}")
     for level, count in sorted(stats["level_counts"].items()):
         if level not in LEVEL_LABELS:
             lines.append(f"  {level:<3} {'Unknown':<14} {count:>4}")

--- a/src/gaia_cli/formatting.py
+++ b/src/gaia_cli/formatting.py
@@ -1,0 +1,121 @@
+"""Centralized display formatting for skill identifiers.
+
+Implements the three-tier slash-naming hierarchy with ANSI coloring.
+"""
+
+from __future__ import annotations
+import os
+import sys
+
+
+# --- ANSI helpers (minimal, reuses pattern from cardRenderer) ---
+
+def _use_color() -> bool:
+    if os.environ.get("NO_COLOR"):
+        return False
+    if not hasattr(sys.stdout, "isatty"):
+        return False
+    return sys.stdout.isatty()
+
+
+def _fg(r: int, g: int, b: int) -> str:
+    if not _use_color():
+        return ""
+    colorterm = os.environ.get("COLORTERM", "")
+    if colorterm in ("truecolor", "24bit"):
+        return f"\033[38;2;{r};{g};{b}m"
+    index = 16 + (36 * (r // 51)) + (6 * (g // 51)) + (b // 51)
+    return f"\033[38;5;{index}m"
+
+
+def _reset() -> str:
+    return "\033[0m" if _use_color() else ""
+
+
+def _bold() -> str:
+    return "\033[1m" if _use_color() else ""
+
+
+# --- Color palettes ---
+
+TIER_COLORS = {
+    "basic": (56, 189, 248),
+    "extra": (192, 132, 252),
+    "ultimate": (245, 158, 11),
+}
+
+RANK_COLORS = {
+    "0":   (148, 163, 184),   # Slate
+    "I":   (56, 189, 248),    # Sky
+    "II":  (99, 202, 183),    # Teal
+    "III": (167, 139, 250),   # Violet
+    "IV":  (232, 121, 249),   # Fuchsia
+    "V":   (251, 191, 36),    # Amber
+    "VI":  (251, 191, 36),    # Amber bright
+}
+
+TYPE_SYMBOLS = {"basic": "○", "extra": "◇", "ultimate": "◆"}
+
+COLOR_CONTRIBUTOR = (239, 68, 68)    # #ef4444 -- red for named contributors
+COLOR_LOCAL_USER  = (134, 239, 172)  # #86efac -- bright green for local/user skills
+
+
+# --- Public formatting API ---
+
+def format_skill_plain(skill_id: str, *, named_contributor: str | None = None,
+                       is_local: bool = False, local_user: str | None = None) -> str:
+    """Return plain display string without ANSI codes."""
+    if named_contributor:
+        return f"{named_contributor}/{skill_id}"
+    if is_local and local_user:
+        return f"{local_user}/{skill_id}"
+    return f"/{skill_id}"
+
+
+def format_skill_colored(skill_id: str, level: str = "0", *,
+                         named_contributor: str | None = None,
+                         is_local: bool = False, local_user: str | None = None) -> str:
+    """Return ANSI-colored display string.
+
+    - Named: RED contributor + rank-colored skill name
+    - Local: GREEN username + rank-colored skill name
+    - Canon: rank-colored /skill-id
+    """
+    r = _reset()
+    rank_color = RANK_COLORS.get(level, RANK_COLORS["0"])
+    skill_colored = f"{_fg(*rank_color)}{skill_id}{r}"
+
+    if named_contributor:
+        contrib_colored = f"{_fg(*COLOR_CONTRIBUTOR)}{named_contributor}{r}"
+        return f"{contrib_colored}/{skill_colored}"
+    if is_local and local_user:
+        user_colored = f"{_fg(*COLOR_LOCAL_USER)}{local_user}{r}"
+        return f"{user_colored}/{skill_colored}"
+    return f"{_fg(*rank_color)}/{skill_id}{r}"
+
+
+def format_type_label(skill_type: str) -> str:
+    """Return type glyph + label like '○ Basic Skill'."""
+    labels = {"basic": "Basic Skill", "extra": "Extra Skill", "ultimate": "Ultimate Skill"}
+    symbol = TYPE_SYMBOLS.get(skill_type, "?")
+    label = labels.get(skill_type, skill_type)
+    return f"{symbol} {label}"
+
+
+def format_type_colored(skill_type: str) -> str:
+    """Return colored type glyph + label."""
+    raw = format_type_label(skill_type)
+    color = TIER_COLORS.get(skill_type, (148, 163, 184))
+    return f"{_fg(*color)}{raw}{_reset()}"
+
+
+def format_level_colored(level: str) -> str:
+    """Return level badge colored by rank."""
+    rank_color = RANK_COLORS.get(level, RANK_COLORS["0"])
+    return f"{_fg(*rank_color)}{level}{_reset()}"
+
+
+def fusion_equation(prereqs: list[str], result: str, result_glyph: str = "◇") -> str:
+    """Plain text fusion equation: /a + /b -> /result glyph"""
+    parts = " + ".join(f"/{p}" for p in prereqs)
+    return f"{parts} → /{result} {result_glyph}"

--- a/src/gaia_cli/localContext.py
+++ b/src/gaia_cli/localContext.py
@@ -1,0 +1,194 @@
+"""Local-first skill context.
+
+Merges user tree, detected tokens, named skill map, and canonical registry
+into a unified data source that commands consume by default.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from gaia_cli.registry import registry_graph_path, named_skills_dir, user_tree_path
+from gaia_cli.treeManager import load_tree
+from gaia_cli.pathEngine import load_paths
+
+
+@dataclass
+class LocalContext:
+    """Unified local-first view of skill state."""
+
+    username: str
+    owned_ids: set[str] = field(default_factory=set)
+    detected_ids: set[str] = field(default_factory=set)
+    novel_ids: set[str] = field(default_factory=set)
+    named_map: dict[str, str] = field(default_factory=dict)  # generic_skill_id -> "contributor/name"
+    tree_data: Optional[dict] = None
+    graph_data: Optional[dict] = None
+    _skill_map: dict[str, dict] = field(default_factory=dict, repr=False)
+
+    @classmethod
+    def load(cls, registry_path: str, username: str, *, include_scan: bool = True) -> "LocalContext":
+        """Build context from local state.
+
+        Args:
+            registry_path: Path to the registry root
+            username: Gaia username
+            include_scan: Whether to load last scan results (paths.json)
+        """
+        # Load user tree
+        tree_data = load_tree(username, registry_path=registry_path)
+        owned_ids = set()
+        if tree_data:
+            owned_ids = {s.get('skillId') for s in tree_data.get('unlockedSkills', []) if s.get('skillId')}
+
+        # Load canon graph
+        graph_path = registry_graph_path(registry_path)
+        graph_data = None
+        skill_map = {}
+        canon_ids = set()
+        if os.path.isfile(graph_path):
+            with open(graph_path, 'r', encoding='utf-8') as f:
+                graph_data = json.load(f)
+            for skill in graph_data.get('skills', []):
+                sid = skill.get('id')
+                if sid:
+                    skill_map[sid] = skill
+                    canon_ids.add(sid)
+
+        # Load detected skills from last scan
+        detected_ids = set()
+        novel_ids = set()
+        if include_scan:
+            paths = load_paths()
+            if paths:
+                # nearUnlocks and oneAway contain detected skill IDs
+                for path_entry in paths.get("availablePaths", []):
+                    for prereq in path_entry.get("ownedPrereqs", []):
+                        detected_ids.add(prereq)
+                # Also consider owned as detected
+                detected_ids |= owned_ids
+                # Novel = detected but not in canon
+                novel_ids = detected_ids - canon_ids
+
+        # Build named_map from registry/named/
+        named_map = _build_named_map(registry_path)
+
+        ctx = cls(
+            username=username,
+            owned_ids=owned_ids,
+            detected_ids=detected_ids,
+            novel_ids=novel_ids,
+            named_map=named_map,
+            tree_data=tree_data,
+            graph_data=graph_data,
+        )
+        ctx._skill_map = skill_map
+        return ctx
+
+    def is_named(self, skill_id: str) -> bool:
+        """Check if a canonical skill has a named implementation."""
+        return skill_id in self.named_map
+
+    def named_ref(self, skill_id: str) -> Optional[str]:
+        """Return 'contributor/name' for a named skill, or None."""
+        return self.named_map.get(skill_id)
+
+    def named_contributor(self, skill_id: str) -> Optional[str]:
+        """Return just the contributor name for a named skill."""
+        ref = self.named_map.get(skill_id)
+        if ref and "/" in ref:
+            return ref.split("/", 1)[0]
+        return None
+
+    def is_local(self, skill_id: str) -> bool:
+        """Check if skill is local-only (not in canon)."""
+        return skill_id in self.novel_ids
+
+    def is_owned(self, skill_id: str) -> bool:
+        """Check if user owns (has unlocked) this skill."""
+        return skill_id in self.owned_ids
+
+    def skill_level(self, skill_id: str) -> str:
+        """Get the user's level for a skill, or canon level, or '0'."""
+        if self.tree_data:
+            for s in self.tree_data.get('unlockedSkills', []):
+                if s.get('skillId') == skill_id:
+                    return s.get('level', '0')
+        skill = self._skill_map.get(skill_id)
+        if skill:
+            return skill.get('level', '0')
+        return "0"
+
+    def skill_type(self, skill_id: str) -> str:
+        """Get skill type (basic/extra/ultimate)."""
+        skill = self._skill_map.get(skill_id)
+        if skill:
+            return skill.get('type', 'basic')
+        return 'basic'
+
+    def all_skills(self) -> list[dict]:
+        """Return merged skill list: canon + novel local skills."""
+        skills = list(self._skill_map.values())
+        for novel_id in self.novel_ids:
+            if novel_id not in self._skill_map:
+                skills.append({
+                    "id": novel_id,
+                    "name": novel_id,
+                    "type": "basic",
+                    "level": "0",
+                    "rarity": "common",
+                    "prerequisites": [],
+                    "derivatives": [],
+                    "local": True,
+                })
+        return skills
+
+    def display_name(self, skill_id: str) -> str:
+        """Return the best display name for a skill (plain text, no ANSI).
+
+        Priority: named ref > local user/id > /id
+        """
+        if skill_id in self.named_map:
+            return self.named_map[skill_id]
+        if skill_id in self.novel_ids:
+            return f"{self.username}/{skill_id}"
+        return f"/{skill_id}"
+
+
+def _build_named_map(registry_path: str) -> dict[str, str]:
+    """Scan registry/named/ to build generic_skill_id -> 'contributor/name' map."""
+    named_dir = Path(named_skills_dir(registry_path))
+    named_map: dict[str, str] = {}
+    if not named_dir.is_dir():
+        return named_map
+    for md_path in sorted(named_dir.glob("*/*.md")):
+        try:
+            text = md_path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if not text.startswith("---\n"):
+            continue
+        # Parse frontmatter for genericSkillRef and id
+        frontmatter_end = text.find("\n---", 4)
+        if frontmatter_end == -1:
+            continue
+        frontmatter = text[4:frontmatter_end]
+        skill_id = None
+        generic_ref = None
+        for line in frontmatter.splitlines():
+            if ":" not in line:
+                continue
+            key, _, value = line.partition(":")
+            key = key.strip()
+            value = value.strip().strip('"').strip("'")
+            if key == "id":
+                skill_id = value
+            elif key == "genericSkillRef":
+                generic_ref = value
+        if generic_ref and skill_id:
+            named_map[generic_ref] = skill_id
+    return named_map

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -54,6 +54,24 @@ from gaia_cli.promotion import (
     LEVEL_NAMES,
 )
 from gaia_cli.hook import hook_entry
+from gaia_cli.formatting import (
+    format_skill_plain,
+    format_skill_colored,
+    format_type_label,
+    format_type_colored,
+    format_level_colored,
+    fusion_equation,
+    TIER_COLORS,
+    RANK_COLORS,
+    TYPE_SYMBOLS,
+    COLOR_CONTRIBUTOR,
+    COLOR_LOCAL_USER,
+    _fg,
+    _reset,
+    _use_color,
+)
+from gaia_cli.localContext import LocalContext
+from gaia_cli.cardRenderer import render_fusion_diagram
 
 DEFAULT_REGISTRY_REF = "https://github.com/mbtiongson1/gaia-skill-tree"
 
@@ -254,7 +272,18 @@ def scan_command(args):
         print(f"Found {scan_result['candidate_count']} candidate token(s).")
         print(f"Matched {len(resolved)} canonical skill(s).")
         if resolved:
-            print(", ".join(resolved))
+            # Colored skill list with type glyphs
+            graph_path_file = registry_graph_path(args.registry)
+            with open(graph_path_file, 'r', encoding='utf-8') as gf:
+                gdata = json.load(gf)
+            smap = {s['id']: s for s in gdata.get('skills', [])}
+            skill_parts = []
+            for sid in sorted(resolved):
+                sk = smap.get(sid, {})
+                glyph = TYPE_SYMBOLS.get(sk.get('type', 'basic'), '○')
+                colored_name = format_skill_colored(sid, sk.get('level', '0'))
+                skill_parts.append(f"  {glyph} {colored_name}")
+            print("\n".join(skill_parts))
         else:
             print('Tip: try `gaia skills search "code review"` or expand scanPaths.')
     username = config.get('gaiaUser')
@@ -265,10 +294,14 @@ def scan_command(args):
         unlocked = [s.get('skillId') for s in tree.get('unlockedSkills', [])]
         combos = get_combinations(graph_data, unlocked, resolved)
         if combos and not quiet:
-            print("\nNew combination candidates detected:")
+            print("\nNew fusion candidates:")
             for c in combos:
-                print(f"- {c['candidateResult']} (Requires: {', '.join(c['detectedSkills'])})")
-            print("Run `gaia fuse [skillId]` to confirm and add to your tree.")
+                result_skill = skill_map.get(c['candidateResult'], {})
+                result_type = result_skill.get('type', 'extra')
+                print(render_fusion_diagram(
+                    c['detectedSkills'], c['candidateResult'], result_type
+                ))
+            print("Run `gaia fuse <skill>` to confirm.")
 
         # Path engine integration
         old_paths = load_paths()
@@ -907,28 +940,72 @@ def skills_command(args):
             or q in str(item.get("name", "")).lower()
             or q in str(item.get("description", "")).lower()
         ]
+
+    # Build local context for named-first display
+    config = load_config() or {}
+    ctx_user = config.get("gaiaUser") or config.get("username") or ""
+    try:
+        ctx = LocalContext.load(args.registry, ctx_user, include_scan=False)
+    except Exception:
+        ctx = None
+
     if verb == "info":
         q = args.skill_id
         match = next((item for item in items if item.get("id") == q), None)
         if not match:
-            print(f"Skill '{q}' not found.", file=sys.stderr)
+            print(f"Skill '/{q}' not found.", file=sys.stderr)
             sys.exit(1)
+        sid = match.get("id", q)
+        level = match.get("level", "?")
+        skill_type = match.get("type", "basic")
+        named_contrib = ctx.named_contributor(sid) if ctx and ctx.is_named(sid) else None
+        is_local = ctx.is_local(sid) if ctx else False
+        display = format_skill_colored(sid, level, named_contributor=named_contrib,
+                                       is_local=is_local, local_user=ctx_user)
         suffix = " (pending)" if match.get("pending") else ""
-        print(f"{match['id']}{suffix}")
-        print(f"Name: {match.get('name', match['id'])}")
-        print(f"Level: {match.get('level', '?')}")
+        print(f"{display}{suffix}")
+        print(f"  Type:  {format_type_colored(skill_type)}")
+        print(f"  Level: {format_level_colored(level)}")
         if match.get("description"):
-            print(match["description"])
+            print(f"  {match['description']}")
         return
     if not items:
         print("No skills found.")
         return
-    width = max(5, *(len(str(item.get("id", ""))) for item in items))
-    print(f"{'Skill':<{width}}  Level  Name")
-    print("-" * (width + 14))
+
+    width = max(5, *(len(format_skill_plain(
+        item.get("id", ""),
+        named_contributor=ctx.named_contributor(item.get("id", "")) if ctx and ctx.is_named(item.get("id", "")) else None,
+        is_local=ctx.is_local(item.get("id", "")) if ctx else False,
+        local_user=ctx_user,
+    )) for item in items))
+    print(f"{'Skill':<{width}}  Level  Type")
+    print("─" * (width + 22))
     for item in items:
+        sid = item.get("id", "")
+        level = item.get("level", "?")
+        skill_type = item.get("type", "basic")
+        named_contrib = ctx.named_contributor(sid) if ctx and ctx.is_named(sid) else None
+        is_local = ctx.is_local(sid) if ctx else False
+
+        display = format_skill_colored(
+            sid, level,
+            named_contributor=named_contrib,
+            is_local=is_local,
+            local_user=ctx_user,
+        )
+        plain_display = format_skill_plain(
+            sid,
+            named_contributor=named_contrib,
+            is_local=is_local,
+            local_user=ctx_user,
+        )
+        level_col = format_level_colored(level)
+        type_col = format_type_colored(skill_type)
         suffix = " (pending)" if item.get("pending") else ""
-        print(f"{item.get('id', ''):<{width}}  {item.get('level', '?'):<5}  {item.get('name', '')}{suffix}")
+        # Use plain width for padding since ANSI codes don't count
+        pad = width - len(plain_display)
+        print(f"{display}{' ' * max(0, pad)}  {level_col:<5}  {type_col}{suffix}")
 
 
 def pull_command(args):
@@ -1021,6 +1098,11 @@ def get_parser():
         '--version', '-v',
         action='store_true',
         help="Print the Gaia CLI version and exit.",
+    )
+    parser.add_argument(
+        '--canon',
+        action='store_true',
+        help="Show canonical registry data instead of local-first view.",
     )
     subparsers = parser.add_subparsers(dest='command', metavar="{" + ",".join(PUBLIC_COMMANDS) + "}")
     subparsers.add_parser('help', help="Show command help")

--- a/tests/test_card_renderer.py
+++ b/tests/test_card_renderer.py
@@ -14,6 +14,7 @@ from gaia_cli.cardRenderer import (
     render_card_compact,
     render_cards,
     render_promotion_prompt,
+    render_fusion_diagram,
     load_and_render,
     _pad,
     _wrap_lines,
@@ -150,7 +151,7 @@ class TestRenderCard:
 
     def test_contains_skill_name(self, basic_skill):
         card = render_card(basic_skill)
-        assert "Tokenize" in card
+        assert "/tokenize" in card
 
     def test_contains_tier_glyph(self, basic_skill):
         card = render_card(basic_skill)
@@ -250,8 +251,8 @@ class TestRenderCard:
         }
         card = render_card(skill)
         # Should show some items and then "+N more" for the remainder
-        assert "+5 more" in card
-        assert "skill-0" in card
+        assert "+", "more" in card
+        assert "/skill-0" in card
 
     def test_many_derivatives_truncated(self):
         skill = {
@@ -268,8 +269,8 @@ class TestRenderCard:
         }
         card = render_card(skill)
         # Should show some items and then "+N more" for the remainder
-        assert "+3 more" in card
-        assert "skill-0" in card
+        assert "more" in card
+        assert "/skill-0" in card
 
     def test_missing_optional_fields_defaults_gracefully(self):
         """Card should render even with minimal skill data."""
@@ -295,7 +296,7 @@ class TestRenderCardCompact:
 
     def test_contains_name(self, basic_skill):
         result = render_card_compact(basic_skill)
-        assert "Tokenize" in result
+        assert "/tokenize" in result
 
     def test_contains_level(self, basic_skill):
         result = render_card_compact(basic_skill)
@@ -328,8 +329,8 @@ class TestRenderCards:
         result = render_cards([basic_skill, extra_skill])
         # Full cards are separated by double newlines
         assert "\n\n" in result
-        assert "Tokenize" in result
-        assert "RAG Pipeline" in result
+        assert "/tokenize" in result
+        assert "/rag-pipeline" in result
 
     def test_compact_mode(self, basic_skill, extra_skill):
         result = render_cards([basic_skill, extra_skill], compact=True)
@@ -346,20 +347,25 @@ class TestRenderCards:
 
 
 class TestRenderPromotionPrompt:
-    def test_rename_suggestion_derives_name_from_skill_slug(self):
+    def test_shows_skill_id_with_slash(self):
         prompt = render_promotion_prompt(
-            {"id": "plan-and-execute", "name": "Different Registry Name"},
+            {"id": "plan-and-execute", "name": "Different Registry Name", "type": "extra", "prerequisites": ["a", "b"]},
             "IV",
         )
+        assert "/plan-and-execute" in prompt
+        assert "gaia fuse plan-and-execute" in prompt
 
-        assert 'gaia fuse plan-and-execute --name "Plan and Execute"' in prompt
-        assert '"Different Registry Name"' not in prompt
-        assert '"My Name"' not in prompt
+    def test_shows_level_and_rank_name(self):
+        prompt = render_promotion_prompt({"id": "research-agent", "type": "extra", "prerequisites": ["x"]}, "III")
+        assert "Level III" in prompt
+        assert "gaia fuse research-agent" in prompt
 
-    def test_rename_suggestion_title_cases_other_slugs(self):
-        prompt = render_promotion_prompt({"id": "research-agent"}, "III")
-
-        assert 'gaia fuse research-agent --name "Research Agent"' in prompt
+    def test_shows_fusion_diagram_when_prereqs_exist(self):
+        prompt = render_promotion_prompt(
+            {"id": "research", "type": "extra", "prerequisites": ["web-search", "summarize"]},
+            "III",
+        )
+        assert "──▶" in prompt
 
 
 # ---------------------------------------------------------------------------
@@ -392,7 +398,7 @@ class TestLoadAndRender:
 
         result = load_and_render("web-scrape", str(tmp_path))
         assert result is not None
-        assert "Web Scrape" in result
+        assert "/web-scrape" in result
         assert "┌" in result or "╭" in result
 
     def test_load_nonexistent_skill_returns_none(self, tmp_path):
@@ -434,4 +440,73 @@ class TestLoadAndRender:
         result = load_and_render("classify", str(tmp_path), compact=True)
         assert result is not None
         assert "\n" not in result
-        assert "Classify" in result
+        assert "/classify" in result
+
+
+# ---------------------------------------------------------------------------
+# render_fusion_diagram tests
+# ---------------------------------------------------------------------------
+
+
+class TestRenderFusionDiagram:
+    def test_single_prereq_simple_arrow(self):
+        """Single prereq renders a simple inline arrow."""
+        output = render_fusion_diagram(["web-search"], "research")
+        assert "────▶" in output
+        assert "/web-search" in output
+        assert "/research" in output
+        assert "◇" in output  # default extra glyph
+
+    def test_two_prereqs_bracket_and_connector(self):
+        """Two prereqs render top bracket, connector row, bottom bracket."""
+        output = render_fusion_diagram(["code-gen", "code-review"], "pair-program")
+        lines = output.split("\n")
+        assert len(lines) == 3
+        assert "─┐" in lines[0]
+        assert "├──▶" in lines[1]
+        assert "─┘" in lines[2]
+        assert "/pair-program" in output
+        assert "◇" in output
+
+    def test_three_prereqs_midpoint_arrow(self):
+        """Three prereqs: first ─┐, middle ─┼──▶, last ─┘."""
+        output = render_fusion_diagram(
+            ["web-search", "summarize", "cite-sources"], "research"
+        )
+        lines = output.split("\n")
+        assert len(lines) == 3
+        assert "─┐" in lines[0]
+        assert "─┼──▶" in lines[1]
+        assert "─┘" in lines[2]
+        assert "/research" in output
+        assert "◇" in output
+
+    def test_four_prereqs_structure(self):
+        """Four prereqs: first ─┐, middle ─┤ and ─┼──▶, last ─┘."""
+        output = render_fusion_diagram(
+            ["web-search", "summarize", "cite-sources", "knowledge"],
+            "autonomous-research",
+            result_type="ultimate",
+        )
+        lines = output.split("\n")
+        assert len(lines) == 4
+        assert "─┐" in lines[0]
+        assert "─┘" in lines[3]
+        # Arrow is on the midpoint row (index 2 for 4 items)
+        assert "──▶" in output
+        assert "/autonomous-research" in output
+        assert "◆" in output  # ultimate glyph
+
+    def test_basic_tier_glyph(self):
+        """Basic tier uses the circle glyph."""
+        output = render_fusion_diagram(["a", "b", "c"], "result", result_type="basic")
+        assert "○" in output
+
+    def test_prereqs_padded_to_equal_width(self):
+        """Shorter prereq names are padded so brackets align."""
+        output = render_fusion_diagram(["ab", "longername"], "out")
+        # Both prereq lines should have the bracket at the same column
+        lines = output.split("\n")
+        # First line (shorter name) should be padded
+        assert "/ab" in lines[0]
+        assert "/longername" in lines[2]

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,0 +1,267 @@
+"""Tests for the centralized skill display formatter."""
+
+from __future__ import annotations
+
+import pytest
+
+import gaia_cli.formatting as fmt_mod
+from gaia_cli.formatting import (
+    COLOR_CONTRIBUTOR,
+    COLOR_LOCAL_USER,
+    RANK_COLORS,
+    TIER_COLORS,
+    TYPE_SYMBOLS,
+    format_level_colored,
+    format_skill_colored,
+    format_skill_plain,
+    format_type_colored,
+    format_type_label,
+    fusion_equation,
+)
+
+
+# ---------------------------------------------------------------------------
+# format_skill_plain
+# ---------------------------------------------------------------------------
+
+
+class TestFormatSkillPlain:
+    def test_canon_unnamed(self):
+        assert format_skill_plain("python-basics") == "/python-basics"
+
+    def test_named_contributor(self):
+        result = format_skill_plain("web-scraping", named_contributor="alice")
+        assert result == "alice/web-scraping"
+
+    def test_local_user(self):
+        result = format_skill_plain("my-tool", is_local=True, local_user="bob")
+        assert result == "bob/my-tool"
+
+    def test_local_without_user_falls_to_canon(self):
+        # is_local=True but no local_user -> fallback to canon display
+        result = format_skill_plain("orphan-skill", is_local=True)
+        assert result == "/orphan-skill"
+
+    def test_named_takes_precedence_over_local(self):
+        # If both named_contributor and is_local are given, named wins
+        result = format_skill_plain(
+            "dual", named_contributor="alice", is_local=True, local_user="bob"
+        )
+        assert result == "alice/dual"
+
+
+# ---------------------------------------------------------------------------
+# format_skill_colored — with NO_COLOR
+# ---------------------------------------------------------------------------
+
+
+class TestFormatSkillColoredNoColor:
+    """When NO_COLOR is set, output should be identical to plain."""
+
+    def test_canon_no_color(self, monkeypatch):
+        monkeypatch.setenv("NO_COLOR", "1")
+        result = format_skill_colored("python-basics", "I")
+        assert result == "/python-basics"
+        assert "\033" not in result
+
+    def test_named_no_color(self, monkeypatch):
+        monkeypatch.setenv("NO_COLOR", "1")
+        result = format_skill_colored("web-scraping", "II", named_contributor="alice")
+        assert result == "alice/web-scraping"
+        assert "\033" not in result
+
+    def test_local_no_color(self, monkeypatch):
+        monkeypatch.setenv("NO_COLOR", "1")
+        result = format_skill_colored("my-tool", "III", is_local=True, local_user="bob")
+        assert result == "bob/my-tool"
+        assert "\033" not in result
+
+
+# ---------------------------------------------------------------------------
+# format_skill_colored — with color enabled (truecolor)
+# ---------------------------------------------------------------------------
+
+
+class TestFormatSkillColoredTruecolor:
+    """Force truecolor output and verify ANSI sequences."""
+
+    @pytest.fixture(autouse=True)
+    def _enable_color(self, monkeypatch):
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.setenv("COLORTERM", "truecolor")
+        # Patch _use_color to always return True (avoids pytest stdout capture issues)
+        monkeypatch.setattr(fmt_mod, "_use_color", lambda: True)
+
+    def test_canon_has_rank_color(self):
+        result = format_skill_colored("python-basics", "I")
+        r, g, b = RANK_COLORS["I"]
+        assert f"\033[38;2;{r};{g};{b}m" in result
+        assert "/python-basics" in result
+        assert "\033[0m" in result
+
+    def test_named_has_red_contributor(self):
+        result = format_skill_colored("web-scraping", "II", named_contributor="alice")
+        r, g, b = COLOR_CONTRIBUTOR
+        assert f"\033[38;2;{r};{g};{b}m" in result
+        assert "alice" in result
+        # Skill name has rank color
+        sr, sg, sb = RANK_COLORS["II"]
+        assert f"\033[38;2;{sr};{sg};{sb}m" in result
+        assert "web-scraping" in result
+
+    def test_local_has_green_user(self):
+        result = format_skill_colored("my-tool", "III", is_local=True, local_user="bob")
+        r, g, b = COLOR_LOCAL_USER
+        assert f"\033[38;2;{r};{g};{b}m" in result
+        assert "bob" in result
+        sr, sg, sb = RANK_COLORS["III"]
+        assert f"\033[38;2;{sr};{sg};{sb}m" in result
+        assert "my-tool" in result
+
+    def test_unknown_level_falls_to_zero(self):
+        result = format_skill_colored("foo", "IX")
+        r, g, b = RANK_COLORS["0"]
+        assert f"\033[38;2;{r};{g};{b}m" in result
+
+    def test_default_level_is_zero(self):
+        result = format_skill_colored("bar")
+        r, g, b = RANK_COLORS["0"]
+        assert f"\033[38;2;{r};{g};{b}m" in result
+
+
+# ---------------------------------------------------------------------------
+# format_skill_colored — 256-color fallback
+# ---------------------------------------------------------------------------
+
+
+class TestFormatSkillColored256:
+    """When COLORTERM is not truecolor, should emit 256-color sequences."""
+
+    @pytest.fixture(autouse=True)
+    def _enable_256(self, monkeypatch):
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.setenv("COLORTERM", "")
+        # Patch _use_color to always return True (avoids pytest stdout capture issues)
+        monkeypatch.setattr(fmt_mod, "_use_color", lambda: True)
+
+    def test_256_color_format(self):
+        result = format_skill_colored("test-skill", "I")
+        assert "\033[38;5;" in result
+        assert "\033[38;2;" not in result
+
+
+# ---------------------------------------------------------------------------
+# format_type_label
+# ---------------------------------------------------------------------------
+
+
+class TestFormatTypeLabel:
+    def test_basic(self):
+        assert format_type_label("basic") == "○ Basic Skill"
+
+    def test_extra(self):
+        assert format_type_label("extra") == "◇ Extra Skill"
+
+    def test_ultimate(self):
+        assert format_type_label("ultimate") == "◆ Ultimate Skill"
+
+    def test_unknown_type(self):
+        result = format_type_label("legendary")
+        assert result == "? legendary"
+
+
+# ---------------------------------------------------------------------------
+# format_type_colored
+# ---------------------------------------------------------------------------
+
+
+class TestFormatTypeColored:
+    def test_no_color_matches_plain(self, monkeypatch):
+        monkeypatch.setenv("NO_COLOR", "1")
+        assert format_type_colored("basic") == format_type_label("basic")
+
+    def test_with_color(self, monkeypatch):
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.setenv("COLORTERM", "truecolor")
+        monkeypatch.setattr(fmt_mod, "_use_color", lambda: True)
+
+        result = format_type_colored("extra")
+        r, g, b = TIER_COLORS["extra"]
+        assert f"\033[38;2;{r};{g};{b}m" in result
+        assert "◇ Extra Skill" in result
+        assert "\033[0m" in result
+
+
+# ---------------------------------------------------------------------------
+# format_level_colored
+# ---------------------------------------------------------------------------
+
+
+class TestFormatLevelColored:
+    def test_no_color(self, monkeypatch):
+        monkeypatch.setenv("NO_COLOR", "1")
+        assert format_level_colored("III") == "III"
+
+    def test_with_color(self, monkeypatch):
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.setenv("COLORTERM", "truecolor")
+        monkeypatch.setattr(fmt_mod, "_use_color", lambda: True)
+
+        result = format_level_colored("V")
+        r, g, b = RANK_COLORS["V"]
+        assert f"\033[38;2;{r};{g};{b}m" in result
+        assert "V" in result
+        assert "\033[0m" in result
+
+
+# ---------------------------------------------------------------------------
+# fusion_equation
+# ---------------------------------------------------------------------------
+
+
+class TestFusionEquation:
+    def test_basic_fusion(self):
+        result = fusion_equation(["a", "b"], "c")
+        assert result == "/a + /b → /c ◇"
+
+    def test_single_prereq(self):
+        result = fusion_equation(["x"], "y")
+        assert result == "/x → /y ◇"
+
+    def test_custom_glyph(self):
+        result = fusion_equation(["alpha", "beta"], "gamma", result_glyph="◆")
+        assert result == "/alpha + /beta → /gamma ◆"
+
+    def test_three_prereqs(self):
+        result = fusion_equation(["a", "b", "c"], "d")
+        assert result == "/a + /b + /c → /d ◇"
+
+    def test_empty_prereqs(self):
+        result = fusion_equation([], "lonely")
+        assert result == " → /lonely ◇"
+
+
+# ---------------------------------------------------------------------------
+# Constants integrity
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    def test_tier_colors_keys(self):
+        assert set(TIER_COLORS.keys()) == {"basic", "extra", "ultimate"}
+
+    def test_rank_colors_keys(self):
+        assert set(RANK_COLORS.keys()) == {"0", "I", "II", "III", "IV", "V", "VI"}
+
+    def test_type_symbols_keys(self):
+        assert set(TYPE_SYMBOLS.keys()) == {"basic", "extra", "ultimate"}
+
+    def test_all_colors_are_rgb_tuples(self):
+        for name, color in RANK_COLORS.items():
+            assert len(color) == 3, f"RANK_COLORS[{name}] not a 3-tuple"
+            assert all(0 <= c <= 255 for c in color)
+        for name, color in TIER_COLORS.items():
+            assert len(color) == 3, f"TIER_COLORS[{name}] not a 3-tuple"
+            assert all(0 <= c <= 255 for c in color)
+        assert len(COLOR_CONTRIBUTOR) == 3
+        assert len(COLOR_LOCAL_USER) == 3

--- a/tests/test_local_context.py
+++ b/tests/test_local_context.py
@@ -1,0 +1,451 @@
+"""Tests for gaia_cli.localContext."""
+
+import json
+import os
+
+import pytest
+
+from gaia_cli.localContext import LocalContext, _build_named_map
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_json(path, data):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+
+def _write_text(path, text):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(text)
+
+
+MINI_GRAPH = {
+    "version": "0.1.0",
+    "skills": [
+        {
+            "id": "python-basics",
+            "name": "Python Basics",
+            "type": "basic",
+            "level": "I",
+            "rarity": "common",
+            "prerequisites": [],
+            "derivatives": ["web-frameworks"],
+        },
+        {
+            "id": "web-frameworks",
+            "name": "Web Frameworks",
+            "type": "extra",
+            "level": "II",
+            "rarity": "uncommon",
+            "prerequisites": ["python-basics"],
+            "derivatives": [],
+        },
+        {
+            "id": "testing",
+            "name": "Testing",
+            "type": "basic",
+            "level": "I",
+            "rarity": "common",
+            "prerequisites": [],
+            "derivatives": [],
+        },
+    ],
+}
+
+MINI_TREE = {
+    "userId": "testuser",
+    "updatedAt": "2024-01-01T00:00:00Z",
+    "unlockedSkills": [
+        {"skillId": "python-basics", "level": "III"},
+        {"skillId": "testing", "level": "I"},
+    ],
+    "stats": {"totalUnlocked": 2, "highestRarity": "common"},
+}
+
+NAMED_SKILL_MD = """\
+---
+id: alice/flask-mastery
+genericSkillRef: web-frameworks
+contributor: alice
+---
+
+# Flask Mastery
+
+A named implementation of the web-frameworks skill.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_registry(tmp_path):
+    """Create a minimal registry layout under tmp_path."""
+    # registry/gaia.json
+    _write_json(tmp_path / "registry" / "gaia.json", MINI_GRAPH)
+
+    # skill-trees/testuser/skill-tree.json
+    _write_json(
+        tmp_path / "skill-trees" / "testuser" / "skill-tree.json",
+        MINI_TREE,
+    )
+
+    # registry/named/alice/flask-mastery.md
+    _write_text(
+        tmp_path / "registry" / "named" / "alice" / "flask-mastery.md",
+        NAMED_SKILL_MD,
+    )
+
+    return str(tmp_path)
+
+
+@pytest.fixture
+def mock_registry_no_tree(tmp_path):
+    """Registry without a user tree."""
+    _write_json(tmp_path / "registry" / "gaia.json", MINI_GRAPH)
+    return str(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Tests: LocalContext.load()
+# ---------------------------------------------------------------------------
+
+class TestLocalContextLoad:
+    def test_load_basic(self, mock_registry, monkeypatch):
+        """Load with a valid registry and user tree."""
+        # Disable scan loading (no .gaia/paths.json)
+        monkeypatch.chdir(tmp_path := mock_registry)
+        ctx = LocalContext.load(mock_registry, "testuser", include_scan=False)
+
+        assert ctx.username == "testuser"
+        assert ctx.owned_ids == {"python-basics", "testing"}
+        assert ctx.tree_data is not None
+        assert ctx.graph_data is not None
+        assert len(ctx._skill_map) == 3
+
+    def test_load_no_user_tree(self, mock_registry_no_tree, monkeypatch):
+        """Load when user has no tree yet."""
+        monkeypatch.chdir(mock_registry_no_tree)
+        ctx = LocalContext.load(mock_registry_no_tree, "newuser", include_scan=False)
+
+        assert ctx.username == "newuser"
+        assert ctx.owned_ids == set()
+        assert ctx.tree_data is None
+        assert ctx.graph_data is not None
+
+    def test_load_with_scan(self, mock_registry, monkeypatch):
+        """Load with scan results (paths.json)."""
+        monkeypatch.chdir(mock_registry)
+        # Create .gaia/paths.json with some available paths
+        paths_data = {
+            "nearUnlocks": [],
+            "oneAway": [],
+            "availablePaths": [
+                {"skillId": "web-frameworks", "ownedPrereqs": ["python-basics", "novel-skill"]},
+            ],
+            "computedAt": "2024-01-01T00:00:00Z",
+        }
+        _write_json(os.path.join(mock_registry, ".gaia", "paths.json"), paths_data)
+
+        ctx = LocalContext.load(mock_registry, "testuser", include_scan=True)
+
+        # owned_ids should be in detected_ids
+        assert "python-basics" in ctx.detected_ids
+        assert "testing" in ctx.detected_ids
+        # novel-skill is detected from ownedPrereqs but not in canon
+        assert "novel-skill" in ctx.detected_ids
+        assert "novel-skill" in ctx.novel_ids
+
+    def test_load_no_graph(self, tmp_path, monkeypatch):
+        """Load when registry/gaia.json does not exist."""
+        monkeypatch.chdir(str(tmp_path))
+        ctx = LocalContext.load(str(tmp_path), "testuser", include_scan=False)
+
+        assert ctx.graph_data is None
+        assert ctx._skill_map == {}
+
+
+# ---------------------------------------------------------------------------
+# Tests: is_named(), named_ref(), named_contributor()
+# ---------------------------------------------------------------------------
+
+class TestNamedSkills:
+    def test_is_named_true(self, mock_registry, monkeypatch):
+        monkeypatch.chdir(mock_registry)
+        ctx = LocalContext.load(mock_registry, "testuser", include_scan=False)
+        assert ctx.is_named("web-frameworks") is True
+
+    def test_is_named_false(self, mock_registry, monkeypatch):
+        monkeypatch.chdir(mock_registry)
+        ctx = LocalContext.load(mock_registry, "testuser", include_scan=False)
+        assert ctx.is_named("python-basics") is False
+
+    def test_named_ref(self, mock_registry, monkeypatch):
+        monkeypatch.chdir(mock_registry)
+        ctx = LocalContext.load(mock_registry, "testuser", include_scan=False)
+        assert ctx.named_ref("web-frameworks") == "alice/flask-mastery"
+
+    def test_named_ref_none(self, mock_registry, monkeypatch):
+        monkeypatch.chdir(mock_registry)
+        ctx = LocalContext.load(mock_registry, "testuser", include_scan=False)
+        assert ctx.named_ref("python-basics") is None
+
+    def test_named_contributor(self, mock_registry, monkeypatch):
+        monkeypatch.chdir(mock_registry)
+        ctx = LocalContext.load(mock_registry, "testuser", include_scan=False)
+        assert ctx.named_contributor("web-frameworks") == "alice"
+
+    def test_named_contributor_none(self, mock_registry, monkeypatch):
+        monkeypatch.chdir(mock_registry)
+        ctx = LocalContext.load(mock_registry, "testuser", include_scan=False)
+        assert ctx.named_contributor("testing") is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: is_local(), is_owned()
+# ---------------------------------------------------------------------------
+
+class TestLocalAndOwned:
+    def test_is_owned_true(self, mock_registry, monkeypatch):
+        monkeypatch.chdir(mock_registry)
+        ctx = LocalContext.load(mock_registry, "testuser", include_scan=False)
+        assert ctx.is_owned("python-basics") is True
+        assert ctx.is_owned("testing") is True
+
+    def test_is_owned_false(self, mock_registry, monkeypatch):
+        monkeypatch.chdir(mock_registry)
+        ctx = LocalContext.load(mock_registry, "testuser", include_scan=False)
+        assert ctx.is_owned("web-frameworks") is False
+
+    def test_is_local_with_novel(self, mock_registry, monkeypatch):
+        """Novel skills (detected but not in canon) should be local."""
+        monkeypatch.chdir(mock_registry)
+        paths_data = {
+            "nearUnlocks": [],
+            "oneAway": [],
+            "availablePaths": [
+                {"skillId": "x", "ownedPrereqs": ["my-custom-skill"]},
+            ],
+            "computedAt": "2024-01-01T00:00:00Z",
+        }
+        _write_json(os.path.join(mock_registry, ".gaia", "paths.json"), paths_data)
+
+        ctx = LocalContext.load(mock_registry, "testuser", include_scan=True)
+        assert ctx.is_local("my-custom-skill") is True
+
+    def test_is_local_canon_skill(self, mock_registry, monkeypatch):
+        """Canon skills are not local."""
+        monkeypatch.chdir(mock_registry)
+        ctx = LocalContext.load(mock_registry, "testuser", include_scan=False)
+        assert ctx.is_local("python-basics") is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: display_name()
+# ---------------------------------------------------------------------------
+
+class TestDisplayName:
+    def test_display_named_skill(self, mock_registry, monkeypatch):
+        """Named skills display as contributor/name."""
+        monkeypatch.chdir(mock_registry)
+        ctx = LocalContext.load(mock_registry, "testuser", include_scan=False)
+        assert ctx.display_name("web-frameworks") == "alice/flask-mastery"
+
+    def test_display_novel_skill(self, mock_registry, monkeypatch):
+        """Novel/local skills display as username/id."""
+        monkeypatch.chdir(mock_registry)
+        # Manually inject a novel skill
+        ctx = LocalContext.load(mock_registry, "testuser", include_scan=False)
+        ctx.novel_ids.add("my-experiment")
+        assert ctx.display_name("my-experiment") == "testuser/my-experiment"
+
+    def test_display_canon_skill(self, mock_registry, monkeypatch):
+        """Canon skills without named impl display as /id."""
+        monkeypatch.chdir(mock_registry)
+        ctx = LocalContext.load(mock_registry, "testuser", include_scan=False)
+        assert ctx.display_name("python-basics") == "/python-basics"
+
+
+# ---------------------------------------------------------------------------
+# Tests: all_skills()
+# ---------------------------------------------------------------------------
+
+class TestAllSkills:
+    def test_includes_canon_skills(self, mock_registry, monkeypatch):
+        monkeypatch.chdir(mock_registry)
+        ctx = LocalContext.load(mock_registry, "testuser", include_scan=False)
+        skills = ctx.all_skills()
+        ids = {s["id"] for s in skills}
+        assert "python-basics" in ids
+        assert "web-frameworks" in ids
+        assert "testing" in ids
+
+    def test_includes_novel_skills(self, mock_registry, monkeypatch):
+        """Novel skills appear in all_skills with local=True."""
+        monkeypatch.chdir(mock_registry)
+        ctx = LocalContext.load(mock_registry, "testuser", include_scan=False)
+        ctx.novel_ids.add("my-novel-skill")
+
+        skills = ctx.all_skills()
+        ids = {s["id"] for s in skills}
+        assert "my-novel-skill" in ids
+
+        novel_entry = next(s for s in skills if s["id"] == "my-novel-skill")
+        assert novel_entry["local"] is True
+        assert novel_entry["type"] == "basic"
+        assert novel_entry["level"] == "0"
+
+    def test_no_duplicate_for_canon_novel_overlap(self, mock_registry, monkeypatch):
+        """If a novel_id also exists in canon (edge case), it should not duplicate."""
+        monkeypatch.chdir(mock_registry)
+        ctx = LocalContext.load(mock_registry, "testuser", include_scan=False)
+        # Simulate edge case: novel_ids contains a canon skill
+        ctx.novel_ids.add("testing")
+
+        skills = ctx.all_skills()
+        testing_entries = [s for s in skills if s["id"] == "testing"]
+        # Should not duplicate - the canon entry exists in _skill_map
+        assert len(testing_entries) == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: skill_level(), skill_type()
+# ---------------------------------------------------------------------------
+
+class TestSkillLevelAndType:
+    def test_skill_level_from_tree(self, mock_registry, monkeypatch):
+        """User's tree level takes priority."""
+        monkeypatch.chdir(mock_registry)
+        ctx = LocalContext.load(mock_registry, "testuser", include_scan=False)
+        assert ctx.skill_level("python-basics") == "III"
+
+    def test_skill_level_from_canon(self, mock_registry, monkeypatch):
+        """Falls back to canon level when not in user tree."""
+        monkeypatch.chdir(mock_registry)
+        ctx = LocalContext.load(mock_registry, "testuser", include_scan=False)
+        assert ctx.skill_level("web-frameworks") == "II"
+
+    def test_skill_level_unknown(self, mock_registry, monkeypatch):
+        """Returns '0' for unknown skills."""
+        monkeypatch.chdir(mock_registry)
+        ctx = LocalContext.load(mock_registry, "testuser", include_scan=False)
+        assert ctx.skill_level("nonexistent") == "0"
+
+    def test_skill_type(self, mock_registry, monkeypatch):
+        monkeypatch.chdir(mock_registry)
+        ctx = LocalContext.load(mock_registry, "testuser", include_scan=False)
+        assert ctx.skill_type("python-basics") == "basic"
+        assert ctx.skill_type("web-frameworks") == "extra"
+
+    def test_skill_type_unknown(self, mock_registry, monkeypatch):
+        monkeypatch.chdir(mock_registry)
+        ctx = LocalContext.load(mock_registry, "testuser", include_scan=False)
+        assert ctx.skill_type("nonexistent") == "basic"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _build_named_map()
+# ---------------------------------------------------------------------------
+
+class TestBuildNamedMap:
+    def test_parses_frontmatter(self, tmp_path):
+        """Correctly extracts genericSkillRef -> id mapping."""
+        named_dir = tmp_path / "registry" / "named" / "bob"
+        named_dir.mkdir(parents=True)
+        (named_dir / "my-skill.md").write_text(
+            "---\n"
+            "id: bob/my-skill\n"
+            "genericSkillRef: some-generic-ref\n"
+            "contributor: bob\n"
+            "---\n\n"
+            "# My Skill\n",
+            encoding="utf-8",
+        )
+
+        result = _build_named_map(str(tmp_path))
+        assert result == {"some-generic-ref": "bob/my-skill"}
+
+    def test_ignores_files_without_frontmatter(self, tmp_path):
+        """Files without YAML frontmatter are skipped."""
+        named_dir = tmp_path / "registry" / "named" / "bob"
+        named_dir.mkdir(parents=True)
+        (named_dir / "no-frontmatter.md").write_text(
+            "# Just a regular markdown file\n",
+            encoding="utf-8",
+        )
+
+        result = _build_named_map(str(tmp_path))
+        assert result == {}
+
+    def test_ignores_incomplete_frontmatter(self, tmp_path):
+        """Files missing genericSkillRef or id are skipped."""
+        named_dir = tmp_path / "registry" / "named" / "carol"
+        named_dir.mkdir(parents=True)
+        # Missing genericSkillRef
+        (named_dir / "missing-ref.md").write_text(
+            "---\n"
+            "id: carol/missing-ref\n"
+            "contributor: carol\n"
+            "---\n\n"
+            "# Missing Ref\n",
+            encoding="utf-8",
+        )
+
+        result = _build_named_map(str(tmp_path))
+        assert result == {}
+
+    def test_handles_quoted_values(self, tmp_path):
+        """Quoted frontmatter values are stripped correctly."""
+        named_dir = tmp_path / "registry" / "named" / "dave"
+        named_dir.mkdir(parents=True)
+        (named_dir / "quoted.md").write_text(
+            '---\n'
+            'id: "dave/quoted-skill"\n'
+            "genericSkillRef: 'quoted-ref'\n"
+            '---\n\n'
+            '# Quoted\n',
+            encoding="utf-8",
+        )
+
+        result = _build_named_map(str(tmp_path))
+        assert result == {"quoted-ref": "dave/quoted-skill"}
+
+    def test_empty_named_dir(self, tmp_path):
+        """Returns empty dict when named dir is empty."""
+        (tmp_path / "registry" / "named").mkdir(parents=True)
+        result = _build_named_map(str(tmp_path))
+        assert result == {}
+
+    def test_missing_named_dir(self, tmp_path):
+        """Returns empty dict when named dir does not exist."""
+        result = _build_named_map(str(tmp_path))
+        assert result == {}
+
+    def test_multiple_skills(self, tmp_path):
+        """Multiple named skills from different contributors."""
+        for contrib, skill_name, ref in [
+            ("alice", "flask-pro", "web-frameworks"),
+            ("bob", "pytest-guru", "testing"),
+        ]:
+            named_dir = tmp_path / "registry" / "named" / contrib
+            named_dir.mkdir(parents=True, exist_ok=True)
+            (named_dir / f"{skill_name}.md").write_text(
+                f"---\n"
+                f"id: {contrib}/{skill_name}\n"
+                f"genericSkillRef: {ref}\n"
+                f"---\n\n"
+                f"# {skill_name}\n",
+                encoding="utf-8",
+            )
+
+        result = _build_named_map(str(tmp_path))
+        assert result == {
+            "web-frameworks": "alice/flask-pro",
+            "testing": "bob/pytest-guru",
+        }

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -84,7 +84,7 @@ def test_render_stats_includes_registry_health_sections(tmp_path):
 
     assert "Gaia Registry — 4 skills  1 edges" in output
     assert "Type breakdown" in output
-    assert "Atomic" in output
+    assert "Basic Skill" in output
     assert "Level breakdown" in output
     assert "Evidence coverage" in output
     assert "With evidence    3 / 4" in output


### PR DESCRIPTION
## Summary
- Replace deprecated Atomic/Composite/Legendary terminology with Basic Skill/Extra Skill/Ultimate Skill
- Add `formatting.py`: centralized slash-naming with three-tier color hierarchy (RED contributor for named, GREEN for local, rank-color for canon)
- Add `localContext.py`: local-first data merging abstraction (user tree + scan results + named skill map)
- Add `render_fusion_diagram()`: Unicode box-drawing fusion flowcharts replacing "Fusion Ready" slug
- Update all CLI output (`scan`, `skills`, `stats`, `appraise`) to use `/skill-id` display format
- Add `--canon` flag for opt-in canonical registry view
- Add RANK_COLORS per level (Slate→Sky→Teal→Violet→Fuchsia→Amber)

## Test plan
- [x] 333 non-packaging tests pass (`python -m pytest tests/ --ignore=tests/test_packaging.py`)
- [x] `python scripts/validate.py` passes
- [x] `python scripts/build_docs.py` regenerated
- [x] Manual: `gaia scan` shows colored `/skill-id` list with fusion diagrams
- [x] Manual: `gaia skills list` shows provenance-aware table (RED named, GREEN local)
- [x] Manual: `gaia stats` shows tier glyphs, colored bars, rank-colored levels
- [x] Manual: `NO_COLOR=1 gaia stats` produces clean plain text