### PR TITLE
Normalize leading-slash named-skill IDs, guard packaging tests, and add outdated-issues audit

### DIFF
--- a/docs/outdated-issues-audit.md
+++ b/docs/outdated-issues-audit.md
@@ -1,0 +1,41 @@
+# Outdated Issues Audit — 2026-05-10
+
+This audit checked the public GitHub issue list, current repository behavior, docs drift, and dependency freshness for issues that look stale, already fixed, or ready for narrowed follow-up.
+
+## How this was checked
+
+- Fetched open issues from `https://api.github.com/repos/mbtiongson1/gaia-skill-tree/issues?state=open&per_page=100` on 2026-05-10.
+- Ran `python scripts/build_docs.py --check` to verify generated docs drift.
+- Ran `PYTHONPATH=src:. python -m gaia_cli --registry . stats` to verify the stats command exists and works.
+- Ran `PYTHONPATH=src:. python -m gaia_cli --registry . skills info /huggingface/hf-cli` to verify the leading-slash named skill issue.
+- Ran `npm outdated --json` in `packages/mcp` and `packages/cli-npm` to identify dependency-update follow-ups.
+
+## Recommended triage
+
+| Issue | Status | Recommendation | Evidence |
+| --- | --- | --- | --- |
+| #65 — `gaia stats` registry health command | Outdated / appears implemented | Close after a quick maintainer review, or retitle to any remaining stats polish. | `src/gaia_cli/commands/stats.py` implements `collect_stats`, `render_stats`, and `stats_command`; `README.md` documents `gaia stats`; `tests/test_stats.py` covers collection, rendering, and CLI output. |
+| #182 — docs drift after version bump | Outdated for the current checkout | Close if the issue only targets the current drift; keep a follow-up only if release automation should enforce this every bump. | `python scripts/build_docs.py --check` reports documentation is up to date. |
+| #180 — leading slash breaks `gaia skills info/install` | Fixed in this branch | Close after merge. Add a changelog note if one is maintained. | Slash-prefixed named skill IDs are normalized before lookup/install, and tests cover `skills info /huggingface/hf-cli` plus `install_skill("/testuser/my-skill", ...)`. |
+| #181 — packaging tests require dev tooling | Fixed in this branch | Close after merge if maintainers accept skipping packaging-only tests when `build` is unavailable. | Packaging tests now skip with an explicit dev-extra hint when `python -m build` is unavailable; `build` remains in the `dev` extra rather than `embeddings`. |
+| #134 — `gaia docs build` requires `--registry` | Outdated / appears fixed | Close or update with any remaining reproduction. | The CLI docs command calls `scripts/build_docs.py` through the resolved registry, and the packaging test explicitly checks `docs build --check` can run from a registry clone without passing `--registry`. |
+| #71 — display all bucket variants in lookup/docs | Partially outdated / blocked by newer command shape | Retitle around `gaia skills info` or a future `gaia lookup`; avoid assuming a top-level `lookup` command exists. | The CLI currently exposes `skills list/search/info/install/uninstall`, not a dedicated top-level `lookup`. |
+| #64 — `gaia browse` interactive explorer | Still valid but should be deferred | Keep open as an enhancement; mark blocked until command surface and optional TUI dependency policy are settled. | No `browse` subcommand is registered in the CLI parser. |
+| #118/#119 — promotion title and duplicate rank issues | Needs reproduction refresh | Keep open, but ask for a current screenshot/output from `gaia scan` and duplicate IDs from the latest registry. | Promotion and duplicate behavior may have shifted with the current rank/effective-level model. |
+| RFC cluster #74-#79 and #115 | Not stale, but aging as design backlog | Move to a milestone/project board and assign owners; close any superseded RFCs once governance/docs lifecycle decisions are recorded. | These are process/design decisions rather than executable bugs. |
+
+## Dependency update follow-ups
+
+Current dependency checks do not show urgent patch updates for runtime Python dependencies, but the JavaScript packages have major-version candidates that should be planned rather than auto-bumped.
+
+- `packages/mcp`: `@types/node` has a patch update in the current range; `typescript` latest is 6.x; `zod` latest is 4.x.
+- `packages/cli-npm`: `@types/node` has a patch update in the current range; `typescript` latest is 6.x.
+- Recommendation: apply safe patch/minor lockfile refreshes separately from major migrations; create dedicated issues for TypeScript 6 and Zod 4 compatibility if they are desired.
+
+## Suggested next actions
+
+1. Close #65, #134, and #182 if maintainers agree the current checkout satisfies them.
+2. Merge the leading-slash normalization fix, then close #180.
+3. Merge the packaging-test guard, then close #181 or retitle it to docs-only dev environment guidance.
+4. Refresh old RFC/enhancement titles so they match the current CLI command surface (`skills info/search` rather than `lookup` unless a new command is still desired).
+5. Open separate dependency-maintenance issues for TypeScript 6 and Zod 4 instead of bundling them into routine patch updates.

