### PR TITLE
cli: add interactive pickers and rank-colored tree display

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ embeddings = [
     "sentence-transformers>=2.2.0",
     "numpy>=1.21.0",
 ]
+interactive = [
+    "questionary>=2.0.0",
+]
 dev = [
     "build>=1.2.0",
     "pytest>=8.0",

--- a/src/gaia_cli/interactive.py
+++ b/src/gaia_cli/interactive.py
@@ -1,0 +1,143 @@
+"""Interactive CLI helpers using questionary.
+
+Gracefully degrades when questionary is not installed or when
+running in a non-interactive context (piped stdin, CI, --yes flag).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Optional
+
+
+def _has_interactive() -> bool:
+    """Check if interactive mode is available and appropriate."""
+    # Not a TTY (piped input, CI)
+    if not sys.stdin.isatty():
+        return False
+    # CI environment
+    if os.environ.get("CI"):
+        return False
+    # Check for questionary
+    try:
+        import questionary  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+def select_skill(skills: list[dict], prompt: str = "Select a skill:") -> Optional[str]:
+    """Arrow-key skill picker. Returns skill ID or None if cancelled/unavailable.
+
+    Args:
+        skills: List of skill dicts with at least 'id', optionally 'type', 'level', 'description'
+        prompt: The prompt message to display
+
+    Returns:
+        Selected skill ID string, or None if cancelled or non-interactive
+    """
+    if not _has_interactive():
+        return None
+    import questionary
+    from gaia_cli.formatting import TYPE_SYMBOLS
+
+    choices = []
+    for s in skills:
+        sid = s.get("id", "unknown")
+        skill_type = s.get("type", "basic")
+        level = s.get("level", "?")
+        glyph = TYPE_SYMBOLS.get(skill_type, "○")
+        desc = s.get("description", "")[:45]
+        title = f"{glyph} /{sid}  [{level}]  {desc}"
+        choices.append(questionary.Choice(title=title, value=sid))
+
+    if not choices:
+        return None
+
+    result = questionary.select(
+        prompt,
+        choices=choices,
+        use_shortcuts=False,
+        use_arrow_keys=True,
+    ).ask()
+    return result
+
+
+def select_fusion_candidate(candidates: list[dict], prompt: str = "Select fusion candidate:") -> Optional[str]:
+    """Arrow-key picker for fusion candidates.
+
+    Args:
+        candidates: List of combo dicts with 'candidateResult' and 'detectedSkills'
+
+    Returns:
+        Selected candidate result skill ID, or None
+    """
+    if not _has_interactive():
+        return None
+    import questionary
+
+    choices = []
+    for c in candidates:
+        result_id = c.get("candidateResult", "?")
+        prereqs = c.get("detectedSkills", [])
+        prereq_str = " + ".join(f"/{p}" for p in prereqs[:3])
+        if len(prereqs) > 3:
+            prereq_str += f" +{len(prereqs) - 3}"
+        title = f"{prereq_str} → /{result_id}"
+        choices.append(questionary.Choice(title=title, value=result_id))
+
+    if not choices:
+        return None
+
+    result = questionary.select(
+        prompt,
+        choices=choices,
+        use_shortcuts=False,
+        use_arrow_keys=True,
+    ).ask()
+    return result
+
+
+def select_promotion_candidate(candidates: list[dict], prompt: str = "Select skill to promote:") -> Optional[str]:
+    """Arrow-key picker for promotion candidates.
+
+    Args:
+        candidates: List of promotion candidate dicts with 'skillId', 'currentLevel', 'suggestedLevel'
+
+    Returns:
+        Selected skill ID, or None
+    """
+    if not _has_interactive():
+        return None
+    import questionary
+
+    choices = []
+    for c in candidates:
+        sid = c.get("skillId", "?")
+        current = c.get("currentLevel", "?")
+        suggested = c.get("suggestedLevel", "?")
+        title = f"/{sid}  {current} → {suggested}"
+        choices.append(questionary.Choice(title=title, value=sid))
+
+    if not choices:
+        return None
+
+    result = questionary.select(
+        prompt,
+        choices=choices,
+        use_shortcuts=False,
+        use_arrow_keys=True,
+    ).ask()
+    return result
+
+
+def confirm(message: str, default: bool = True) -> bool:
+    """Interactive yes/no confirmation.
+
+    Falls back to the default value when non-interactive.
+    """
+    if not _has_interactive():
+        return default
+    import questionary
+    return questionary.confirm(message, default=default).ask()

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -72,6 +72,7 @@ from gaia_cli.formatting import (
 )
 from gaia_cli.localContext import LocalContext
 from gaia_cli.cardRenderer import render_fusion_diagram
+from gaia_cli.interactive import select_skill, select_fusion_candidate, select_promotion_candidate
 
 DEFAULT_REGISTRY_REF = "https://github.com/mbtiongson1/gaia-skill-tree"
 
@@ -428,8 +429,13 @@ def appraise_command(args):
     # Determine which skill to appraise
     skill_id = getattr(args, 'skillId', None)
     if not skill_id:
-        # Default: most recently unlocked skill
-        if tree and tree.get('unlockedSkills'):
+        # Try interactive picker first
+        all_skills = list(skill_map.values())
+        picked = select_skill(all_skills, "Select a skill to appraise:")
+        if picked:
+            skill_id = picked
+        elif tree and tree.get('unlockedSkills'):
+            # Fallback: most recently unlocked skill
             sorted_skills = sorted(
                 tree['unlockedSkills'],
                 key=lambda s: s.get('unlockedAt', ''),
@@ -533,11 +539,18 @@ def promote_command(args):
                 print("No skills eligible for promotion.")
                 return
             for result in results:
-                print(f"Promoted {result['skillId']} to Level {result['newLevel']}.")
+                print(f"Promoted /{result['skillId']} to Level {result['newLevel']}.")
             return
         if not skill_id:
-            print("Usage: gaia promote <skill> or gaia promote --all", file=sys.stderr)
-            sys.exit(2)
+            # Try interactive picker
+            candidates = promotable_candidates(username, args.registry)
+            if candidates:
+                picked = select_promotion_candidate(candidates, "Select skill to promote:")
+                if picked:
+                    skill_id = picked
+            if not skill_id:
+                print("Usage: gaia promote <skill> or gaia promote --all", file=sys.stderr)
+                sys.exit(2)
         result = promote_from_candidates(username, skill_id, args.registry, new_display_name=display_name)
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
@@ -697,16 +710,28 @@ def fuse_command(args):
     tree = load_tree(username, registry_path=args.registry)
     if not tree:
         return
-    
-    target = args.skillId
+
+    target = getattr(args, 'skillId', None)
     display_name = getattr(args, 'name', None)
-    
+
+    # Interactive picker when no target specified
+    if not target:
+        pending_combos = tree.get('pendingCombinations', [])
+        if pending_combos:
+            picked = select_fusion_candidate(pending_combos, "Select fusion candidate:")
+            if picked:
+                target = picked
+        if not target:
+            print("Usage: gaia fuse <skill>", file=sys.stderr)
+            print("Run `gaia scan` to detect fusion candidates.")
+            return
+
     # Check combinations first
     pending_combos = tree.get('pendingCombinations', [])
     combo_match = next((p for p in pending_combos if p.get('candidateResult') == target), None)
     
     if combo_match:
-        print(f"Fusing combination {target}...")
+        print(f"Fusing combination /{target}...")
         tree.setdefault('unlockedSkills', []).append({
             "skillId": target,
             "level": combo_match.get('levelFloor'),
@@ -726,14 +751,14 @@ def fuse_command(args):
     try:
         payload = load_promotion_candidates(args.registry)
         if any(c.get('skillId') == target for c in payload.get('candidates', [])):
-            print(f"Fusing promotion for {target}...")
+            print(f"Fusing promotion for /{target}...")
             result = promote_from_candidates(username, target, args.registry, new_display_name=display_name)
-            print(f"Promoted {result['skillId']} to Level {result['newLevel']}.")
+            print(f"Promoted /{result['skillId']} to Level {result['newLevel']}.")
             return
     except Exception:
         pass
 
-    print(f"Skill {target} is not a valid combination or promotion candidate.")
+    print(f"Skill /{target} is not a valid combination or promotion candidate.")
     print("Run `gaia scan` to refresh candidates.")
 
 _EMBEDDINGS_INSTALL_STEPS = """\
@@ -1150,7 +1175,7 @@ def get_parser():
     promote_parser.add_argument('--all', action='store_true', help="Promote every candidate from the last scan")
     promote_parser.add_argument('--name', help="Optional display name for the promoted skill")
     fuse_parser = subparsers.add_parser('fuse', help="Confirm a skill combination or promotion candidate")
-    fuse_parser.add_argument('skillId', help="Skill ID to fuse or promote")
+    fuse_parser.add_argument('skillId', nargs='?', default=None, help="Skill ID to fuse or promote")
     fuse_parser.add_argument('--name', help="Optional display name for the skill")
     docs_parser = subparsers.add_parser('docs', help="Documentation maintenance commands")
     docs_sub = docs_parser.add_subparsers(dest='docs_command')

--- a/src/gaia_cli/treeManager.py
+++ b/src/gaia_cli/treeManager.py
@@ -110,17 +110,26 @@ def _gradient_text(text, start_rgb, end_rgb):
 
 
 def _color_entry(symbol, plain_label, tier, is_named, level):
-    from gaia_cli.cardRenderer import fg, reset, bold, _use_color, TIER_COLORS
+    from gaia_cli.cardRenderer import fg, reset, bold, _use_color, TIER_COLORS, RANK_COLORS, COLOR_CONTRIBUTOR, COLOR_LOCAL_USER
     if not _use_color():
         return f"{symbol} {plain_label}"
     if is_named:
         if level in _TRANSCENDENT_LEVELS:
             colored = _gradient_text(f"{symbol} {plain_label}", _GRAD_GOLD, _GRAD_RED)
             return f"{bold()}{colored}{reset()}"
-        r, g, b = _COLOR_NAMED
-        return f"{bold()}{fg(r, g, b)}{symbol} {plain_label}{reset()}"
-    r, g, b = TIER_COLORS.get(tier, (56, 189, 248))
-    return f"{fg(r, g, b)}{symbol} {plain_label}{reset()}"
+        # Named skills: contributor in red, rest in rank color
+        rc = RANK_COLORS.get(level, (148, 163, 184))
+        cr, cg, cb = COLOR_CONTRIBUTOR
+        # Check if label has contributor prefix (contains / before [)
+        if "/" in plain_label.split("[")[0]:
+            parts = plain_label.split("/", 1)
+            contrib_part = parts[0]
+            rest = parts[1]
+            return f"{fg(cr, cg, cb)}{symbol} {contrib_part}{reset()}/{fg(*rc)}{rest}{reset()}"
+        return f"{bold()}{fg(cr, cg, cb)}{symbol} {plain_label}{reset()}"
+    # Canon skills: rank color for entire label
+    rc = RANK_COLORS.get(level, (148, 163, 184))
+    return f"{fg(*rc)}{symbol} {plain_label}{reset()}"
 
 
 def _dim(text):

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -1,0 +1,127 @@
+"""Tests for gaia_cli.interactive module.
+
+Validates graceful degradation when questionary is not installed
+or when running in a non-interactive context.
+"""
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from gaia_cli.interactive import (
+    _has_interactive,
+    confirm,
+    select_fusion_candidate,
+    select_promotion_candidate,
+    select_skill,
+)
+
+
+class TestHasInteractive:
+    """Tests for _has_interactive() detection logic."""
+
+    def test_returns_false_when_stdin_not_tty(self, monkeypatch):
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+        monkeypatch.delenv("CI", raising=False)
+        assert _has_interactive() is False
+
+    def test_returns_false_when_ci_env_set(self, monkeypatch):
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+        monkeypatch.setenv("CI", "true")
+        assert _has_interactive() is False
+
+    def test_returns_false_when_questionary_missing(self, monkeypatch):
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+        monkeypatch.delenv("CI", raising=False)
+        with patch.dict(sys.modules, {"questionary": None}):
+            # Simulate ImportError by removing the module
+            import importlib
+            with patch("builtins.__import__", side_effect=_make_import_raiser("questionary")):
+                assert _has_interactive() is False
+
+    def test_returns_true_when_all_conditions_met(self, monkeypatch):
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+        monkeypatch.delenv("CI", raising=False)
+        # questionary may or may not be installed; mock it as available
+        with patch("builtins.__import__", side_effect=_make_import_passer("questionary")):
+            assert _has_interactive() is True
+
+
+class TestSelectSkill:
+    """Tests for select_skill() in non-interactive mode."""
+
+    def test_returns_none_when_non_interactive(self, monkeypatch):
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+        skills = [{"id": "python-basics", "type": "basic", "level": "1"}]
+        assert select_skill(skills) is None
+
+    def test_returns_none_with_empty_skills(self, monkeypatch):
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+        assert select_skill([]) is None
+
+
+class TestSelectFusionCandidate:
+    """Tests for select_fusion_candidate() in non-interactive mode."""
+
+    def test_returns_none_when_non_interactive(self, monkeypatch):
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+        candidates = [
+            {"candidateResult": "advanced-python", "detectedSkills": ["python-basics", "oop"]}
+        ]
+        assert select_fusion_candidate(candidates) is None
+
+    def test_returns_none_with_empty_candidates(self, monkeypatch):
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+        assert select_fusion_candidate([]) is None
+
+
+class TestSelectPromotionCandidate:
+    """Tests for select_promotion_candidate() in non-interactive mode."""
+
+    def test_returns_none_when_non_interactive(self, monkeypatch):
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+        candidates = [
+            {"skillId": "python-basics", "currentLevel": "1", "suggestedLevel": "2"}
+        ]
+        assert select_promotion_candidate(candidates) is None
+
+
+class TestConfirm:
+    """Tests for confirm() in non-interactive mode."""
+
+    def test_returns_default_true_when_non_interactive(self, monkeypatch):
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+        assert confirm("Proceed?", default=True) is True
+
+    def test_returns_default_false_when_non_interactive(self, monkeypatch):
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+        assert confirm("Proceed?", default=False) is False
+
+
+# -- Helpers --
+
+def _make_import_raiser(blocked_module):
+    """Create an __import__ side_effect that raises ImportError for a specific module."""
+    real_import = __builtins__.__import__ if hasattr(__builtins__, "__import__") else __import__
+
+    def _import(name, *args, **kwargs):
+        if name == blocked_module:
+            raise ImportError(f"No module named '{blocked_module}'")
+        return real_import(name, *args, **kwargs)
+
+    return _import
+
+
+def _make_import_passer(allowed_module):
+    """Create an __import__ side_effect that returns a mock for a specific module."""
+    from unittest.mock import MagicMock
+    real_import = __builtins__.__import__ if hasattr(__builtins__, "__import__") else __import__
+
+    def _import(name, *args, **kwargs):
+        if name == allowed_module:
+            return MagicMock()
+        return real_import(name, *args, **kwargs)
+
+    return _import


### PR DESCRIPTION
## Summary
- Add `interactive.py`: optional `questionary`-based TUI pickers (arrow-key navigation)
- Wire interactive pickers into `appraise`, `fuse`, and `promote` commands
- Make `fuse skillId` optional to enable interactive mode
- Update `treeManager` to use RANK_COLORS per level and RED contributor names
- Add `[interactive]` optional dependency group in pyproject.toml

## Test plan
- [x] 344 tests pass (`python -m pytest tests/ --ignore=tests/test_packaging.py`)
- [x] Interactive features degrade gracefully (non-TTY, CI, no questionary)
- [x] Manual: `pip install -e ".[interactive]"` then `gaia appraise` shows arrow-key picker
- [x] Manual: `gaia fuse` with no args shows fusion candidate picker
- [x] Manual: `echo "" | gaia fuse` does not hang (non-interactive fallback)

Depends on: #177