### PR TITLE
dev(mcp): add protocol-layer tests and fix resource registration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "enabledMcpjsonServers": ["gaia"],
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": false
   },

--- a/.github/workflows/cli-wrapper.yml
+++ b/.github/workflows/cli-wrapper.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Install Python dependencies
+        run: pip install -e ".[dev]"
+
       - name: Install npm dependencies
         working-directory: packages/cli-npm
         run: npm ci

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "gaia": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["packages/mcp/dist/bin/gaia-mcp.js"]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Skills level up through evidence, not declaration. Each demerit lowers effective
 ## Install
 
 <!-- gaia:version-start -->
-Current Gaia CLI version: `3.1.1`.
+Current Gaia CLI version: `3.1.2`.
 
 Python install:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -562,5 +562,5 @@
 </html>
 
 <!-- gaia:stats-start -->
-<!-- skills=133; namedSkills=32; version=3.1.1 -->
+<!-- skills=133; namedSkills=32; version=3.1.2 -->
 <!-- gaia:stats-end -->

--- a/packages/cli-npm/package.json
+++ b/packages/cli-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia-registry/cli",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Gaia CLI - Integrate your AI agent skills with the Gaia registry",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gaia-registry/mcp-server",
-  "version": "2.2.1",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gaia-registry/mcp-server",
-      "version": "2.2.1",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia-registry/mcp-server",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "MCP server for the Gaia Skill Registry \u2014 agent-native skill detection, fusion, and progression",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,4 +1,4 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import { lookupSkill } from "./tools/lookup.js";
@@ -77,8 +77,8 @@ export function createServer(): McpServer {
   );
 
   server.resource(
+    "gaia-registry",
     "gaia://registry",
-    "The Gaia skill registry — all skills with their types, levels, rarities, and prerequisites",
     async () => {
       const data = await getRegistryResource();
       return { contents: [{ uri: "gaia://registry", text: data, mimeType: "application/json" }] };
@@ -86,8 +86,8 @@ export function createServer(): McpServer {
   );
 
   server.resource(
-    "gaia://tree/{username}",
-    "A user's Gaia skill tree",
+    "gaia-tree",
+    new ResourceTemplate("gaia://tree/{username}", { list: undefined }),
     async (uri) => {
       const username = uri.pathname.split("/").pop() ?? "";
       const data = await getUserTreeResource(username);

--- a/packages/mcp/tests/mcp-protocol.test.ts
+++ b/packages/mcp/tests/mcp-protocol.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createServer } from "../src/index.js";
+
+describe("MCP protocol layer", () => {
+  let client: Client;
+
+  beforeAll(async () => {
+    const server = createServer();
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    client = new Client({ name: "test-client", version: "1.0.0" });
+    await client.connect(clientTransport);
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  // ── Server identity ──────────────────────────────────────────────────────
+
+  it("reports server name after initialize", () => {
+    const info = client.getServerVersion();
+    expect(info?.name).toBe("gaia-skill-registry");
+  });
+
+  // ── tools/list ───────────────────────────────────────────────────────────
+
+  it("exposes exactly the 5 expected tools", async () => {
+    const { tools } = await client.listTools();
+    const names = tools.map((t) => t.name).sort();
+    expect(names).toEqual([
+      "gaia_lookup",
+      "gaia_my_tree",
+      "gaia_propose",
+      "gaia_scan_context",
+      "gaia_suggest",
+    ]);
+  });
+
+  it("all tools have inputSchema and description", async () => {
+    const { tools } = await client.listTools();
+    for (const tool of tools) {
+      expect(tool.description, `${tool.name} missing description`).toBeTruthy();
+      expect(tool.inputSchema, `${tool.name} missing inputSchema`).toBeTruthy();
+    }
+  });
+
+  // ── gaia_lookup ──────────────────────────────────────────────────────────
+
+  it("gaia_lookup returns skill metadata for a known ID", async () => {
+    const result = await client.callTool({ name: "gaia_lookup", arguments: { query: "web-search" } });
+    const text = getText(result);
+    expect(text).toContain("web-search");
+    expect(text).toContain("Web Search");
+  });
+
+  it("gaia_lookup handles an unknown skill ID without throwing", async () => {
+    const result = await client.callTool({
+      name: "gaia_lookup",
+      arguments: { query: "this-skill-does-not-exist-xyz" },
+    });
+    expect(getText(result).length).toBeGreaterThan(0);
+  });
+
+  // ── gaia_my_tree ─────────────────────────────────────────────────────────
+
+  it("gaia_my_tree returns a message when no user is configured", async () => {
+    const saved = process.env.GAIA_USER;
+    delete process.env.GAIA_USER;
+    try {
+      const result = await client.callTool({ name: "gaia_my_tree", arguments: {} });
+      expect(getText(result).length).toBeGreaterThan(0);
+    } finally {
+      if (saved !== undefined) process.env.GAIA_USER = saved;
+    }
+  });
+
+  it("gaia_my_tree accepts an explicit username", async () => {
+    const result = await client.callTool({
+      name: "gaia_my_tree",
+      arguments: { username: "mbtiongson1" },
+    });
+    const text = getText(result);
+    expect(text.length).toBeGreaterThan(0);
+  });
+
+  // ── gaia_propose ─────────────────────────────────────────────────────────
+
+  it("gaia_propose returns a descriptive error when GITHUB_TOKEN is absent", async () => {
+    const savedToken = process.env.GITHUB_TOKEN;
+    const savedGh = process.env.GH_TOKEN;
+    const savedUser = process.env.GAIA_USER;
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.GH_TOKEN;
+    process.env.GAIA_USER = "test-user";
+    try {
+      const result = await client.callTool({
+        name: "gaia_propose",
+        arguments: { skillId: "web-search", type: "basic" },
+      });
+      expect(getText(result).toLowerCase()).toMatch(/token/);
+    } finally {
+      if (savedToken !== undefined) process.env.GITHUB_TOKEN = savedToken;
+      if (savedGh !== undefined) process.env.GH_TOKEN = savedGh;
+      if (savedUser !== undefined) process.env.GAIA_USER = savedUser;
+      else delete process.env.GAIA_USER;
+    }
+  });
+
+  // ── gaia_suggest / gaia_scan_context ─────────────────────────────────────
+
+  it("gaia_suggest returns text content", async () => {
+    const result = await client.callTool({
+      name: "gaia_suggest",
+      arguments: { context: ["building a web scraper"], tools: ["bash"] },
+    });
+    expect(getText(result).length).toBeGreaterThan(0);
+  });
+
+  it("gaia_scan_context returns text content", async () => {
+    const result = await client.callTool({
+      name: "gaia_scan_context",
+      arguments: { connectedTools: ["bash", "read_file"], projectSignals: ["vitest in package.json"] },
+    });
+    expect(getText(result).length).toBeGreaterThan(0);
+  });
+
+  // ── resources ────────────────────────────────────────────────────────────
+
+  it("exposes the gaia://registry static resource", async () => {
+    const { resources } = await client.listResources();
+    const uris = resources.map((r) => r.uri);
+    expect(uris).toContain("gaia://registry");
+  });
+
+  it("exposes a gaia://tree/{username} resource template", async () => {
+    const { resourceTemplates } = await client.listResourceTemplates();
+    const templates = resourceTemplates.map((r) => r.uriTemplate);
+    expect(templates.some((t) => t.includes("tree"))).toBe(true);
+  });
+
+  it("gaia://registry returns valid JSON with a skills key", async () => {
+    const result = await client.readResource({ uri: "gaia://registry" });
+    const text = (result.contents[0] as { text: string }).text;
+    const data = JSON.parse(text);
+    expect(data).toHaveProperty("skills");
+  });
+});
+
+function getText(result: Awaited<ReturnType<Client["callTool"]>>): string {
+  return (result.content[0] as { type: string; text: string }).text;
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gaia-cli"
-version = "3.1.1"
+version = "3.1.2"
 description = "Gaia AI Agent Skill Registry CLI"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/registry/gaia.json
+++ b/registry/gaia.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./schema/skill.schema.json",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "generatedAt": "2026-05-06T00:00:00Z",
   "meta": {
     "typeLabels": {
@@ -9,49 +9,49 @@
       "ultimate": "Ultimate Skill"
     },
     "levelLabels": {
-      "0★": "Basic",
-      "1★": "Awakened",
-      "2★": "Named",
-      "3★": "Evolved",
-      "4★": "Hardened",
-      "5★": "Transcendent",
-      "6★": "Transcendent \u2605"
+      "0\u2605": "Basic",
+      "1\u2605": "Awakened",
+      "2\u2605": "Named",
+      "3\u2605": "Evolved",
+      "4\u2605": "Hardened",
+      "5\u2605": "Transcendent",
+      "6\u2605": "Transcendent \u2605"
     },
     "rarityLabels": {
       "legendary": "Divine"
     },
     "levelColors": {
-      "0★": {
+      "0\u2605": {
         "hex": "#94a3b8",
         "bg": "rgba(148,163,184,.12)",
         "border": "rgba(148,163,184,.4)"
       },
-      "1★": {
+      "1\u2605": {
         "hex": "#38bdf8",
         "bg": "rgba(56,189,248,.12)",
         "border": "rgba(56,189,248,.4)"
       },
-      "2★": {
+      "2\u2605": {
         "hex": "#63cab7",
         "bg": "rgba(99,202,183,.15)",
         "border": "rgba(99,202,183,.4)"
       },
-      "3★": {
+      "3\u2605": {
         "hex": "#a78bfa",
         "bg": "rgba(167,139,250,.15)",
         "border": "rgba(167,139,250,.4)"
       },
-      "4★": {
+      "4\u2605": {
         "hex": "#e879f9",
         "bg": "rgba(232,121,249,.15)",
         "border": "rgba(232,121,249,.4)"
       },
-      "5★": {
+      "5\u2605": {
         "hex": "#fbbf24",
         "bg": "rgba(251,191,36,.15)",
         "border": "rgba(251,191,36,.4)"
       },
-      "6★": {
+      "6\u2605": {
         "hex": "#fbbf24",
         "bg": "rgba(251,191,36,.22)",
         "border": "rgba(251,191,36,.55)"
@@ -87,7 +87,7 @@
       "id": "tokenize",
       "name": "Tokenize",
       "type": "basic",
-      "level": "0★",
+      "level": "0\u2605",
       "rarity": "common",
       "description": "Splits input text into discrete tokens suitable for downstream processing by language models.",
       "prerequisites": [],
@@ -114,7 +114,7 @@
       "id": "classify",
       "name": "Classify",
       "type": "basic",
-      "level": "0★",
+      "level": "0\u2605",
       "rarity": "common",
       "description": "Assigns one or more categorical labels to an input based on learned or rule-based criteria.",
       "prerequisites": [],
@@ -142,7 +142,7 @@
       "id": "retrieve",
       "name": "Retrieve",
       "type": "basic",
-      "level": "1★",
+      "level": "1\u2605",
       "rarity": "common",
       "description": "Fetches relevant documents or passages from an indexed corpus given a query.",
       "prerequisites": [],
@@ -172,7 +172,7 @@
       "id": "rank",
       "name": "Rank",
       "type": "basic",
-      "level": "1★",
+      "level": "1\u2605",
       "rarity": "common",
       "description": "Orders a set of candidate items by relevance, quality, or fitness for a given objective.",
       "prerequisites": [],
@@ -199,7 +199,7 @@
       "id": "parse-json",
       "name": "Parse JSON",
       "type": "basic",
-      "level": "1★",
+      "level": "1\u2605",
       "rarity": "common",
       "description": "Extracts structured data from JSON-formatted input, handling nested objects and arrays.",
       "prerequisites": [],
@@ -227,7 +227,7 @@
       "id": "parse-html",
       "name": "Parse HTML",
       "type": "basic",
-      "level": "1★",
+      "level": "1\u2605",
       "rarity": "common",
       "description": "Extracts structured content from raw HTML, navigating DOM trees and handling malformed markup.",
       "prerequisites": [],
@@ -254,7 +254,7 @@
       "id": "execute-bash",
       "name": "Execute Bash",
       "type": "basic",
-      "level": "1★",
+      "level": "1\u2605",
       "rarity": "common",
       "description": "Runs shell commands in a sandboxed environment, captures stdout/stderr, and handles exit codes.",
       "prerequisites": [],
@@ -285,7 +285,7 @@
       "id": "generate-text",
       "name": "Generate Text",
       "type": "basic",
-      "level": "0★",
+      "level": "0\u2605",
       "rarity": "common",
       "description": "Produces coherent natural language output given a prompt, instruction, or context window.",
       "prerequisites": [],
@@ -314,7 +314,7 @@
       "id": "summarize",
       "name": "Summarize",
       "type": "basic",
-      "level": "0★",
+      "level": "0\u2605",
       "rarity": "common",
       "description": "Condenses longer input into a shorter representation that preserves key information and intent.",
       "prerequisites": [],
@@ -345,7 +345,7 @@
       "id": "cite-sources",
       "name": "Cite Sources",
       "type": "basic",
-      "level": "1★",
+      "level": "1\u2605",
       "rarity": "common",
       "description": "Attributes claims to specific sources with proper references, URLs, or bibliographic entries.",
       "prerequisites": [],
@@ -376,7 +376,7 @@
       "id": "extract-entities",
       "name": "Extract Entities",
       "type": "basic",
-      "level": "1★",
+      "level": "1\u2605",
       "rarity": "common",
       "description": "Identifies and extracts named entities such as people, organizations, dates, and locations from text.",
       "prerequisites": [],
@@ -408,7 +408,7 @@
       "id": "route-intent",
       "name": "Route Intent",
       "type": "basic",
-      "level": "1★",
+      "level": "1\u2605",
       "rarity": "common",
       "description": "Classifies user intent and directs execution to the appropriate handler, tool, or sub-agent.",
       "prerequisites": [],
@@ -437,7 +437,7 @@
       "id": "evaluate-output",
       "name": "Evaluate Output",
       "type": "basic",
-      "level": "1★",
+      "level": "1\u2605",
       "rarity": "common",
       "description": "Assesses the quality, correctness, or safety of generated output against defined criteria.",
       "prerequisites": [],
@@ -472,7 +472,7 @@
       "id": "embed-text",
       "name": "Embed Text",
       "type": "basic",
-      "level": "1★",
+      "level": "1\u2605",
       "rarity": "common",
       "description": "Converts text into dense vector representations suitable for similarity search and clustering.",
       "prerequisites": [],
@@ -501,7 +501,7 @@
       "id": "chunk-document",
       "name": "Chunk Document",
       "type": "basic",
-      "level": "1★",
+      "level": "1\u2605",
       "rarity": "common",
       "description": "Splits a document into semantically meaningful segments optimized for embedding and retrieval.",
       "prerequisites": [],
@@ -528,7 +528,7 @@
       "id": "plan-decompose",
       "name": "Plan and Decompose",
       "type": "basic",
-      "level": "1★",
+      "level": "1\u2605",
       "rarity": "common",
       "description": "Breaks a complex objective into an ordered sequence of executable sub-tasks.",
       "prerequisites": [],
@@ -561,7 +561,7 @@
       "id": "write-report",
       "name": "Write Report",
       "type": "basic",
-      "level": "1★",
+      "level": "1\u2605",
       "rarity": "common",
       "description": "Produces structured, multi-section written output with headings, citations, and coherent narrative.",
       "prerequisites": [],
@@ -591,7 +591,7 @@
       "id": "audience-model",
       "name": "Audience Model",
       "type": "basic",
-      "level": "1★",
+      "level": "1\u2605",
       "rarity": "common",
       "description": "Adapts tone, complexity, and framing of output to match a target audience profile.",
       "prerequisites": [],
@@ -620,7 +620,7 @@
       "id": "tool-select",
       "name": "Tool Select",
       "type": "basic",
-      "level": "1★",
+      "level": "1\u2605",
       "rarity": "common",
       "description": "Chooses the most appropriate tool or API from a set of available options given a task description.",
       "prerequisites": [],
@@ -649,7 +649,7 @@
       "id": "error-interpretation",
       "name": "Error Interpretation",
       "type": "basic",
-      "level": "1★",
+      "level": "1\u2605",
       "rarity": "common",
       "description": "Diagnoses error messages, stack traces, and failure modes to identify root causes and suggest fixes.",
       "prerequisites": [],
@@ -677,7 +677,7 @@
       "id": "code-generation",
       "name": "Code Generation",
       "type": "basic",
-      "level": "1★",
+      "level": "1\u2605",
       "rarity": "common",
       "description": "Produces syntactically correct and functionally appropriate source code from specifications or prompts.",
       "prerequisites": [],
@@ -709,7 +709,7 @@
       "id": "web-search",
       "name": "Web Search",
       "type": "basic",
-      "level": "1★",
+      "level": "1\u2605",
       "rarity": "common",
       "description": "Queries external search engines or APIs and retrieves relevant result sets.",
       "prerequisites": [],
@@ -739,7 +739,7 @@
       "id": "score-relevance",
       "name": "Score Relevance",
       "type": "basic",
-      "level": "1★",
+      "level": "1\u2605",
       "rarity": "common",
       "description": "Assigns a numerical relevance score to candidate items relative to a query or objective.",
       "prerequisites": [],
@@ -767,7 +767,7 @@
       "id": "format-output",
       "name": "Format Output",
       "type": "basic",
-      "level": "0★",
+      "level": "0\u2605",
       "rarity": "common",
       "description": "Structures raw output into a specified format such as markdown, JSON, CSV, or HTML.",
       "prerequisites": [],
@@ -798,7 +798,7 @@
       "id": "diff-content",
       "name": "Diff Content",
       "type": "basic",
-      "level": "1★",
+      "level": "1\u2605",
       "rarity": "common",
       "description": "Compares two versions of content and produces a structured delta highlighting additions, deletions, and modifications.",
       "prerequisites": [],
@@ -825,7 +825,7 @@
       "id": "web-scrape",
       "name": "Web Scrape",
       "type": "extra",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "uncommon",
       "description": "Retrieves and structures data from web pages into usable entities.",
       "prerequisites": [
@@ -856,7 +856,7 @@
       "id": "research",
       "name": "Research",
       "type": "extra",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "uncommon",
       "description": "Conducts multi-source information gathering, synthesis, and citation for a given topic.",
       "prerequisites": [
@@ -891,7 +891,7 @@
       "id": "ghostwrite",
       "name": "Ghostwrite",
       "type": "extra",
-      "level": "4★",
+      "level": "4\u2605",
       "rarity": "rare",
       "description": "Produces audience-tailored, research-backed long-form written content.",
       "prerequisites": [
@@ -920,7 +920,7 @@
       "id": "autonomous-debug",
       "name": "Autonomous Debug",
       "type": "extra",
-      "level": "4★",
+      "level": "4\u2605",
       "rarity": "rare",
       "description": "Independently identifies, diagnoses, and fixes software bugs through code generation and execution.",
       "prerequisites": [
@@ -949,7 +949,7 @@
       "id": "plan-and-execute",
       "name": "Plan and Execute",
       "type": "extra",
-      "level": "4★",
+      "level": "4\u2605",
       "rarity": "rare",
       "description": "Decomposes complex objectives into sub-tasks, selects tools, and orchestrates execution.",
       "prerequisites": [
@@ -980,7 +980,7 @@
       "id": "knowledge-harvest",
       "name": "Knowledge Harvest",
       "type": "extra",
-      "level": "4★",
+      "level": "4\u2605",
       "rarity": "rare",
       "description": "Extracts, structures, and embeds knowledge from web sources into a searchable corpus.",
       "prerequisites": [
@@ -1009,7 +1009,7 @@
       "id": "rag-pipeline",
       "name": "RAG Pipeline",
       "type": "extra",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "uncommon",
       "description": "End-to-end retrieval-augmented generation combining document chunking, embedding, retrieval, and relevance scoring.",
       "prerequisites": [
@@ -1048,7 +1048,7 @@
       "id": "document-analyst",
       "name": "Document Analyst",
       "type": "extra",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "uncommon",
       "description": "Parses, extracts entities from, summarizes, and formats structured documents.",
       "prerequisites": [
@@ -1078,7 +1078,7 @@
       "id": "recursive-self-improvement",
       "name": "Recursive Self-Improvement",
       "type": "ultimate",
-      "level": "5★",
+      "level": "5\u2605",
       "rarity": "legendary",
       "description": "Agent iteratively refines its own prompts, tools, or strategies based on performance feedback loops.",
       "prerequisites": [
@@ -1108,7 +1108,7 @@
       "id": "multi-agent-orchestration-v",
       "name": "Multi-Agent Orchestration",
       "type": "ultimate",
-      "level": "5★",
+      "level": "5\u2605",
       "rarity": "legendary",
       "description": "Coordinates multiple specialized agents across complex workflows with dynamic task allocation and conflict resolution.",
       "prerequisites": [
@@ -1138,7 +1138,7 @@
       "id": "autonomous-research-agent",
       "name": "Autonomous Research Agent",
       "type": "ultimate",
-      "level": "6★",
+      "level": "6\u2605",
       "rarity": "legendary",
       "description": "Independently conducts end-to-end research cycles including hypothesis generation, evidence gathering, synthesis, and reporting.",
       "prerequisites": [
@@ -1175,7 +1175,7 @@
       "id": "translate",
       "name": "Translate",
       "type": "basic",
-      "level": "0★",
+      "level": "0\u2605",
       "rarity": "common",
       "description": "Converts text from one natural language to another while preserving meaning, tone, and formatting.",
       "prerequisites": [],
@@ -1202,7 +1202,7 @@
       "id": "sentiment-analysis",
       "name": "Sentiment Analysis",
       "type": "basic",
-      "level": "0★",
+      "level": "0\u2605",
       "rarity": "common",
       "description": "Determines the emotional valence (positive, negative, neutral) and intensity of text input.",
       "prerequisites": [],
@@ -1230,7 +1230,7 @@
       "id": "image-caption",
       "name": "Image Caption",
       "type": "basic",
-      "level": "2★",
+      "level": "2\u2605",
       "rarity": "uncommon",
       "description": "Generates accurate natural-language descriptions of images, capturing objects, actions, and spatial relationships.",
       "prerequisites": [],
@@ -1257,7 +1257,7 @@
       "id": "speech-to-text",
       "name": "Speech to Text",
       "type": "basic",
-      "level": "2★",
+      "level": "2\u2605",
       "rarity": "common",
       "description": "Transcribes spoken audio into accurate text, handling diverse accents, noise conditions, and multiple languages.",
       "prerequisites": [],
@@ -1284,7 +1284,7 @@
       "id": "text-to-speech",
       "name": "Text to Speech",
       "type": "basic",
-      "level": "2★",
+      "level": "2\u2605",
       "rarity": "common",
       "description": "Synthesizes natural-sounding speech audio from text input, supporting voice cloning and prosody control.",
       "prerequisites": [],
@@ -1311,7 +1311,7 @@
       "id": "generate-sql",
       "name": "Generate SQL",
       "type": "basic",
-      "level": "2★",
+      "level": "2\u2605",
       "rarity": "common",
       "description": "Translates natural-language data questions into syntactically correct, executable SQL queries against a given schema.",
       "prerequisites": [],
@@ -1339,7 +1339,7 @@
       "id": "question-answer",
       "name": "Question Answer",
       "type": "basic",
-      "level": "0★",
+      "level": "0\u2605",
       "rarity": "common",
       "description": "Produces accurate, context-grounded answers to natural-language questions, handling unanswerable cases.",
       "prerequisites": [],
@@ -1368,7 +1368,7 @@
       "id": "image-generate",
       "name": "Image Generate",
       "type": "basic",
-      "level": "2★",
+      "level": "2\u2605",
       "rarity": "uncommon",
       "description": "Creates photorealistic or stylized images from text prompts using diffusion-based or autoregressive generative models.",
       "prerequisites": [],
@@ -1393,7 +1393,7 @@
       "id": "math-reason",
       "name": "Math Reason",
       "type": "basic",
-      "level": "2★",
+      "level": "2\u2605",
       "rarity": "uncommon",
       "description": "Solves multi-step mathematical problems including arithmetic, algebra, calculus, and competition mathematics through symbolic and numeric reasoning.",
       "prerequisites": [],
@@ -1421,7 +1421,7 @@
       "id": "logical-inference",
       "name": "Logical Inference",
       "type": "basic",
-      "level": "1★",
+      "level": "1\u2605",
       "rarity": "uncommon",
       "description": "Applies deductive, inductive, or abductive reasoning to derive valid conclusions from premises and structured knowledge.",
       "prerequisites": [],
@@ -1449,7 +1449,7 @@
       "id": "memory-manage",
       "name": "Memory Manage",
       "type": "basic",
-      "level": "2★",
+      "level": "2\u2605",
       "rarity": "uncommon",
       "description": "Maintains, indexes, and retrieves conversational and long-term memory across sessions, managing context window constraints.",
       "prerequisites": [],
@@ -1477,7 +1477,7 @@
       "id": "api-call",
       "name": "API Call",
       "type": "basic",
-      "level": "2★",
+      "level": "2\u2605",
       "rarity": "common",
       "description": "Constructs, executes, and handles responses from HTTP APIs by interpreting documentation and selecting appropriate endpoints and parameters.",
       "prerequisites": [],
@@ -1506,7 +1506,7 @@
       "id": "refactor-code",
       "name": "Refactor Code",
       "type": "basic",
-      "level": "2★",
+      "level": "2\u2605",
       "rarity": "uncommon",
       "description": "Restructures existing source code to improve readability, maintainability, or performance without changing observable behavior.",
       "prerequisites": [],
@@ -1533,7 +1533,7 @@
       "id": "generate-test",
       "name": "Generate Test",
       "type": "basic",
-      "level": "2★",
+      "level": "2\u2605",
       "rarity": "common",
       "description": "Produces unit tests, integration tests, and edge-case test cases from source code or natural-language specifications.",
       "prerequisites": [],
@@ -1560,7 +1560,7 @@
       "id": "parse-pdf",
       "name": "Parse PDF",
       "type": "basic",
-      "level": "1★",
+      "level": "1\u2605",
       "rarity": "common",
       "description": "Extracts text, tables, equations, and structure from PDF documents, preserving layout and reading order.",
       "prerequisites": [],
@@ -1587,7 +1587,7 @@
       "id": "detect-anomaly",
       "name": "Detect Anomaly",
       "type": "basic",
-      "level": "2★",
+      "level": "2\u2605",
       "rarity": "uncommon",
       "description": "Identifies statistical outliers, novel patterns, or deviations from expected behavior in structured or unstructured data.",
       "prerequisites": [],
@@ -1614,7 +1614,7 @@
       "id": "data-visualize",
       "name": "Data Visualize",
       "type": "basic",
-      "level": "2★",
+      "level": "2\u2605",
       "rarity": "common",
       "description": "Generates charts, graphs, and visual summaries from datasets by selecting appropriate visualization types and mapping data dimensions.",
       "prerequisites": [],
@@ -1642,7 +1642,7 @@
       "id": "conversational-agent",
       "name": "Conversational Agent",
       "type": "extra",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "uncommon",
       "description": "Manages coherent multi-turn dialogue by routing intent, maintaining memory across turns, and generating contextually appropriate responses.",
       "prerequisites": [
@@ -1671,7 +1671,7 @@
       "id": "text-to-sql-pipeline",
       "name": "Text-to-SQL Pipeline",
       "type": "extra",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "uncommon",
       "description": "Converts natural-language queries into validated, executable SQL against a target schema and returns formatted result sets.",
       "prerequisites": [
@@ -1700,7 +1700,7 @@
       "id": "code-review-pipeline",
       "name": "Code Review Pipeline",
       "type": "extra",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "uncommon",
       "description": "Performs automated code review by generating, diffing, and evaluating code changes for correctness, style, security, and maintainability.",
       "prerequisites": [
@@ -1732,7 +1732,7 @@
       "id": "data-analysis",
       "name": "Data Analysis",
       "type": "extra",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "uncommon",
       "description": "Conducts end-to-end quantitative analysis: queries data via SQL, computes statistics, generates visualizations, and summarizes findings.",
       "prerequisites": [
@@ -1765,7 +1765,7 @@
       "id": "voice-agent",
       "name": "Voice Agent",
       "type": "extra",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "uncommon",
       "description": "Handles spoken interactions end-to-end: transcribes audio input, produces language responses, and synthesizes speech output.",
       "prerequisites": [
@@ -1799,7 +1799,7 @@
       "id": "automated-testing",
       "name": "Automated Testing",
       "type": "extra",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "uncommon",
       "description": "Generates test suites, executes them in a sandbox, interprets failures, and iterates until the target pass rate is reached.",
       "prerequisites": [
@@ -1832,7 +1832,7 @@
       "id": "content-moderation",
       "name": "Content Moderation",
       "type": "extra",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "uncommon",
       "description": "Detects policy-violating content by combining intent classification, sentiment scoring, and entity extraction across text, images, and mixed media.",
       "prerequisites": [
@@ -1861,7 +1861,7 @@
       "id": "multimodal-reasoning",
       "name": "Multimodal Reasoning",
       "type": "extra",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "rare",
       "description": "Integrates information from images and text to answer questions requiring visual grounding and logical inference across modalities.",
       "prerequisites": [
@@ -1893,7 +1893,7 @@
       "id": "translation-pipeline",
       "name": "Translation Pipeline",
       "type": "extra",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "uncommon",
       "description": "Translates content end-to-end while preserving sentiment and adapting tone and register for the target audience.",
       "prerequisites": [
@@ -1922,7 +1922,7 @@
       "id": "document-digitization",
       "name": "Document Digitization",
       "type": "extra",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "uncommon",
       "description": "Converts scanned or PDF documents into structured, machine-readable output by parsing layout, extracting entities, and formatting results.",
       "prerequisites": [
@@ -1951,7 +1951,7 @@
       "id": "full-stack-developer",
       "name": "Full-Stack Developer",
       "type": "ultimate",
-      "level": "5★",
+      "level": "5\u2605",
       "rarity": "legendary",
       "description": "Autonomously implements, reviews, tests, and refactors complete software features across the full development lifecycle from specification to merged PR.",
       "prerequisites": [
@@ -1995,7 +1995,7 @@
       "id": "autonomous-data-scientist",
       "name": "Autonomous Data Scientist",
       "type": "ultimate",
-      "level": "5★",
+      "level": "5\u2605",
       "rarity": "legendary",
       "description": "Conducts end-to-end data science workflows autonomously: hypothesis generation, data analysis, statistical modeling, and insight reporting.",
       "prerequisites": [
@@ -2039,7 +2039,7 @@
       "id": "real-time-voice-assistant",
       "name": "Real-Time Voice Assistant",
       "type": "ultimate",
-      "level": "5★",
+      "level": "5\u2605",
       "rarity": "legendary",
       "description": "Provides low-latency spoken interactions combining real-time speech I/O, persistent memory, and goal-directed task execution across multi-session conversations.",
       "prerequisites": [
@@ -2083,7 +2083,7 @@
       "id": "registry-curation",
       "name": "Registry Curation",
       "type": "extra",
-      "level": "4★",
+      "level": "4\u2605",
       "rarity": "rare",
       "description": "Systematically discovers, evaluates, and ingests new skill definitions into a structured skill registry: researching capabilities, sourcing reproducible evidence, scripting graph updates, validating schema and DAG integrity, and publishing via pull request.",
       "prerequisites": [
@@ -2142,7 +2142,7 @@
       "id": "gaia-audit",
       "name": "Gaia Audit",
       "type": "extra",
-      "level": "2★",
+      "level": "2\u2605",
       "rarity": "uncommon",
       "description": "Reviews one Gaia skill, named skill, or real-skill catalog item against current evidence, source URLs, taxonomy mapping, promotion status, and demotion criteria, then proposes the smallest source-of-truth correction.",
       "prerequisites": [
@@ -2173,7 +2173,7 @@
       "id": "gaia-triage",
       "name": "Gaia Triage",
       "type": "extra",
-      "level": "2★",
+      "level": "2\u2605",
       "rarity": "uncommon",
       "description": "Triage and audit GitHub issues for the Gaia Skill Tree project. Helps identify stale issues, gather evidence from the codebase, and manage issue lifecycle via GitHub CLI.",
       "prerequisites": [
@@ -2201,7 +2201,7 @@
       "id": "gaia-meta-audit",
       "name": "Gaia Meta Audit",
       "type": "extra",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "rare",
       "description": "Scans Gaia registry and real-skill catalog entries for review candidates whose evidence may be outdated, superseded, overpromoted, unmapped, stale, or insufficient for their current level or named-skill claim.",
       "prerequisites": [
@@ -2230,7 +2230,7 @@
       "id": "tool-use",
       "name": "Tool Use",
       "type": "basic",
-      "level": "1★",
+      "level": "1\u2605",
       "rarity": "uncommon",
       "description": "Invokes external functions or APIs by generating well-formed call signatures, parsing results, and incorporating them into reasoning.",
       "prerequisites": [],
@@ -2267,7 +2267,7 @@
       "id": "function-calling",
       "name": "Function Calling",
       "type": "extra",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "uncommon",
       "description": "Selects an external callable, emits schema-valid arguments, invokes the function or API, and integrates the returned result into the agent loop.",
       "prerequisites": [
@@ -2303,7 +2303,7 @@
       "id": "chain-of-thought",
       "name": "Chain-of-Thought Reasoning",
       "type": "basic",
-      "level": "1★",
+      "level": "1\u2605",
       "rarity": "uncommon",
       "description": "Produces explicit intermediate reasoning steps before arriving at a final answer, dramatically improving accuracy on multi-step problems.",
       "prerequisites": [],
@@ -2340,7 +2340,7 @@
       "id": "self-critique",
       "name": "Self-Critique",
       "type": "basic",
-      "level": "1★",
+      "level": "1\u2605",
       "rarity": "uncommon",
       "description": "Iteratively evaluates and refines its own outputs using self-generated feedback, improving quality without external supervision.",
       "prerequisites": [],
@@ -2375,7 +2375,7 @@
       "id": "structured-output",
       "name": "Structured Output Generation",
       "type": "basic",
-      "level": "1★",
+      "level": "1\u2605",
       "rarity": "common",
       "description": "Generates output guaranteed to conform to a given schema (JSON, YAML, Pydantic model, etc.) using constrained decoding or grammar-guided generation.",
       "prerequisites": [],
@@ -2413,7 +2413,7 @@
       "id": "code-execution",
       "name": "Code Execution",
       "type": "basic",
-      "level": "2★",
+      "level": "2\u2605",
       "rarity": "common",
       "description": "Writes and executes code in a sandboxed environment, uses the runtime output to verify correctness, and iterates until the result is correct.",
       "prerequisites": [],
@@ -2449,7 +2449,7 @@
       "id": "computer-use",
       "name": "Computer Use",
       "type": "basic",
-      "level": "2★",
+      "level": "2\u2605",
       "rarity": "rare",
       "description": "Controls desktop GUIs and web browsers by interpreting screenshots, issuing mouse/keyboard actions, and verifying visual state to complete open-ended computer tasks.",
       "prerequisites": [],
@@ -2483,7 +2483,7 @@
       "id": "hypothesis-generate",
       "name": "Hypothesis Generation",
       "type": "basic",
-      "level": "2★",
+      "level": "2\u2605",
       "rarity": "rare",
       "description": "Formulates novel, testable scientific hypotheses by synthesising existing literature, identifying knowledge gaps, and proposing mechanistic explanations.",
       "prerequisites": [],
@@ -2524,7 +2524,7 @@
       "id": "re-act-reasoning",
       "name": "ReAct Reasoning",
       "type": "extra",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "uncommon",
       "description": "Interleaves free-form reasoning traces with discrete tool actions in a single loop, enabling agents to plan, act, observe, and update beliefs step-by-step.",
       "prerequisites": [
@@ -2562,7 +2562,7 @@
       "id": "browser-automation",
       "name": "Browser Automation",
       "type": "extra",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "uncommon",
       "description": "Navigates web pages, fills forms, clicks elements, and extracts information by combining web search with screenshot-based GUI control to complete multi-step web tasks.",
       "prerequisites": [
@@ -2600,7 +2600,7 @@
       "id": "knowledge-graph-build",
       "name": "Knowledge Graph Construction",
       "type": "extra",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "uncommon",
       "description": "Extracts entities and relations from unstructured text, resolves co-references, and assembles them into a queryable graph structure with typed edges.",
       "prerequisites": [
@@ -2638,7 +2638,7 @@
       "id": "scientific-discovery",
       "name": "Autonomous Scientific Discovery",
       "type": "ultimate",
-      "level": "5★",
+      "level": "5\u2605",
       "rarity": "legendary",
       "description": "Autonomously generates novel scientific hypotheses, designs and executes experiments, analyses results, and produces a written report \u00e2\u20ac\u201d completing a full research cycle without human intervention.",
       "prerequisites": [
@@ -2682,7 +2682,7 @@
       "id": "self-consistency",
       "name": "Self-Consistency",
       "type": "basic",
-      "level": "4★",
+      "level": "4\u2605",
       "rarity": "rare",
       "description": "Samples multiple independent reasoning paths for the same problem and selects the answer by majority vote, improving robustness without any additional training.",
       "prerequisites": [],
@@ -2710,7 +2710,7 @@
       "id": "few-shot-learning",
       "name": "Few-Shot Learning",
       "type": "basic",
-      "level": "4★",
+      "level": "4\u2605",
       "rarity": "common",
       "description": "Conditions a language model on a small number of input-output demonstrations within the prompt, enabling task adaptation without weight updates.",
       "prerequisites": [],
@@ -2738,7 +2738,7 @@
       "id": "tree-of-thought",
       "name": "Tree of Thought",
       "type": "extra",
-      "level": "4★",
+      "level": "4\u2605",
       "rarity": "rare",
       "description": "Frames problem solving as a search over a tree of partial solutions, using LLM-generated evaluations to prune unpromising branches and backtrack, dramatically improving success on complex reasoning tasks.",
       "prerequisites": [
@@ -2775,7 +2775,7 @@
       "id": "prompt-optimization",
       "name": "Prompt Optimization",
       "type": "extra",
-      "level": "4★",
+      "level": "4\u2605",
       "rarity": "uncommon",
       "description": "Automatically improves prompt instructions through iterative compilation, treating prompts as programs that can be optimized against a metric using LLM-driven feedback loops.",
       "prerequisites": [
@@ -2812,7 +2812,7 @@
       "id": "tool-creation",
       "name": "Tool Creation",
       "type": "extra",
-      "level": "4★",
+      "level": "4\u2605",
       "rarity": "rare",
       "description": "Dynamically generates reusable tool functions (code) at runtime to solve novel sub-tasks, then invokes those tools to complete the overall objective without human-written APIs.",
       "prerequisites": [
@@ -2851,7 +2851,7 @@
       "id": "ocr",
       "name": "OCR",
       "type": "basic",
-      "level": "2★",
+      "level": "2\u2605",
       "rarity": "uncommon",
       "description": "Extracts machine-readable text from raster images, scanned pages, and photo documents using optical character recognition, preserving layout and handling skew, noise, and varied fonts.",
       "prerequisites": [],
@@ -2885,7 +2885,7 @@
       "id": "object-detection",
       "name": "Object Detection",
       "type": "basic",
-      "level": "2★",
+      "level": "2\u2605",
       "rarity": "uncommon",
       "description": "Locates and classifies multiple objects within images by producing bounding boxes, confidence scores, and category labels in a single forward pass.",
       "prerequisites": [],
@@ -2920,7 +2920,7 @@
       "id": "code-explain",
       "name": "Code Explain",
       "type": "basic",
-      "level": "2★",
+      "level": "2\u2605",
       "rarity": "common",
       "description": "Generates accurate natural-language explanations of source code, describing intent, logic flow, and key decisions at function or module level.",
       "prerequisites": [],
@@ -2955,7 +2955,7 @@
       "id": "reward-modeling",
       "name": "Reward Modeling",
       "type": "basic",
-      "level": "2★",
+      "level": "2\u2605",
       "rarity": "rare",
       "description": "Learns a scalar reward signal from human preference comparisons between model outputs, enabling reinforcement learning from human feedback (RLHF) to align model behavior with human values.",
       "prerequisites": [],
@@ -2990,7 +2990,7 @@
       "id": "grounding",
       "name": "Grounding",
       "type": "extra",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "uncommon",
       "description": "Verifies generated claims against retrieved evidence, identifies unsupported or contradicted assertions, and anchors outputs in traceable, cited sources.",
       "prerequisites": [
@@ -3026,7 +3026,7 @@
       "id": "multi-agent-debate",
       "name": "Multi-Agent Debate",
       "type": "extra",
-      "level": "4★",
+      "level": "4\u2605",
       "rarity": "rare",
       "description": "Runs multiple LLM agents that propose, critique, and iteratively refine answers across structured debate rounds, converging on more accurate and well-reasoned responses than any single agent achieves.",
       "prerequisites": [
@@ -3062,7 +3062,7 @@
       "id": "fine-tune",
       "name": "Fine-Tune",
       "type": "basic",
-      "level": "4★",
+      "level": "4\u2605",
       "rarity": "uncommon",
       "description": "Adapts a pre-trained model to a new task or domain by updating model weights using parameter-efficient methods such as LoRA, QLoRA, or full supervised fine-tuning, without retraining from scratch.",
       "prerequisites": [],
@@ -3101,7 +3101,7 @@
       "id": "guardrails",
       "name": "Guardrails",
       "type": "extra",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "uncommon",
       "description": "Wraps LLM outputs with programmatic safety rules, content filters, and topical constraints that detect policy violations and enforce compliant, on-policy responses before they reach the user.",
       "prerequisites": [
@@ -3137,7 +3137,7 @@
       "id": "agent-eval",
       "name": "Agent Evaluation",
       "type": "extra",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "uncommon",
       "description": "Holistically evaluates an AI agent's performance on multi-step tasks by running standardised benchmarks, scoring full interaction trajectories, and producing reproducible capability reports.",
       "prerequisites": [
@@ -3181,7 +3181,7 @@
       "id": "semantic-cache",
       "name": "Semantic Cache",
       "type": "basic",
-      "level": "4★",
+      "level": "4\u2605",
       "rarity": "rare",
       "description": "Stores LLM responses keyed by embedding similarity so that semantically equivalent queries are served from cache, reducing inference latency and token cost without sacrificing answer quality.",
       "prerequisites": [],
@@ -3220,7 +3220,7 @@
       "id": "workflow-automation",
       "name": "Workflow Automation",
       "type": "extra",
-      "level": "4★",
+      "level": "4\u2605",
       "rarity": "uncommon",
       "description": "Designs, configures, and runs trigger-based multi-step automation pipelines that connect external services, schedule jobs, and orchestrate tool sequences without continuous human supervision.",
       "prerequisites": [
@@ -3266,7 +3266,7 @@
       "id": "framework-upgrade",
       "name": "Framework Upgrade",
       "type": "basic",
-      "level": "0★",
+      "level": "0\u2605",
       "rarity": "common",
       "description": "Guides an agent through upgrading a project from one major framework version to another, including breaking-change detection, migration steps, and post-upgrade validation.",
       "prerequisites": [],
@@ -3291,7 +3291,7 @@
       "id": "skill-discovery",
       "name": "Skill Discovery",
       "type": "basic",
-      "level": "0★",
+      "level": "0\u2605",
       "rarity": "common",
       "description": "Searches a skill or tool registry, ranks results by relevance and install count, and surfaces candidates for the agent to adopt or invoke.",
       "prerequisites": [],
@@ -3319,7 +3319,7 @@
       "id": "document-editing",
       "name": "Document Editing",
       "type": "basic",
-      "level": "0★",
+      "level": "0\u2605",
       "rarity": "common",
       "description": "Reads, edits, repacks, and applies styling or design principles to structured binary document formats such as PPTX, DOCX, and XLSX.",
       "prerequisites": [],
@@ -3346,7 +3346,7 @@
       "id": "test-driven-development",
       "name": "Test-Driven Development",
       "type": "basic",
-      "level": "0★",
+      "level": "0\u2605",
       "rarity": "uncommon",
       "description": "Enforces a strict red-green-refactor TDD loop: writes failing tests before implementation, blocks code generation that skips the test step, and validates coverage thresholds before marking tasks complete.",
       "prerequisites": [],
@@ -3371,7 +3371,7 @@
       "id": "ux-audit",
       "name": "UX Audit",
       "type": "basic",
-      "level": "0★",
+      "level": "0\u2605",
       "rarity": "uncommon",
       "description": "Systematically evaluates a user interface against established usability heuristics or accessibility standards, producing a scored finding report with remediation recommendations.",
       "prerequisites": [],
@@ -3396,7 +3396,7 @@
       "id": "context-compression",
       "name": "Context Compression",
       "type": "basic",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "common",
       "description": "Reduces the length of prompts or retrieved context to fit token limits while preserving semantic content, using techniques such as selective token removal, summarization, or token-classification-based pruning (e.g. LLMLingua).",
       "prerequisites": [],
@@ -3435,7 +3435,7 @@
       "id": "prompt-injection-defense",
       "name": "Prompt Injection Defense",
       "type": "basic",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "uncommon",
       "description": "Detects and neutralizes adversarial instructions injected into agent context from untrusted external sources (indirect prompt injection), using techniques such as context isolation, hierarchical intent verification, or semantic consistency checks.",
       "prerequisites": [],
@@ -3476,7 +3476,7 @@
       "id": "vision-qa",
       "name": "Visual Question Answering",
       "type": "basic",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "uncommon",
       "description": "Answers natural-language questions grounded in a specific image or screenshot by combining visual perception with language reasoning, enabling visual debugging, UI analysis, and document-image Q&A.",
       "prerequisites": [],
@@ -3508,7 +3508,7 @@
       "id": "tool-chaining",
       "name": "Tool Chaining",
       "type": "extra",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "uncommon",
       "description": "Sequences multiple tool invocations into a dependency graph where the output of each tool feeds as structured input to the next, handling state propagation, intermediate result validation, and error recovery across multi-step execution pipelines.",
       "prerequisites": [
@@ -3543,7 +3543,7 @@
       "id": "issue-triage",
       "name": "Issue Triage",
       "type": "basic",
-      "level": "4★",
+      "level": "4\u2605",
       "rarity": "uncommon",
       "description": "Classifies incoming issue reports through a structured state machine, assigns triage roles (bug/enhancement, needs-info/ready-for-agent/wontfix), reproduces bugs, requests missing detail, and produces structured resolution briefs for agent or human handoff.",
       "prerequisites": [],
@@ -3582,7 +3582,7 @@
       "id": "prd-generation",
       "name": "PRD Generation",
       "type": "extra",
-      "level": "4★",
+      "level": "4\u2605",
       "rarity": "uncommon",
       "description": "Synthesizes conversation context and codebase knowledge into a structured Product Requirements Document containing a problem statement, extensive user stories, implementation decisions, module boundaries, testing decisions, and out-of-scope items.",
       "prerequisites": [
@@ -3617,7 +3617,7 @@
       "id": "vertical-slice-planning",
       "name": "Vertical Slice Planning",
       "type": "extra",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "uncommon",
       "description": "Decomposes a product plan into independently-demoable vertical slices that each cut through all integration layers end-to-end. Classifies each slice as HITL (human-in-the-loop) or AFK (autonomous), identifies dependency ordering, and publishes structured issues with acceptance criteria.",
       "prerequisites": [
@@ -3645,7 +3645,7 @@
       "id": "design-review",
       "name": "Design Review",
       "type": "extra",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "rare",
       "description": "Stress-tests a plan or design through relentless targeted questioning, walking the decision tree branch-by-branch, resolving concept dependencies, surfacing contradictions against the existing codebase, and crystallising ubiquitous language \u2014 optionally persisting resolved decisions to CONTEXT.md and ADRs.",
       "prerequisites": [
@@ -3680,7 +3680,7 @@
       "id": "statistical-analysis",
       "name": "Statistical Analysis",
       "type": "basic",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "uncommon",
       "description": "Performs hypothesis testing, regression analysis, and Bayesian modelling with effect size calculation and APA-formatted statistical reporting using scipy, statsmodels, and PyMC.",
       "prerequisites": [],
@@ -3715,7 +3715,7 @@
       "id": "scientific-visualization",
       "name": "Scientific Visualization",
       "type": "basic",
-      "level": "2★",
+      "level": "2\u2605",
       "rarity": "uncommon",
       "description": "Creates publication-ready scientific figures with multi-panel layouts, statistical annotations, colorblind-safe palettes, and journal-specific formatting (Nature, Science, Cell) using matplotlib, seaborn, and plotly.",
       "prerequisites": [],
@@ -3742,7 +3742,7 @@
       "id": "literature-review",
       "name": "Literature Review",
       "type": "extra",
-      "level": "4★",
+      "level": "4\u2605",
       "rarity": "uncommon",
       "description": "Conducts systematic multi-database academic literature searches following PRISMA/SWARM protocols, screens and synthesises findings, verifies all citations, and generates a structured review report.",
       "prerequisites": [
@@ -3778,7 +3778,7 @@
       "id": "scientific-writing",
       "name": "Scientific Writing",
       "type": "extra",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "uncommon",
       "description": "Composes research manuscripts in IMRAD structure with reporting-guideline compliance (CONSORT, STROBE, PRISMA), citation management, publication-quality figures, and LaTeX/PDF formatting.",
       "prerequisites": [
@@ -3814,7 +3814,7 @@
       "id": "ml-pipeline",
       "name": "ML Pipeline",
       "type": "extra",
-      "level": "4★",
+      "level": "4\u2605",
       "rarity": "rare",
       "description": "Designs and implements production ML pipelines with experiment tracking (MLflow, W&B), feature stores (Feast), orchestration (Kubeflow, Airflow), and automated retraining workflows including model evaluation gates and A/B deployment.",
       "prerequisites": [
@@ -3850,7 +3850,7 @@
       "id": "mcp-integration",
       "name": "MCP Integration",
       "type": "basic",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "uncommon",
       "description": "Connect to and invoke tools exposed by Model Context Protocol (MCP) servers \u2014 enumerate available tools, execute calls, and handle responses across any MCP-compatible backend.",
       "prerequisites": [],
@@ -3894,7 +3894,7 @@
       "id": "parallel-execution",
       "name": "Parallel Execution",
       "type": "basic",
-      "level": "2★",
+      "level": "2\u2605",
       "rarity": "uncommon",
       "description": "Decompose a task into independent sub-tasks and execute them concurrently, merging results with configurable concurrency limits and queue-based state tracking.",
       "prerequisites": [],
@@ -3919,7 +3919,7 @@
       "id": "requirements-analysis",
       "name": "Requirements Analysis",
       "type": "basic",
-      "level": "2★",
+      "level": "2\u2605",
       "rarity": "common",
       "description": "Elicit and structure requirements from stakeholder inputs into formal specifications \u2014 user stories, acceptance criteria, and traceability matrices.",
       "prerequisites": [],
@@ -3944,7 +3944,7 @@
       "id": "schema-design",
       "name": "Schema Design",
       "type": "basic",
-      "level": "2★",
+      "level": "2\u2605",
       "rarity": "common",
       "description": "Design database schemas across relational, NoSQL, graph, and time-series stores \u2014 entity modelling, normalization, indexing strategies, and migration planning.",
       "prerequisites": [],
@@ -3969,7 +3969,7 @@
       "id": "e2e-testing",
       "name": "End-to-End Testing",
       "type": "extra",
-      "level": "3★",
+      "level": "3\u2605",
       "rarity": "uncommon",
       "description": "Execute full end-to-end user journey tests using browser automation frameworks (Playwright/Puppeteer), validating complete workflows from UI to backend across real environments.",
       "prerequisites": [
@@ -4004,7 +4004,7 @@
       "id": "security-audit",
       "name": "Security Audit",
       "type": "extra",
-      "level": "2★",
+      "level": "2\u2605",
       "rarity": "rare",
       "description": "Systematically identify security vulnerabilities, assess attack surface, and produce actionable remediation guidance across code, dependencies, and infrastructure.",
       "prerequisites": [
@@ -4041,7 +4041,7 @@
       "id": "release-automation",
       "name": "Release Automation",
       "type": "extra",
-      "level": "2★",
+      "level": "2\u2605",
       "rarity": "uncommon",
       "description": "Automate the full software release cycle: determine semantic version bump, update CHANGELOG, commit, create a git tag, and publish a GitHub release with release notes.",
       "prerequisites": [
@@ -4070,7 +4070,7 @@
       "id": "deployment-automation",
       "name": "Deployment Automation",
       "type": "extra",
-      "level": "2★",
+      "level": "2\u2605",
       "rarity": "uncommon",
       "description": "Automate CI/CD pipeline execution and deployment to target environments \u2014 build, test, artifact publishing, environment promotion, and rollback strategies.",
       "prerequisites": [
@@ -4101,7 +4101,7 @@
       "id": "feed-monitoring",
       "name": "Feed Monitoring",
       "type": "basic",
-      "level": "4★",
+      "level": "4\u2605",
       "rarity": "common",
       "description": "Monitors RSS, Atom, blog, or other recurring content feeds, discovers updates, tracks read state, and surfaces new signals for downstream agent workflows.",
       "prerequisites": [],
@@ -4128,7 +4128,7 @@
       "id": "wiki-search",
       "name": "Wiki Search",
       "type": "extra",
-      "level": "4★",
+      "level": "4\u2605",
       "rarity": "uncommon",
       "description": "Builds, maintains, and queries an interlinked markdown or wiki-style knowledge base so an agent can retrieve durable local context across research sessions.",
       "prerequisites": [
@@ -4159,7 +4159,7 @@
       "id": "prediction-market-analysis",
       "name": "Prediction Market Analysis",
       "type": "extra",
-      "level": "4★",
+      "level": "4\u2605",
       "rarity": "rare",
       "description": "Queries prediction-market data, compares market probabilities and price history, and summarizes probabilistic signals for forecasting or decision-support workflows.",
       "prerequisites": [
@@ -4190,7 +4190,7 @@
       "id": "humanize-prose",
       "name": "Humanize Prose",
       "type": "extra",
-      "level": "4★",
+      "level": "4\u2605",
       "rarity": "uncommon",
       "description": "Audits and rewrites prose to remove generic AI-writing patterns, preserve author intent, and adapt tone toward a more natural human voice.",
       "prerequisites": [
@@ -4221,7 +4221,7 @@
       "id": "architecture-diagram",
       "name": "Architecture Diagram",
       "type": "extra",
-      "level": "4★",
+      "level": "4\u2605",
       "rarity": "uncommon",
       "description": "Generates technical architecture, infrastructure, or cloud diagrams as structured visual artifacts from natural-language system descriptions.",
       "prerequisites": [
@@ -4252,7 +4252,7 @@
       "id": "skill-authoring",
       "name": "Skill Authoring",
       "type": "extra",
-      "level": "4★",
+      "level": "4\u2605",
       "rarity": "rare",
       "description": "Designs, writes, packages, and iteratively improves reusable agent skill directories with metadata, progressive instructions, supporting assets, and measurable trigger criteria.",
       "prerequisites": [
@@ -4293,7 +4293,7 @@
       "id": "skill-performance-benchmarking",
       "name": "Skill Performance Benchmarking",
       "type": "extra",
-      "level": "4★",
+      "level": "4\u2605",
       "rarity": "rare",
       "description": "Builds and runs task suites that measure whether agents select, invoke, and complete installed skills correctly across artifact-rich workflows and repeated trials.",
       "prerequisites": [
@@ -4341,7 +4341,7 @@
       "id": "skill-security-analysis",
       "name": "Skill Security Analysis",
       "type": "extra",
-      "level": "4★",
+      "level": "4\u2605",
       "rarity": "rare",
       "description": "Assesses third-party agent skills for malicious behavior, unsafe permissions, prompt-injection exposure, repository-context mismatch, and supply-chain risk before installation or invocation.",
       "prerequisites": [
@@ -4387,7 +4387,7 @@
       "id": "mcp-server-creation",
       "name": "MCP Server Creation",
       "type": "extra",
-      "level": "4★",
+      "level": "4\u2605",
       "rarity": "rare",
       "description": "Designs and implements Model Context Protocol servers that expose external APIs, files, or services as well-typed tools with clear schemas, authentication, and testable agent workflows.",
       "prerequisites": [
@@ -4432,7 +4432,7 @@
       "targetSkillId": "web-scrape",
       "edgeType": "prerequisite",
       "condition": "Structured output mode required.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "webScrape#evidence[0]"
       ]
@@ -4442,7 +4442,7 @@
       "targetSkillId": "web-scrape",
       "edgeType": "prerequisite",
       "condition": "Structured output mode required.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "webScrape#evidence[0]"
       ]
@@ -4452,7 +4452,7 @@
       "targetSkillId": "web-scrape",
       "edgeType": "prerequisite",
       "condition": "Structured output mode required.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "webScrape#evidence[0]"
       ]
@@ -4462,7 +4462,7 @@
       "targetSkillId": "research",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "research#evidence[0]"
       ]
@@ -4472,7 +4472,7 @@
       "targetSkillId": "research",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "research#evidence[0]"
       ]
@@ -4482,7 +4482,7 @@
       "targetSkillId": "research",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "research#evidence[0]"
       ]
@@ -4492,7 +4492,7 @@
       "targetSkillId": "ghostwrite",
       "edgeType": "prerequisite",
       "condition": "Requires research output as input context.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "ghostwrite#evidence[0]"
       ]
@@ -4502,7 +4502,7 @@
       "targetSkillId": "ghostwrite",
       "edgeType": "prerequisite",
       "condition": "Requires research output as input context.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "ghostwrite#evidence[0]"
       ]
@@ -4512,7 +4512,7 @@
       "targetSkillId": "ghostwrite",
       "edgeType": "prerequisite",
       "condition": "Requires research output as input context.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "ghostwrite#evidence[0]"
       ]
@@ -4522,7 +4522,7 @@
       "targetSkillId": "autonomous-debug",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "autonomousDebug#evidence[0]"
       ]
@@ -4532,7 +4532,7 @@
       "targetSkillId": "autonomous-debug",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "autonomousDebug#evidence[0]"
       ]
@@ -4542,7 +4542,7 @@
       "targetSkillId": "autonomous-debug",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "autonomousDebug#evidence[0]"
       ]
@@ -4552,7 +4552,7 @@
       "targetSkillId": "plan-and-execute",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "planAndExecute#evidence[0]"
       ]
@@ -4562,7 +4562,7 @@
       "targetSkillId": "plan-and-execute",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "planAndExecute#evidence[0]"
       ]
@@ -4572,7 +4572,7 @@
       "targetSkillId": "plan-and-execute",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "planAndExecute#evidence[0]"
       ]
@@ -4582,7 +4582,7 @@
       "targetSkillId": "knowledge-harvest",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "knowledgeHarvest#evidence[0]"
       ]
@@ -4592,7 +4592,7 @@
       "targetSkillId": "knowledge-harvest",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "knowledgeHarvest#evidence[0]"
       ]
@@ -4602,7 +4602,7 @@
       "targetSkillId": "knowledge-harvest",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "knowledgeHarvest#evidence[0]"
       ]
@@ -4612,7 +4612,7 @@
       "targetSkillId": "rag-pipeline",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "ragPipeline#evidence[0]"
       ]
@@ -4622,7 +4622,7 @@
       "targetSkillId": "rag-pipeline",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "ragPipeline#evidence[0]"
       ]
@@ -4632,7 +4632,7 @@
       "targetSkillId": "rag-pipeline",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "ragPipeline#evidence[0]"
       ]
@@ -4642,7 +4642,7 @@
       "targetSkillId": "rag-pipeline",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "ragPipeline#evidence[0]"
       ]
@@ -4652,7 +4652,7 @@
       "targetSkillId": "document-analyst",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "documentAnalyst#evidence[0]"
       ]
@@ -4662,7 +4662,7 @@
       "targetSkillId": "document-analyst",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "documentAnalyst#evidence[0]"
       ]
@@ -4672,7 +4672,7 @@
       "targetSkillId": "document-analyst",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "documentAnalyst#evidence[0]"
       ]
@@ -4682,7 +4682,7 @@
       "targetSkillId": "document-analyst",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "documentAnalyst#evidence[0]"
       ]
@@ -4692,7 +4692,7 @@
       "targetSkillId": "recursive-self-improvement",
       "edgeType": "prerequisite",
       "condition": "Requires extensive multi-system validation before level advancement.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": []
     },
     {
@@ -4700,7 +4700,7 @@
       "targetSkillId": "recursive-self-improvement",
       "edgeType": "prerequisite",
       "condition": "Requires extensive multi-system validation before level advancement.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": []
     },
     {
@@ -4708,7 +4708,7 @@
       "targetSkillId": "recursive-self-improvement",
       "edgeType": "prerequisite",
       "condition": "Requires extensive multi-system validation before level advancement.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": []
     },
     {
@@ -4716,7 +4716,7 @@
       "targetSkillId": "multi-agent-orchestration-v",
       "edgeType": "prerequisite",
       "condition": "Requires extensive multi-system validation before level advancement.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": []
     },
     {
@@ -4724,7 +4724,7 @@
       "targetSkillId": "multi-agent-orchestration-v",
       "edgeType": "prerequisite",
       "condition": "Requires extensive multi-system validation before level advancement.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": []
     },
     {
@@ -4732,7 +4732,7 @@
       "targetSkillId": "multi-agent-orchestration-v",
       "edgeType": "prerequisite",
       "condition": "Requires extensive multi-system validation before level advancement.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": []
     },
     {
@@ -4740,7 +4740,7 @@
       "targetSkillId": "autonomous-research-agent",
       "edgeType": "prerequisite",
       "condition": "Requires extensive multi-system validation before level advancement.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": []
     },
     {
@@ -4748,7 +4748,7 @@
       "targetSkillId": "autonomous-research-agent",
       "edgeType": "prerequisite",
       "condition": "Requires extensive multi-system validation before level advancement.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": []
     },
     {
@@ -4756,7 +4756,7 @@
       "targetSkillId": "autonomous-research-agent",
       "edgeType": "prerequisite",
       "condition": "Requires extensive multi-system validation before level advancement.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": []
     },
     {
@@ -4764,7 +4764,7 @@
       "targetSkillId": "conversational-agent",
       "edgeType": "prerequisite",
       "condition": "Requires persistent memory store across turns.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "conversationalAgent#evidence[0]"
       ]
@@ -4774,7 +4774,7 @@
       "targetSkillId": "conversational-agent",
       "edgeType": "prerequisite",
       "condition": "Requires persistent memory store across turns.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "conversationalAgent#evidence[0]"
       ]
@@ -4784,7 +4784,7 @@
       "targetSkillId": "conversational-agent",
       "edgeType": "prerequisite",
       "condition": "Requires persistent memory store across turns.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "conversationalAgent#evidence[0]"
       ]
@@ -4794,7 +4794,7 @@
       "targetSkillId": "text-to-sql-pipeline",
       "edgeType": "prerequisite",
       "condition": "Requires schema context in prompt.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "textToSqlPipeline#evidence[0]"
       ]
@@ -4804,7 +4804,7 @@
       "targetSkillId": "text-to-sql-pipeline",
       "edgeType": "prerequisite",
       "condition": "Requires schema context in prompt.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "textToSqlPipeline#evidence[0]"
       ]
@@ -4814,7 +4814,7 @@
       "targetSkillId": "text-to-sql-pipeline",
       "edgeType": "prerequisite",
       "condition": "Requires schema context in prompt.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "textToSqlPipeline#evidence[0]"
       ]
@@ -4824,7 +4824,7 @@
       "targetSkillId": "code-review-pipeline",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "codeReviewPipeline#evidence[0]"
       ]
@@ -4834,7 +4834,7 @@
       "targetSkillId": "code-review-pipeline",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "codeReviewPipeline#evidence[0]"
       ]
@@ -4844,7 +4844,7 @@
       "targetSkillId": "code-review-pipeline",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "codeReviewPipeline#evidence[0]"
       ]
@@ -4854,7 +4854,7 @@
       "targetSkillId": "data-analysis",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "dataAnalysis#evidence[0]"
       ]
@@ -4864,7 +4864,7 @@
       "targetSkillId": "data-analysis",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "dataAnalysis#evidence[0]"
       ]
@@ -4874,7 +4874,7 @@
       "targetSkillId": "data-analysis",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "dataAnalysis#evidence[0]"
       ]
@@ -4884,7 +4884,7 @@
       "targetSkillId": "voice-agent",
       "edgeType": "prerequisite",
       "condition": "Requires real-time audio I/O or audio file access.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "voiceAgent#evidence[0]"
       ]
@@ -4894,7 +4894,7 @@
       "targetSkillId": "voice-agent",
       "edgeType": "prerequisite",
       "condition": "Requires real-time audio I/O or audio file access.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "voiceAgent#evidence[0]"
       ]
@@ -4904,7 +4904,7 @@
       "targetSkillId": "voice-agent",
       "edgeType": "prerequisite",
       "condition": "Requires real-time audio I/O or audio file access.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "voiceAgent#evidence[0]"
       ]
@@ -4914,7 +4914,7 @@
       "targetSkillId": "automated-testing",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "automatedTesting#evidence[0]"
       ]
@@ -4924,7 +4924,7 @@
       "targetSkillId": "automated-testing",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "automatedTesting#evidence[0]"
       ]
@@ -4934,7 +4934,7 @@
       "targetSkillId": "automated-testing",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "automatedTesting#evidence[0]"
       ]
@@ -4944,7 +4944,7 @@
       "targetSkillId": "content-moderation",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "contentModeration#evidence[0]"
       ]
@@ -4954,7 +4954,7 @@
       "targetSkillId": "content-moderation",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "contentModeration#evidence[0]"
       ]
@@ -4964,7 +4964,7 @@
       "targetSkillId": "content-moderation",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "contentModeration#evidence[0]"
       ]
@@ -4974,7 +4974,7 @@
       "targetSkillId": "multimodal-reasoning",
       "edgeType": "prerequisite",
       "condition": "Requires vision-language model capability.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "multimodalReasoning#evidence[0]"
       ]
@@ -4984,7 +4984,7 @@
       "targetSkillId": "multimodal-reasoning",
       "edgeType": "prerequisite",
       "condition": "Requires vision-language model capability.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "multimodalReasoning#evidence[0]"
       ]
@@ -4994,7 +4994,7 @@
       "targetSkillId": "multimodal-reasoning",
       "edgeType": "prerequisite",
       "condition": "Requires vision-language model capability.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "multimodalReasoning#evidence[0]"
       ]
@@ -5004,7 +5004,7 @@
       "targetSkillId": "translation-pipeline",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "translationPipeline#evidence[0]"
       ]
@@ -5014,7 +5014,7 @@
       "targetSkillId": "translation-pipeline",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "translationPipeline#evidence[0]"
       ]
@@ -5024,7 +5024,7 @@
       "targetSkillId": "translation-pipeline",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "translationPipeline#evidence[0]"
       ]
@@ -5034,7 +5034,7 @@
       "targetSkillId": "document-digitization",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "documentDigitization#evidence[0]"
       ]
@@ -5044,7 +5044,7 @@
       "targetSkillId": "document-digitization",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "documentDigitization#evidence[0]"
       ]
@@ -5054,7 +5054,7 @@
       "targetSkillId": "document-digitization",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "documentDigitization#evidence[0]"
       ]
@@ -5064,7 +5064,7 @@
       "targetSkillId": "full-stack-developer",
       "edgeType": "prerequisite",
       "condition": "Requires access to repository, execution environment, and test runner. Minimum 3 Class A/B evidence sources.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "fullStackDeveloper#evidence[0]"
       ]
@@ -5074,7 +5074,7 @@
       "targetSkillId": "full-stack-developer",
       "edgeType": "prerequisite",
       "condition": "Requires access to repository, execution environment, and test runner. Minimum 3 Class A/B evidence sources.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "fullStackDeveloper#evidence[0]"
       ]
@@ -5084,7 +5084,7 @@
       "targetSkillId": "full-stack-developer",
       "edgeType": "prerequisite",
       "condition": "Requires access to repository, execution environment, and test runner. Minimum 3 Class A/B evidence sources.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "fullStackDeveloper#evidence[0]"
       ]
@@ -5094,7 +5094,7 @@
       "targetSkillId": "autonomous-data-scientist",
       "edgeType": "prerequisite",
       "condition": "Requires dataset access and compute environment. Minimum 3 Class A/B evidence sources.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "autonomousDataScientist#evidence[0]"
       ]
@@ -5104,7 +5104,7 @@
       "targetSkillId": "autonomous-data-scientist",
       "edgeType": "prerequisite",
       "condition": "Requires dataset access and compute environment. Minimum 3 Class A/B evidence sources.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "autonomousDataScientist#evidence[0]"
       ]
@@ -5114,7 +5114,7 @@
       "targetSkillId": "autonomous-data-scientist",
       "edgeType": "prerequisite",
       "condition": "Requires dataset access and compute environment. Minimum 3 Class A/B evidence sources.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "autonomousDataScientist#evidence[0]"
       ]
@@ -5124,7 +5124,7 @@
       "targetSkillId": "real-time-voice-assistant",
       "edgeType": "prerequisite",
       "condition": "Requires real-time audio pipeline, <500ms end-to-end latency target, and persistent session store. Minimum 3 Class A/B evidence sources.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "realTimeVoiceAssistant#evidence[0]"
       ]
@@ -5134,7 +5134,7 @@
       "targetSkillId": "real-time-voice-assistant",
       "edgeType": "prerequisite",
       "condition": "Requires real-time audio pipeline, <500ms end-to-end latency target, and persistent session store. Minimum 3 Class A/B evidence sources.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "realTimeVoiceAssistant#evidence[0]"
       ]
@@ -5144,7 +5144,7 @@
       "targetSkillId": "real-time-voice-assistant",
       "edgeType": "prerequisite",
       "condition": "Requires real-time audio pipeline, <500ms end-to-end latency target, and persistent session store. Minimum 3 Class A/B evidence sources.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "realTimeVoiceAssistant#evidence[0]"
       ]
@@ -5154,7 +5154,7 @@
       "targetSkillId": "registry-curation",
       "edgeType": "prerequisite",
       "condition": "Requires write access to the canonical graph and a passing validation suite.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "registryCuration#evidence[0]"
       ]
@@ -5164,7 +5164,7 @@
       "targetSkillId": "registry-curation",
       "edgeType": "prerequisite",
       "condition": "Requires write access to the canonical graph and a passing validation suite.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "registryCuration#evidence[0]"
       ]
@@ -5174,7 +5174,7 @@
       "targetSkillId": "registry-curation",
       "edgeType": "prerequisite",
       "condition": "Requires write access to the canonical graph and a passing validation suite.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "registryCuration#evidence[0]"
       ]
@@ -5184,7 +5184,7 @@
       "targetSkillId": "re-act-reasoning",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5192,7 +5192,7 @@
       "targetSkillId": "re-act-reasoning",
       "edgeType": "enhances",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5200,7 +5200,7 @@
       "targetSkillId": "scientific-discovery",
       "edgeType": "enhances",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5208,7 +5208,7 @@
       "targetSkillId": "recursive-self-improvement",
       "edgeType": "enhances",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5216,7 +5216,7 @@
       "targetSkillId": "rag-pipeline",
       "edgeType": "enhances",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5224,7 +5224,7 @@
       "targetSkillId": "text-to-sql-pipeline",
       "edgeType": "enhances",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5232,7 +5232,7 @@
       "targetSkillId": "autonomous-debug",
       "edgeType": "enhances",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5240,7 +5240,7 @@
       "targetSkillId": "code-review-pipeline",
       "edgeType": "enhances",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5248,7 +5248,7 @@
       "targetSkillId": "automated-testing",
       "edgeType": "enhances",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5256,7 +5256,7 @@
       "targetSkillId": "browser-automation",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5264,7 +5264,7 @@
       "targetSkillId": "scientific-discovery",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5272,7 +5272,7 @@
       "targetSkillId": "re-act-reasoning",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5280,7 +5280,7 @@
       "targetSkillId": "plan-and-execute",
       "edgeType": "enhances",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5288,7 +5288,7 @@
       "targetSkillId": "autonomous-research-agent",
       "edgeType": "enhances",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5296,7 +5296,7 @@
       "targetSkillId": "browser-automation",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5304,7 +5304,7 @@
       "targetSkillId": "autonomous-research-agent",
       "edgeType": "enhances",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5312,7 +5312,7 @@
       "targetSkillId": "knowledge-graph-build",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5320,7 +5320,7 @@
       "targetSkillId": "knowledge-graph-build",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5328,7 +5328,7 @@
       "targetSkillId": "rag-pipeline",
       "edgeType": "enhances",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5336,7 +5336,7 @@
       "targetSkillId": "autonomous-research-agent",
       "edgeType": "enhances",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5344,7 +5344,7 @@
       "targetSkillId": "scientific-discovery",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5352,7 +5352,7 @@
       "targetSkillId": "scientific-discovery",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5360,7 +5360,7 @@
       "targetSkillId": "tree-of-thought",
       "edgeType": "enhances",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5368,7 +5368,7 @@
       "targetSkillId": "re-act-reasoning",
       "edgeType": "enhances",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5376,7 +5376,7 @@
       "targetSkillId": "chain-of-thought",
       "edgeType": "enhances",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5384,7 +5384,7 @@
       "targetSkillId": "conversational-agent",
       "edgeType": "enhances",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5392,7 +5392,7 @@
       "targetSkillId": "tree-of-thought",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5400,7 +5400,7 @@
       "targetSkillId": "tree-of-thought",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5408,7 +5408,7 @@
       "targetSkillId": "scientific-discovery",
       "edgeType": "enhances",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5416,7 +5416,7 @@
       "targetSkillId": "prompt-optimization",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5424,7 +5424,7 @@
       "targetSkillId": "prompt-optimization",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5432,7 +5432,7 @@
       "targetSkillId": "registry-curation",
       "edgeType": "enhances",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5440,7 +5440,7 @@
       "targetSkillId": "tool-creation",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5448,7 +5448,7 @@
       "targetSkillId": "tool-creation",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5456,7 +5456,7 @@
       "targetSkillId": "full-stack-developer",
       "edgeType": "enhances",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5464,7 +5464,7 @@
       "targetSkillId": "autonomous-research-agent",
       "edgeType": "enhances",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5472,7 +5472,7 @@
       "targetSkillId": "function-calling",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5480,7 +5480,7 @@
       "targetSkillId": "function-calling",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5488,7 +5488,7 @@
       "targetSkillId": "function-calling",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5496,7 +5496,7 @@
       "targetSkillId": "document-digitization",
       "edgeType": "enhances",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5504,7 +5504,7 @@
       "targetSkillId": "multimodal-reasoning",
       "edgeType": "enhances",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5512,7 +5512,7 @@
       "targetSkillId": "browser-automation",
       "edgeType": "enhances",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5520,7 +5520,7 @@
       "targetSkillId": "code-review-pipeline",
       "edgeType": "enhances",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5528,7 +5528,7 @@
       "targetSkillId": "autonomous-debug",
       "edgeType": "enhances",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5536,7 +5536,7 @@
       "targetSkillId": "recursive-self-improvement",
       "edgeType": "enhances",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5544,7 +5544,7 @@
       "targetSkillId": "prompt-optimization",
       "edgeType": "enhances",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5552,7 +5552,7 @@
       "targetSkillId": "grounding",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5560,7 +5560,7 @@
       "targetSkillId": "grounding",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5568,7 +5568,7 @@
       "targetSkillId": "grounding",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5576,7 +5576,7 @@
       "targetSkillId": "multi-agent-debate",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5584,7 +5584,7 @@
       "targetSkillId": "multi-agent-debate",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5592,7 +5592,7 @@
       "targetSkillId": "multi-agent-debate",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5600,7 +5600,7 @@
       "targetSkillId": "guardrails",
       "edgeType": "prerequisite",
       "condition": "Requires a defined policy schema and an evaluation loop.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "guardrails#evidence[0]"
       ]
@@ -5610,7 +5610,7 @@
       "targetSkillId": "guardrails",
       "edgeType": "prerequisite",
       "condition": "Requires a defined policy schema and an evaluation loop.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "guardrails#evidence[0]"
       ]
@@ -5620,7 +5620,7 @@
       "targetSkillId": "guardrails",
       "edgeType": "prerequisite",
       "condition": "Requires a defined policy schema and an evaluation loop.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "guardrails#evidence[0]"
       ]
@@ -5630,7 +5630,7 @@
       "targetSkillId": "agent-eval",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "agent-eval#evidence[0]"
       ]
@@ -5640,7 +5640,7 @@
       "targetSkillId": "agent-eval",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "agent-eval#evidence[0]"
       ]
@@ -5650,7 +5650,7 @@
       "targetSkillId": "workflow-automation",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "workflow-automation#evidence[0]"
       ]
@@ -5660,7 +5660,7 @@
       "targetSkillId": "workflow-automation",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "workflow-automation#evidence[0]"
       ]
@@ -5670,7 +5670,7 @@
       "targetSkillId": "workflow-automation",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "workflow-automation#evidence[0]"
       ]
