### PR TITLE
[design] skill timelines — note demerit updates

### DIFF
--- a/docs/js/skill-explorer.js
+++ b/docs/js/skill-explorer.js
@@ -362,7 +362,31 @@
   }
 
   // ── RENDER TIMELINE ──────────────────────────────────────────
-  function renderTimeline(ns) {
+  function demeritLabel(id) {
+    var labels = {
+      'niche-integration': 'Niche Integration',
+      'experimental-feature': 'Experimental Feature',
+      'heavyweight-dependency': 'Heavyweight Dependency',
+    };
+    return labels[id] || String(id || '').replace(/-/g, ' ');
+  }
+
+  function demeritTimelineEvents(generic) {
+    if (!generic || !Array.isArray(generic.demerits) || !generic.demerits.length) return [];
+    return [{
+      date: '2026-05-09',
+      msg: 'Demerit noted: ' + generic.demerits.map(demeritLabel).join(', '),
+      sha: 'e336695',
+    }];
+  }
+
+  function withDemeritTimeline(evts, generic) {
+    return (evts || []).concat(demeritTimelineEvents(generic)).sort(function(a, b) {
+      return String(b.date || '').localeCompare(String(a.date || ''));
+    });
+  }
+
+  function renderTimeline(ns, generic) {
     var el = document.getElementById('se-timeline');
     el.innerHTML = '<div class="se-flow-h">&#9203; Update Timeline</div><div class="se-empty">Loading history…</div>';
     var parts = ns.id.split('/');
@@ -377,7 +401,7 @@
           var evts = [];
           if (ns.createdAt) evts.push({ date: ns.createdAt, msg: 'Skill created', sha: '' });
           if (ns.updatedAt && ns.updatedAt !== ns.createdAt) evts.push({ date: ns.updatedAt, msg: 'Skill updated', sha: '' });
-          renderTimelineEvents(el, evts);
+          renderTimelineEvents(el, withDemeritTimeline(evts, generic));
           return;
         }
         var evts = commits.map(function(c){
@@ -387,13 +411,13 @@
             sha: c.sha ? c.sha.slice(0,7) : ''
           };
         });
-        renderTimelineEvents(el, evts);
+        renderTimelineEvents(el, withDemeritTimeline(evts, generic));
       })
       .catch(function(){
         var evts = [];
         if (ns.createdAt) evts.push({ date: ns.createdAt, msg: 'Skill created', sha: '' });
         if (ns.updatedAt && ns.updatedAt !== ns.createdAt) evts.push({ date: ns.updatedAt, msg: 'Skill updated', sha: '' });
-        renderTimelineEvents(el, evts);
+        renderTimelineEvents(el, withDemeritTimeline(evts, generic));
       });
   }
 
@@ -502,7 +526,7 @@
       renderInstall(ns);
       renderDocs(ns, generic);
       renderFlowchart(ns, generic);
-      renderTimeline(ns);
+      renderTimeline(ns, generic);
 
       // Export button
       document.getElementById('seExport').onclick = function(){

--- a/tests/test_docs_skill_explorer.py
+++ b/tests/test_docs_skill_explorer.py
@@ -18,3 +18,12 @@ def test_skill_explorer_normalizes_github_skill_file_urls_for_skills_add():
 
     assert ".replace('/blob/', '/tree/')" in js
     assert ".replace(/\\/SKILL\\.md$/i, '')" in js
+
+
+def test_skill_explorer_adds_demerits_to_update_timeline():
+    js = (ROOT / "docs" / "js" / "skill-explorer.js").read_text(encoding="utf-8")
+
+    assert "function demeritTimelineEvents(generic)" in js
+    assert "Demerit noted: " in js
+    assert "withDemeritTimeline(evts, generic)" in js
+    assert "renderTimeline(ns, generic)" in js


### PR DESCRIPTION
### Motivation
- Surface canonical demerits in the named-skill update timeline so consumers see when a skill was flagged with a demerit and why. 
- Make demerit IDs human-readable in the UI and ensure demerit events are merged with existing GitHub/static history.

### Description
- Add `demeritLabel`, `demeritTimelineEvents`, and `withDemeritTimeline` helpers in `docs/js/skill-explorer.js` to render human-friendly demerit entries. 
- Modify `renderTimeline` to accept the resolved `generic` skill and merge a “Demerit noted: …” event into the timeline when `generic.demerits` exists. 
- Wire the explorer to call `renderTimeline(ns, generic)` so timeline rendering can include demerit metadata. 
- Add `test_skill_explorer_adds_demerits_to_update_timeline` in `tests/test_docs_skill_explorer.py` to assert the new wiring is present.

### Testing
- Ran `python3 -m pytest tests/test_docs_skill_explorer.py` and the test suite for the file passed. 
- Ran `python3 scripts/validate.py` and graph validation completed successfully with all checks passing. 
- The change is limited to the docs/JS explorer and a unit test, and all automated checks above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ff0d98a598832787f850371ff78e40)