### PR TITLE
Fix mobile hero layout

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -40,6 +40,16 @@
   button.nav-tree{background:none;border:none;cursor:pointer;font:inherit;font-size:.9rem;padding:0}
   .nav-named-explorer{color:#ef4444!important;font-weight:700}
   .nav-named-explorer:hover{color:#f87171!important}
+  .nav-menu-toggle{
+    display:none;align-items:center;justify-content:center;flex-direction:column;gap:4px;
+    width:40px;height:40px;margin-right:-.5rem;
+    color:var(--muted);background:transparent;border:0;border-radius:10px;cursor:pointer;
+    transition:color .2s,background .2s;
+  }
+  .nav-menu-toggle span{
+    display:block;width:22px;height:2px;border-radius:999px;background:currentColor;
+  }
+  .nav-menu-toggle:hover,.nav-menu-toggle:focus-visible{color:var(--text);background:rgba(255,255,255,.06);outline:none}
   /* ── HERO ── */
   #hero{
     position:relative;min-height:100vh;
@@ -1558,4 +1568,184 @@
     section{padding:2.8rem .75rem}
     pre{font-size:.72rem}
     .tier-card{padding:1.1rem 1rem}
+  }
+
+  /* ── Mobile index hero port ── */
+  @media (max-width:700px){
+    .home-page nav{
+      padding:.8rem 1.5rem;
+      flex-wrap:nowrap;
+      row-gap:0;
+      background:rgba(11,15,25,.94);
+      border-bottom:1px solid rgba(255,255,255,.05);
+    }
+    .home-page .nav-logo{
+      font-size:1.125rem;
+      line-height:1;
+      letter-spacing:.16em;
+      color:var(--basic);
+      background:none;
+      -webkit-text-fill-color:currentColor;
+    }
+    .home-page .nav-menu-toggle{display:flex;flex-shrink:0}
+    .home-page nav ul{display:none}
+    .home-page nav.nav-open ul{
+      display:flex;
+      position:absolute;
+      top:100%;left:0;right:0;
+      flex-direction:column;
+      gap:.5rem;
+      width:auto;
+      padding:1rem 1.5rem 1.25rem;
+      background:rgba(11,15,25,.98);
+      border-bottom:1px solid rgba(255,255,255,.08);
+    }
+
+    #hero{
+      min-height:100svh;
+      justify-content:flex-start;
+      padding:5.4rem 1.5rem 2rem;
+      background:#0b0f19;
+    }
+    #hero::before,#hero::after{
+      content:"";
+      position:absolute;
+      pointer-events:none;
+      border-radius:999px;
+      z-index:0;
+    }
+    #hero::before{
+      top:11%;left:50%;
+      width:500px;height:500px;
+      transform:translate(-50%,-15%);
+      background:rgba(147,51,234,.3);
+      filter:blur(120px);
+    }
+    #hero::after{
+      top:52%;left:24%;
+      width:300px;height:300px;
+      background:rgba(59,130,246,.2);
+      filter:blur(100px);
+    }
+    #canvas3d{
+      z-index:1;
+      opacity:.2;
+      background-image:radial-gradient(circle at center, rgba(255,255,255,.55) 1px, transparent 1px);
+      background-size:40px 40px;
+    }
+    .hero-content{
+      z-index:2;
+      display:flex;
+      flex-direction:column;
+      align-items:center;
+      width:100%;
+      max-width:24rem;
+      margin:0 auto;
+    }
+    .hero-eyebrow{
+      margin-bottom:1.5rem;
+      padding:.35rem 1rem;
+      border-color:rgba(59,130,246,.3);
+      background:rgba(59,130,246,.1);
+      color:#60a5fa;
+      box-shadow:none;
+      font-size:.625rem;
+      font-weight:700;
+      letter-spacing:.2em;
+    }
+    h1.hero-title{
+      margin-bottom:1.25rem;
+      font-size:clamp(2.3rem,10vw,2.85rem);
+      line-height:1.15;
+      letter-spacing:-.045em;
+    }
+    h1.hero-title span{
+      display:block;
+      margin-top:.25rem;
+      padding-bottom:.25rem;
+      background:linear-gradient(90deg,#60a5fa,#818cf8,#c084fc);
+      -webkit-background-clip:text;
+      -webkit-text-fill-color:transparent;
+    }
+    .hero-sub{
+      max-width:20rem;
+      margin:0 auto 2rem;
+      color:#9ca3af;
+      font-size:.9375rem;
+      line-height:1.65;
+    }
+    .hero-cta{
+      width:100%;
+      max-width:24rem;
+      flex-direction:column;
+      align-items:stretch;
+      gap:.75rem;
+      margin-bottom:2.5rem;
+    }
+    .hero-cta .btn{
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      gap:.5rem;
+      width:100%;
+      border-radius:12px;
+      padding:.875rem 1.5rem;
+      font-size:.9375rem;
+      line-height:1.2;
+      text-align:center;
+    }
+    .btn-primary{
+      background:linear-gradient(90deg,#3b82f6,#9333ea);
+      box-shadow:0 0 30px rgba(99,102,241,.2);
+    }
+    .btn-ghost{
+      background:rgba(255,255,255,.05);
+      border-color:rgba(255,255,255,.1);
+      color:#d1d5db;
+    }
+    .registry-stats{
+      display:grid;
+      grid-template-columns:repeat(2,minmax(0,1fr));
+      width:100%;
+      max-width:24rem;
+      margin:0 auto;
+      gap:1px;
+      border:1px solid rgba(255,255,255,.1);
+      border-radius:1rem;
+      background:rgba(255,255,255,.1);
+      box-shadow:0 25px 50px -12px rgba(0,0,0,.45);
+    }
+    .rs-divider{display:none}
+    .rs-stat{
+      display:flex;
+      flex-direction:column;
+      align-items:center;
+      justify-content:center;
+      min-height:6.25rem;
+      padding:1.35rem;
+      background:rgba(11,15,25,.95);
+      backdrop-filter:blur(12px);
+      -webkit-backdrop-filter:blur(12px);
+    }
+    .rs-stat:nth-child(1),.rs-stat:nth-child(3),.rs-stat:nth-child(5){border:0}
+    .rs-num{
+      margin-bottom:.25rem;
+      font-size:1.875rem;
+      line-height:1;
+      color:#fff;
+    }
+    .rs-label{
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      gap:.25rem;
+      color:#6b7280;
+      font-size:.625rem;
+      font-weight:700;
+      letter-spacing:.16em;
+    }
+    .rs-named{color:#f87171}
+    .rs-stat .rs-num[style]{color:#c084fc!important}
+    .rs-legendary{color:#eab308}
+    .rs-legendary-link .rs-label::before{content:"★";color:#eab308;letter-spacing:0}
   }

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,11 +8,16 @@
   <link rel="stylesheet" href="css/styles.css">
 </head>
 
-<body>
+<body class="home-page">
 
   <!-- ─── NAV ─── -->
   <nav>
     <span class="nav-logo">◆ GAIA</span>
+    <button class="nav-menu-toggle" type="button" aria-label="Open navigation" aria-expanded="false">
+      <span></span>
+      <span></span>
+      <span></span>
+    </button>
     <ul>
       <li><a href="#what">What</a></li>
       <li><a href="#ranks">Ranks</a></li>

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -7,6 +7,24 @@ window.switchOsTab = function(btn) {
 (function(){
   var CLIP='<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="5" width="9" height="9" rx="1.5"/><path d="M11 5V3a1 1 0 00-1-1H3a1 1 0 00-1 1v7a1 1 0 001 1h2"/></svg>';
   var CHECK='<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="#4ade80" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 8l4 4 8-8"/></svg>';
+
+  function initMobileNav(){
+    var toggle = document.querySelector('.nav-menu-toggle');
+    if(!toggle) return;
+    var nav = toggle.closest('nav');
+    if(!nav) return;
+    toggle.addEventListener('click', function(){
+      var open = nav.classList.toggle('nav-open');
+      toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+    });
+    nav.querySelectorAll('a, .nav-tree').forEach(function(item){
+      item.addEventListener('click', function(){
+        nav.classList.remove('nav-open');
+        toggle.setAttribute('aria-expanded', 'false');
+      });
+    });
+  }
+
   function initCopyButtons(){
     document.querySelectorAll('pre').forEach(function(pre){
       if(pre.closest('.pre-wrap')) return;
@@ -33,8 +51,9 @@ window.switchOsTab = function(btn) {
     });
   }
   if(document.readyState === 'loading'){
-    document.addEventListener('DOMContentLoaded', initCopyButtons);
+    document.addEventListener('DOMContentLoaded', function(){ initCopyButtons(); initMobileNav(); });
   } else {
     initCopyButtons();
+    initMobileNav();
   }
 })();


### PR DESCRIPTION
### Motivation
- Improve the index hero presentation on small screens so content remains readable and visually balanced. 
- Provide an accessible collapsed navigation for the index page via a hamburger control. 
- Port the provided mobile mockup visual language (backdrop glows, subtle graph dots, stacked CTAs, compact stats) to the site.

### Description
- Add a hamburger button into the header and scope index mobile behavior with a `home-page` body class and a `.nav-menu-toggle` element in `docs/index.html`.
- Implement a mobile-scoped CSS module in `docs/css/styles.css` that adjusts the hero: darker backdrop blobs via `#hero::before`/`::after`, toned-down `#canvas3d` dot background, tighter headline/subcopy sizing, stacked CTA styles, and a 2×2 `registry-stats` grid with glassy cells. 
- Add styles for the hamburger UI and an open menu state (`.home-page nav.nav-open ul`) so the collapsed menu is revealed on toggle. 
- Wire a small JS helper `initMobileNav` in `docs/js/ui.js` to toggle `nav-open`, manage `aria-expanded`, and auto-close the menu when a nav item is selected.

### Testing
- Run a CSS/JS brace and size sanity check via a small Python script to ensure no obvious truncation or broken blocks, which passed. 
- Run `git diff --check` to surface whitespace/merge issues, which reported no problems. 
- Serve the `docs` directory with `python -m http.server` and verify the index responds via `curl -I`, which succeeded. 
- Capture a mobile viewport screenshot using Playwright (`npx playwright screenshot --viewport-size=390,844`) to validate the mobile hero render, which produced a screenshot after installing the required Playwright browser artifacts and system dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a02492c69bc8327b1560f6da72a4006)