@@ -5680,7 +5680,7 @@
       "targetSkillId": "tool-chaining",
       "edgeType": "prerequisite",
       "condition": "Requires at least two distinct tools whose data schemas are compatible for chaining.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "tool-chaining#evidence[0]"
       ]
@@ -5690,7 +5690,7 @@
       "targetSkillId": "tool-chaining",
       "edgeType": "prerequisite",
       "condition": "Requires at least two distinct tools whose data schemas are compatible for chaining.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "tool-chaining#evidence[0]"
       ]
@@ -5700,7 +5700,7 @@
       "targetSkillId": "rag-pipeline",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5708,7 +5708,7 @@
       "targetSkillId": "rag-pipeline",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": []
     },
     {
@@ -5716,7 +5716,7 @@
       "targetSkillId": "prd-generation",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "3★",
+      "levelFloor": "3\u2605",
       "evidenceRefs": []
     },
     {
@@ -5724,7 +5724,7 @@
       "targetSkillId": "prd-generation",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "3★",
+      "levelFloor": "3\u2605",
       "evidenceRefs": []
     },
     {
@@ -5732,7 +5732,7 @@
       "targetSkillId": "vertical-slice-planning",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": []
     },
     {
@@ -5740,7 +5740,7 @@
       "targetSkillId": "vertical-slice-planning",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": []
     },
     {
@@ -5748,7 +5748,7 @@
       "targetSkillId": "design-review",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": []
     },
     {
@@ -5756,7 +5756,7 @@
       "targetSkillId": "design-review",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": []
     },
     {
@@ -5764,7 +5764,7 @@
       "targetSkillId": "route-intent",
       "edgeType": "enhances",
       "condition": "",
-      "levelFloor": "3★",
+      "levelFloor": "3\u2605",
       "evidenceRefs": []
     },
     {
@@ -5772,7 +5772,7 @@
       "targetSkillId": "vertical-slice-planning",
       "edgeType": "enhances",
       "condition": "",
-      "levelFloor": "3★",
+      "levelFloor": "3\u2605",
       "evidenceRefs": []
     },
     {
@@ -5780,7 +5780,7 @@
       "targetSkillId": "literature-review",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "literature-review#evidence[0]"
       ]
