### PR TITLE
Add four agent-skill nodes (authoring, benchmarking, security, MCP server creation) and update registry evidence

### DIFF
--- a/docs/audits/2026-05-10-agent-skill-evidence-audit.md
+++ b/docs/audits/2026-05-10-agent-skill-evidence-audit.md
@@ -1,0 +1,33 @@
+# Agent Skill Evidence Audit — 2026-05-10
+
+## Scope
+
+Quick evidence-quality audit for the four skills added in commit `9f3a965`:
+
+- `skill-authoring`
+- `skill-performance-benchmarking`
+- `skill-security-analysis`
+- `mcp-server-creation`
+
+## Method
+
+- Checked each evidence URL for resolvability.
+- Confirmed whether the evidence directly supports the claimed capability, rather than merely an adjacent engineering workflow.
+- Preferred direct agent-skill papers, official SDKs, and reproducible repositories over broad or archived sources.
+
+## Verdict
+
+Overall evidence quality is now acceptable for provisional Level IV nodes: every skill has at least one directly relevant Class A or Class B source, and the weakest sources from the initial pass were replaced or supplemented.
+
+## Findings and corrections
+
+| Skill | Audit result | Correction |
+|---|---|---|
+| `skill-authoring` | Good. The Anthropic `skill-creator` SKILL.md directly demonstrates authoring, iteration, and evaluation; the arXiv ecosystem paper supports the skill abstraction. | No registry change. |
+| `skill-performance-benchmarking` | Good after supplement. The arXiv AgentSkillOS paper is directly relevant, but the original second source reused `skill-creator`; adding the AgentSkillOS repository makes the benchmark implementation evidence reproducible. | Added `https://github.com/ynulihao/AgentSkillOS` as Class B evidence. |
+| `skill-security-analysis` | Improved. The original `security-and-hardening` SKILL.md was too generic because it covered application security, not third-party agent-skill package review. | Removed the generic hardening source and added `https://arxiv.org/abs/2604.25109`, which directly studies pre-load auditing of untrusted Agent Skills. |
+| `mcp-server-creation` | Improved. Anthropic `mcp-builder` is strong direct evidence, but `modelcontextprotocol/create-python-server` is archived and therefore a weak current implementation source. | Replaced the archived scaffold with active official `https://github.com/modelcontextprotocol/python-sdk` evidence. |
+
+## Remaining caveat
+
+Gaia currently treats arXiv papers as Class A evidence throughout the registry. These entries are suitable under that repository convention, but several are preprints rather than independently peer-reviewed publications; keep `status: "provisional"` until maintainer review.

--- a/docs/index.html
+++ b/docs/index.html
@@ -454,5 +454,5 @@
 </html>
 
 <!-- gaia:stats-start -->
-<!-- skills=128; namedSkills=32; version=3.1.1 -->
+<!-- skills=132; namedSkills=32; version=3.1.1 -->
 <!-- gaia:stats-end -->

--- a/registry/combinations.md
+++ b/registry/combinations.md
@@ -29,6 +29,7 @@
 | ◇ Extra Skill: /knowledge-graph-build | Extra Skill | Extract Entities, Logical Inference | III |  |
 | ◇ Extra Skill: /knowledge-harvest | Extra Skill | Web Scrape, Extract Entities, Embed Text | IV |  |
 | ◇ Extra Skill: huggingface/huggingface-papers | Extra Skill | Research, Cite Sources, Summarize | IV | Requires access to academic databases (PubMed, bioRxiv, ChEMBL, or equivalent). |
+| ◇ Extra Skill: /mcp-server-creation | Extra Skill | MCP Integration, Tool Creation, API Call | IV | Requires an integration target, a supported MCP SDK, tool schemas, authentication handling, and local validation against an MCP client. |
 | ◇ Extra Skill: /ml-pipeline | Extra Skill | Data Analysis, Automated Testing, Code Generation | IV | Requires access to a container orchestration environment and model registry. |
 | ◇ Extra Skill: /multi-agent-debate | Extra Skill | Self-Critique, Evaluate Output, Chain-of-Thought Reasoning | IV |  |
 | ◆ Ultimate Skill: ruvnet/flow-nexus-swarm | Ultimate Skill | Plan and Execute, Route Intent, Tool Select | V | Requires extensive multi-system validation before level advancement. |
@@ -47,6 +48,9 @@
 | ◆ Ultimate Skill: /scientific-discovery [Unclaimed ✦] | Ultimate Skill | Hypothesis Generation, Research, Math Reason | V | Requires laboratory tool access or simulation environment. Minimum 3 Class A/B evidence sources. |
 | ◇ Extra Skill: /scientific-writing | Extra Skill | Write Report, Cite Sources, Scientific Visualization | III |  |
 | ◇ Extra Skill: /security-audit | Extra Skill | Code Review Pipeline, Evaluate Output | II | Requires access to the full codebase or diff; output must include severity classification and reproduction steps. |
+| ◇ Extra Skill: /skill-authoring | Extra Skill | Generate Text, Structured Output Generation, Code Generation | IV | Requires a target agent skill format and a repeatable evaluation loop for trigger accuracy and task success. |
+| ◇ Extra Skill: /skill-performance-benchmarking | Extra Skill | Agent Evaluation, Skill Discovery, Statistical Analysis | IV | Requires a skill corpus, benchmark tasks, success rubrics, and variance-aware reporting across multiple runs. |
+| ◇ Extra Skill: /skill-security-analysis | Extra Skill | Security Audit, Prompt Injection Defense, Skill Discovery | IV | Requires access to the skill manifest, referenced files, source repository context, and a policy for trusted permissions. |
 | ◇ Extra Skill: /text-to-sql-pipeline | Extra Skill | Generate SQL, Parse JSON, Format Output | III | Requires schema context in prompt. |
 | ◇ Extra Skill: /tool-chaining | Extra Skill | Tool Use, Tool Select | III | Requires at least two distinct tools whose data schemas are compatible for chaining. |
 | ◇ Extra Skill: anthropic/skill-creator | Extra Skill | Code Generation, Tool Use | IV |  |

--- a/registry/gaia.gexf
+++ b/registry/gaia.gexf
@@ -508,6 +508,14 @@
           <attvalue for="type" value="basic" />
         </attvalues>
       </node>
+      <node id="mcp-server-creation" label="MCP Server Creation">
+        <attvalues>
+          <attvalue for="level" value="IV" />
+          <attvalue for="rarity" value="rare" />
+          <attvalue for="status" value="provisional" />
+          <attvalue for="type" value="extra" />
+        </attvalues>
+      </node>
       <node id="memory-manage" label="Memory Manage">
         <attvalues>
           <attvalue for="level" value="II" />
@@ -836,12 +844,36 @@
           <attvalue for="type" value="basic" />
         </attvalues>
       </node>