--- a/scripts/triage_outdated_issues.sh
+++ b/scripts/triage_outdated_issues.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Triage/update Gaia GitHub issues without changing repo code.
+#
+# Default mode is a dry run that prints the comments/actions.
+# Run with --apply to post comments with GitHub CLI.
+# Run with --apply --close-resolved to close issues that appear resolved/outdated.
+#
+# Requirements for --apply:
+#   gh auth login
+#   gh auth status
+#
+# Optional:
+#   REPO=owner/name scripts/triage_outdated_issues.sh --apply
+
+REPO="${REPO:-mbtiongson1/gaia-skill-tree}"
+APPLY=0
+CLOSE_RESOLVED=0
+
+usage() {
+  cat <<USAGE
+Usage: $0 [--apply] [--close-resolved]
+
+Posts triage comments for likely outdated/stale Gaia issues.
+
+Options:
+  --apply            Actually post comments using gh. Without this, prints a dry run.
+  --close-resolved   With --apply, close issues that appear resolved/outdated (#65, #134, #182).
+  -h, --help         Show this help.
+
+Environment:
+  REPO               GitHub repo, default: ${REPO}
+USAGE
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --apply)
+      APPLY=1
+      ;;
+    --close-resolved)
+      CLOSE_RESOLVED=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $arg" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$APPLY" -eq 1 ]]; then
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "error: gh is required for --apply. Install GitHub CLI and run gh auth login." >&2
+    exit 1
+  fi
+  gh auth status >/dev/null
+fi
+
+comment_issue() {
+  local issue="$1"
+  local body
+  body="$(cat)"
+
+  if [[ "$APPLY" -eq 1 ]]; then
+    echo "Commenting on #${issue}..."
+    gh issue comment "$issue" --repo "$REPO" --body "$body"
+  else
+    echo "--- DRY RUN: would comment on #${issue} in ${REPO} ---"
+    printf '%s\n' "$body"
+    echo
+  fi
+}
+
+close_issue() {
+  local issue="$1"
+  local reason="$2"
+
+  if [[ "$CLOSE_RESOLVED" -ne 1 ]]; then
+    return 0
+  fi
+
+  if [[ "$APPLY" -eq 1 ]]; then
+    echo "Closing #${issue}..."
+    gh issue close "$issue" --repo "$REPO" --reason completed --comment "$reason"
+  else
+    echo "--- DRY RUN: would close #${issue} in ${REPO} ---"
+    printf '%s\n\n' "$reason"
+  fi
+}
+
+comment_issue 65 <<'BODY'
+Triage update: this appears implemented in the current checkout.
+
+Evidence:
+- `src/gaia_cli/commands/stats.py` contains the stats collection/rendering command.
+- `README.md` documents `gaia stats`.
+- `tests/test_stats.py` covers collection, rendering, and CLI output.
+
+Recommendation: close this issue after maintainer review, or retitle it to any remaining stats polish that is not already covered by the current command.
+BODY
+close_issue 65 'Closing as implemented by the current gaia stats command and tests. Please reopen or file a narrower follow-up if specific stats polish remains.'
+
+comment_issue 182 <<'BODY'
+Triage update: I could not reproduce current docs drift.
+
+Verification command:
+
+```bash
+python scripts/build_docs.py --check
+```
+
+Current result: documentation is up to date.
+
+Recommendation: close this issue if it only tracks the already-fixed drift. If the real ask is release-process enforcement, retitle this as a release automation hardening issue, e.g. "Ensure docs build runs with every version bump".
+BODY
+close_issue 182 'Closing because python scripts/build_docs.py --check reports the generated docs are currently up to date. Please reopen or retitle if release-process enforcement is still needed.'
+
+comment_issue 134 <<'BODY'
+Triage update: this appears outdated or already addressed in the current CLI/package tests.
+
+Evidence:
+- `gaia docs build` resolves the registry path before calling `scripts/build_docs.py`.
+- `tests/test_packaging.py` includes coverage that `python -m gaia_cli docs build --check` can run from a registry clone without passing `--registry` explicitly.
+
+Recommendation: close if no current reproduction remains. If this still fails in a specific install mode, please update the issue with the exact command, working directory, and install method.
+BODY
+close_issue 134 "Closing as outdated based on current docs-build behavior and packaging coverage. Please reopen with a current reproduction if this still fails."
+
+comment_issue 181 <<'BODY'
+Triage update: this still looks valid, but the acceptance criteria should be narrowed.
+
+Current root cause still appears to be that packaging tests call `python -m build`, while `build` is in the `dev` extra, not the `embeddings` extra.
+
+Recommended resolution options:
+1. Docs-only: document `pip install -e ".[embeddings,dev]"` for running the full test suite.
+2. Test behavior: skip packaging-only tests when `build` is unavailable, with a message telling contributors to install `.[dev]`.
+3. Dependency policy: move `build` to a broader contributor extra if packaging tests are expected in the default local suite.
+
+Recommendation: keep open, but choose one of the options above and update the issue title/body accordingly.
+BODY
+
+comment_issue 180 <<'BODY'
+Triage update: this still looks like a valid CLI bug and should stay open until fixed.
+
+Current expected fix scope:
+- Normalize display-style named skill IDs such as `/huggingface/hf-cli` before `skills info` matching.
+- Normalize the same input before named-skill install resolution.
+- Add regression tests for both `gaia skills info /contributor/name` and `gaia skills install /contributor/name`.
+
+Recommendation: keep open and mark as ready for implementation.
+BODY
+
+comment_issue 71 <<'BODY'
+Triage update: this issue is partially stale because the proposed command shape references `gaia lookup`, while the current CLI exposes named-skill discovery through `gaia skills list/search/info/install/uninstall`.
+
+Recommendation: keep the feature request if bucket variants are still desired, but retitle/reframe around one of these paths:
+- extend `gaia skills info <skill>` to show all bucket variants, or
+- add a new `gaia lookup <skill>` command explicitly as part of this issue.
+
+This should stay blocked on the bucket/origin/variant data model being finalized.
+BODY
+
+comment_issue 64 <<'BODY'
+Triage update: this still looks valid as an enhancement, but it should be treated as deferred rather than stale.
+
+Current state:
+- There is no registered `gaia browse` subcommand.
+- Adding a TUI likely needs an explicit optional dependency policy and fallback UX decision.
+
+Recommendation: keep open, mark as enhancement/deferred, and split dependency-policy discussion from implementation if needed.
+BODY
+
+comment_issue 118 <<'BODY'
+Triage update: this needs a fresh reproduction before implementation.
+
+The promotion UI and rank/effective-level behavior have changed enough that the original screenshot may no longer describe the current output exactly.
+
+Recommendation: keep open, but ask for current output from:
+
+```bash
+gaia scan
+gaia appraise <affected-skill>
+```
+
+Then narrow this issue to the specific card rendering/title problems still present.
+BODY
+
+comment_issue 119 <<'BODY'
+Triage update: this needs a current duplicate inventory before implementation.
+
+Recommendation: keep open, but update the issue with:
+- exact duplicate skill IDs/names observed in the latest `registry/gaia.json`,
+- whether the duplication is canonical skills, named implementations, or display buckets,
+- expected consolidation behavior.
+
+This likely overlaps with bucket/origin/variant work, so it may need to be linked to the named-skill duplicate/bucket issues.
+BODY
+
+cat <<DONE
+Done.
+Mode: $([[ "$APPLY" -eq 1 ]] && echo apply || echo dry-run)
+Repo: ${REPO}
+Close resolved: $([[ "$CLOSE_RESOLVED" -eq 1 ]] && echo yes || echo no)
+DONE