@@ -5790,7 +5790,7 @@
       "targetSkillId": "literature-review",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "literature-review#evidence[0]"
       ]
@@ -5800,7 +5800,7 @@
       "targetSkillId": "literature-review",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "literature-review#evidence[0]"
       ]
@@ -5810,7 +5810,7 @@
       "targetSkillId": "scientific-writing",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "scientific-writing#evidence[0]"
       ]
@@ -5820,7 +5820,7 @@
       "targetSkillId": "scientific-writing",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "scientific-writing#evidence[0]"
       ]
@@ -5830,7 +5830,7 @@
       "targetSkillId": "scientific-writing",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "scientific-writing#evidence[0]"
       ]
@@ -5840,7 +5840,7 @@
       "targetSkillId": "ml-pipeline",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "ml-pipeline#evidence[0]"
       ]
@@ -5850,7 +5850,7 @@
       "targetSkillId": "ml-pipeline",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "ml-pipeline#evidence[0]"
       ]
@@ -5860,7 +5860,7 @@
       "targetSkillId": "ml-pipeline",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "ml-pipeline#evidence[0]"
       ]
@@ -5870,7 +5870,7 @@
       "targetSkillId": "e2e-testing",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": []
     },
     {
@@ -5878,7 +5878,7 @@
       "targetSkillId": "e2e-testing",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": []
     },
     {
@@ -5886,7 +5886,7 @@
       "targetSkillId": "security-audit",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": []
     },
     {
@@ -5894,7 +5894,7 @@
       "targetSkillId": "security-audit",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": []
     },
     {
@@ -5902,7 +5902,7 @@
       "targetSkillId": "release-automation",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": []
     },
     {
@@ -5910,7 +5910,7 @@
       "targetSkillId": "release-automation",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": []
     },
     {
@@ -5918,7 +5918,7 @@
       "targetSkillId": "release-automation",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": []
     },
     {
@@ -5926,7 +5926,7 @@
       "targetSkillId": "deployment-automation",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": []
     },
     {
@@ -5934,7 +5934,7 @@
       "targetSkillId": "deployment-automation",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": []
     },
     {
@@ -5942,7 +5942,7 @@
       "targetSkillId": "gaia-audit",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": [
         "gaia-audit#evidence[0]"
       ]
