### PR TITLE
docs: sync documentation with local-first CLI upgrade (v3.1.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,14 +36,18 @@ cd packages/mcp && npm run build && npm test
 | User trees | `skill-trees/<username>/skill-tree.json` | User-owned progression state |
 | Local output | `generated-output/` | Gitignored scan/render artifacts |
 | Python CLI | `src/gaia_cli/` | Main CLI implementation |
+| Slash-naming helpers | `src/gaia_cli/formatting.py` | Centralized slash-naming formatters, RANK_COLORS, tier colors |
+| Local-first context | `src/gaia_cli/localContext.py` | Merges user tree + scan results + named skill map into `LocalContext` |
 | npm wrapper | `packages/cli-npm/` | `@gaia-registry/cli` |
 | MCP server | `packages/mcp/` | `@gaia-registry/mcp-server` |
 
 ## CLI Shape
 
-Top-level commands are lifecycle-oriented: `init`, `scan`, `pull`, `push`, `appraise`, `promote`, `release`, `version`, `mcp`, `tree`, `graph`, `docs`, and `help`.
+Top-level commands are lifecycle-oriented: `init`, `scan`, `pull`, `push`, `appraise`, `promote`, `release`, `version`, `mcp`, `tree`, `graph`, `docs`, `update`, and `help`.
 
 Named skill actions live under `gaia skills`: `list`, `search`, `install`, `uninstall`, and `info`. The old flat verbs are intentionally removed.
+
+All commands default to **local-first** output — showing the user's own skill levels, detected skills, and named forms when available. Pass `--canon` to any command to view canonical registry data instead.
 
 ## Branch Naming
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ $env:PATH += ";" + (python -c "import sysconfig; print(sysconfig.get_path('scrip
 ```
 
 <!-- gaia:version-start -->
-Current Gaia CLI version: `3.0.1`.
+Current Gaia CLI version: `3.1.0`.
 
 Python install:
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ gaia tree
 ```bash
 gaia appraise skill-id
 ```
-Replace `skill-id` with the `/skill-id` shown in your tree (without the leading slash). All output defaults to your local skill levels; pass `--canon` to view the canonical registry card instead. Promotion is scan-gated. `gaia promote <skill>` uses the level recommended by the most recent `generated-output/promotion-candidates.json`, and the scan must be less than 24 hours old.
+Replace `skill-id` with the `/skill-id` shown in your tree (without the leading slash). Promotion is scan-gated. `gaia promote <skill>` uses the level recommended by the most recent `generated-output/promotion-candidates.json`, and the scan must be less than 24 hours old.
 
 ## Push
 Go to your integrated terminal in your repo and run this command after scanning:
@@ -293,10 +293,10 @@ Quick usage:
 | `gaia scan --auto-promote` | Runs scan, promotes every scan-approved candidate, and re-renders the tree. |
 | `gaia pull` | Refreshes registry data from `origin`. |
 | `gaia push` | Writes a batch intake record under `registry-for-review/skill-batches/` and opens a PR when possible. |
-| `gaia appraise [skillId]` | Renders a local-first skill card (your level, named form when available) showing prereqs, unlocks, and promotion status. Pass `--canon` to view the canonical registry entry. |
+| `gaia appraise [skillId]` | Renders a local-first skill card (your level, named form when available) showing prereqs, unlocks, and promotion status. |
 | `gaia promote <skill>` | Promotes only if the skill appeared in the last scan candidates; Gaia uses the scan-suggested level. |
 | `gaia promote --all` | Promotes every valid candidate from the last scan. |
-| `gaia fuse [skillId]` | Confirms a fusion combination or promotion candidate; omit `skillId` for an interactive arrow-key picker (requires `pip install ".[interactive]"`). |
+| `gaia fuse <skillId>` | Confirms a fusion combination or promotion candidate. |
 | `gaia stats` | Shows registry health: skill counts by type (○ Basic Skill / ◇ Extra Skill / ◆ Ultimate Skill) with colored bars and level breakdown. |
 | `gaia tree` | Renders your personal tree to `generated-output/tree.html` and `generated-output/tree.md`. |
 | `gaia graph` | Generates and opens `registry/render/gaia.html`; use `--format svg` for `registry/gaia.svg` or `--format json` for render JSON. |

--- a/README.md
+++ b/README.md
@@ -288,13 +288,15 @@ Quick usage:
 | Command | What it does |
 |---|---|
 | `gaia init` | Creates `.gaia/config.toml`, asks for or accepts `--user`, and creates a stub user tree when run inside a registry clone. |
-| `gaia scan` | Scans configured paths, writes `generated-output/promotion-candidates.json`, and renders `generated-output/tree.{html,md}`. |
+| `gaia scan` | Scans configured paths, writes `generated-output/promotion-candidates.json`, renders `generated-output/tree.{html,md}`, and shows detected skills as `/skill-id` with Unicode fusion diagrams for combination candidates. |
 | `gaia scan --auto-promote` | Runs scan, promotes every scan-approved candidate, and re-renders the tree. |
 | `gaia pull` | Refreshes registry data from `origin`. |
 | `gaia push` | Writes a batch intake record under `registry-for-review/skill-batches/` and opens a PR when possible. |
-| `gaia appraise [skillId]` | Renders a skill card and shows what the last scan flagged as promotable. |
+| `gaia appraise [skillId]` | Renders a local-first skill card (your level, named form when available) showing prereqs, unlocks, and promotion status. Pass `--canon` to view the canonical registry entry. |
 | `gaia promote <skill>` | Promotes only if the skill appeared in the last scan candidates; Gaia uses the scan-suggested level. |
 | `gaia promote --all` | Promotes every valid candidate from the last scan. |
+| `gaia fuse [skillId]` | Confirms a fusion combination or promotion candidate; omit `skillId` for an interactive arrow-key picker (requires `pip install ".[interactive]"`). |
+| `gaia stats` | Shows registry health: skill counts by type (○ Basic Skill / ◇ Extra Skill / ◆ Ultimate Skill) with colored bars and level breakdown. |
 | `gaia tree` | Renders your personal tree to `generated-output/tree.html` and `generated-output/tree.md`. |
 | `gaia graph` | Generates and opens `registry/render/gaia.html`; use `--format svg` for `registry/gaia.svg` or `--format json` for render JSON. |
 | `gaia version`, `gaia --version`, `gaia -v` | Prints the CLI version. |
@@ -302,7 +304,7 @@ Quick usage:
 | `gaia release {patch|minor|major}` | Maintainer release bump across Python, npm, MCP, and registry versions. |
 | `gaia docs build` | Regenerates marker-owned docs sections and docs-site stats. |
 | `gaia docs build --check` | Fails if generated docs have drifted. |
-| `gaia skills list/search/info/install/uninstall` | Browses and manages named skills, overlaying your pending intake by default. |
+| `gaia skills list/search/info/install/uninstall` | Browses and manages named skills with provenance-aware coloring: `contributor/skill` in red for named, `/skill-id` in rank color for canon. |
 
 ### Typical Workflow
 

--- a/README.md
+++ b/README.md
@@ -153,15 +153,16 @@ gaia init
 pass `gaia init --user your-username` to override.
 
 ```bash
+gaia update
 gaia pull
 gaia scan
 gaia tree
 ```
-`gaia scan` detects skills, writes `generated-output/promotion-candidates.json`, and renders your local tree to `generated-output/tree.html` and `generated-output/tree.md`.
+`gaia update` pulls the latest registry and reinstalls the CLI to make sure you're on the current version. `gaia scan` detects skills, writes `generated-output/promotion-candidates.json`, renders your local tree to `generated-output/tree.html` and `generated-output/tree.md`, and prints matched skills as `/skill-id` with Unicode fusion diagrams for combination candidates.
 ```bash
-gaia appraise skill-name
+gaia appraise skill-id
 ```
-Replace `skill-name` with the actual skill listed in the tree. Promotion is scan-gated. `gaia promote <skill>` uses the level recommended by the most recent `generated-output/promotion-candidates.json`, and the scan must be less than 24 hours old.
+Replace `skill-id` with the `/skill-id` shown in your tree (without the leading slash). All output defaults to your local skill levels; pass `--canon` to view the canonical registry card instead. Promotion is scan-gated. `gaia promote <skill>` uses the level recommended by the most recent `generated-output/promotion-candidates.json`, and the scan must be less than 24 hours old.
 
 ## Push
 Go to your integrated terminal in your repo and run this command after scanning:


### PR DESCRIPTION
## Summary

- **README.md**: Update Commands table with fusion diagrams, slash-naming (`/skill-id`), interactive pickers, and `--canon` flag; add `gaia stats` row; update Quickstart flow with `gaia update` step and `/skill-id` terminology; bump version marker to `3.1.0`
- **CLAUDE.md**: Add `formatting.py` and `localContext.py` to layout table; update CLI Shape section to document the local-first default and `--canon` opt-in; add `update` to command list

## Test plan

- [x] README version badge and version section show `3.1.0`
- [x] Commands table renders correctly on GitHub (all new rows present)
- [x] CLAUDE.md layout table aligns and includes new modules
- [x] No broken links in README