--- a/src/gaia_cli/install.py
+++ b/src/gaia_cli/install.py
@@ -57,7 +57,13 @@ def compute_sha256(filepath):
     return h.hexdigest()
 
 
+def normalize_named_skill_reference(skill_ref):
+    """Return a named-skill reference without a display-only leading slash."""
+    return str(skill_ref).strip().lstrip("/")
+
+
 def find_named_skill_source(skill_id, registry_path):
+    skill_id = normalize_named_skill_reference(skill_id)
     parts = skill_id.split("/", 1)
     if len(parts) != 2:
         return None
@@ -69,6 +75,7 @@ def find_named_skill_source(skill_id, registry_path):
 
 
 def _named_skill_source_for_id(skill_id, registry_path):
+    skill_id = normalize_named_skill_reference(skill_id)
     contributor, skill_name = skill_id.split("/", 1)
     return os.path.join(named_skills_dir(registry_path), contributor, f"{skill_name}.md")
 
@@ -81,6 +88,7 @@ def resolve_named_skill_reference(skill_ref, registry_path):
     - exact catalogRef frontmatter slug
     - unique bare skill-name slug
     """
+    skill_ref = normalize_named_skill_reference(skill_ref)
     source = find_named_skill_source(skill_ref, registry_path)
     if source:
         return skill_ref, source
@@ -112,6 +120,7 @@ def resolve_named_skill_reference(skill_ref, registry_path):
 
 
 def install_skill(skill_id, registry_path):
+    skill_id = normalize_named_skill_reference(skill_id)
     try:
         resolved = resolve_named_skill_reference(skill_id, registry_path)
     except ValueError as exc:
@@ -189,6 +198,7 @@ def sync_skills(registry_path):
 
 
 def uninstall_skill(skill_id):
+    skill_id = normalize_named_skill_reference(skill_id)
     parts = skill_id.split("/", 1)
     if len(parts) != 2:
         print("Error: Invalid skill ID format. Expected 'contributor/skill-name'.", file=sys.stderr)

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -18,7 +18,15 @@ from gaia_cli.push import build_skill_batch, write_skill_batch, build_proposed_s
 from gaia_cli.embeddings import generate_embeddings
 from gaia_cli.semantic_search import search as semantic_search, load_embeddings
 from gaia_cli.name import find_awakened_skill, promote_to_named, update_batch_lifecycle
-from gaia_cli.install import install_skill, sync_skills, uninstall_skill, list_installed, interactive_install, list_available
+from gaia_cli.install import (
+    install_skill,
+    sync_skills,
+    uninstall_skill,
+    list_installed,
+    interactive_install,
+    list_available,
+    normalize_named_skill_reference,
+)
 from gaia_cli.graph import graph_command
 from gaia_cli.commands.stats import stats_command
 from gaia_cli.registry import (
@@ -979,7 +987,7 @@ def skills_command(args):
         ctx = None
 
     if verb == "info":
-        q = args.skill_id
+        q = normalize_named_skill_reference(args.skill_id)
         match = next((item for item in items if item.get("id") == q), None)
         if not match:
             print(f"Skill '/{q}' not found.", file=sys.stderr)

--- a/tests/test_dx.py
+++ b/tests/test_dx.py
@@ -8,6 +8,8 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 from gaia_cli.main import main
 from gaia_cli.scanner import scan_repo, scan_repo_detailed
 
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
 
 def run_cli(monkeypatch, argv):
     monkeypatch.setattr(sys, "argv", ["gaia", *argv])
@@ -133,6 +135,17 @@ def test_skills_help_shows_subcommands_with_usage(monkeypatch, capsys):
         assert command in output
     assert "gaia skills list [--exclude-pending]" in output
     assert "gaia skills install <skill> [--global | --local]" in output
+
+
+def test_skills_info_accepts_leading_slash(monkeypatch, capsys):
+    run_cli(
+        monkeypatch,
+        ["--registry", str(REPO_ROOT), "skills", "info", "/huggingface/hf-cli"],
+    )
+
+    output = capsys.readouterr().out
+    assert "huggingface/hf-cli" in output
+    assert "Skill '//huggingface/hf-cli'" not in output
 
 
 def test_bare_skills_command_prints_skills_help(monkeypatch, capsys):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -50,6 +50,16 @@ class TestInstallInfra:
         f2.write_text("content B")
         assert compute_sha256(str(f1)) != compute_sha256(str(f2))
 
+    def test_find_named_skill_source_accepts_leading_slash(self, tmp_path):
+        """find_named_skill_source accepts slash-prefixed display IDs."""
+        skill_dir = tmp_path / "registry" / "named" / "contributor"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "my-skill.md").write_text("---\nid: contributor/my-skill\n---\n")
+
+        result = find_named_skill_source("/contributor/my-skill", str(tmp_path))
+        assert result is not None
+        assert result.endswith("my-skill.md")
+
     def test_find_named_skill_source_exists(self, tmp_path):
         """find_named_skill_source returns the path when the file exists."""
         skill_dir = tmp_path / "registry" / "named" / "contributor"
@@ -106,6 +116,22 @@ class TestInstallInfra:
 
 class TestInstallFlow:
     """Tests for the full install / uninstall flow."""
+
+    def test_install_accepts_leading_slash_id(self, tmp_path, monkeypatch):
+        """install_skill normalizes slash-prefixed named skill IDs."""
+        monkeypatch.chdir(tmp_path)
+
+        skill_dir = tmp_path / "registry" / "named" / "testuser"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "my-skill.md").write_text(
+            "---\nid: testuser/my-skill\n---\nContent here."
+        )
+
+        result = install_skill("/testuser/my-skill", str(tmp_path))
+        assert result is True
+
+        manifest = load_manifest()
+        assert manifest["installed"][0]["id"] == "testuser/my-skill"
 
     def test_install_creates_manifest_entry(self, tmp_path, monkeypatch):
         """install_skill adds an entry to the manifest."""

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,3 +1,4 @@
+import importlib.util
 import json
 import os
 import shutil
@@ -30,7 +31,16 @@ def run_python(args, *, cwd=None, env=None):
     )
 
 
+def require_build_module():
+    if importlib.util.find_spec("build") is None:
+        pytest.skip(
+            'python -m build is required for packaging tests; '
+            'install the dev extra with pip install -e ".[dev]"'
+        )
+
+
 def build_wheel(dist_dir):
+    require_build_module()
     shutil.rmtree(REPO_ROOT / "build", ignore_errors=True)
     return subprocess.run(
         [


### PR DESCRIPTION
### Motivation

- Users reported that passing a leading slash to named-skill commands (e.g. `/huggingface/hf-cli`) produced not-found or crash behavior, so lookups and installs should accept display-style IDs. 
- Packaging tests require the optional `build` tool and can fail in developer environments that only install `.[embeddings]`, so packaging-only checks should be guardable. 
- The repository had several open issues that appeared stale or already addressed in the current checkout and needed an audit and triage guidance.

### Description

- Normalize slash-prefixed named-skill references by adding `normalize_named_skill_reference()` and applying it to lookups, resolution, `install_skill()`, and `uninstall_skill()` in `src/gaia_cli/install.py`. 
- Update `gaia skills info` handling in `src/gaia_cli/main.py` to normalize the query before matching so `skills info /contributor/name` works as expected. 
- Add tests covering leading-slash acceptance for lookup and install (`tests/test_dx.py`, `tests/test_install.py`) and update `tests/test_packaging.py` to skip wheel-building packaging tests when `python -m build` is not installed, with a clear dev-extra hint. 
- Add an audit document `docs/outdated-issues-audit.md` recommending triage actions for several open issues and dependency follow-ups.

### Testing

- Ran the full test suite with `PYTHONPATH=src:. python -m pytest -q`, resulting in `380 passed, 2 skipped`, where packaging-only tests skip when `build` is absent. 
- Verified docs generation with `python scripts/build_docs.py --check`, which reported documentation is up to date. 
- Verified CLI behavior via `PYTHONPATH=src:. python -m gaia_cli --registry . skills info /huggingface/hf-cli` and confirmed the leading-slash lookup prints the expected skill card.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a00774c7e448327a8356fca0061c04a)