### PR TITLE
Validate duplicate Gaia graph identifiers

### DIFF
--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -3,11 +3,15 @@
 
 Validates registry/gaia.json against:
 1. JSON Schema validation for all skill nodes and edges.
-2. DAG cycle detection (DFS from all root nodes).
-3. Reference integrity (every parent ID resolves to an existing node).
-4. Evidence threshold by level.
-5. Ultimate approval count check (placeholder).
-6. Summary statistics output.
+2. Unique skill IDs and edge declarations.
+3. DAG cycle detection (DFS from all root nodes).
+4. Reference integrity (every parent ID resolves to an existing node).
+5. Prerequisite minimums by skill type.
+6. Evidence threshold by level.
+7. Ultimate approval count check (placeholder).
+8. Demerit constraints.
+9. Named skill frontmatter consistency.
+10. Summary statistics output.
 
 Usage:
     python scripts/validate.py [--graph PATH]
@@ -81,6 +85,41 @@ def validate_schema(graph, schema_dir):
             jsonschema.validate(instance=edge, schema=combo_schema)
         except jsonschema.ValidationError as e:
             errors.append(f"Schema error in edge '{edge.get('sourceSkillId', '?')}->{edge.get('targetSkillId', '?')}': {e.message}")
+
+    return errors
+
+
+def validate_unique_ids(graph):
+    """Check that skill IDs and edges are unique within the graph."""
+    errors = []
+
+    seen_skill_ids = set()
+    duplicate_skill_ids = set()
+    for skill in graph.get("skills", []):
+        skill_id = skill.get("id")
+        if skill_id in seen_skill_ids:
+            duplicate_skill_ids.add(skill_id)
+        seen_skill_ids.add(skill_id)
+
+    for skill_id in sorted(duplicate_skill_ids):
+        errors.append(f"Duplicate skill id '{skill_id}' found in skills.")
+
+    seen_edges = set()
+    duplicate_edges = set()
+    for edge in graph.get("edges", []):
+        edge_key = (
+            edge.get("sourceSkillId"),
+            edge.get("targetSkillId"),
+            edge.get("edgeType", "prerequisite"),
+        )
+        if edge_key in seen_edges:
+            duplicate_edges.add(edge_key)
+        seen_edges.add(edge_key)
+
+    for source, target, edge_type in sorted(duplicate_edges):
+        errors.append(
+            f"Duplicate edge '{source}->{target}' with edgeType '{edge_type}' found in edges."
+        )
 
     return errors
 
@@ -613,35 +652,39 @@ def main():
     all_errors = []
 
     # 1. Schema validation
-    print("   [1/8] Schema validation...")
+    print("   [1/9] Schema validation...")
     all_errors.extend(validate_schema(graph, schema_dir))
 
-    # 2. DAG cycle detection
-    print("   [2/8] DAG cycle detection...")
+    # 2. Unique identifiers
+    print("   [2/9] Unique identifiers...")
+    all_errors.extend(validate_unique_ids(graph))
+
+    # 3. DAG cycle detection
+    print("   [3/9] DAG cycle detection...")
     all_errors.extend(validate_dag(graph))
 
-    # 3. Reference integrity
-    print("   [3/8] Reference integrity...")
+    # 4. Reference integrity
+    print("   [4/9] Reference integrity...")
     all_errors.extend(validate_references(graph))
 
-    # 4. Prerequisite count
-    print("   [4/8] Prerequisite count...")
+    # 5. Prerequisite count
+    print("   [5/9] Prerequisite count...")
     all_errors.extend(validate_prerequisites_count(graph))
 
-    # 5. Evidence threshold
-    print("   [5/8] Evidence thresholds...")
+    # 6. Evidence threshold
+    print("   [6/9] Evidence thresholds...")
     all_errors.extend(validate_evidence(graph))
 
-    # 6. Ultimate constraints
-    print("   [6/8] Ultimate constraints...")
+    # 7. Ultimate constraints
+    print("   [7/9] Ultimate constraints...")
     all_errors.extend(validate_ultimate(graph))
 
-    # 7. Named skills validation (includes reviewer gate + catalog cross-refs)
-    print("   [7/8] Demerit constraints...")
+    # 8. Demerit constraints
+    print("   [8/9] Demerit constraints...")
     all_errors.extend(validate_demerits(graph))
 
-    # 8. Named skills validation (includes reviewer gate + catalog cross-refs)
-    print("   [8/8] Named skills validation...")
+    # 9. Named skills validation (includes reviewer gate + catalog cross-refs)
+    print("   [9/9] Named skills validation...")
     all_errors.extend(validate_named_skills(graph))
 
     # Stats

