### PR TITLE
Add scatter slider to skill graph HUD (default +30%)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Skills level up through evidence, not declaration. Each demerit lowers effective
 ## Install
 
 <!-- gaia:version-start -->
-Current Gaia CLI version: `3.1.5`.
+Current Gaia CLI version: `3.1.6`.
 
 Python install:
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Skills level up through evidence, not declaration. Each demerit lowers effective
 ## Install
 
 <!-- gaia:version-start -->
-Current Gaia CLI version: `3.1.8`.
+Current Gaia CLI version: `3.1.9`.
 
 Python install:
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Skills level up through evidence, not declaration. Each demerit lowers effective
 ## Install
 
 <!-- gaia:version-start -->
-Current Gaia CLI version: `3.1.6`.
+Current Gaia CLI version: `3.1.7`.
 
 Python install:
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Skills level up through evidence, not declaration. Each demerit lowers effective
 ## Install
 
 <!-- gaia:version-start -->
-Current Gaia CLI version: `3.1.7`.
+Current Gaia CLI version: `3.1.8`.
 
 Python install:
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Skills level up through evidence, not declaration. Each demerit lowers effective
 ## Install
 
 <!-- gaia:version-start -->
-Current Gaia CLI version: `3.1.9`.
+Current Gaia CLI version: `3.1.10`.
 
 Python install:
 

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -515,16 +515,9 @@
   }
   .graph-legend-rank-pill:hover{transform:scale(1.18);box-shadow:0 0 8px currentColor}
   .graph-legend-rank-pill.active{transform:scale(1.18);box-shadow:0 0 10px currentColor,inset 0 0 0 1.5px currentColor}
