### PR TITLE
fix(schema): enforce unique demerit IDs in skill schema

### DIFF
--- a/registry/schema/skill.schema.json
+++ b/registry/schema/skill.schema.json
@@ -94,6 +94,19 @@
       "type": "string",
       "description": "Optional free-text conditions required for fusion or level-up."
     },
+    "demerits": {
+      "type": "array",
+      "description": "Optional canonical demerit IDs that lower effective progression ceiling.",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": [
+          "niche-integration",
+          "experimental-feature",
+          "heavyweight-dependency"
+        ]
+      }
+    },
     "realVariants": {
       "type": "array",
       "description": "Named real-world implementations of this abstract skill. Populated by generateNamedIndex.py from status:named entries — do not hand-edit.",


### PR DESCRIPTION
## Scope
Schema-only PR for `registry/schema/skill.schema.json`.

## Change
- Add `uniqueItems: true` for `demerits` so duplicate demerit IDs are schema-invalid.

## Why split
This isolates `registry/schema/*` changes into a dedicated `schema/*` branch/PR that can merge to `main` first.