--- a/tests/fixtures/duplicate_edge.json
+++ b/tests/fixtures/duplicate_edge.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "../../schema/skill.schema.json",
+  "version": "0.1.0",
+  "generatedAt": "2026-04-26T00:00:00Z",
+  "skills": [
+    {
+      "id": "source-skill",
+      "name": "Source Skill",
+      "type": "basic",
+      "level": "0",
+      "rarity": "common",
+      "description": "A source skill for duplicate edge validation.",
+      "prerequisites": [],
+      "derivatives": ["target-skill"],
+      "evidence": [],
+      "knownAgents": [],
+      "status": "provisional",
+      "createdAt": "2026-04-26",
+      "updatedAt": "2026-04-26",
+      "version": "0.1.0"
+    },
+    {
+      "id": "helper-skill",
+      "name": "Helper Skill",
+      "type": "basic",
+      "level": "0",
+      "rarity": "common",
+      "description": "A helper skill that satisfies the target prerequisite count.",
+      "prerequisites": [],
+      "derivatives": ["target-skill"],
+      "evidence": [],
+      "knownAgents": [],
+      "status": "provisional",
+      "createdAt": "2026-04-26",
+      "updatedAt": "2026-04-26",
+      "version": "0.1.0"
+    },
+    {
+      "id": "target-skill",
+      "name": "Target Skill",
+      "type": "extra",
+      "level": "II",
+      "rarity": "uncommon",
+      "description": "A target skill reached through duplicated edges.",
+      "prerequisites": ["source-skill", "helper-skill"],
+      "derivatives": [],
+      "evidence": [
+        {
+          "class": "C",
+          "source": "http://example.com/target-skill",
+          "evaluator": "test",
+          "date": "2026-04-26"
+        }
+      ],
+      "knownAgents": [],
+      "status": "provisional",
+      "createdAt": "2026-04-26",
+      "updatedAt": "2026-04-26",
+      "version": "0.1.0"
+    }
+  ],
+  "edges": [
+    {
+      "sourceSkillId": "source-skill",
+      "targetSkillId": "target-skill",
+      "edgeType": "prerequisite"
+    },
+    {
+      "sourceSkillId": "source-skill",
+      "targetSkillId": "target-skill",
+      "edgeType": "prerequisite"
+    },
+    {
+      "sourceSkillId": "helper-skill",
+      "targetSkillId": "target-skill",
+      "edgeType": "prerequisite"
+    }
+  ]
+}

--- a/tests/fixtures/duplicate_id.json
+++ b/tests/fixtures/duplicate_id.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "../../schema/skill.schema.json",
+  "version": "0.1.0",
+  "generatedAt": "2026-04-26T00:00:00Z",
+  "skills": [
+    {
+      "id": "duplicate-skill",
+      "name": "Duplicate Skill One",
+      "type": "basic",
+      "level": "0",
+      "rarity": "common",
+      "description": "First skill with a duplicate identifier.",
+      "prerequisites": [],
+      "derivatives": [],
+      "evidence": [],
+      "knownAgents": [],
+      "status": "provisional",
+      "createdAt": "2026-04-26",
+      "updatedAt": "2026-04-26",
+      "version": "0.1.0"
+    },
+    {
+      "id": "duplicate-skill",
+      "name": "Duplicate Skill Two",
+      "type": "basic",
+      "level": "0",
+      "rarity": "common",
+      "description": "Second skill with the same duplicate identifier.",
+      "prerequisites": [],
+      "derivatives": [],
+      "evidence": [],
+      "knownAgents": [],
+      "status": "provisional",
+      "createdAt": "2026-04-26",
+      "updatedAt": "2026-04-26",
+      "version": "0.1.0"
+    }
+  ],
+  "edges": []
+}

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -44,6 +44,18 @@ class TestValidate(unittest.TestCase):
         self.assertEqual(code, 1, "Expected missing ref graph to fail validation.")
         self.assertIn("references missing prerequisite", out)
 
+    def test_duplicate_skill_id(self):
+        """Ensure duplicate skill IDs are rejected."""
+        code, out = run_validate(os.path.join(FIXTURES_DIR, "duplicate_id.json"))
+        self.assertEqual(code, 1, "Expected duplicate skill ID graph to fail validation.")
+        self.assertIn("Duplicate skill id", out)
+
+    def test_duplicate_edge(self):
+        """Ensure duplicate graph edges are rejected."""
+        code, out = run_validate(os.path.join(FIXTURES_DIR, "duplicate_edge.json"))
+        self.assertEqual(code, 1, "Expected duplicate edge graph to fail validation.")
+        self.assertIn("Duplicate edge", out)
+
     def test_bad_evidence(self):
         """Ensure insufficient evidence is caught."""
         code, out = run_validate(os.path.join(FIXTURES_DIR, "bad_evidence.json"))


### PR DESCRIPTION
### Motivation
- Prevent subtle graph corruption by ensuring skill IDs and edge declarations are unique before running DAG/reference checks.
- Provide clearer, earlier failure messages for repository contributors and CI when duplicate identifiers are introduced.

### Description
- Add `validate_unique_ids(graph)` to `scripts/validate.py` to detect duplicate skill `id` values and duplicate `(source,target,edgeType)` edge tuples and return human-readable errors.
- Wire the uniqueness check into the main validation flow before cycle detection and reference integrity with updated progress numbering and header documentation in `scripts/validate.py`.
- Add regression fixtures `tests/fixtures/duplicate_id.json` and `tests/fixtures/duplicate_edge.json` and two tests in `tests/test_validate.py` to assert duplicate skill IDs and duplicate edges cause validation to fail.

### Testing
- Ran `python scripts/validate.py` against the canonical graph and it reported all checks passed (no new errors).
- Ran `pytest -q tests/test_validate.py` and the new validation tests passed.
- Ran full test suite with `pytest -q` which completed successfully (`378 passed`).
- Ran intake and docs checks with `python scripts/validate_intake.py`, `python scripts/validate.py --check-meta-sync`, and `gaia --registry . docs build --check`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ff02156ce08327b344084c7e78494d)