@@ -5952,7 +5952,7 @@
       "targetSkillId": "gaia-audit",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": [
         "gaia-audit#evidence[0]"
       ]
@@ -5962,7 +5962,7 @@
       "targetSkillId": "gaia-audit",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": [
         "gaia-audit#evidence[0]"
       ]
@@ -5972,7 +5972,7 @@
       "targetSkillId": "gaia-triage",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": [
         "gaia-triage#evidence[0]"
       ]
@@ -5982,7 +5982,7 @@
       "targetSkillId": "gaia-triage",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "1★",
+      "levelFloor": "1\u2605",
       "evidenceRefs": [
         "gaia-triage#evidence[0]"
       ]
@@ -5992,7 +5992,7 @@
       "targetSkillId": "gaia-meta-audit",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "gaia-meta-audit#evidence[0]"
       ]
@@ -6002,7 +6002,7 @@
       "targetSkillId": "gaia-meta-audit",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "gaia-meta-audit#evidence[0]"
       ]
@@ -6012,7 +6012,7 @@
       "targetSkillId": "gaia-meta-audit",
       "edgeType": "prerequisite",
       "condition": "",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "gaia-meta-audit#evidence[0]"
       ]
@@ -6022,7 +6022,7 @@
       "targetSkillId": "wiki-search",
       "edgeType": "prerequisite",
       "condition": "Requires an accessible local wiki or markdown knowledge-base directory and a consistent linking or indexing convention.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "wiki-search#evidence[0]"
       ]