-  .graph-label-toggle{
-    position:absolute;right:1rem;bottom:1rem;z-index:2;
-    color:#94a3b8;font-size:.72rem;font-weight:700;background:rgba(3,7,18,.68);
-    border:1px solid rgba(148,163,184,.18);border-radius:999px;padding:.3rem .7rem;
-    cursor:pointer;transition:border-color .2s,color .2s,background .2s;font-family:inherit;
-  }
-  .graph-label-toggle:hover{border-color:rgba(56,189,248,.5);color:#e2e8f0}
-  .graph-label-toggle.active{background:rgba(56,189,248,.12);border-color:rgba(56,189,248,.45);color:#e2e8f0}
+  .graph-label-toggle{display:none}
   .graph-redpill{
-    position:absolute;bottom:3.4rem;right:.75rem;z-index:10;
+    position:absolute;bottom:calc(52px + .75rem);right:.75rem;z-index:10;
     color:#f87171;font-size:.72rem;font-weight:700;background:rgba(3,7,18,.68);
     border:1px solid rgba(239,68,68,.45);border-radius:999px;padding:.3rem .78rem;
     cursor:pointer;transition:all .2s;font-family:inherit;white-space:nowrap;
@@ -535,7 +528,7 @@
     color:#fca5a5;box-shadow:0 0 14px rgba(239,68,68,.35);
   }
   .graph-scatter-strip{
-    position:absolute;left:0;top:0;bottom:0;width:52px;z-index:10;
+    position:absolute;left:0;top:0;bottom:52px;width:52px;z-index:10;
     display:flex;flex-direction:column;align-items:center;
     background:linear-gradient(to bottom,rgba(56,189,248,.07) 0%,rgba(3,7,18,.65) 22%,rgba(3,7,18,.65) 78%,rgba(192,132,252,.07) 100%);
     border-right:1px solid rgba(148,163,184,.1);
@@ -569,7 +562,68 @@
     font-size:.49rem;font-weight:700;letter-spacing:.12em;text-transform:uppercase;
     color:rgba(148,163,184,.3);padding:.45rem 0;white-space:nowrap;
   }
-  @media(max-width:700px){.graph-scatter-strip{display:none}}
+  /* ── Bottom bar ── */
+  .graph-bottom-bar{
+    position:absolute;bottom:0;left:0;right:0;height:52px;z-index:10;
+    display:flex;flex-direction:row;align-items:stretch;
+    background:linear-gradient(to right,rgba(56,189,248,.07) 0%,rgba(3,7,18,.65) 12%,rgba(3,7,18,.65) 88%,rgba(192,132,252,.07) 100%);
+    border-top:1px solid rgba(148,163,184,.1);
+  }
+  .graph-pause-btn{
+    flex:0 0 52px;display:flex;align-items:center;justify-content:center;
+    font-size:1.1rem;color:rgba(148,163,184,.65);
+    background:transparent;border:none;border-right:1px solid rgba(148,163,184,.1);
+    cursor:pointer;transition:color .15s,background .15s;font-family:inherit;
+  }
+  .graph-pause-btn:hover{color:#e2e8f0;background:rgba(255,255,255,.04)}
+  .graph-pause-btn.active{color:rgba(56,189,248,.9)}
+  .graph-bottom-btn{
+    flex:0 0 auto;padding:0 .85rem;
+    display:flex;align-items:center;justify-content:center;
+    font-size:.65rem;font-weight:700;letter-spacing:.06em;text-transform:uppercase;
+    color:rgba(148,163,184,.55);background:transparent;
+    border:none;border-right:1px solid rgba(148,163,184,.1);
+    cursor:pointer;transition:color .15s,background .15s;
+    font-family:inherit;white-space:nowrap;
+  }
+  .graph-bottom-btn:hover{color:#e2e8f0;background:rgba(255,255,255,.04)}
+  .graph-bottom-btn.active{color:rgba(56,189,248,.9)}
+  .graph-bottom-btn.off{color:rgba(148,163,184,.2);text-decoration:line-through}
+  .graph-speed-strip{
+    flex:1;display:flex;flex-direction:row;align-items:center;
+    position:relative;cursor:ew-resize;user-select:none;
+  }
+  .graph-speed-edge{
+    font-size:.9rem;font-weight:700;line-height:1;padding:0 .55rem;
+    flex-shrink:0;user-select:none;
+  }
+  .graph-speed-edge--left{color:rgba(148,163,184,.28)}
+  .graph-speed-edge--right{color:rgba(192,132,252,.45)}
+  .graph-speed-track{
+    flex:1;position:relative;height:100%;
+    display:flex;align-items:center;justify-content:center;
+  }
+  .graph-speed-line{
+    width:100%;height:1px;pointer-events:none;
+    background:linear-gradient(to right,rgba(148,163,184,.15),rgba(56,189,248,.4) 40%,rgba(56,189,248,.4) 60%,rgba(192,132,252,.4));
+  }
+  .graph-speed-knob{
+    position:absolute;width:26px;height:26px;top:50%;left:50%;
+    transform:translate(-50%,-50%);
+    background:rgba(3,7,18,.9);
+    border:1.5px solid rgba(56,189,248,.55);border-radius:50%;
+    pointer-events:none;transition:border-color .15s,box-shadow .15s;
+  }
+  .graph-speed-knob.active{
+    border-color:rgba(56,189,248,1);
+    box-shadow:0 0 14px rgba(56,189,248,.55),0 0 4px rgba(56,189,248,.3);
+  }
+  .graph-speed-title{
+    position:absolute;top:3px;left:50%;transform:translateX(-50%);
+    font-size:.49rem;font-weight:700;letter-spacing:.12em;text-transform:uppercase;
+    color:rgba(148,163,184,.25);white-space:nowrap;pointer-events:none;
+  }
+  @media(max-width:700px){.graph-scatter-strip,.graph-bottom-bar{display:none}}
   @media (max-width:700px){
     html,body{overflow-x:clip}
     nav{

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -534,22 +534,42 @@
     background:rgba(239,68,68,.18);border-color:rgba(239,68,68,.7);
     color:#fca5a5;box-shadow:0 0 14px rgba(239,68,68,.35);
   }
-  .graph-scatter-wrap{
-    position:absolute;left:.75rem;top:50%;transform:translateY(-50%);z-index:10;
-    display:flex;flex-direction:column;align-items:center;gap:.42rem;
-    background:rgba(3,7,18,.68);border:1px solid rgba(148,163,184,.12);
-    border-radius:8px;padding:.7rem .45rem;user-select:none;
+  .graph-scatter-strip{
+    position:absolute;left:0;top:0;bottom:0;width:52px;z-index:10;
+    display:flex;flex-direction:column;align-items:center;
+    background:linear-gradient(to bottom,rgba(56,189,248,.07) 0%,rgba(3,7,18,.65) 22%,rgba(3,7,18,.65) 78%,rgba(192,132,252,.07) 100%);
+    border-right:1px solid rgba(148,163,184,.1);
+    cursor:ns-resize;user-select:none;
   }
-  .graph-scatter-label{
-    font-size:.55rem;font-weight:700;letter-spacing:.1em;text-transform:uppercase;
-    color:#64748b;white-space:nowrap;
+  .graph-scatter-edge{
+    font-size:1.15rem;font-weight:700;line-height:1;padding:.55rem 0;user-select:none;
   }
-  .graph-scatter-track{width:20px;height:110px;position:relative}
-  .graph-scatter-slider{
-    position:absolute;width:110px;left:50%;top:50%;
-    transform:translate(-50%,-50%) rotate(-90deg);
-    margin:0;cursor:pointer;accent-color:rgba(56,189,248,.8);
+  .graph-scatter-edge--top{color:rgba(56,189,248,.55)}
+  .graph-scatter-edge--bot{color:rgba(192,132,252,.45)}
+  .graph-scatter-track{
+    flex:1;position:relative;width:100%;
+    display:flex;align-items:center;justify-content:center;
   }
+  .graph-scatter-line{
+    width:1px;height:100%;pointer-events:none;
+    background:linear-gradient(to bottom,rgba(56,189,248,.5),rgba(148,163,184,.15) 40%,rgba(148,163,184,.15) 60%,rgba(192,132,252,.4));
+  }
+  .graph-scatter-knob{
+    position:absolute;width:26px;height:26px;left:50%;
+    transform:translate(-50%,-50%);
+    background:rgba(3,7,18,.9);
+    border:1.5px solid rgba(56,189,248,.55);border-radius:50%;
+    pointer-events:none;transition:border-color .15s,box-shadow .15s;
+  }
+  .graph-scatter-knob.active{
+    border-color:rgba(56,189,248,1);
+    box-shadow:0 0 14px rgba(56,189,248,.55),0 0 4px rgba(56,189,248,.3);
+  }
+  .graph-scatter-title{
+    font-size:.49rem;font-weight:700;letter-spacing:.12em;text-transform:uppercase;
+    color:rgba(148,163,184,.3);padding:.45rem 0;white-space:nowrap;
+  }
+  @media(max-width:700px){.graph-scatter-strip{display:none}}
   @media (max-width:700px){
     html,body{overflow-x:clip}
     nav{

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -382,9 +382,31 @@
   .graph-canvas-wrap{position:relative;flex:1;min-height:0;background:radial-gradient(circle at center,rgba(15,23,42,.75),#020617 68%)}
   #graphDialogCanvas{position:absolute;inset:0;width:100%;height:100%}
   .graph-status{
-    position:absolute;left:1rem;bottom:1rem;z-index:2;
-    color:#94a3b8;font-size:.78rem;background:rgba(3,7,18,.68);
-    border:1px solid rgba(148,163,184,.18);border-radius:999px;padding:.35rem .75rem;
+    position:absolute;top:.6rem;left:60px;z-index:5;
+    display:flex;align-items:center;gap:.42rem;flex-wrap:nowrap;
+    pointer-events:none;
+  }
+  .gst-stat{
+    color:rgba(148,163,184,.7);font-size:.7rem;white-space:nowrap;
+    background:rgba(3,7,18,.68);border:1px solid rgba(148,163,184,.15);
+    border-radius:999px;padding:.26rem .62rem;
+  }
+  .gst-dim{color:rgba(148,163,184,.4)}
+  .gst-tip{
+    display:inline-flex;align-items:center;gap:.24rem;
+    color:rgba(148,163,184,.42);font-size:.67rem;white-space:nowrap;
+  }
+  .gst-tip span{color:rgba(148,163,184,.55)}
+  .gst-or{color:rgba(148,163,184,.28)!important;font-size:.6rem}
+  .gst-ctrl{
+    font:.7rem/1 Inter,system-ui,sans-serif;font-weight:700;
+    color:rgba(148,163,184,.6);background:rgba(3,7,18,.68);
+    border:1px solid rgba(148,163,184,.22);border-bottom-width:2px;
+    border-radius:3px;padding:.08rem .3rem;
+  }
+  .gst-icon{
+    width:10px;height:15px;flex-shrink:0;
+    color:rgba(148,163,184,.55);overflow:visible;
   }
   /* ── tree dialog ── */
   .tree-dialog{

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -534,6 +534,22 @@
     background:rgba(239,68,68,.18);border-color:rgba(239,68,68,.7);
     color:#fca5a5;box-shadow:0 0 14px rgba(239,68,68,.35);
   }
+  .graph-scatter-wrap{
+    position:absolute;left:.75rem;top:50%;transform:translateY(-50%);z-index:10;
+    display:flex;flex-direction:column;align-items:center;gap:.42rem;
+    background:rgba(3,7,18,.68);border:1px solid rgba(148,163,184,.12);
+    border-radius:8px;padding:.7rem .45rem;user-select:none;
+  }
+  .graph-scatter-label{
+    font-size:.55rem;font-weight:700;letter-spacing:.1em;text-transform:uppercase;
+    color:#64748b;white-space:nowrap;
+  }
+  .graph-scatter-track{width:20px;height:110px;position:relative}
+  .graph-scatter-slider{
+    position:absolute;width:110px;left:50%;top:50%;
+    transform:translate(-50%,-50%) rotate(-90deg);
+    margin:0;cursor:pointer;accent-color:rgba(56,189,248,.8);
+  }
   @media (max-width:700px){
     html,body{overflow-x:clip}
     nav{

--- a/docs/index.html
+++ b/docs/index.html
@@ -554,5 +554,5 @@
 </html>
 
 <!-- gaia:stats-start -->
-<!-- skills=133; namedSkills=32; uniqueSkills=1; version=3.1.8 -->
+<!-- skills=133; namedSkills=32; uniqueSkills=1; version=3.1.9 -->
 <!-- gaia:stats-end -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -554,5 +554,5 @@
 </html>
 
 <!-- gaia:stats-start -->
-<!-- skills=133; namedSkills=32; uniqueSkills=1; version=3.1.5 -->
+<!-- skills=133; namedSkills=32; uniqueSkills=1; version=3.1.6 -->
 <!-- gaia:stats-end -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -554,5 +554,5 @@
 </html>
 
 <!-- gaia:stats-start -->
-<!-- skills=133; namedSkills=32; uniqueSkills=1; version=3.1.6 -->
+<!-- skills=133; namedSkills=32; uniqueSkills=1; version=3.1.7 -->
 <!-- gaia:stats-end -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -554,5 +554,5 @@
 </html>
 
 <!-- gaia:stats-start -->
-<!-- skills=133; namedSkills=32; uniqueSkills=1; version=3.1.7 -->
+<!-- skills=133; namedSkills=32; uniqueSkills=1; version=3.1.8 -->
 <!-- gaia:stats-end -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -554,5 +554,5 @@
 </html>
 
 <!-- gaia:stats-start -->
-<!-- skills=133; namedSkills=32; uniqueSkills=1; version=3.1.9 -->
+<!-- skills=133; namedSkills=32; uniqueSkills=1; version=3.1.10 -->
 <!-- gaia:stats-end -->

--- a/docs/js/skill-graph.js
+++ b/docs/js/skill-graph.js
@@ -254,9 +254,18 @@
       state.nodeAlphas = newAlphas;
       if (state.statusEl) {
         const edgeCount = skills.reduce((sum, skill) => sum + skill.prerequisites.length, 0);
-        const zoomNote = options.zoomable ? ' · scroll to zoom' : '';
-        const dragNote = options.draggable ? ' · drag to orbit' : '';
-        state.statusEl.textContent = `${skills.length} skills · ${edgeCount} links${zoomNote}${dragNote}`;
+        const mb = (fill) => `<svg class="gst-icon" viewBox="0 0 10 15" fill="none" stroke="currentColor" stroke-width="1.1" stroke-linecap="round"><rect x=".7" y=".7" width="8.6" height="13.6" rx="4.3"/><path d="M5 .7v5.8" stroke-width="1"/><path d="M.7 6.5h8.6" stroke-width="1"/>${fill}</svg>`;
+        const iL = mb('<rect x=".7" y=".7" width="4.3" height="5.8" rx="2 0 0 2" stroke="none" fill="currentColor" opacity=".55"/>');
+        const iM = mb('<rect x="3.4" y="1.4" width="3.2" height="4.2" rx="1.6" stroke="none" fill="currentColor" opacity=".55"/>');
+        const iS = mb('<rect x="3.4" y="1.4" width="3.2" height="4.2" rx="1.6" stroke-width=".9" opacity=".5"/><path d="M5 2.2v3.2M4 3.1 5 2.2 6 3.1M4 4.5 5 5.4 6 4.5" stroke-width=".9"/>');
+        const stat = `<span class="gst-stat">${skills.length}<span class="gst-dim"> skills</span> · ${edgeCount}<span class="gst-dim"> links</span></span>`;
+        let tips = '';
+        if (options.draggable) {
+          tips += `<span class="gst-tip">${iL}<span>pan</span></span>`;
+          tips += `<span class="gst-tip"><kbd class="gst-ctrl">⌃</kbd>${iL}<span class="gst-or">/</span>${iM}<span>orbit</span></span>`;
+        }
+        if (options.zoomable) tips += `<span class="gst-tip">${iS}<span>zoom</span></span>`;
+        state.statusEl.innerHTML = stat + tips;
       }
     }
 

--- a/docs/js/skill-graph.js
+++ b/docs/js/skill-graph.js
@@ -154,28 +154,23 @@
     const uniqueCount = satellite.unique.length;
     satellite.unique.forEach((skill, idx) => {
       const seed = stableHash(skill.id);
-      const spread = uniqueCount > 1 ? (idx - (uniqueCount - 1) / 2) * 120 * scale : 0;
       positions[skill.id] = {
-        x: -340 * scale + spread * 0.4,
-        y: spread,
-        z: ((seed % 80) - 40) * scale,
-        phase: (seed % 628) / 100,
+        ...spherePoint(330 * scale, seed, idx, Math.max(uniqueCount, 1)),
         _satellite: 'unique',
       };
     });
-    satellite.orphan.forEach((skill) => {
+    satellite.orphan.forEach((skill, idx) => {
       const seed = stableHash(skill.id);
-      const angle = Math.PI * 0.4 + (seed % 1000) / 1000 * Math.PI * 1.2;
-      const dist = (160 + (seed % 140)) * scale;
+      const baseR = (320 + (seed % 70)) * scale;
+      const pos = spherePoint(baseR, seed, idx, Math.max(satellite.orphan.length, 1));
       positions[skill.id] = {
-        x: -340 * scale + Math.cos(angle) * dist,
-        y: Math.sin(angle) * dist * 0.7,
-        z: ((seed % 100) - 50) * scale,
-        phase: (seed % 628) / 100,
+        ...pos,
         _satellite: 'orphan',
-        _orbitSpeed: 0.3 + (seed % 100) / 100 * 0.9,
-        _orbitRadius: dist,
-        _orbitAngle: angle,
+        _orbitSpeed: 0.2 + (seed % 100) / 100 * 0.65,
+        _orbitAmp:   (22 + (seed % 38)) * scale,
+        _phX: (seed % 628) / 100,
+        _phY: ((seed * 7) % 628) / 100,
+        _phZ: ((seed * 13) % 628) / 100,
       };
     });
     return positions;
@@ -436,17 +431,14 @@
       state.skills.forEach(skill => {
         const p0 = state.positions[skill.id];
         if (!p0) return;
-        if (p0._satellite === 'unique') {
-          xf[skill.id] = { x: p0.x, y: p0.y, z: p0.z, phase: p0.phase };
-        } else if (p0._satellite === 'orphan') {
-          const a = p0._orbitAngle + state.t * p0._orbitSpeed;
-          const cx = -340 * state.scale;
-          xf[skill.id] = {
-            x: cx + Math.cos(a) * p0._orbitRadius,
-            y: Math.sin(a) * p0._orbitRadius * 0.7,
-            z: p0.z * Math.cos(state.t * p0._orbitSpeed * 0.5),
+        if (p0._satellite === 'orphan') {
+          const s = p0._orbitSpeed, amp = p0._orbitAmp;
+          xf[skill.id] = rotX(rotY({
+            x: p0.x + Math.cos(state.t * s + p0._phX) * amp,
+            y: p0.y + Math.sin(state.t * s * 1.3 + p0._phY) * amp,
+            z: p0.z + Math.sin(state.t * s * 0.7 + p0._phZ) * amp,
             phase: p0.phase,
-          };
+          }, ry), rx);
         } else {
           xf[skill.id] = rotX(rotY(p0, ry), rx);
         }

--- a/docs/js/skill-graph.js
+++ b/docs/js/skill-graph.js
@@ -667,30 +667,63 @@
       canvas.parentElement.appendChild(legend);
       state.legendEl = legend;
 
-      const scatterWrap = document.createElement('div');
-      scatterWrap.className = 'graph-scatter-wrap';
-      const scatterLabel = document.createElement('div');
-      scatterLabel.className = 'graph-scatter-label';
-      scatterLabel.textContent = 'Scatter';
-      const scatterTrack = document.createElement('div');
-      scatterTrack.className = 'graph-scatter-track';
-      const scatterInput = document.createElement('input');
-      scatterInput.type = 'range';
-      scatterInput.className = 'graph-scatter-slider';
-      scatterInput.min = '0.5';
-      scatterInput.max = '3.0';
-      scatterInput.step = '0.05';
-      scatterInput.value = String(state.scale);
-      scatterInput.setAttribute('aria-label', 'Graph scatter');
-      scatterInput.addEventListener('input', () => {
-        state.scale = parseFloat(scatterInput.value);
-        state.positions = buildPositions(state.skills, state.scale);
+      const scatterStrip = document.createElement('div');
+      scatterStrip.className = 'graph-scatter-strip';
+      scatterStrip.setAttribute('aria-label', 'Scatter — drag up to spread, drag down to clump');
+      const scatterTop = document.createElement('div');
+      scatterTop.className = 'graph-scatter-edge graph-scatter-edge--top';
+      scatterTop.textContent = '+';
+      const scatterTrackWrap = document.createElement('div');
+      scatterTrackWrap.className = 'graph-scatter-track';
+      const scatterLine = document.createElement('div');
+      scatterLine.className = 'graph-scatter-line';
+      const scatterKnob = document.createElement('div');
+      scatterKnob.className = 'graph-scatter-knob';
+      scatterTrackWrap.appendChild(scatterLine);
+      scatterTrackWrap.appendChild(scatterKnob);
+      const scatterBot = document.createElement('div');
+      scatterBot.className = 'graph-scatter-edge graph-scatter-edge--bot';
+      scatterBot.textContent = '−';
+      const scatterTitle = document.createElement('div');
+      scatterTitle.className = 'graph-scatter-title';
+      scatterTitle.textContent = 'SCATTER';
+      scatterStrip.appendChild(scatterTop);
+      scatterStrip.appendChild(scatterTrackWrap);
+      scatterStrip.appendChild(scatterBot);
+      scatterStrip.appendChild(scatterTitle);
+
+      let scatterDragging = false, scatterLastY = 0, scatterKnobPct = 0.5;
+      function updateScatterKnob() {
+        const h = scatterTrackWrap.clientHeight || 200;
+        scatterKnob.style.top = (scatterKnobPct * h) + 'px';
+      }
+      scatterStrip.addEventListener('mousedown', e => e.stopPropagation());
+      scatterStrip.addEventListener('pointerdown', e => {
+        e.preventDefault(); e.stopPropagation();
+        scatterStrip.setPointerCapture(e.pointerId);
+        scatterDragging = true;
+        scatterLastY = e.clientY;
+        scatterKnob.classList.add('active');
+        const rect = scatterTrackWrap.getBoundingClientRect();
+        scatterKnobPct = Math.max(0, Math.min(1, (e.clientY - rect.top) / rect.height));
+        updateScatterKnob();
       });
-      scatterInput.addEventListener('mousedown', e => e.stopPropagation());
-      scatterTrack.appendChild(scatterInput);
-      scatterWrap.appendChild(scatterLabel);
-      scatterWrap.appendChild(scatterTrack);
-      canvas.parentElement.appendChild(scatterWrap);
+      scatterStrip.addEventListener('pointermove', e => {
+        if (!scatterDragging) return;
+        const dy = scatterLastY - e.clientY;
+        scatterLastY = e.clientY;
+        state.scale = Math.max(0.05, state.scale * Math.exp(dy * 0.007));
+        state.positions = buildPositions(state.skills, state.scale);
+        const rect = scatterTrackWrap.getBoundingClientRect();
+        scatterKnobPct = Math.max(0, Math.min(1, (e.clientY - rect.top) / rect.height));
+        updateScatterKnob();
+      });
+      scatterStrip.addEventListener('pointerup', e => {
+        scatterDragging = false;
+        scatterKnob.classList.remove('active');
+        scatterStrip.releasePointerCapture(e.pointerId);
+      });
+      canvas.parentElement.appendChild(scatterStrip);
 
       const redPill = document.createElement('button');
       redPill.type = 'button';

--- a/docs/js/skill-graph.js
+++ b/docs/js/skill-graph.js
@@ -1,6 +1,6 @@
 (function () {
   const GRAPH_JSON_URL = 'graph/gaia.json';
-  const GRAPH_SCALE = 1.25;
+  const GRAPH_SCALE = 1.625;
 
   // Defaults — overwritten from meta once data loads
   let PALETTE = {
@@ -667,6 +667,31 @@
       canvas.parentElement.appendChild(legend);
       state.legendEl = legend;
 
+      const scatterWrap = document.createElement('div');
+      scatterWrap.className = 'graph-scatter-wrap';
+      const scatterLabel = document.createElement('div');
+      scatterLabel.className = 'graph-scatter-label';
+      scatterLabel.textContent = 'Scatter';
+      const scatterTrack = document.createElement('div');
+      scatterTrack.className = 'graph-scatter-track';
+      const scatterInput = document.createElement('input');
+      scatterInput.type = 'range';
+      scatterInput.className = 'graph-scatter-slider';
+      scatterInput.min = '0.5';
+      scatterInput.max = '3.0';
+      scatterInput.step = '0.05';
+      scatterInput.value = String(state.scale);
+      scatterInput.setAttribute('aria-label', 'Graph scatter');
+      scatterInput.addEventListener('input', () => {
+        state.scale = parseFloat(scatterInput.value);
+        state.positions = buildPositions(state.skills, state.scale);
+      });
+      scatterInput.addEventListener('mousedown', e => e.stopPropagation());
+      scatterTrack.appendChild(scatterInput);
+      scatterWrap.appendChild(scatterLabel);
+      scatterWrap.appendChild(scatterTrack);
+      canvas.parentElement.appendChild(scatterWrap);
+
       const redPill = document.createElement('button');
       redPill.type = 'button';
       redPill.className = 'graph-redpill';
@@ -774,7 +799,7 @@
   const closeBtn = document.querySelector('[data-graph-close]');
   const heroGraph = createSkillGraph(document.getElementById('canvas3d'), { labelMode:'none', scale:GRAPH_SCALE, stars:280, pointerTarget:hero });
   const modalGraph = createSkillGraph(document.getElementById('graphDialogCanvas'), {
-    labelMode:'all', scale:1.38, stars:320, statusEl:document.querySelector('[data-graph-status]'), autostart:false, zoomable:true, draggable:true, hoverable:true,
+    labelMode:'all', scale:1.8, stars:320, statusEl:document.querySelector('[data-graph-status]'), autostart:false, zoomable:true, draggable:true, hoverable:true,
     onNodeClick: function(id) {
       var buckets = window._gaiaNamedBuckets || {};
       if (buckets[id] && buckets[id].length) {

--- a/docs/js/skill-graph.js
+++ b/docs/js/skill-graph.js
@@ -203,11 +203,16 @@
       orbitX: 0,
       orbitY: 0,
       dragging: false,
+      dragMode: 'pan',
       dragLastX: 0,
       dragLastY: 0,
       dragStartX: 0,
       dragStartY: 0,
       dragMoved: false,
+      panX: 0,
+      panY: 0,
+      paused: false,
+      rotSpeed: 1,
       hoveredId: null,
       lastHoveredId: null,
       projectedNodes: {},
@@ -267,7 +272,7 @@
       const fov = Math.min(state.width, state.height) * 0.75;
       const dist = fov / (fov + p.z + 360 * state.scale);
       const z = state.zoom;
-      return { sx: state.width / 2 + p.x * dist * z, sy: state.height / 2 + p.y * dist * z, scale: dist * z };
+      return { sx: state.width / 2 + p.x * dist * z + state.panX, sy: state.height / 2 + p.y * dist * z + state.panY, scale: dist * z };
     }
     function drawNode(sx, sy, r, color, alpha) {
       const grad = ctx.createRadialGradient(sx, sy, 0, sx, sy, r * 3.9);
@@ -407,7 +412,7 @@
     }
     function draw() {
       if (!state.running) return;
-      state.t += 0.006;
+      if (!state.paused) state.t += 0.006 * state.rotSpeed;
       ctx.clearRect(0, 0, state.width, state.height);
       state.projectedNodes = {};
       const ry = options.draggable
@@ -738,25 +743,122 @@
       canvas.parentElement.appendChild(redPill);
       state.redPillEl = redPill;
 
+      // ── Bottom bar: [pause][labels][titles][speed strip] ──
+      const bottomBar = document.createElement('div');
+      bottomBar.className = 'graph-bottom-bar';
+      bottomBar.addEventListener('mousedown', e => e.stopPropagation());
+
+      const pauseBtn = document.createElement('button');
+      pauseBtn.type = 'button';
+      pauseBtn.className = 'graph-pause-btn';
+      pauseBtn.textContent = '⏸';
+      pauseBtn.title = 'Pause / resume rotation';
+      pauseBtn.addEventListener('click', () => {
+        state.paused = !state.paused;
+        pauseBtn.textContent = state.paused ? '▶' : '⏸';
+        pauseBtn.classList.toggle('active', state.paused);
+      });
+      bottomBar.appendChild(pauseBtn);
+      state.pauseBtnEl = pauseBtn;
+
+      const labelsToggle = document.createElement('button');
+      labelsToggle.type = 'button';
+      labelsToggle.className = 'graph-bottom-btn';
+      labelsToggle.textContent = 'Labels';
+      labelsToggle.title = 'Toggle skill labels';
+      labelsToggle.addEventListener('click', () => {
+        if (state.labelMode === 'none') {
+          state.labelMode = options.labelMode || 'ultimate';
+          labelsToggle.classList.remove('off');
+        } else {
+          state.labelMode = 'none';
+          labelsToggle.classList.add('off');
+        }
+      });
+      bottomBar.appendChild(labelsToggle);
+      state.labelsToggleEl = labelsToggle;
+
       const labelToggle = document.createElement('button');
       labelToggle.type = 'button';
-      labelToggle.className = 'graph-label-toggle';
-      labelToggle.textContent = 'Show Title';
-      labelToggle.addEventListener('mousedown', e => e.stopPropagation());
+      labelToggle.className = 'graph-bottom-btn';
+      labelToggle.textContent = 'Titles';
+      labelToggle.title = 'Show skill titles instead of /IDs';
       labelToggle.addEventListener('click', () => {
         state.showTitles = !state.showTitles;
         labelToggle.classList.toggle('active', state.showTitles);
       });
-      canvas.parentElement.appendChild(labelToggle);
+      bottomBar.appendChild(labelToggle);
       state.labelToggleEl = labelToggle;
+
+      // Speed strip — horizontal infinite drag, right=faster
+      const speedStrip = document.createElement('div');
+      speedStrip.className = 'graph-speed-strip';
+      const speedLeft = document.createElement('div');
+      speedLeft.className = 'graph-speed-edge graph-speed-edge--left';
+      speedLeft.textContent = '◀';
+      const speedTrackWrap = document.createElement('div');
+      speedTrackWrap.className = 'graph-speed-track';
+      const speedLine = document.createElement('div');
+      speedLine.className = 'graph-speed-line';
+      const speedKnob = document.createElement('div');
+      speedKnob.className = 'graph-speed-knob';
+      speedTrackWrap.appendChild(speedLine);
+      speedTrackWrap.appendChild(speedKnob);
+      const speedRight = document.createElement('div');
+      speedRight.className = 'graph-speed-edge graph-speed-edge--right';
+      speedRight.textContent = '▶';
+      const speedTitle = document.createElement('div');
+      speedTitle.className = 'graph-speed-title';
+      speedTitle.textContent = 'SPEED';
+      speedStrip.appendChild(speedLeft);
+      speedStrip.appendChild(speedTrackWrap);
+      speedStrip.appendChild(speedRight);
+      speedStrip.appendChild(speedTitle);
+
+      let speedDragging = false, speedLastX = 0, speedKnobPct = 0.5;
+      function updateSpeedKnob() {
+        const w = speedTrackWrap.clientWidth || 200;
+        speedKnob.style.left = (speedKnobPct * w) + 'px';
+      }
+      speedStrip.addEventListener('pointerdown', e => {
+        e.preventDefault();
+        speedStrip.setPointerCapture(e.pointerId);
+        speedDragging = true;
+        speedLastX = e.clientX;
+        speedKnob.classList.add('active');
+        const rect = speedTrackWrap.getBoundingClientRect();
+        speedKnobPct = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+        updateSpeedKnob();
+      });
+      speedStrip.addEventListener('pointermove', e => {
+        if (!speedDragging) return;
+        const dx = e.clientX - speedLastX;
+        speedLastX = e.clientX;
+        state.rotSpeed = Math.max(0, state.rotSpeed * Math.exp(dx * 0.007));
+        const rect = speedTrackWrap.getBoundingClientRect();
+        speedKnobPct = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+        updateSpeedKnob();
+      });
+      speedStrip.addEventListener('pointerup', e => {
+        speedDragging = false;
+        speedKnob.classList.remove('active');
+        speedStrip.releasePointerCapture(e.pointerId);
+      });
+      bottomBar.appendChild(speedStrip);
+      canvas.parentElement.appendChild(bottomBar);
     }
     window.addEventListener('resize', resize);
     const pointerTarget = options.pointerTarget || canvas;
     pointerTarget.addEventListener('mousemove', event => {
       const rect = canvas.getBoundingClientRect();
       if (options.draggable && state.dragging) {
-        state.orbitY += (event.clientX - state.dragLastX) * 0.007;
-        state.orbitX += (event.clientY - state.dragLastY) * 0.007;
+        if (state.dragMode === 'orbit') {
+          state.orbitY += (event.clientX - state.dragLastX) * 0.007;
+          state.orbitX += (event.clientY - state.dragLastY) * 0.007;
+        } else {
+          state.panX += event.clientX - state.dragLastX;
+          state.panY += event.clientY - state.dragLastY;
+        }
         state.dragLastX = event.clientX;
         state.dragLastY = event.clientY;
         if (Math.hypot(event.clientX - state.dragStartX, event.clientY - state.dragStartY) > 5) state.dragMoved = true;
@@ -780,15 +882,18 @@
     if (options.draggable) {
       canvas.style.cursor = 'grab';
       canvas.addEventListener('mouseleave', () => { if (!state.dragging) state.hoveredId = null; });
+      canvas.addEventListener('contextmenu', e => e.preventDefault());
       canvas.addEventListener('mousedown', e => {
+        if (e.button === 2) return;
         e.preventDefault();
         state.dragging = true;
+        state.dragMode = (e.button === 1 || e.ctrlKey) ? 'orbit' : 'pan';
         state.dragMoved = false;
         state.dragStartX = e.clientX;
         state.dragStartY = e.clientY;
         state.dragLastX = e.clientX;
         state.dragLastY = e.clientY;
-        canvas.style.cursor = 'grabbing';
+        canvas.style.cursor = state.dragMode === 'orbit' ? 'grabbing' : 'move';
       });
       window.addEventListener('mouseup', e => {
         if (!state.dragging) return;
@@ -813,6 +918,10 @@
       state.showTitles = false;
       state.searchText = '';
       state.redPillActive = false;
+      state.panX = 0; state.panY = 0;
+      state.paused = false; state.rotSpeed = 1;
+      if (state.pauseBtnEl) { state.pauseBtnEl.textContent = '⏸'; state.pauseBtnEl.classList.remove('active'); }
+      if (state.labelsToggleEl) { state.labelMode = options.labelMode || 'ultimate'; state.labelsToggleEl.classList.remove('off'); }
       if (state.redPillEl) state.redPillEl.classList.remove('active');
       if (state.legendEl) {
         state.legendEl.querySelectorAll('.active').forEach(el => el.classList.remove('active'));

--- a/packages/cli-npm/package.json
+++ b/packages/cli-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia-registry/cli",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "description": "Gaia CLI - Integrate your AI agent skills with the Gaia registry",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli-npm/package.json
+++ b/packages/cli-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia-registry/cli",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "description": "Gaia CLI - Integrate your AI agent skills with the Gaia registry",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli-npm/package.json
+++ b/packages/cli-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia-registry/cli",
-  "version": "3.1.9",
+  "version": "3.1.10",
   "description": "Gaia CLI - Integrate your AI agent skills with the Gaia registry",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli-npm/package.json
+++ b/packages/cli-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia-registry/cli",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "description": "Gaia CLI - Integrate your AI agent skills with the Gaia registry",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli-npm/package.json
+++ b/packages/cli-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia-registry/cli",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "description": "Gaia CLI - Integrate your AI agent skills with the Gaia registry",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia-registry/mcp-server",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "description": "MCP server for the Gaia Skill Registry \u2014 agent-native skill detection, fusion, and progression",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia-registry/mcp-server",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "description": "MCP server for the Gaia Skill Registry \u2014 agent-native skill detection, fusion, and progression",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia-registry/mcp-server",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "description": "MCP server for the Gaia Skill Registry \u2014 agent-native skill detection, fusion, and progression",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia-registry/mcp-server",
-  "version": "3.1.9",
+  "version": "3.1.10",
   "description": "MCP server for the Gaia Skill Registry \u2014 agent-native skill detection, fusion, and progression",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia-registry/mcp-server",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "description": "MCP server for the Gaia Skill Registry \u2014 agent-native skill detection, fusion, and progression",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gaia-cli"
-version = "3.1.9"
+version = "3.1.10"
 description = "Gaia AI Agent Skill Registry CLI"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gaia-cli"
-version = "3.1.6"
+version = "3.1.7"
 description = "Gaia AI Agent Skill Registry CLI"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gaia-cli"
-version = "3.1.7"
+version = "3.1.8"
 description = "Gaia AI Agent Skill Registry CLI"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gaia-cli"
-version = "3.1.5"
+version = "3.1.6"
 description = "Gaia AI Agent Skill Registry CLI"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gaia-cli"
-version = "3.1.8"
+version = "3.1.9"
 description = "Gaia AI Agent Skill Registry CLI"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/registry/gaia.json
+++ b/registry/gaia.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./schema/skill.schema.json",
-  "version": "3.1.9",
+  "version": "3.1.10",
   "generatedAt": "2026-05-06T00:00:00Z",
   "meta": {
     "typeLabels": {

--- a/registry/gaia.json
+++ b/registry/gaia.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./schema/skill.schema.json",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "generatedAt": "2026-05-06T00:00:00Z",
   "meta": {
     "typeLabels": {

--- a/registry/gaia.json
+++ b/registry/gaia.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./schema/skill.schema.json",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "generatedAt": "2026-05-06T00:00:00Z",
   "meta": {
     "typeLabels": {

--- a/registry/gaia.json
+++ b/registry/gaia.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./schema/skill.schema.json",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "generatedAt": "2026-05-06T00:00:00Z",
   "meta": {
     "typeLabels": {

--- a/registry/gaia.json
+++ b/registry/gaia.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./schema/skill.schema.json",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "generatedAt": "2026-05-06T00:00:00Z",
   "meta": {
     "typeLabels": {


### PR DESCRIPTION
## Summary

- Vertical **Scatter** range slider on the left side of the full-graph modal — drag up to spread nodes out, down to cluster them (range 0.5 – 3.0)
- Live-rebuilds node positions via `buildPositions()` on every `input` event, no restart needed
- Default scatter increased 30%: `GRAPH_SCALE` 1.25 → 1.625 (hero canvas), modal scale 1.38 → 1.8

## Test plan

- [x] Open the skill graph modal — nodes should appear noticeably more spread than before
- [x] Drag the left-side slider up → nodes scatter further; drag down → nodes clump together
- [x] Slider does not interfere with drag-to-orbit or scroll-to-zoom
- [x] Hero background canvas is also 30% more spread