### PR TITLE
Fix docs build script imports

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -454,5 +454,5 @@
 </html>
 
 <!-- gaia:stats-start -->
-<!-- skills=128; namedSkills=32; version=3.0.1 -->
+<!-- skills=128; namedSkills=32; version=3.1.0 -->
 <!-- gaia:stats-end -->

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -6,13 +6,16 @@ from __future__ import annotations
 import re
 import argparse
 import json
-import subprocess
 import sys
 from functools import partial
 from pathlib import Path
-from gaia_cli.main import PUBLIC_COMMANDS, get_parser
 
 ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from gaia_cli.main import PUBLIC_COMMANDS, get_parser  # noqa: E402
 
 
 def _read_version() -> str:


### PR DESCRIPTION
### Motivation
- Running `python scripts/build_docs.py` from a source checkout raised `ModuleNotFoundError: No module named 'gaia_cli'` because the repository `src` directory was not on `sys.path`. 
- The generated docs stats were stale and needed to be updated to the current CLI version.

### Description
- Add the repository `src` directory to `sys.path` in `scripts/build_docs.py` so `gaia_cli` can be imported from a source checkout and annotate the import with `# noqa: E402` to avoid import-order lint noise. 
- Remove the now-unused `subprocess` import from `scripts/build_docs.py`.
- Regenerate `docs/index.html` stats to update the reported CLI version to `3.1.0`.

### Testing
- Ran `python scripts/build_docs.py` which regenerated the docs successfully. 
- Ran `python scripts/build_docs.py --check` which reported the docs are up to date. 
- Ran `pytest tests/test_docs_site.py tests/test_dx.py -q` which passed (`12` tests), and ran `python -m py_compile scripts/build_docs.py` and `git diff --check` which all succeeded; packaging tests including `tests/test_packaging.py` were attempted but failed in the environment due to a missing `build` Python module.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fe3b0aba04832784672d260e7468bd)