@@ -6032,7 +6032,7 @@
       "targetSkillId": "wiki-search",
       "edgeType": "prerequisite",
       "condition": "Requires an accessible local wiki or markdown knowledge-base directory and a consistent linking or indexing convention.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "wiki-search#evidence[0]"
       ]
@@ -6042,7 +6042,7 @@
       "targetSkillId": "wiki-search",
       "edgeType": "prerequisite",
       "condition": "Requires an accessible local wiki or markdown knowledge-base directory and a consistent linking or indexing convention.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "wiki-search#evidence[0]"
       ]
@@ -6052,7 +6052,7 @@
       "targetSkillId": "prediction-market-analysis",
       "edgeType": "prerequisite",
       "condition": "Requires read-only market data sources and clear separation between analysis output and financial advice or trade execution.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "prediction-market-analysis#evidence[0]"
       ]
@@ -6062,7 +6062,7 @@
       "targetSkillId": "prediction-market-analysis",
       "edgeType": "prerequisite",
       "condition": "Requires read-only market data sources and clear separation between analysis output and financial advice or trade execution.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "prediction-market-analysis#evidence[0]"
       ]
@@ -6072,7 +6072,7 @@
       "targetSkillId": "prediction-market-analysis",
       "edgeType": "prerequisite",
       "condition": "Requires read-only market data sources and clear separation between analysis output and financial advice or trade execution.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "prediction-market-analysis#evidence[0]"
       ]