+      <node id="skill-authoring" label="Skill Authoring">
+        <attvalues>
+          <attvalue for="level" value="IV" />
+          <attvalue for="rarity" value="rare" />
+          <attvalue for="status" value="provisional" />
+          <attvalue for="type" value="extra" />
+        </attvalues>
+      </node>
       <node id="skill-discovery" label="Skill Discovery">
         <attvalues>
           <attvalue for="level" value="0" />
           <attvalue for="rarity" value="common" />
           <attvalue for="status" value="provisional" />
           <attvalue for="type" value="basic" />
+        </attvalues>
+      </node>
+      <node id="skill-performance-benchmarking" label="Skill Performance Benchmarking">
+        <attvalues>
+          <attvalue for="level" value="IV" />
+          <attvalue for="rarity" value="rare" />
+          <attvalue for="status" value="provisional" />
+          <attvalue for="type" value="extra" />
+        </attvalues>
+      </node>
+      <node id="skill-security-analysis" label="Skill Security Analysis">
+        <attvalues>
+          <attvalue for="level" value="IV" />
+          <attvalue for="rarity" value="rare" />
+          <attvalue for="status" value="provisional" />
+          <attvalue for="type" value="extra" />
         </attvalues>
       </node>
       <node id="speech-to-text" label="Speech to Text">
@@ -1114,85 +1146,97 @@
       <edge id="e73" source="research" target="literature-review" />
       <edge id="e74" source="cite-sources" target="literature-review" />
       <edge id="e75" source="summarize" target="literature-review" />