@@ -6082,7 +6082,7 @@
       "targetSkillId": "humanize-prose",
       "edgeType": "prerequisite",
       "condition": "Requires explicit user permission to revise voice, tone, and stylistic markers without changing factual claims.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "humanize-prose#evidence[0]"
       ]
@@ -6092,7 +6092,7 @@
       "targetSkillId": "humanize-prose",
       "edgeType": "prerequisite",
       "condition": "Requires explicit user permission to revise voice, tone, and stylistic markers without changing factual claims.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "humanize-prose#evidence[0]"
       ]
@@ -6102,7 +6102,7 @@
       "targetSkillId": "humanize-prose",
       "edgeType": "prerequisite",
       "condition": "Requires explicit user permission to revise voice, tone, and stylistic markers without changing factual claims.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "humanize-prose#evidence[0]"
       ]
@@ -6112,7 +6112,7 @@
       "targetSkillId": "architecture-diagram",
       "edgeType": "prerequisite",
       "condition": "Requires enough system context to identify components, relationships, boundaries, and rendering constraints.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "architecture-diagram#evidence[0]"
       ]
@@ -6122,7 +6122,7 @@
       "targetSkillId": "architecture-diagram",
       "edgeType": "prerequisite",
       "condition": "Requires enough system context to identify components, relationships, boundaries, and rendering constraints.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "architecture-diagram#evidence[0]"
       ]