-      <edge id="e76" source="data-analysis" target="ml-pipeline" />
-      <edge id="e77" source="automated-testing" target="ml-pipeline" />
-      <edge id="e78" source="code-generation" target="ml-pipeline" />
-      <edge id="e79" source="self-critique" target="multi-agent-debate" />
-      <edge id="e80" source="evaluate-output" target="multi-agent-debate" />
-      <edge id="e81" source="chain-of-thought" target="multi-agent-debate" />
-      <edge id="e82" source="plan-and-execute" target="multi-agent-orchestration-v" />
-      <edge id="e83" source="route-intent" target="multi-agent-orchestration-v" />
-      <edge id="e84" source="tool-select" target="multi-agent-orchestration-v" />
-      <edge id="e85" source="image-caption" target="multimodal-reasoning" />
-      <edge id="e86" source="question-answer" target="multimodal-reasoning" />
-      <edge id="e87" source="logical-inference" target="multimodal-reasoning" />
-      <edge id="e88" source="route-intent" target="plan-and-execute" />
-      <edge id="e89" source="plan-decompose" target="plan-and-execute" />
-      <edge id="e90" source="tool-select" target="plan-and-execute" />
-      <edge id="e91" source="write-report" target="prd-generation" />
-      <edge id="e92" source="plan-decompose" target="prd-generation" />
-      <edge id="e93" source="data-analysis" target="prediction-market-analysis" />
-      <edge id="e94" source="web-search" target="prediction-market-analysis" />
-      <edge id="e95" source="statistical-analysis" target="prediction-market-analysis" />
-      <edge id="e96" source="evaluate-output" target="prompt-optimization" />
-      <edge id="e97" source="generate-text" target="prompt-optimization" />
-      <edge id="e98" source="retrieve" target="rag-pipeline" />
-      <edge id="e99" source="chunk-document" target="rag-pipeline" />
-      <edge id="e100" source="embed-text" target="rag-pipeline" />
-      <edge id="e101" source="score-relevance" target="rag-pipeline" />
-      <edge id="e102" source="tokenize" target="rag-pipeline" />
-      <edge id="e103" source="rank" target="rag-pipeline" />
-      <edge id="e104" source="plan-decompose" target="re-act-reasoning" />
-      <edge id="e105" source="tool-use" target="re-act-reasoning" />
-      <edge id="e106" source="voice-agent" target="real-time-voice-assistant" />
-      <edge id="e107" source="memory-manage" target="real-time-voice-assistant" />
-      <edge id="e108" source="plan-and-execute" target="real-time-voice-assistant" />
-      <edge id="e109" source="autonomous-debug" target="recursive-self-improvement" />
-      <edge id="e110" source="evaluate-output" target="recursive-self-improvement" />
-      <edge id="e111" source="plan-and-execute" target="recursive-self-improvement" />
-      <edge id="e112" source="research" target="registry-curation" />
-      <edge id="e113" source="code-generation" target="registry-curation" />
-      <edge id="e114" source="execute-bash" target="registry-curation" />
-      <edge id="e115" source="workflow-automation" target="release-automation" />
-      <edge id="e116" source="execute-bash" target="release-automation" />
-      <edge id="e117" source="generate-text" target="release-automation" />
-      <edge id="e118" source="web-search" target="research" />
-      <edge id="e119" source="summarize" target="research" />
-      <edge id="e120" source="cite-sources" target="research" />
-      <edge id="e121" source="hypothesis-generate" target="scientific-discovery" />
-      <edge id="e122" source="research" target="scientific-discovery" />
-      <edge id="e123" source="math-reason" target="scientific-discovery" />
-      <edge id="e124" source="write-report" target="scientific-writing" />
-      <edge id="e125" source="cite-sources" target="scientific-writing" />
-      <edge id="e126" source="scientific-visualization" target="scientific-writing" />
-      <edge id="e127" source="code-review-pipeline" target="security-audit" />
-      <edge id="e128" source="evaluate-output" target="security-audit" />
-      <edge id="e129" source="generate-sql" target="text-to-sql-pipeline" />
-      <edge id="e130" source="parse-json" target="text-to-sql-pipeline" />
-      <edge id="e131" source="format-output" target="text-to-sql-pipeline" />
-      <edge id="e132" source="tool-use" target="tool-chaining" />
-      <edge id="e133" source="tool-select" target="tool-chaining" />
-      <edge id="e134" source="code-generation" target="tool-creation" />
-      <edge id="e135" source="tool-use" target="tool-creation" />
-      <edge id="e136" source="translate" target="translation-pipeline" />
-      <edge id="e137" source="sentiment-analysis" target="translation-pipeline" />
-      <edge id="e138" source="audience-model" target="translation-pipeline" />
-      <edge id="e139" source="chain-of-thought" target="tree-of-thought" />
-      <edge id="e140" source="plan-decompose" target="tree-of-thought" />
-      <edge id="e141" source="plan-decompose" target="vertical-slice-planning" />
-      <edge id="e142" source="route-intent" target="vertical-slice-planning" />
-      <edge id="e143" source="speech-to-text" target="voice-agent" />
-      <edge id="e144" source="question-answer" target="voice-agent" />
-      <edge id="e145" source="text-to-speech" target="voice-agent" />
-      <edge id="e146" source="web-search" target="web-scrape" />
-      <edge id="e147" source="parse-html" target="web-scrape" />
-      <edge id="e148" source="extract-entities" target="web-scrape" />
-      <edge id="e149" source="retrieve" target="wiki-search" />
-      <edge id="e150" source="embed-text" target="wiki-search" />
-      <edge id="e151" source="summarize" target="wiki-search" />
-      <edge id="e152" source="plan-decompose" target="workflow-automation" />
-      <edge id="e153" source="tool-use" target="workflow-automation" />
-      <edge id="e154" source="api-call" target="workflow-automation" />
+      <edge id="e76" source="mcp-integration" target="mcp-server-creation" />
+      <edge id="e77" source="tool-creation" target="mcp-server-creation" />
+      <edge id="e78" source="api-call" target="mcp-server-creation" />
+      <edge id="e79" source="data-analysis" target="ml-pipeline" />
+      <edge id="e80" source="automated-testing" target="ml-pipeline" />
+      <edge id="e81" source="code-generation" target="ml-pipeline" />
+      <edge id="e82" source="self-critique" target="multi-agent-debate" />
+      <edge id="e83" source="evaluate-output" target="multi-agent-debate" />
+      <edge id="e84" source="chain-of-thought" target="multi-agent-debate" />
+      <edge id="e85" source="plan-and-execute" target="multi-agent-orchestration-v" />
+      <edge id="e86" source="route-intent" target="multi-agent-orchestration-v" />
+      <edge id="e87" source="tool-select" target="multi-agent-orchestration-v" />
+      <edge id="e88" source="image-caption" target="multimodal-reasoning" />
+      <edge id="e89" source="question-answer" target="multimodal-reasoning" />
+      <edge id="e90" source="logical-inference" target="multimodal-reasoning" />
+      <edge id="e91" source="route-intent" target="plan-and-execute" />
+      <edge id="e92" source="plan-decompose" target="plan-and-execute" />
+      <edge id="e93" source="tool-select" target="plan-and-execute" />
+      <edge id="e94" source="write-report" target="prd-generation" />
+      <edge id="e95" source="plan-decompose" target="prd-generation" />
+      <edge id="e96" source="data-analysis" target="prediction-market-analysis" />
+      <edge id="e97" source="web-search" target="prediction-market-analysis" />
+      <edge id="e98" source="statistical-analysis" target="prediction-market-analysis" />
+      <edge id="e99" source="evaluate-output" target="prompt-optimization" />
+      <edge id="e100" source="generate-text" target="prompt-optimization" />
+      <edge id="e101" source="retrieve" target="rag-pipeline" />
+      <edge id="e102" source="chunk-document" target="rag-pipeline" />
+      <edge id="e103" source="embed-text" target="rag-pipeline" />
+      <edge id="e104" source="score-relevance" target="rag-pipeline" />
+      <edge id="e105" source="tokenize" target="rag-pipeline" />
+      <edge id="e106" source="rank" target="rag-pipeline" />
+      <edge id="e107" source="plan-decompose" target="re-act-reasoning" />
+      <edge id="e108" source="tool-use" target="re-act-reasoning" />
+      <edge id="e109" source="voice-agent" target="real-time-voice-assistant" />
+      <edge id="e110" source="memory-manage" target="real-time-voice-assistant" />
+      <edge id="e111" source="plan-and-execute" target="real-time-voice-assistant" />
+      <edge id="e112" source="autonomous-debug" target="recursive-self-improvement" />
+      <edge id="e113" source="evaluate-output" target="recursive-self-improvement" />
+      <edge id="e114" source="plan-and-execute" target="recursive-self-improvement" />
+      <edge id="e115" source="research" target="registry-curation" />
+      <edge id="e116" source="code-generation" target="registry-curation" />
+      <edge id="e117" source="execute-bash" target="registry-curation" />
+      <edge id="e118" source="workflow-automation" target="release-automation" />
+      <edge id="e119" source="execute-bash" target="release-automation" />
+      <edge id="e120" source="generate-text" target="release-automation" />
+      <edge id="e121" source="web-search" target="research" />
+      <edge id="e122" source="summarize" target="research" />
+      <edge id="e123" source="cite-sources" target="research" />
+      <edge id="e124" source="hypothesis-generate" target="scientific-discovery" />
+      <edge id="e125" source="research" target="scientific-discovery" />
+      <edge id="e126" source="math-reason" target="scientific-discovery" />
+      <edge id="e127" source="write-report" target="scientific-writing" />
+      <edge id="e128" source="cite-sources" target="scientific-writing" />
+      <edge id="e129" source="scientific-visualization" target="scientific-writing" />
+      <edge id="e130" source="code-review-pipeline" target="security-audit" />
+      <edge id="e131" source="evaluate-output" target="security-audit" />
+      <edge id="e132" source="generate-text" target="skill-authoring" />
+      <edge id="e133" source="structured-output" target="skill-authoring" />
+      <edge id="e134" source="code-generation" target="skill-authoring" />
+      <edge id="e135" source="agent-eval" target="skill-performance-benchmarking" />
+      <edge id="e136" source="skill-discovery" target="skill-performance-benchmarking" />
+      <edge id="e137" source="statistical-analysis" target="skill-performance-benchmarking" />
+      <edge id="e138" source="security-audit" target="skill-security-analysis" />
+      <edge id="e139" source="prompt-injection-defense" target="skill-security-analysis" />
+      <edge id="e140" source="skill-discovery" target="skill-security-analysis" />
+      <edge id="e141" source="generate-sql" target="text-to-sql-pipeline" />
+      <edge id="e142" source="parse-json" target="text-to-sql-pipeline" />
+      <edge id="e143" source="format-output" target="text-to-sql-pipeline" />
+      <edge id="e144" source="tool-use" target="tool-chaining" />
+      <edge id="e145" source="tool-select" target="tool-chaining" />
+      <edge id="e146" source="code-generation" target="tool-creation" />
+      <edge id="e147" source="tool-use" target="tool-creation" />
+      <edge id="e148" source="translate" target="translation-pipeline" />
+      <edge id="e149" source="sentiment-analysis" target="translation-pipeline" />
+      <edge id="e150" source="audience-model" target="translation-pipeline" />
+      <edge id="e151" source="chain-of-thought" target="tree-of-thought" />
+      <edge id="e152" source="plan-decompose" target="tree-of-thought" />
+      <edge id="e153" source="plan-decompose" target="vertical-slice-planning" />
+      <edge id="e154" source="route-intent" target="vertical-slice-planning" />
+      <edge id="e155" source="speech-to-text" target="voice-agent" />
+      <edge id="e156" source="question-answer" target="voice-agent" />
+      <edge id="e157" source="text-to-speech" target="voice-agent" />
+      <edge id="e158" source="web-search" target="web-scrape" />
+      <edge id="e159" source="parse-html" target="web-scrape" />
+      <edge id="e160" source="extract-entities" target="web-scrape" />
+      <edge id="e161" source="retrieve" target="wiki-search" />
+      <edge id="e162" source="embed-text" target="wiki-search" />
+      <edge id="e163" source="summarize" target="wiki-search" />
+      <edge id="e164" source="plan-decompose" target="workflow-automation" />
+      <edge id="e165" source="tool-use" target="workflow-automation" />
+      <edge id="e166" source="api-call" target="workflow-automation" />
     </edges>
   </graph>
 </gexf>

--- a/registry/gaia.json
+++ b/registry/gaia.json
@@ -291,7 +291,8 @@
       "prerequisites": [],
       "derivatives": [
         "prompt-optimization",
-        "release-automation"
+        "release-automation",
+        "skill-authoring"
       ],
       "conditions": "",
       "evidence": [
@@ -306,7 +307,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-26",
-      "updatedAt": "2026-04-29",
+      "updatedAt": "2026-05-10",
       "version": "0.1.0"
     },
     {
@@ -685,7 +686,8 @@
         "code-review-pipeline",
         "registry-curation",
         "tool-creation",
-        "ml-pipeline"
+        "ml-pipeline",
+        "skill-authoring"
       ],
       "conditions": "",
       "evidence": [
@@ -700,7 +702,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-26",
-      "updatedAt": "2026-04-30",
+      "updatedAt": "2026-05-10",
       "version": "0.1.0"
     },
     {
@@ -1481,7 +1483,8 @@
       "prerequisites": [],
       "derivatives": [
         "function-calling",
-        "workflow-automation"
+        "workflow-automation",
+        "mcp-server-creation"
       ],
       "conditions": "",
       "evidence": [
@@ -1496,7 +1499,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-28",
-      "updatedAt": "2026-04-28",
+      "updatedAt": "2026-05-10",
       "version": "0.2.0"
     },
     {
@@ -2352,7 +2355,8 @@
         "rag-pipeline",
         "text-to-sql-pipeline",
         "function-calling",
-        "guardrails"
+        "guardrails",
+        "skill-authoring"
       ],
       "conditions": "",
       "evidence": [
@@ -2374,7 +2378,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-28",
-      "updatedAt": "2026-04-28",
+      "updatedAt": "2026-05-10",
       "version": "0.2.0"
     },
     {
@@ -2789,7 +2793,8 @@
       ],
       "derivatives": [
         "full-stack-developer",
-        "autonomous-research-agent"
+        "autonomous-research-agent",
+        "mcp-server-creation"
       ],
       "conditions": "",
       "evidence": [
@@ -2811,7 +2816,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-29",
-      "updatedAt": "2026-04-29",
+      "updatedAt": "2026-05-10",
       "version": "0.2.0"
     },
     {
@@ -3111,7 +3116,9 @@
         "evaluate-output",
         "score-relevance"
       ],
-      "derivatives": [],
+      "derivatives": [
+        "skill-performance-benchmarking"
+      ],
       "conditions": "",
       "evidence": [
         {
@@ -3139,7 +3146,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-30",
-      "updatedAt": "2026-04-30",
+      "updatedAt": "2026-05-10",
       "version": "0.1.0"
     },
     {
@@ -3260,7 +3267,10 @@
       "rarity": "common",
       "description": "Searches a skill or tool registry, ranks results by relevance and install count, and surfaces candidates for the agent to adopt or invoke.",
       "prerequisites": [],
-      "derivatives": [],
+      "derivatives": [
+        "skill-performance-benchmarking",
+        "skill-security-analysis"
+      ],
       "conditions": "",
       "evidence": [
         {
@@ -3274,7 +3284,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-30",
-      "updatedAt": "2026-04-30",
+      "updatedAt": "2026-05-10",
       "version": "0.1.0"
     },
     {
@@ -3401,7 +3411,9 @@
       "rarity": "uncommon",
       "description": "Detects and neutralizes adversarial instructions injected into agent context from untrusted external sources (indirect prompt injection), using techniques such as context isolation, hierarchical intent verification, or semantic consistency checks.",
       "prerequisites": [],
-      "derivatives": [],
+      "derivatives": [
+        "skill-security-analysis"
+      ],
       "conditions": "",
       "evidence": [
         {
@@ -3429,7 +3441,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-30",
-      "updatedAt": "2026-04-30",
+      "updatedAt": "2026-05-10",
       "version": "0.1.0"
     },
     {
@@ -3645,7 +3657,8 @@
       "description": "Performs hypothesis testing, regression analysis, and Bayesian modelling with effect size calculation and APA-formatted statistical reporting using scipy, statsmodels, and PyMC.",
       "prerequisites": [],
       "derivatives": [
-        "prediction-market-analysis"
+        "prediction-market-analysis",
+        "skill-performance-benchmarking"
       ],
       "conditions": "",
       "evidence": [
@@ -3667,7 +3680,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-30",
-      "updatedAt": "2026-05-06",
+      "updatedAt": "2026-05-10",
       "version": "0.1.0"
     },
     {
@@ -3813,7 +3826,9 @@
       "rarity": "uncommon",
       "description": "Connect to and invoke tools exposed by Model Context Protocol (MCP) servers \u2014 enumerate available tools, execute calls, and handle responses across any MCP-compatible backend.",
       "prerequisites": [],
-      "derivatives": [],
+      "derivatives": [
+        "mcp-server-creation"
+      ],
       "conditions": "",
       "evidence": [
         {
@@ -3844,7 +3859,7 @@
       ],
       "status": "provisional",
       "createdAt": "2026-04-30",
-      "updatedAt": "2026-04-30",
+      "updatedAt": "2026-05-10",
       "version": "0.2.0"
     },
     {
@@ -3968,7 +3983,9 @@
         "code-review-pipeline",
         "evaluate-output"
       ],
-      "derivatives": [],
+      "derivatives": [
+        "skill-security-analysis"
+      ],
       "conditions": "Requires access to the full codebase or diff; output must include severity classification and reproduction steps.",
       "evidence": [
         {
@@ -3989,7 +4006,7 @@
       "knownAgents": [],
       "status": "provisional",
       "createdAt": "2026-04-30",
-      "updatedAt": "2026-04-30",
+      "updatedAt": "2026-05-10",
       "version": "0.2.0"
     },
     {
@@ -4201,6 +4218,183 @@
       "status": "provisional",
       "createdAt": "2026-05-06",
       "updatedAt": "2026-05-06",
+      "version": "0.1.0"
+    },
+    {
+      "id": "skill-authoring",
+      "name": "Skill Authoring",
+      "type": "extra",
+      "level": "IV",
+      "rarity": "rare",
+      "description": "Designs, writes, packages, and iteratively improves reusable agent skill directories with metadata, progressive instructions, supporting assets, and measurable trigger criteria.",
+      "prerequisites": [
+        "generate-text",
+        "structured-output",
+        "code-generation"
+      ],
+      "derivatives": [
+        "skill-performance-benchmarking",
+        "registry-curation"
+      ],
+      "conditions": "Requires a target agent skill format and a repeatable evaluation loop for trigger accuracy and task success.",
+      "evidence": [
+        {
+          "class": "A",
+          "source": "https://arxiv.org/abs/2602.08004",
+          "evaluator": "codex",
+          "date": "2026-05-10",
+          "notes": "Agent Skills data-driven analysis characterizes SKILL.md packages as an emerging infrastructure layer and quantifies common design, reuse, and safety patterns."
+        },
+        {
+          "class": "B",
+          "source": "https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md",
+          "evaluator": "codex",
+          "date": "2026-05-10",
+          "notes": "Anthropic skill-creator provides a reproducible workflow for creating, editing, evaluating, benchmarking, and optimizing agent skills."
+        }
+      ],
+      "knownAgents": [
+        "Claude"
+      ],
+      "status": "provisional",
+      "createdAt": "2026-05-10",
+      "updatedAt": "2026-05-10",
+      "version": "0.1.0"
+    },
+    {
+      "id": "skill-performance-benchmarking",
+      "name": "Skill Performance Benchmarking",
+      "type": "extra",
+      "level": "IV",
+      "rarity": "rare",
+      "description": "Builds and runs task suites that measure whether agents select, invoke, and complete installed skills correctly across artifact-rich workflows and repeated trials.",
+      "prerequisites": [
+        "agent-eval",
+        "skill-discovery",
+        "statistical-analysis"
+      ],
+      "derivatives": [
+        "registry-curation",
+        "gaia-meta-audit"
+      ],
+      "conditions": "Requires a skill corpus, benchmark tasks, success rubrics, and variance-aware reporting across multiple runs.",
+      "evidence": [
+        {
+          "class": "A",
+          "source": "https://arxiv.org/abs/2603.02176",
+          "evaluator": "codex",
+          "date": "2026-05-10",
+          "notes": "AgentSkillOS paper introduces ecosystem-scale organization, orchestration, and benchmarking with a 30-task suite spanning data computation, documents, video, design, and web interaction."
+        },
+        {
+          "class": "B",
+          "source": "https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md",
+          "evaluator": "codex",
+          "date": "2026-05-10",
+          "notes": "Anthropic skill-creator explicitly includes measuring skill performance, benchmarking with variance analysis, and optimizing skill descriptions for triggering accuracy."
+        },
+        {
+          "class": "B",
+          "source": "https://github.com/ynulihao/AgentSkillOS",
+          "evaluator": "codex",
+          "date": "2026-05-10",
+          "notes": "AgentSkillOS repository provides the reproducible retrieval/orchestration framework and benchmark implementation for 30 artifact-rich agent-skill tasks with Bradley-Terry scoring."
+        }
+      ],
+      "knownAgents": [
+        "Claude"
+      ],
+      "status": "provisional",
+      "createdAt": "2026-05-10",
+      "updatedAt": "2026-05-10",
+      "version": "0.1.0"
+    },
+    {
+      "id": "skill-security-analysis",
+      "name": "Skill Security Analysis",
+      "type": "extra",
+      "level": "IV",
+      "rarity": "rare",
+      "description": "Assesses third-party agent skills for malicious behavior, unsafe permissions, prompt-injection exposure, repository-context mismatch, and supply-chain risk before installation or invocation.",
+      "prerequisites": [
+        "security-audit",
+        "prompt-injection-defense",
+        "skill-discovery"
+      ],
+      "derivatives": [
+        "guardrails",
+        "registry-curation"
+      ],
+      "conditions": "Requires access to the skill manifest, referenced files, source repository context, and a policy for trusted permissions.",
+      "evidence": [
+        {
+          "class": "A",
+          "source": "https://arxiv.org/abs/2603.16572",
+          "evaluator": "codex",
+          "date": "2026-05-10",
+          "notes": "Malicious Or Not studies agent skill classification and improves detection by comparing skill descriptions with surrounding repository context."
+        },
+        {
+          "class": "A",
+          "source": "https://arxiv.org/abs/2602.12430",
+          "evaluator": "codex",
+          "date": "2026-05-10",
+          "notes": "Agent Skills architecture and security survey reports vulnerabilities in community-contributed skills and proposes a governance framework for provenance and deployment permissions."
+        },
+        {
+          "class": "A",
+          "source": "https://arxiv.org/abs/2604.25109",
+          "evaluator": "codex",
+          "date": "2026-05-10",
+          "notes": "SkillGuard-Robust formulates pre-load auditing for untrusted Agent Skills as cross-file package review over SKILL.md, scripts, references, and repository context, with reported high exact-match and malicious-risk recall."
+        }
+      ],
+      "knownAgents": [],
+      "status": "provisional",
+      "createdAt": "2026-05-10",
+      "updatedAt": "2026-05-10",
+      "version": "0.1.0"
+    },
+    {
+      "id": "mcp-server-creation",
+      "name": "MCP Server Creation",
+      "type": "extra",
+      "level": "IV",
+      "rarity": "rare",
+      "description": "Designs and implements Model Context Protocol servers that expose external APIs, files, or services as well-typed tools with clear schemas, authentication, and testable agent workflows.",
+      "prerequisites": [
+        "mcp-integration",
+        "tool-creation",
+        "api-call"
+      ],
+      "derivatives": [
+        "workflow-automation",
+        "tool-chaining",
+        "multi-agent-orchestration-v"
+      ],
+      "conditions": "Requires an integration target, a supported MCP SDK, tool schemas, authentication handling, and local validation against an MCP client.",
+      "evidence": [
+        {
+          "class": "B",
+          "source": "https://github.com/anthropics/skills/blob/main/skills/mcp-builder/SKILL.md",
+          "evaluator": "codex",
+          "date": "2026-05-10",
+          "notes": "Anthropic mcp-builder skill gives a reproducible guide for building high-quality MCP servers in Python FastMCP or the Node/TypeScript MCP SDK."
+        },
+        {
+          "class": "B",
+          "source": "https://github.com/modelcontextprotocol/python-sdk",
+          "evaluator": "codex",
+          "date": "2026-05-10",
+          "notes": "Official MCP Python SDK is active and provides FastMCP server examples for exposing tools, resources, prompts, structured outputs, transports, and inspector-based testing."
+        }
+      ],
+      "knownAgents": [
+        "Claude"
+      ],
+      "status": "provisional",
+      "createdAt": "2026-05-10",
+      "updatedAt": "2026-05-10",
       "version": "0.1.0"
     }
   ],
@@ -5893,6 +6087,126 @@
       "levelFloor": "II",
       "evidenceRefs": [
         "architecture-diagram#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "generate-text",
+      "targetSkillId": "skill-authoring",
+      "edgeType": "prerequisite",
+      "condition": "Requires a target agent skill format and a repeatable evaluation loop for trigger accuracy and task success.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "skill-authoring#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "structured-output",
+      "targetSkillId": "skill-authoring",
+      "edgeType": "prerequisite",
+      "condition": "Requires a target agent skill format and a repeatable evaluation loop for trigger accuracy and task success.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "skill-authoring#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "code-generation",
+      "targetSkillId": "skill-authoring",
+      "edgeType": "prerequisite",
+      "condition": "Requires a target agent skill format and a repeatable evaluation loop for trigger accuracy and task success.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "skill-authoring#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "agent-eval",
+      "targetSkillId": "skill-performance-benchmarking",
+      "edgeType": "prerequisite",
+      "condition": "Requires a skill corpus, benchmark tasks, success rubrics, and variance-aware reporting across multiple runs.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "skill-performance-benchmarking#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "skill-discovery",
+      "targetSkillId": "skill-performance-benchmarking",
+      "edgeType": "prerequisite",
+      "condition": "Requires a skill corpus, benchmark tasks, success rubrics, and variance-aware reporting across multiple runs.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "skill-performance-benchmarking#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "statistical-analysis",
+      "targetSkillId": "skill-performance-benchmarking",
+      "edgeType": "prerequisite",
+      "condition": "Requires a skill corpus, benchmark tasks, success rubrics, and variance-aware reporting across multiple runs.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "skill-performance-benchmarking#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "security-audit",
+      "targetSkillId": "skill-security-analysis",
+      "edgeType": "prerequisite",
+      "condition": "Requires access to the skill manifest, referenced files, source repository context, and a policy for trusted permissions.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "skill-security-analysis#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "prompt-injection-defense",
+      "targetSkillId": "skill-security-analysis",
+      "edgeType": "prerequisite",
+      "condition": "Requires access to the skill manifest, referenced files, source repository context, and a policy for trusted permissions.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "skill-security-analysis#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "skill-discovery",
+      "targetSkillId": "skill-security-analysis",
+      "edgeType": "prerequisite",
+      "condition": "Requires access to the skill manifest, referenced files, source repository context, and a policy for trusted permissions.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "skill-security-analysis#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "mcp-integration",
+      "targetSkillId": "mcp-server-creation",
+      "edgeType": "prerequisite",
+      "condition": "Requires an integration target, a supported MCP SDK, tool schemas, authentication handling, and local validation against an MCP client.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "mcp-server-creation#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "tool-creation",
+      "targetSkillId": "mcp-server-creation",
+      "edgeType": "prerequisite",
+      "condition": "Requires an integration target, a supported MCP SDK, tool schemas, authentication handling, and local validation against an MCP client.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "mcp-server-creation#evidence[0]"
+      ]
+    },
+    {
+      "sourceSkillId": "api-call",
+      "targetSkillId": "mcp-server-creation",
+      "edgeType": "prerequisite",
+      "condition": "Requires an integration target, a supported MCP SDK, tool schemas, authentication handling, and local validation against an MCP client.",
+      "levelFloor": "II",
+      "evidenceRefs": [
+        "mcp-server-creation#evidence[0]"
       ]
     }
   ]

--- a/registry/registry.md
+++ b/registry/registry.md
@@ -54,6 +54,8 @@
 | ◇ Extra Skill: huggingface/huggingface-papers | Extra Skill | IV | Hardened | `/literature-review` |
 | ○ /logical-inference | Basic Skill | I | Awakened | `/logical-inference` |
 | ○ /math-reason | Basic Skill | II | Named | `/math-reason` |
+| ○ /mcp-integration | Basic Skill | III → II | Evolved | `/mcp-integration` |
+| ◇ Extra Skill: /mcp-server-creation | Extra Skill | IV | Hardened | `/mcp-server-creation` |
 | ○ /memory-manage | Basic Skill | II | Named | `/memory-manage` |
 | ◇ Extra Skill: /ml-pipeline | Extra Skill | IV | Hardened | `/ml-pipeline` |
 | ◇ Extra Skill: /multi-agent-debate | Extra Skill | IV | Hardened | `/multi-agent-debate` |
@@ -66,6 +68,7 @@
 | ○ /plan-decompose | Basic Skill | I | Awakened | `/plan-decompose` |
 | ◇ Extra Skill: mattpocock/to-prd | Extra Skill | IV | Hardened | `/prd-generation` |
 | ◇ Extra Skill: /prediction-market-analysis | Extra Skill | IV | Hardened | `/prediction-market-analysis` |
+| ○ /prompt-injection-defense | Basic Skill | III | Evolved | `/prompt-injection-defense` |
 | ◇ Extra Skill: /prompt-optimization | Extra Skill | IV | Hardened | `/prompt-optimization` |
 | ○ /question-answer | Basic Skill | 0 | Basic | `/question-answer` |
 | ◇ Extra Skill: yonatangross/orchestkit-rag | Extra Skill | III | Evolved | `/rag-pipeline` |
@@ -86,6 +89,10 @@
 | ◇ Extra Skill: /security-audit | Extra Skill | II | Named | `/security-audit` |
 | ○ /self-critique | Basic Skill | I | Awakened | `/self-critique` |
 | ○ /sentiment-analysis | Basic Skill | 0 | Basic | `/sentiment-analysis` |
+| ◇ Extra Skill: /skill-authoring | Extra Skill | IV | Hardened | `/skill-authoring` |
+| ○ vercel/find-skills | Basic Skill | 0 | Basic | `/skill-discovery` |
+| ◇ Extra Skill: /skill-performance-benchmarking | Extra Skill | IV | Hardened | `/skill-performance-benchmarking` |
+| ◇ Extra Skill: /skill-security-analysis | Extra Skill | IV | Hardened | `/skill-security-analysis` |
 | ○ /speech-to-text | Basic Skill | II | Named | `/speech-to-text` |
 | ○ /statistical-analysis | Basic Skill | III | Evolved | `/statistical-analysis` |
 | ○ /structured-output | Basic Skill | I | Awakened | `/structured-output` |
@@ -123,17 +130,14 @@
 | ○ Framework Upgrade | Intrinsic Skill | 0 | Basic | `/framework-upgrade` |
 | ○ Image Generate | Intrinsic Skill | II | Named | `/image-generate` |
 | ○ Issue Triage | Intrinsic Skill | IV | Hardened | `/issue-triage` |
-| ○ MCP Integration | Intrinsic Skill | III → II | Evolved | `/mcp-integration` |
 | ○ Object Detection | Intrinsic Skill | II | Named | `/object-detection` |
 | ○ OCR | Intrinsic Skill | II | Named | `/ocr` |
 | ○ Parallel Execution | Intrinsic Skill | II | Named | `/parallel-execution` |
-| ○ Prompt Injection Defense | Intrinsic Skill | III | Evolved | `/prompt-injection-defense` |
 | ○ Requirements Analysis | Intrinsic Skill | II | Named | `/requirements-analysis` |
 | ○ Reward Modeling | Intrinsic Skill | II | Named | `/reward-modeling` |
 | ○ Schema Design | Intrinsic Skill | II | Named | `/schema-design` |
 | ○ Self-Consistency | Intrinsic Skill | IV | Hardened | `/self-consistency` |
 | ○ Semantic Cache | Intrinsic Skill | IV | Hardened | `/semantic-cache` |
-| ○ Skill Discovery | Intrinsic Skill | 0 | Basic | `/skill-discovery` |
 | ○ Test-Driven Development | Intrinsic Skill | 0 | Basic | `/test-driven-development` |
 | ○ UX Audit | Intrinsic Skill | 0 | Basic | `/ux-audit` |
 | ○ Visual Question Answering | Intrinsic Skill | III | Evolved | `/vision-qa` |

--- a/registry/skill-sources.md
+++ b/registry/skill-sources.md
@@ -11,6 +11,7 @@ Authoritative list of known skill sources and marketplaces. `gaia-curate` agents
 | Name | URL | Type | Search |
 |---|---|---|---|
 | SkillsMP | https://skillsmp.com | marketplace | `GET /api/v1/skills/search?q=<skill>` — 50 req/day unauthenticated |
+| SkillKit | https://skillkit.io | marketplace | browse directory pages for SKILL.md packages and source links |
 | GLINCKER Claude Marketplace | https://github.com/GLINCKER/claude-code-marketplace | github-repo | `gh api repos/GLINCKER/claude-code-marketplace/contents/skills` |
 | MCP.so Registry | https://mcp.so | mcp-registry | `WebFetch /servers` — list all MCP servers as skill evidence candidates |
 | Smithery MCP Registry | https://smithery.ai | mcp-registry | `WebFetch /` — browse MCP tool listings |
@@ -19,7 +20,9 @@ Authoritative list of known skill sources and marketplaces. `gaia-curate` agents
 
 | Name | URL | Type | Search |
 |---|---|---|---|
+| anthropics/skills | https://github.com/anthropics/skills | github-repo | `gh api repos/anthropics/skills/contents/skills` |
 | mattpocock/skills | https://github.com/mattpocock/skills | github-repo | `gh api repos/mattpocock/skills/contents/skills` |
+| addyosmani/agent-skills | https://github.com/addyosmani/agent-skills | github-repo | `gh api repos/addyosmani/agent-skills/contents/skills` |
 | intelligentcode-ai/skills | https://github.com/intelligentcode-ai/skills | github-repo | `gh api repos/intelligentcode-ai/skills/contents/skills` |
 | ruvnet/ruflo | https://github.com/ruvnet/ruflo | github-repo | orchestration platform; check `/skills` and `/.claude/skills` |
 | karpathy/autoresearch | https://github.com/karpathy/autoresearch | github-repo | origin implementation of autonomous-research-agent |

--- a/registry/skills/basic/api-call.md
+++ b/registry/skills/basic/api-call.md
@@ -16,6 +16,7 @@ _None._
 ## Unlocks
 - [Function Calling](../extra/function-calling.md)
 - [Workflow Automation](../extra/workflow-automation.md)
+- [MCP Server Creation](../extra/mcp-server-creation.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/registry/skills/basic/code-generation.md
+++ b/registry/skills/basic/code-generation.md
@@ -19,6 +19,7 @@ _None._
 - [Registry Curation](../extra/registry-curation.md)
 - [Tool Creation](../extra/tool-creation.md)
 - [ML Pipeline](../extra/ml-pipeline.md)
+- [Skill Authoring](../extra/skill-authoring.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/registry/skills/basic/generate-text.md
+++ b/registry/skills/basic/generate-text.md
@@ -16,6 +16,7 @@ _None._
 ## Unlocks
 - [Prompt Optimization](../extra/prompt-optimization.md)
 - [Release Automation](../extra/release-automation.md)
+- [Skill Authoring](../extra/skill-authoring.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/registry/skills/basic/mcp-integration.md
+++ b/registry/skills/basic/mcp-integration.md
@@ -16,7 +16,7 @@ Connect to and invoke tools exposed by Model Context Protocol (MCP) servers — 
 _None._
 
 ## Unlocks
-_None._
+- [MCP Server Creation](../extra/mcp-server-creation.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/registry/skills/basic/prompt-injection-defense.md
+++ b/registry/skills/basic/prompt-injection-defense.md
@@ -14,7 +14,7 @@ Detects and neutralizes adversarial instructions injected into agent context fro
 _None._
 
 ## Unlocks
-_None._
+- [Skill Security Analysis](../extra/skill-security-analysis.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/registry/skills/basic/skill-discovery.md
+++ b/registry/skills/basic/skill-discovery.md
@@ -14,7 +14,8 @@ Searches a skill or tool registry, ranks results by relevance and install count,
 _None._
 
 ## Unlocks
-_None._
+- [Skill Performance Benchmarking](../extra/skill-performance-benchmarking.md)
+- [Skill Security Analysis](../extra/skill-security-analysis.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/registry/skills/basic/statistical-analysis.md
+++ b/registry/skills/basic/statistical-analysis.md
@@ -15,6 +15,7 @@ _None._
 
 ## Unlocks
 - [Prediction Market Analysis](../extra/prediction-market-analysis.md)
+- [Skill Performance Benchmarking](../extra/skill-performance-benchmarking.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/registry/skills/basic/structured-output.md
+++ b/registry/skills/basic/structured-output.md
@@ -18,6 +18,7 @@ _None._
 - [Text-to-SQL Pipeline](../extra/text-to-sql-pipeline.md)
 - [Function Calling](../extra/function-calling.md)
 - [Guardrails](../extra/guardrails.md)
+- [Skill Authoring](../extra/skill-authoring.md)
 
 ## Evidence
 | Class | Source | Evaluator | Date |

--- a/registry/skills/extra/agent-eval.md
+++ b/registry/skills/extra/agent-eval.md
@@ -15,7 +15,7 @@ Holistically evaluates an AI agent's performance on multi-step tasks by running 
 - [Score Relevance](../basic/score-relevance.md)
 
 ## Unlocks
-_None._
+- [Skill Performance Benchmarking](../extra/skill-performance-benchmarking.md)
 
 ## Fusion Condition
 _None specified._

--- a/registry/skills/extra/mcp-server-creation.md
+++ b/registry/skills/extra/mcp-server-creation.md
@@ -1,0 +1,35 @@
+# Extra Skill: /mcp-server-creation  [IV · Hardened]
+**ID:** mcp-server-creation  
+**Type:** Extra Skill  
+**Level:** IV  
+**Tier:** Hardened  
+**Skill Call:** `/mcp-server-creation`
+
+---
+
+## Description
+Designs and implements Model Context Protocol servers that expose external APIs, files, or services as well-typed tools with clear schemas, authentication, and testable agent workflows.
+
+## Prerequisites
+- [MCP Integration](../basic/mcp-integration.md)
+- [Tool Creation](../extra/tool-creation.md)
+- [API Call](../basic/api-call.md)
+
+## Unlocks
+- [Workflow Automation](../extra/workflow-automation.md)
+- [Tool Chaining](../extra/tool-chaining.md)
+- [Multi-Agent Orchestration](../ultimate/multi-agent-orchestration-v.md)
+
+## Fusion Condition
+Requires an integration target, a supported MCP SDK, tool schemas, authentication handling, and local validation against an MCP client.
+
+## Evidence
+| Class | Source | Evaluator | Date |
+|---|---|---|---|
+| B | https://github.com/anthropics/skills/blob/main/skills/mcp-builder/SKILL.md | codex | 2026-05-10 |
+| B | https://github.com/modelcontextprotocol/python-sdk | codex | 2026-05-10 |
+
+## Known Agents
+- Claude
+
+---

--- a/registry/skills/extra/security-audit.md
+++ b/registry/skills/extra/security-audit.md
@@ -15,7 +15,7 @@ Systematically identify security vulnerabilities, assess attack surface, and pro
 - [Evaluate Output](../basic/evaluate-output.md)
 
 ## Unlocks
-_None._
+- [Skill Security Analysis](../extra/skill-security-analysis.md)
 
 ## Fusion Condition
 Requires access to the full codebase or diff; output must include severity classification and reproduction steps.

--- a/registry/skills/extra/skill-authoring.md
+++ b/registry/skills/extra/skill-authoring.md
@@ -1,0 +1,34 @@
+# Extra Skill: /skill-authoring  [IV · Hardened]
+**ID:** skill-authoring  
+**Type:** Extra Skill  
+**Level:** IV  
+**Tier:** Hardened  
+**Skill Call:** `/skill-authoring`
+
+---
+
+## Description
+Designs, writes, packages, and iteratively improves reusable agent skill directories with metadata, progressive instructions, supporting assets, and measurable trigger criteria.
+
+## Prerequisites
+- [Generate Text](../basic/generate-text.md)
+- [Structured Output Generation](../basic/structured-output.md)
+- [Code Generation](../basic/code-generation.md)
+
+## Unlocks
+- [Skill Performance Benchmarking](../extra/skill-performance-benchmarking.md)
+- [Registry Curation](../extra/registry-curation.md)
+
+## Fusion Condition
+Requires a target agent skill format and a repeatable evaluation loop for trigger accuracy and task success.
+
+## Evidence
+| Class | Source | Evaluator | Date |
+|---|---|---|---|
+| A | https://arxiv.org/abs/2602.08004 | codex | 2026-05-10 |
+| B | https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md | codex | 2026-05-10 |
+
+## Known Agents
+- Claude
+
+---

--- a/registry/skills/extra/skill-performance-benchmarking.md
+++ b/registry/skills/extra/skill-performance-benchmarking.md
@@ -1,0 +1,35 @@
+# Extra Skill: /skill-performance-benchmarking  [IV · Hardened]
+**ID:** skill-performance-benchmarking  
+**Type:** Extra Skill  
+**Level:** IV  
+**Tier:** Hardened  
+**Skill Call:** `/skill-performance-benchmarking`
+
+---
+
+## Description
+Builds and runs task suites that measure whether agents select, invoke, and complete installed skills correctly across artifact-rich workflows and repeated trials.
+
+## Prerequisites
+- [Agent Evaluation](../extra/agent-eval.md)
+- [Skill Discovery](../basic/skill-discovery.md)
+- [Statistical Analysis](../basic/statistical-analysis.md)
+
+## Unlocks
+- [Registry Curation](../extra/registry-curation.md)
+- [Gaia Meta Audit](../extra/gaia-meta-audit.md)
+
+## Fusion Condition
+Requires a skill corpus, benchmark tasks, success rubrics, and variance-aware reporting across multiple runs.
+
+## Evidence
+| Class | Source | Evaluator | Date |
+|---|---|---|---|
+| A | https://arxiv.org/abs/2603.02176 | codex | 2026-05-10 |
+| B | https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md | codex | 2026-05-10 |
+| B | https://github.com/ynulihao/AgentSkillOS | codex | 2026-05-10 |
+
+## Known Agents
+- Claude
+
+---

--- a/registry/skills/extra/skill-security-analysis.md
+++ b/registry/skills/extra/skill-security-analysis.md
@@ -1,0 +1,35 @@
+# Extra Skill: /skill-security-analysis  [IV · Hardened]
+**ID:** skill-security-analysis  
+**Type:** Extra Skill  
+**Level:** IV  
+**Tier:** Hardened  
+**Skill Call:** `/skill-security-analysis`
+
+---
+
+## Description
+Assesses third-party agent skills for malicious behavior, unsafe permissions, prompt-injection exposure, repository-context mismatch, and supply-chain risk before installation or invocation.
+
+## Prerequisites
+- [Security Audit](../extra/security-audit.md)
+- [Prompt Injection Defense](../basic/prompt-injection-defense.md)
+- [Skill Discovery](../basic/skill-discovery.md)
+
+## Unlocks
+- [Guardrails](../extra/guardrails.md)
+- [Registry Curation](../extra/registry-curation.md)
+
+## Fusion Condition
+Requires access to the skill manifest, referenced files, source repository context, and a policy for trusted permissions.
+
+## Evidence
+| Class | Source | Evaluator | Date |
+|---|---|---|---|
+| A | https://arxiv.org/abs/2603.16572 | codex | 2026-05-10 |
+| A | https://arxiv.org/abs/2602.12430 | codex | 2026-05-10 |
+| A | https://arxiv.org/abs/2604.25109 | codex | 2026-05-10 |
+
+## Known Agents
+_None verified yet._
+
+---

--- a/registry/skills/extra/tool-creation.md
+++ b/registry/skills/extra/tool-creation.md
@@ -17,6 +17,7 @@ Dynamically generates reusable tool functions (code) at runtime to solve novel s
 ## Unlocks
 - [Full-Stack Developer](../ultimate/full-stack-developer.md)
 - [Autonomous Research Agent](../ultimate/autonomous-research-agent.md)
+- [MCP Server Creation](../extra/mcp-server-creation.md)
 
 ## Fusion Condition
 _None specified._


### PR DESCRIPTION
### Motivation
- Introduce and formalize recently curated agent-skill capabilities so they appear in the registry graph and documentation. 
- Replace weak/archived evidence with active or directly relevant sources to raise evidence quality for provisional Level IV nodes. 
- Wire new skills into the dependency graph so downstream unlocks and prerequisites are discoverable by curation tooling. 

### Description
- Added four new extra skills: `skill-authoring`, `skill-performance-benchmarking`, `skill-security-analysis`, and `mcp-server-creation`, including new markdown pages under `registry/skills/extra/` and corresponding JSON/GEXF graph nodes. 
- Updated `registry/gaia.json`, `registry/gaia.gexf`, `registry/combinations.md`, `registry/registry.md`, and multiple `registry/skills/basic/*.md` and `extra/*.md` files to add prerequisites, derivatives, unlocks, evidence, and graph edges for the new skills. 
- Replaced or supplemented weaker sources: added `https://github.com/ynulihao/AgentSkillOS`, swapped archived MCP scaffold for `https://github.com/modelcontextprotocol/python-sdk`, and added arXiv papers (e.g. `2602.08004`, `2603.02176`, `2604.25109`) as Class A evidence where appropriate. 
- Added an audit document `docs/audits/2026-05-10-agent-skill-evidence-audit.md` and incremented site stats/skill counts in `docs/index.html`.

### Testing
- No automated test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0077b2c2a083279adbfb3a8bd79c93)