@@ -6132,7 +6132,7 @@
       "targetSkillId": "architecture-diagram",
       "edgeType": "prerequisite",
       "condition": "Requires enough system context to identify components, relationships, boundaries, and rendering constraints.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "architecture-diagram#evidence[0]"
       ]
@@ -6142,7 +6142,7 @@
       "targetSkillId": "skill-authoring",
       "edgeType": "prerequisite",
       "condition": "Requires a target agent skill format and a repeatable evaluation loop for trigger accuracy and task success.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "skill-authoring#evidence[0]"
       ]
@@ -6152,7 +6152,7 @@
       "targetSkillId": "skill-authoring",
       "edgeType": "prerequisite",
       "condition": "Requires a target agent skill format and a repeatable evaluation loop for trigger accuracy and task success.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "skill-authoring#evidence[0]"
       ]
@@ -6162,7 +6162,7 @@
       "targetSkillId": "skill-authoring",
       "edgeType": "prerequisite",
       "condition": "Requires a target agent skill format and a repeatable evaluation loop for trigger accuracy and task success.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "skill-authoring#evidence[0]"
       ]
@@ -6172,7 +6172,7 @@
       "targetSkillId": "skill-performance-benchmarking",
       "edgeType": "prerequisite",
       "condition": "Requires a skill corpus, benchmark tasks, success rubrics, and variance-aware reporting across multiple runs.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "skill-performance-benchmarking#evidence[0]"
       ]
@@ -6182,7 +6182,7 @@
       "targetSkillId": "skill-performance-benchmarking",
       "edgeType": "prerequisite",
       "condition": "Requires a skill corpus, benchmark tasks, success rubrics, and variance-aware reporting across multiple runs.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "skill-performance-benchmarking#evidence[0]"
       ]
@@ -6192,7 +6192,7 @@
       "targetSkillId": "skill-performance-benchmarking",
       "edgeType": "prerequisite",
       "condition": "Requires a skill corpus, benchmark tasks, success rubrics, and variance-aware reporting across multiple runs.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "skill-performance-benchmarking#evidence[0]"
       ]
@@ -6202,7 +6202,7 @@
       "targetSkillId": "skill-security-analysis",
       "edgeType": "prerequisite",
       "condition": "Requires access to the skill manifest, referenced files, source repository context, and a policy for trusted permissions.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "skill-security-analysis#evidence[0]"
       ]
@@ -6212,7 +6212,7 @@
       "targetSkillId": "skill-security-analysis",
       "edgeType": "prerequisite",
       "condition": "Requires access to the skill manifest, referenced files, source repository context, and a policy for trusted permissions.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "skill-security-analysis#evidence[0]"
       ]
@@ -6222,7 +6222,7 @@
       "targetSkillId": "skill-security-analysis",
       "edgeType": "prerequisite",
       "condition": "Requires access to the skill manifest, referenced files, source repository context, and a policy for trusted permissions.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "skill-security-analysis#evidence[0]"
       ]
@@ -6232,7 +6232,7 @@
       "targetSkillId": "mcp-server-creation",
       "edgeType": "prerequisite",
       "condition": "Requires an integration target, a supported MCP SDK, tool schemas, authentication handling, and local validation against an MCP client.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "mcp-server-creation#evidence[0]"
       ]
@@ -6242,7 +6242,7 @@
       "targetSkillId": "mcp-server-creation",
       "edgeType": "prerequisite",
       "condition": "Requires an integration target, a supported MCP SDK, tool schemas, authentication handling, and local validation against an MCP client.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "mcp-server-creation#evidence[0]"
       ]
@@ -6252,7 +6252,7 @@
       "targetSkillId": "mcp-server-creation",
       "edgeType": "prerequisite",
       "condition": "Requires an integration target, a supported MCP SDK, tool schemas, authentication handling, and local validation against an MCP client.",
-      "levelFloor": "2★",
+      "levelFloor": "2\u2605",
       "evidenceRefs": [
         "mcp-server-creation#evidence[0]"
       ]


### PR DESCRIPTION
- Add packages/mcp/tests/mcp-protocol.test.ts: 13 in-process MCP tests covering initialize, tools/list, gaia_lookup, gaia_my_tree, gaia_propose (no-token error), gaia_suggest, gaia_scan_context, listResources, listResourceTemplates, and readResource
- Fix src/index.ts: resource() calls had name/uri swapped — description string was landing in the uri field, breaking readResource at runtime; switch tree entry to ResourceTemplate for correct template registration
- Add .mcp.json wiring gaia MCP server for local Claude Code use
- Enable gaia MCP server in .claude/settings.json