### PR TITLE
feat(cli): add lookup command and support for named skill roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,13 +116,13 @@ gaia push            # submit for maintainer review
 <!-- gaia:cli-start -->
 ```text
 usage: gaia [-h] [--registry REGISTRY] [--global] [--version]
-            {help,init,scan,pull,tree,push,propose,version,mcp,release,graph,stats,appraise,promote,fuse,docs,update,skills}
+            {help,init,scan,pull,tree,push,propose,version,mcp,release,graph,stats,appraise,promote,fuse,docs,lookup,update,skills}
             ...
 
 Gaia Registry CLI
 
 positional arguments:
-  {help,init,scan,pull,tree,push,propose,version,mcp,release,graph,stats,appraise,promote,fuse,docs,update,skills}
+  {help,init,scan,pull,tree,push,propose,version,mcp,release,graph,stats,appraise,promote,fuse,docs,lookup,update,skills}
     help                Show command help
     init                Create or update local Gaia config
     scan                Scan configured paths for skill evidence
@@ -140,6 +140,7 @@ positional arguments:
     promote             Promote a skill eligible for level-up
     fuse                Confirm a skill combination or promotion candidate
     docs                Documentation maintenance commands
+    lookup              Look up a canonical skill and its named implementations
     skills              Browse and manage named skills
 
 options:
@@ -167,6 +168,7 @@ Quick usage:
   gaia update
   gaia stats
   gaia docs build [--check]
+  gaia lookup <skillId>
   gaia skills <list|search|info|install|uninstall>
   gaia skills list [--exclude-pending]
   gaia skills search <query> [--exclude-pending]

--- a/docs/graph/named/index.json
+++ b/docs/graph/named/index.json
@@ -24,7 +24,8 @@
         ],
         "links": {
           "github": "https://github.com/aiskillstore/marketplace"
-        }
+        },
+        "role": "origin"
       }
     ],
     "test-driven-development": [
@@ -48,7 +49,8 @@
         ],
         "links": {
           "github": "https://github.com/addyosmani/agent-skills/blob/main/skills/test-driven-development/SKILL.md"
-        }
+        },
+        "role": "origin"
       },
       {
         "id": "mattpocock/tdd",
@@ -70,7 +72,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/tdd/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "document-editing": [
@@ -94,7 +97,8 @@
         ],
         "links": {
           "github": "https://github.com/anthropics/skills/blob/main/skills/pptx/SKILL.md"
-        }
+        },
+        "role": "origin"
       },
       {
         "id": "mattpocock/edit-article",
@@ -116,7 +120,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/personal/edit-article/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "tool-creation": [
@@ -139,7 +144,8 @@
         ],
         "links": {
           "github": "https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md"
-        }
+        },
+        "role": "origin"
       },
       {
         "id": "mattpocock/write-a-skill",
@@ -161,7 +167,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/productivity/write-a-skill/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "autonomous-debug": [
@@ -185,7 +192,8 @@
         ],
         "links": {
           "github": "https://github.com/cognition-labs/devin"
-        }
+        },
+        "role": "origin"
       },
       {
         "id": "mattpocock/diagnose",
@@ -207,7 +215,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/diagnose/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "write-report": [
@@ -230,7 +239,8 @@
         ],
         "links": {
           "github": "https://github.com/GLINCKER/claude-code-marketplace/blob/main/skills/documentation/readme-generator/SKILL.md"
-        }
+        },
+        "role": "origin"
       },
       {
         "id": "spring-ai/readme-generate",
@@ -252,7 +262,8 @@
         ],
         "links": {
           "github": "https://github.com/spring-ai-alibaba/examples/blob/main/.claude/skills/readme-generate/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "browser-automation": [
@@ -276,7 +287,8 @@
         ],
         "links": {
           "github": "https://github.com/gooseworks-ai/goose-skills"
-        }
+        },
+        "role": "origin"
       }
     ],
     "api-call": [
@@ -300,7 +312,8 @@
         ],
         "links": {
           "github": "https://github.com/huggingface/skills/blob/main/skills/hf-cli/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "data-analysis": [
@@ -324,7 +337,8 @@
         ],
         "links": {
           "github": "https://github.com/huggingface/skills/blob/main/skills/huggingface-datasets/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "fine-tune": [
@@ -348,7 +362,8 @@
         ],
         "links": {
           "github": "https://github.com/huggingface/skills/blob/main/skills/huggingface-llm-trainer/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "literature-review": [
@@ -372,7 +387,8 @@
         ],
         "links": {
           "github": "https://github.com/huggingface/skills/blob/main/skills/huggingface-papers/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "object-detection": [
@@ -396,7 +412,8 @@
         ],
         "links": {
           "github": "https://github.com/huggingface/skills/blob/main/skills/huggingface-vision-trainer/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "multimodal-reasoning": [
@@ -420,7 +437,8 @@
         ],
         "links": {
           "github": "https://github.com/huggingface/skills/blob/main/skills/transformers-js/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "autonomous-research-agent": [
@@ -442,7 +460,8 @@
         ],
         "links": {
           "github": "https://github.com/karpathy/autoresearch"
-        }
+        },
+        "role": "origin"
       }
     ],
     "framework-upgrade": [
@@ -465,7 +484,8 @@
         ],
         "links": {
           "github": "https://github.com/laravel/boost/issues/698"
-        }
+        },
+        "role": "origin"
       }
     ],
     "ux-audit": [
@@ -489,7 +509,8 @@
         ],
         "links": {
           "github": "https://github.com/mastepanoski/claude-skills/blob/main/skills/nielsen-heuristics-audit/SKILL.md"
-        }
+        },
+        "role": "origin"
       }
     ],
     "design-review": [
@@ -513,7 +534,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/productivity/grill-me/SKILL.md"
-        }
+        },
+        "role": "variant"
       },
       {
         "id": "mattpocock/grill-with-docs",
@@ -536,7 +558,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/grill-with-docs/SKILL.md"
-        }
+        },
+        "role": "origin"
       }
     ],
     "refactor-code": [
@@ -561,7 +584,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/improve-codebase-architecture/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "vertical-slice-planning": [
@@ -586,7 +610,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/to-issues/SKILL.md"
-        }
+        },
+        "role": "origin"
       }
     ],
     "prd-generation": [
@@ -610,7 +635,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/to-prd/SKILL.md"
-        }
+        },
+        "role": "origin"
       }
     ],
     "issue-triage": [
@@ -634,7 +660,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/triage/SKILL.md"
-        }
+        },
+        "role": "origin"
       }
     ],
     "code-explain": [
@@ -658,7 +685,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/zoom-out/SKILL.md"
-        }
+        },
+        "role": "origin"
       }
     ],
     "multi-agent-orchestration-v": [
@@ -682,7 +710,8 @@
         ],
         "links": {
           "github": "https://github.com/ruvnet/ruflo"
-        }
+        },
+        "role": "origin"
       }
     ],
     "generate-test": [
@@ -706,7 +735,8 @@
         ],
         "links": {
           "github": "https://github.com/Upsonic/Upsonic"
-        }
+        },
+        "role": "origin"
       }
     ],
     "skill-discovery": [
@@ -729,7 +759,8 @@
         ],
         "links": {
           "github": "https://github.com/vercel-labs/skills/blob/main/skills/find-skills/SKILL.md"
-        }
+        },
+        "role": "origin"
       }
     ],
     "rag-pipeline": [
@@ -755,7 +786,8 @@
         ],
         "links": {
           "github": "https://github.com/yonatangross/orchestkit"
-        }
+        },
+        "role": "origin"
       }
     ]
   },

--- a/packages/mcp/src/graph/types.ts
+++ b/packages/mcp/src/graph/types.ts
@@ -102,6 +102,7 @@ export interface NamedSkill {
   name: string;
   contributor: string;
   origin: boolean;
+  role?: "origin" | "variant";
   genericSkillRef: string;
   status: "awakened" | "named";
   level: "2★" | "3★" | "4★" | "5★" | "6★";

--- a/packages/mcp/src/tools/lookup.ts
+++ b/packages/mcp/src/tools/lookup.ts
@@ -75,8 +75,8 @@ function formatNamedImplementations(named: NamedSkill[]): string {
     if (ns.links?.agentskills) linkParts.push(`[AgentSkills](${ns.links.agentskills})`);
     if (ns.links?.docs) linkParts.push(`[Docs](${ns.links.docs})`);
     const links = linkParts.length > 0 ? ` — ${linkParts.join(", ")}` : "";
-    const origin = ns.origin ? " ★ origin" : "";
-    lines.push(`- **${ns.name}** (${ns.id})${origin}${links}`);
+    const role = ns.role || (ns.origin ? "origin" : "variant");
+    lines.push(`- [${role}] **${ns.name}** (${ns.id})${links}`);
     lines.push(`  ${ns.description.slice(0, 120)}`);
   }
   return lines.join("\n");

--- a/registry/named-skills.json
+++ b/registry/named-skills.json
@@ -24,7 +24,8 @@
         ],
         "links": {
           "github": "https://github.com/aiskillstore/marketplace"
-        }
+        },
+        "role": "origin"
       }
     ],
     "test-driven-development": [
@@ -48,7 +49,8 @@
         ],
         "links": {
           "github": "https://github.com/addyosmani/agent-skills/blob/main/skills/test-driven-development/SKILL.md"
-        }
+        },
+        "role": "origin"
       },
       {
         "id": "mattpocock/tdd",
@@ -70,7 +72,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/tdd/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "document-editing": [
@@ -94,7 +97,8 @@
         ],
         "links": {
           "github": "https://github.com/anthropics/skills/blob/main/skills/pptx/SKILL.md"
-        }
+        },
+        "role": "origin"
       },
       {
         "id": "mattpocock/edit-article",
@@ -116,7 +120,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/personal/edit-article/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "tool-creation": [
@@ -139,7 +144,8 @@
         ],
         "links": {
           "github": "https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md"
-        }
+        },
+        "role": "origin"
       },
       {
         "id": "mattpocock/write-a-skill",
@@ -161,7 +167,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/productivity/write-a-skill/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "autonomous-debug": [
@@ -185,7 +192,8 @@
         ],
         "links": {
           "github": "https://github.com/cognition-labs/devin"
-        }
+        },
+        "role": "origin"
       },
       {
         "id": "mattpocock/diagnose",
@@ -207,7 +215,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/diagnose/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "write-report": [
@@ -230,7 +239,8 @@
         ],
         "links": {
           "github": "https://github.com/GLINCKER/claude-code-marketplace/blob/main/skills/documentation/readme-generator/SKILL.md"
-        }
+        },
+        "role": "origin"
       },
       {
         "id": "spring-ai/readme-generate",
@@ -252,7 +262,8 @@
         ],
         "links": {
           "github": "https://github.com/spring-ai-alibaba/examples/blob/main/.claude/skills/readme-generate/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "browser-automation": [
@@ -276,7 +287,8 @@
         ],
         "links": {
           "github": "https://github.com/gooseworks-ai/goose-skills"
-        }
+        },
+        "role": "origin"
       }
     ],
     "api-call": [
@@ -300,7 +312,8 @@
         ],
         "links": {
           "github": "https://github.com/huggingface/skills/blob/main/skills/hf-cli/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "data-analysis": [
@@ -324,7 +337,8 @@
         ],
         "links": {
           "github": "https://github.com/huggingface/skills/blob/main/skills/huggingface-datasets/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "fine-tune": [
@@ -348,7 +362,8 @@
         ],
         "links": {
           "github": "https://github.com/huggingface/skills/blob/main/skills/huggingface-llm-trainer/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "literature-review": [
@@ -372,7 +387,8 @@
         ],
         "links": {
           "github": "https://github.com/huggingface/skills/blob/main/skills/huggingface-papers/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "object-detection": [
@@ -396,7 +412,8 @@
         ],
         "links": {
           "github": "https://github.com/huggingface/skills/blob/main/skills/huggingface-vision-trainer/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "multimodal-reasoning": [
@@ -420,7 +437,8 @@
         ],
         "links": {
           "github": "https://github.com/huggingface/skills/blob/main/skills/transformers-js/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "autonomous-research-agent": [
@@ -442,7 +460,8 @@
         ],
         "links": {
           "github": "https://github.com/karpathy/autoresearch"
-        }
+        },
+        "role": "origin"
       }
     ],
     "framework-upgrade": [
@@ -465,7 +484,8 @@
         ],
         "links": {
           "github": "https://github.com/laravel/boost/issues/698"
-        }
+        },
+        "role": "origin"
       }
     ],
     "ux-audit": [
@@ -489,7 +509,8 @@
         ],
         "links": {
           "github": "https://github.com/mastepanoski/claude-skills/blob/main/skills/nielsen-heuristics-audit/SKILL.md"
-        }
+        },
+        "role": "origin"
       }
     ],
     "design-review": [
@@ -513,7 +534,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/productivity/grill-me/SKILL.md"
-        }
+        },
+        "role": "variant"
       },
       {
         "id": "mattpocock/grill-with-docs",
@@ -536,7 +558,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/grill-with-docs/SKILL.md"
-        }
+        },
+        "role": "origin"
       }
     ],
     "refactor-code": [
@@ -561,7 +584,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/improve-codebase-architecture/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "vertical-slice-planning": [
@@ -586,7 +610,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/to-issues/SKILL.md"
-        }
+        },
+        "role": "origin"
       }
     ],
     "prd-generation": [
@@ -610,7 +635,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/to-prd/SKILL.md"
-        }
+        },
+        "role": "origin"
       }
     ],
     "issue-triage": [
@@ -634,7 +660,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/triage/SKILL.md"
-        }
+        },
+        "role": "origin"
       }
     ],
     "code-explain": [
@@ -658,7 +685,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/zoom-out/SKILL.md"
-        }
+        },
+        "role": "origin"
       }
     ],
     "multi-agent-orchestration-v": [
@@ -682,7 +710,8 @@
         ],
         "links": {
           "github": "https://github.com/ruvnet/ruflo"
-        }
+        },
+        "role": "origin"
       }
     ],
     "generate-test": [
@@ -706,7 +735,8 @@
         ],
         "links": {
           "github": "https://github.com/Upsonic/Upsonic"
-        }
+        },
+        "role": "origin"
       }
     ],
     "skill-discovery": [
@@ -729,7 +759,8 @@
         ],
         "links": {
           "github": "https://github.com/vercel-labs/skills/blob/main/skills/find-skills/SKILL.md"
-        }
+        },
+        "role": "origin"
       }
     ],
     "rag-pipeline": [
@@ -755,7 +786,8 @@
         ],
         "links": {
           "github": "https://github.com/yonatangross/orchestkit"
-        }
+        },
+        "role": "origin"
       }
     ]
   },

--- a/scripts/generateNamedIndex.py
+++ b/scripts/generateNamedIndex.py
@@ -54,6 +54,11 @@ INDEX_SKILL_FIELDS = [
 ]
 
 
+def role_for_entry(entry):
+    """Return the display role for a named skill bucket entry."""
+    return "origin" if entry.get("origin") is True else "variant"
+
+
 def parse_frontmatter(text):
     """Parse YAML frontmatter from a markdown string.
 
@@ -316,6 +321,7 @@ def validate_and_group(named_skills, valid_ids):
         # Route by status: named → buckets (real variants); awakened → awaiting
         status = fm.get("status", "awakened")
         if status == "named":
+            entry["role"] = role_for_entry(entry)
             bucket_key = ref or "__unknown__"
             if bucket_key not in buckets:
                 buckets[bucket_key] = []

--- a/scripts/validate_intake.py
+++ b/scripts/validate_intake.py
@@ -103,8 +103,18 @@ def validate_schema(batch, schema, path):
         return [f"{path}: schema error: {exc.message}"]
 
 
-def validate_intake(intake_dir, graph_path, schema_path=None):
+def canonical_duplicate_warning(path, skill_id):
+    return (
+        f"{path}: Warning: '{skill_id}' already exists as a generic skill.\n"
+        f"  - To add a named implementation: create registry/named/<contributor>/{skill_id}.md\n"
+        "  - To reclassify or evolve the generic skill: use PR type [reclassify]\n"
+        "Treating this proposal as a named-skill submission. Review required."
+    )
+
+
+def validate_intake(intake_dir, graph_path, schema_path=None, strict=False):
     errors = []
+    warnings = []
     canonical_ids = load_canonical_ids(graph_path)
     schema = load_json(schema_path) if schema_path and HAS_JSONSCHEMA else None
     proposed_seen = {}
@@ -132,7 +142,11 @@ def validate_intake(intake_dir, graph_path, schema_path=None):
             if not skill_id:
                 continue
             if skill_id in canonical_ids:
-                errors.append(f"{path}: proposed skill '{skill_id}' duplicates canonical skill.")
+                message = canonical_duplicate_warning(path, skill_id)
+                if strict:
+                    errors.append(message)
+                else:
+                    warnings.append(message)
             if skill_id in proposed_seen:
                 errors.append(
                     f"{path}: Duplicate proposed skill '{skill_id}' also appears in {proposed_seen[skill_id]}."
@@ -149,24 +163,34 @@ def validate_intake(intake_dir, graph_path, schema_path=None):
             if target and target not in known_candidate_ids:
                 errors.append(f"{path}: similarity has unknown targetSkillId '{target}'.")
 
-    return errors, len(batches)
+    return errors, warnings, len(batches)
 
 
 def main():
+    if sys.platform == "win32" and hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
     parser = argparse.ArgumentParser(description="Validate Gaia intake skill batches.")
     repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     parser.add_argument("--intake-dir", default=os.path.join(repo_root, "registry-for-review"))
     parser.add_argument("--graph", default=os.path.join(repo_root, "registry", "gaia.json"))
     parser.add_argument("--schema", default=os.path.join(repo_root, "registry", "schema", "skillBatch.schema.json"))
+    parser.add_argument("--strict", action="store_true", help="Treat canonical skill ID proposals as errors.")
     args = parser.parse_args()
 
     if not HAS_JSONSCHEMA:
         print("⚠  jsonschema not installed — skipping intake schema validation.")
         print("   Install with: pip install jsonschema")
 
-    errors, total = validate_intake(args.intake_dir, args.graph, args.schema)
+    errors, warnings, total = validate_intake(args.intake_dir, args.graph, args.schema, strict=args.strict)
     print(f"Validating intake batches: {args.intake_dir}")
     print(f"Found {total} batch file(s).")
+
+    if warnings:
+        print(f"\n{len(warnings)} intake validation warning(s):")
+        for idx, warning in enumerate(warnings, 1):
+            print(f"   {idx}. {warning}")
 
     if errors:
         print(f"\n❌ {len(errors)} intake validation error(s):")

--- a/src/gaia_cli/data/registry/named-skills.json
+++ b/src/gaia_cli/data/registry/named-skills.json
@@ -9,7 +9,7 @@
         "origin": true,
         "genericSkillRef": "automated-testing",
         "status": "named",
-        "level": "3★",
+        "level": "3\u2605",
         "description": "Comprehensive pytest skill covering modern patterns for Python test automation including fixtures, parametrize, async testing, mocking, coverage strategies, integration tests, and conftest organisation for pytest 7.0+ projects.",
         "title": "The Quality Guardian",
         "catalogRef": "0xdarkmatter-pytest-patterns",
@@ -24,7 +24,8 @@
         ],
         "links": {
           "github": "https://github.com/aiskillstore/marketplace"
-        }
+        },
+        "role": "origin"
       }
     ],
     "test-driven-development": [
@@ -35,7 +36,7 @@
         "origin": true,
         "genericSkillRef": "test-driven-development",
         "status": "named",
-        "level": "2★",
+        "level": "2\u2605",
         "description": "Forces the AI agent to follow a strict red-green-refactor TDD workflow \u2014 writing failing tests before any implementation code, blocking code generation that skips the test step, and enforcing coverage thresholds before completing a task.",
         "title": "The Red-Green Oath",
         "catalogRef": "addy-osmani-test-driven-development",
@@ -48,7 +49,8 @@
         ],
         "links": {
           "github": "https://github.com/addyosmani/agent-skills/blob/main/skills/test-driven-development/SKILL.md"
-        }
+        },
+        "role": "origin"
       },
       {
         "id": "mattpocock/tdd",
@@ -57,7 +59,7 @@
         "origin": false,
         "genericSkillRef": "test-driven-development",
         "status": "named",
-        "level": "3★",
+        "level": "3\u2605",
         "description": "Enforces strict vertical-slice TDD \u2014 one test then one implementation at a time \u2014 explicitly blocking horizontal slicing (all tests first, then all code). Tests verify behaviour through public interfaces only; mocking internal collaborators is treated as an anti-pattern.",
         "title": "Vertical-Slice TDD",
         "catalogRef": "mattpocock-tdd",
@@ -70,7 +72,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/tdd/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "document-editing": [
@@ -81,7 +84,7 @@
         "origin": true,
         "genericSkillRef": "document-editing",
         "status": "named",
-        "level": "2★",
+        "level": "2\u2605",
         "description": "Extracts slide content from PowerPoint (.pptx) files using markitdown, applies edits or design principles in-place, and repacks the file \u2014 enabling agents to read, modify, and write structured presentation files without a GUI.",
         "title": "The Slide Artisan",
         "catalogRef": "anthropic-pptx",
@@ -94,7 +97,8 @@
         ],
         "links": {
           "github": "https://github.com/anthropics/skills/blob/main/skills/pptx/SKILL.md"
-        }
+        },
+        "role": "origin"
       },
       {
         "id": "mattpocock/edit-article",
@@ -103,7 +107,7 @@
         "origin": false,
         "genericSkillRef": "document-editing",
         "status": "named",
-        "level": "2★",
+        "level": "2\u2605",
         "description": "Edits articles by first sectioning them as a DAG of information dependencies, confirming the section order, then rewriting each section for clarity and flow with a 240-character-per-paragraph constraint.",
         "title": "The Section-by-Section Rewrite",
         "catalogRef": "mattpocock-edit-article",
@@ -116,7 +120,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/personal/edit-article/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "tool-creation": [
@@ -127,7 +132,7 @@
         "origin": true,
         "genericSkillRef": "tool-creation",
         "status": "named",
-        "level": "2★",
+        "level": "2\u2605",
         "description": "Interviews the user through a structured dialogue to elicit the skill's purpose, trigger conditions, and step-by-step instructions, then programmatically writes a new SKILL.md file ready for use in a Claude Code or Codex CLI skills directory.",
         "title": "The Skill Forger's Art",
         "catalogRef": "anthropic-skill-creator",
@@ -139,7 +144,8 @@
         ],
         "links": {
           "github": "https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md"
-        }
+        },
+        "role": "origin"
       },
       {
         "id": "mattpocock/write-a-skill",
@@ -148,7 +154,7 @@
         "origin": false,
         "genericSkillRef": "tool-creation",
         "status": "named",
-        "level": "3★",
+        "level": "3\u2605",
         "description": "Guides creation of new agent skills through a structured requirements interview, then produces a SKILL.md with a trigger-aware description, progressive-disclosure layout, and optional bundled scripts or reference files \u2014 ready for installation in any Claude Code, Cursor, or Codex CLI skills directory.",
         "title": "The Skill Scaffolder",
         "catalogRef": "mattpocock-write-a-skill",
@@ -161,7 +167,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/productivity/write-a-skill/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "autonomous-debug": [
@@ -172,7 +179,7 @@
         "origin": true,
         "genericSkillRef": "autonomous-debug",
         "status": "named",
-        "level": "3★",
+        "level": "3\u2605",
         "description": "Autonomous software engineering agent capable of end-to-end debugging, code generation, and self-correction across complex multi-file codebases.",
         "title": "The Codebreaker's Will",
         "catalogRef": "devin-ai-autonomous-swe",
@@ -185,7 +192,8 @@
         ],
         "links": {
           "github": "https://github.com/cognition-labs/devin"
-        }
+        },
+        "role": "origin"
       },
       {
         "id": "mattpocock/diagnose",
@@ -194,7 +202,7 @@
         "origin": false,
         "genericSkillRef": "autonomous-debug",
         "status": "named",
-        "level": "2★",
+        "level": "2\u2605",
         "description": "Drives a rigorous five-phase debugging discipline \u2014 build a feedback loop, minimise, hypothesise, instrument, fix and regression-test \u2014 refusing to proceed until a fast deterministic pass/fail signal exists. Applies to hard bugs and performance regressions.",
         "title": "The Disciplined Diagnosis Loop",
         "catalogRef": "mattpocock-diagnose",
@@ -207,7 +215,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/diagnose/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "write-report": [
@@ -218,7 +227,7 @@
         "origin": true,
         "genericSkillRef": "write-report",
         "status": "named",
-        "level": "2★",
+        "level": "2\u2605",
         "description": "Analyzes a project's directory structure, dependency manifests, and configuration files to generate a professional README.md covering installation, usage, API reference, and contributing guidelines.",
         "title": "The Document Weaver",
         "catalogRef": "glincker-readme-generator",
@@ -230,7 +239,8 @@
         ],
         "links": {
           "github": "https://github.com/GLINCKER/claude-code-marketplace/blob/main/skills/documentation/readme-generator/SKILL.md"
-        }
+        },
+        "role": "origin"
       },
       {
         "id": "spring-ai/readme-generate",
@@ -239,7 +249,7 @@
         "origin": false,
         "genericSkillRef": "write-report",
         "status": "named",
-        "level": "2★",
+        "level": "2\u2605",
         "description": "Scans a Java Spring project for controller annotations, extracts REST API endpoint definitions, and automatically generates structured API documentation in README format.",
         "title": "The Endpoint Scribe",
         "catalogRef": "spring-ai-readme-generate",
@@ -252,7 +262,8 @@
         ],
         "links": {
           "github": "https://github.com/spring-ai-alibaba/examples/blob/main/.claude/skills/readme-generate/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "browser-automation": [
@@ -263,7 +274,7 @@
         "origin": true,
         "genericSkillRef": "browser-automation",
         "status": "named",
-        "level": "3★",
+        "level": "3\u2605",
         "description": "AI-first browser automation using the Notte Browser API to control browser sessions, scrape pages, fill forms, take screenshots, and run autonomous web agents with managed credential handling.",
         "title": "The Digital Navigator",
         "catalogRef": "gooseworks-notte-browser",
@@ -276,7 +287,8 @@
         ],
         "links": {
           "github": "https://github.com/gooseworks-ai/goose-skills"
-        }
+        },
+        "role": "origin"
       }
     ],
     "api-call": [
@@ -287,7 +299,7 @@
         "origin": false,
         "genericSkillRef": "api-call",
         "status": "named",
-        "level": "2★",
+        "level": "2\u2605",
         "description": "Guides Hugging Face Hub CLI operations for downloading, uploading, managing repos, running Jobs, querying datasets, configuring Spaces, and handling Hub authentication.",
         "title": "The Hub Operator",
         "catalogRef": "huggingface-hf-cli",
@@ -300,7 +312,8 @@
         ],
         "links": {
           "github": "https://github.com/huggingface/skills/blob/main/skills/hf-cli/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "data-analysis": [
@@ -311,7 +324,7 @@
         "origin": false,
         "genericSkillRef": "data-analysis",
         "status": "named",
-        "level": "2★",
+        "level": "2\u2605",
         "description": "Explores Hugging Face datasets through the Dataset Viewer API, resolving configs and splits, previewing rows, paginating records, searching text, filtering rows, and retrieving parquet metadata.",
         "title": "The Dataset Cartographer",
         "catalogRef": "huggingface-datasets",
@@ -324,7 +337,8 @@
         ],
         "links": {
           "github": "https://github.com/huggingface/skills/blob/main/skills/huggingface-datasets/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "fine-tune": [
@@ -335,7 +349,7 @@
         "origin": false,
         "genericSkillRef": "fine-tune",
         "status": "named",
-        "level": "3★",
+        "level": "3\u2605",
         "description": "Runs LLM fine-tuning on Hugging Face Jobs using TRL or Unsloth, covering SFT, DPO, GRPO, reward modeling, dataset validation, hardware selection, Trackio monitoring, and Hub persistence.",
         "title": "The Cloud Fine-Tuner",
         "catalogRef": "huggingface-llm-trainer",
@@ -348,7 +362,8 @@
         ],
         "links": {
           "github": "https://github.com/huggingface/skills/blob/main/skills/huggingface-llm-trainer/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "literature-review": [
@@ -359,7 +374,7 @@
         "origin": false,
         "genericSkillRef": "literature-review",
         "status": "named",
-        "level": "2★",
+        "level": "2\u2605",
         "description": "Looks up Hugging Face paper pages and arXiv IDs, fetching markdown paper content and structured metadata such as authors, linked models, datasets, Spaces, GitHub repos, and project pages.",
         "title": "The Paper Indexer",
         "catalogRef": "huggingface-papers",
@@ -372,7 +387,8 @@
         ],
         "links": {
           "github": "https://github.com/huggingface/skills/blob/main/skills/huggingface-papers/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "object-detection": [
@@ -383,7 +399,7 @@
         "origin": false,
         "genericSkillRef": "object-detection",
         "status": "named",
-        "level": "3★",
+        "level": "3\u2605",
         "description": "Trains and fine-tunes object detection, image classification, and SAM/SAM2 segmentation models on Hugging Face Jobs or locally with dataset validation, metrics, Trackio, and Hub persistence.",
         "title": "The Vision Forge",
         "catalogRef": "huggingface-vision-trainer",
@@ -396,7 +412,8 @@
         ],
         "links": {
           "github": "https://github.com/huggingface/skills/blob/main/skills/huggingface-vision-trainer/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "multimodal-reasoning": [
@@ -407,7 +424,7 @@
         "origin": false,
         "genericSkillRef": "multimodal-reasoning",
         "status": "named",
-        "level": "2★",
+        "level": "2\u2605",
         "description": "Runs Hugging Face Transformers.js models directly in JavaScript and TypeScript across browser and server runtimes for NLP, vision, audio, and multimodal inference with WebGPU or WASM.",
         "title": "The Browser Modelwright",
         "catalogRef": "huggingface-transformers-js",
@@ -420,7 +437,8 @@
         ],
         "links": {
           "github": "https://github.com/huggingface/skills/blob/main/skills/transformers-js/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "autonomous-research-agent": [
@@ -431,7 +449,7 @@
         "origin": true,
         "genericSkillRef": "autonomous-research-agent",
         "status": "named",
-        "level": "6★",
+        "level": "6\u2605",
         "description": "Autonomous research agent that iteratively searches, reads, and synthesizes academic papers into structured summaries.",
         "title": "The Scholar's Compass",
         "catalogRef": "karpathy-autoresearch",
@@ -442,7 +460,8 @@
         ],
         "links": {
           "github": "https://github.com/karpathy/autoresearch"
-        }
+        },
+        "role": "origin"
       }
     ],
     "framework-upgrade": [
@@ -453,7 +472,7 @@
         "origin": true,
         "genericSkillRef": "framework-upgrade",
         "status": "named",
-        "level": "2★",
+        "level": "2\u2605",
         "description": "Guides an AI agent through upgrading a Laravel 12 application to Laravel 13 safely, covering breaking changes, dependency updates, config migrations, and post-upgrade test validation.",
         "title": "The Versionist's Trial",
         "catalogRef": "laravel-upgrade-laravel-v13",
@@ -465,7 +484,8 @@
         ],
         "links": {
           "github": "https://github.com/laravel/boost/issues/698"
-        }
+        },
+        "role": "origin"
       }
     ],
     "ux-audit": [
@@ -476,7 +496,7 @@
         "origin": true,
         "genericSkillRef": "ux-audit",
         "status": "named",
-        "level": "2★",
+        "level": "2\u2605",
         "description": "Audits a UI interface against Jakob Nielsen's 10 usability heuristics step-by-step, scoring each heuristic, surfacing violations, and producing a prioritized remediation report.",
         "title": "The Ten Laws of Sight",
         "catalogRef": "martin-stepanoski-nielsen-heuristics-audit",
@@ -489,7 +509,8 @@
         ],
         "links": {
           "github": "https://github.com/mastepanoski/claude-skills/blob/main/skills/nielsen-heuristics-audit/SKILL.md"
-        }
+        },
+        "role": "origin"
       }
     ],
     "design-review": [
@@ -500,7 +521,7 @@
         "origin": false,
         "genericSkillRef": "design-review",
         "status": "named",
-        "level": "2★",
+        "level": "2\u2605",
         "description": "Conducts a relentless one-question-at-a-time interview about a plan or design, walking every branch of the decision tree with a recommended answer per question, resolving dependencies in order, and substituting codebase exploration wherever a question can be answered empirically.",
         "title": "The Relentless Interviewer",
         "catalogRef": "mattpocock-grill-me",
@@ -513,7 +534,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/productivity/grill-me/SKILL.md"
-        }
+        },
+        "role": "variant"
       },
       {
         "id": "mattpocock/grill-with-docs",
@@ -522,7 +544,7 @@
         "origin": true,
         "genericSkillRef": "design-review",
         "status": "named",
-        "level": "3★",
+        "level": "3\u2605",
         "description": "Stress-tests a plan against the project's domain model by relentlessly questioning each design decision one at a time, surfacing language conflicts with CONTEXT.md, cross-referencing code contradictions, and crystallising decisions as inline CONTEXT.md updates and ADRs as they are resolved.",
         "title": "The Domain-Aware Interrogator",
         "catalogRef": "mattpocock-grill-with-docs",
@@ -536,7 +558,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/grill-with-docs/SKILL.md"
-        }
+        },
+        "role": "origin"
       }
     ],
     "refactor-code": [
@@ -547,7 +570,7 @@
         "origin": false,
         "genericSkillRef": "refactor-code",
         "status": "named",
-        "level": "3★",
+        "level": "3\u2605",
         "description": "Identifies architectural deepening opportunities in a codebase \u2014 shallow modules with high interface-to-implementation ratios \u2014 using domain-glossary vocabulary and the deletion test, then grills the developer on the chosen candidate to design a deep-module replacement with better locality and testability.",
         "title": "The Depth Seeker",
         "catalogRef": "mattpocock-improve-codebase-architecture",
@@ -561,7 +584,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/improve-codebase-architecture/SKILL.md"
-        }
+        },
+        "role": "variant"
       }
     ],
     "vertical-slice-planning": [
@@ -572,7 +596,7 @@
         "origin": true,
         "genericSkillRef": "vertical-slice-planning",
         "status": "named",
-        "level": "3★",
+        "level": "3\u2605",
         "description": "Breaks a plan, spec, or PRD into independently-grabbable GitHub issues as tracer-bullet vertical slices that each cut through all integration layers end-to-end. Classifies each slice HITL or AFK, maps dependency chains, quizzes the user on granularity, and publishes structured issues with acceptance criteria in dependency order.",
         "title": "The Vertical Slicer",
         "catalogRef": "mattpocock-to-issues",
@@ -586,7 +610,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/to-issues/SKILL.md"
-        }
+        },
+        "role": "origin"
       }
     ],
     "prd-generation": [
@@ -597,7 +622,7 @@
         "origin": true,
         "genericSkillRef": "prd-generation",
         "status": "named",
-        "level": "2★",
+        "level": "2\u2605",
         "description": "Synthesises the current conversation context and codebase knowledge into a fully-structured PRD \u2014 problem statement, extensive numbered user stories, implementation decisions (modules, interfaces, schema), testing decisions, and out-of-scope items \u2014 then publishes it to the project issue tracker.",
         "title": "The PRD Synthesiser",
         "catalogRef": "mattpocock-to-prd",
@@ -610,7 +635,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/to-prd/SKILL.md"
-        }
+        },
+        "role": "origin"
       }
     ],
     "issue-triage": [
@@ -621,7 +647,7 @@
         "origin": true,
         "genericSkillRef": "issue-triage",
         "status": "named",
-        "level": "3★",
+        "level": "3\u2605",
         "description": "Moves GitHub issues through a two-category (bug/enhancement) \u00d7 five-state (needs-triage/needs-info/ready-for-agent/ready-for-human/wontfix) state machine. Reproduces bugs from issue steps, runs a domain-aware grilling session when needed, writes structured agent briefs, and appends AI-generated triage notes with the required disclaimer.",
         "title": "The State-Machine Triager",
         "catalogRef": "mattpocock-triage",
@@ -634,7 +660,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/triage/SKILL.md"
-        }
+        },
+        "role": "origin"
       }
     ],
     "code-explain": [
@@ -645,7 +672,7 @@
         "origin": true,
         "genericSkillRef": "code-explain",
         "status": "named",
-        "level": "2★",
+        "level": "2\u2605",
         "description": "Signals the agent to ascend one layer of abstraction and produce a map of all relevant modules, callers, and domain-glossary terms in the unfamiliar code area, without explaining implementation details.",
         "title": "The Abstraction Lift",
         "catalogRef": "mattpocock-zoom-out",
@@ -658,7 +685,8 @@
         ],
         "links": {
           "github": "https://github.com/mattpocock/skills/blob/main/skills/engineering/zoom-out/SKILL.md"
-        }
+        },
+        "role": "origin"
       }
     ],
     "multi-agent-orchestration-v": [
@@ -669,7 +697,7 @@
         "origin": true,
         "genericSkillRef": "multi-agent-orchestration-v",
         "status": "named",
-        "level": "3★",
+        "level": "3\u2605",
         "description": "Cloud-based AI swarm orchestration platform supporting hierarchical, mesh, ring, and star topologies with event-driven workflows, message queue processing, and intelligent agent assignment.",
         "title": "The Grand Conductor's Blueprint",
         "catalogRef": "ruvnet-flow-nexus-swarm",
@@ -682,7 +710,8 @@
         ],
         "links": {
           "github": "https://github.com/ruvnet/ruflo"
-        }
+        },
+        "role": "origin"
       }
     ],
     "generate-test": [
@@ -693,7 +722,7 @@
         "origin": true,
         "genericSkillRef": "generate-test",
         "status": "named",
-        "level": "2★",
+        "level": "2\u2605",
         "description": "Autonomous Claude agent that generates comprehensive unittest.TestCase suites from source code, organising tests into concept-based subfolders under a tests/ directory with proper imports, fixtures, and edge-case coverage.",
         "title": "The Test Weaver",
         "catalogRef": "upsonic-unittest-generator",
@@ -706,7 +735,8 @@
         ],
         "links": {
           "github": "https://github.com/Upsonic/Upsonic"
-        }
+        },
+        "role": "origin"
       }
     ],
     "skill-discovery": [
@@ -717,7 +747,7 @@
         "origin": true,
         "genericSkillRef": "skill-discovery",
         "status": "named",
-        "level": "2★",
+        "level": "2\u2605",
         "description": "Searches the skills.sh registry by keyword or category, queries install counts to surface popular skills, and auto-installs the selected skill into the current project's skills directory.",
         "title": "The Registry Scout",
         "catalogRef": "vercel-find-skills",
@@ -729,7 +759,8 @@
         ],
         "links": {
           "github": "https://github.com/vercel-labs/skills/blob/main/skills/find-skills/SKILL.md"
-        }
+        },
+        "role": "origin"
       }
     ],
     "rag-pipeline": [
@@ -740,7 +771,7 @@
         "origin": true,
         "genericSkillRef": "rag-pipeline",
         "status": "named",
-        "level": "3★",
+        "level": "3\u2605",
         "description": "Production-grade RAG retrieval skill covering 30+ patterns including core pipeline composition, HyDE query expansion, pgvector hybrid search, cross-encoder reranking, multimodal chunking, and agentic self-RAG and corrective-RAG loops.",
         "title": "The Knowledge Architect",
         "catalogRef": "yonatangross-orchestkit-rag",
@@ -755,11 +786,32 @@
         ],
         "links": {
           "github": "https://github.com/yonatangross/orchestkit"
-        }
+        },
+        "role": "origin"
       }
     ]
   },
   "awaitingClassification": [
+    {
+      "id": "gaiabot/gaia-triage",
+      "name": "Gaia Triage (Internal)",
+      "contributor": "gaiabot",
+      "origin": false,
+      "genericSkillRef": "gaia-triage",
+      "status": "awakened",
+      "level": "2\u2605",
+      "description": "Automates repository triage for the Gaia Skill Tree, including fixing documentation drift, managing build dependencies (build, setuptools, wheel), and synchronizing generated graph projections and GEXF exports.",
+      "tags": [
+        "maintenance",
+        "triage",
+        "automation",
+        "ci-fix",
+        "packaging"
+      ],
+      "links": {
+        "repo": "https://github.com/mbtiongson1/gaia-skill-tree"
+      }
+    },
     {
       "id": "gaiabot/repo-docs-before-pr",
       "name": "Repo Docs Before PR",
@@ -767,7 +819,7 @@
       "origin": false,
       "genericSkillRef": "write-report",
       "status": "awakened",
-      "level": "2★",
+      "level": "2\u2605",
       "description": "Builds and validates repository documentation as a pre-PR guardrail by reminding contributors to run the local docs drift check, then surfaces actionable regeneration commands so pull requests do not fail CI on documentation freshness.",
       "tags": [
         "documentation",
@@ -787,7 +839,7 @@
       "origin": "https://github.com/intelligentcode-ai/skills/blob/main/skills/database-engineer/SKILL.md",
       "genericSkillRef": "schema-design",
       "status": "awakened",
-      "level": "2★",
+      "level": "2\u2605",
       "description": "Schema design and query optimization expert across relational, NoSQL, graph, time-series, and data warehouse stores with sub-second response targets.",
       "tags": [
         "database",
@@ -806,7 +858,7 @@
       "origin": "https://github.com/intelligentcode-ai/skills/blob/main/skills/devops-engineer/SKILL.md",
       "genericSkillRef": "deployment-automation",
       "status": "awakened",
-      "level": "2★",
+      "level": "2\u2605",
       "description": "CI/CD pipeline design and deployment automation specialist \u2014 build systems, artifact publishing, environment promotion, and rollback strategies.",
       "tags": [
         "cicd",
@@ -825,7 +877,7 @@
       "origin": "https://github.com/intelligentcode-ai/skills/blob/main/skills/mcp-client/SKILL.md",
       "genericSkillRef": "mcp-integration",
       "status": "awakened",
-      "level": "3★",
+      "level": "3\u2605",
       "description": "Portable CLI tool that connects to MCP servers on-demand, enumerates available tools, displays them, and executes calls \u2014 works with any MCP-compatible backend without platform lock-in.",
       "tags": [
         "mcp",
@@ -841,7 +893,7 @@
       "origin": "https://github.com/intelligentcode-ai/skills/blob/main/skills/parallel-execution/SKILL.md",
       "genericSkillRef": "parallel-execution",
       "status": "awakened",
-      "level": "2★",
+      "level": "2\u2605",
       "description": "Manages concurrent work item execution with independence verification, queue-based state tracking, and configurable concurrency limits (default 5).",
       "tags": [
         "parallelism",
@@ -857,7 +909,7 @@
       "origin": "https://github.com/intelligentcode-ai/skills/blob/main/skills/release/SKILL.md",
       "genericSkillRef": "release-automation",
       "status": "awakened",
-      "level": "2★",
+      "level": "2\u2605",
       "description": "Automates the full release cycle \u2014 semantic version bump, CHANGELOG update, PR merge, git tag, and GitHub release creation with multiple verification gates.",
       "tags": [
         "release",
@@ -875,7 +927,7 @@
       "origin": "https://github.com/intelligentcode-ai/skills/blob/main/skills/requirements-engineer/SKILL.md",
       "genericSkillRef": "requirements-analysis",
       "status": "awakened",
-      "level": "2★",
+      "level": "2\u2605",
       "description": "Business analysis specialist bridging stakeholders and technical teams \u2014 requirements gathering, user story writing, acceptance criteria, and full requirements lifecycle management.",
       "tags": [
         "requirements",
@@ -892,7 +944,7 @@
       "origin": "https://github.com/intelligentcode-ai/skills/blob/main/skills/security-engineer/SKILL.md",
       "genericSkillRef": "security-audit",
       "status": "awakened",
-      "level": "2★",
+      "level": "2\u2605",
       "description": "Security architecture specialist \u2014 vulnerability assessment, zero-trust design, compliance management, and incident response with severity-classified remediation guidance.",
       "tags": [
         "security",
@@ -910,7 +962,7 @@
       "origin": "https://github.com/intelligentcode-ai/skills/blob/main/skills/user-tester/SKILL.md",
       "genericSkillRef": "e2e-testing",
       "status": "awakened",
-      "level": "3★",
+      "level": "3\u2605",
       "description": "E2E testing specialist with Puppeteer/Playwright automation \u2014 cross-browser validation, full user journey simulation, and visual regression detection.",
       "tags": [
         "e2e",
@@ -937,6 +989,7 @@
       "devin-ai/autonomous-swe"
     ],
     "gaiabot": [
+      "gaiabot/gaia-triage",
       "gaiabot/repo-docs-before-pr"
     ],
     "glincker": [

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -25,6 +25,7 @@ from gaia_cli.registry import (
     generated_output_dir,
     embeddings_path,
     named_skills_dir,
+    named_skills_index_path,
     promotion_candidates_path,
     registry_graph_path,
     skill_batches_dir,
@@ -95,6 +96,7 @@ Quick usage:
   gaia update
   gaia stats
   gaia docs build [--check]
+  gaia lookup <skillId>
   gaia skills <list|search|info|install|uninstall>
   gaia skills list [--exclude-pending]
   gaia skills search <query> [--exclude-pending]
@@ -129,6 +131,7 @@ PUBLIC_COMMANDS = (
     "promote",
     "fuse",
     "docs",
+    "lookup",
     "update",
     "skills",
 )
@@ -395,6 +398,61 @@ def promote_all_candidates(username: str, registry_path: str) -> list[dict]:
             registry_path,
         ))
     return promoted
+
+
+def _entry_role(entry):
+    return entry.get("role") or ("origin" if entry.get("origin") is True else "variant")
+
+
+def lookup_command(args):
+    graph_path = registry_graph_path(args.registry)
+    if not os.path.exists(graph_path):
+        print("Registry graph not found.", file=sys.stderr)
+        sys.exit(1)
+
+    with open(graph_path, "r", encoding="utf-8") as f:
+        graph_data = json.load(f)
+
+    query = args.skillId.strip().lstrip("/")
+    skill_map = {s["id"]: s for s in graph_data.get("skills", [])}
+    skill = skill_map.get(query)
+    if not skill:
+        matches = [
+            s for s in graph_data.get("skills", [])
+            if query.lower() in s.get("id", "").lower()
+            or query.lower() in s.get("name", "").lower()
+        ]
+        if len(matches) == 1:
+            skill = matches[0]
+        else:
+            print(f"Skill '{query}' not found.", file=sys.stderr)
+            if matches:
+                print("Matches:")
+                for candidate in matches[:10]:
+                    print(f"  /{candidate['id']} - {candidate.get('name', candidate['id'])}")
+            sys.exit(1)
+
+    skill_id = skill["id"]
+    print(f"/{skill_id} - {skill.get('name', skill_id)}")
+    print(f"Type: {skill.get('type', 'unknown')}    Level: {skill.get('level', '?')}")
+    if skill.get("description"):
+        print(skill["description"])
+
+    named_path = named_skills_index_path(args.registry)
+    named_index = {}
+    if os.path.exists(named_path):
+        with open(named_path, "r", encoding="utf-8") as f:
+            named_index = json.load(f)
+    entries = named_index.get("buckets", {}).get(skill_id, [])
+    if entries:
+        print("\nNamed implementations:")
+        for entry in entries:
+            role = _entry_role(entry)
+            name = entry.get("name") or entry.get("id", "unknown")
+            entry_id = entry.get("id", "unknown")
+            print(f"- [{role}] {name} ({entry_id})")
+    else:
+        print("\nNamed implementations: none")
 
 def status_command(args):
     config = load_config()
@@ -1204,6 +1262,8 @@ def get_parser():
     docs_sub = docs_parser.add_subparsers(dest='docs_command')
     docs_build = docs_sub.add_parser('build', help="Regenerate generated documentation regions")
     docs_build.add_argument('--check', action='store_true', help="Fail if docs are stale without writing")
+    lookup_parser = subparsers.add_parser('lookup', help="Look up a canonical skill and its named implementations")
+    lookup_parser.add_argument('skillId', help='Skill ID to inspect')
     skills_parser = subparsers.add_parser(
         'skills',
         help="Browse and manage named skills",
@@ -1279,6 +1339,8 @@ def main():
         fuse_command(args)
     elif args.command == 'docs' and getattr(args, 'docs_command', None) == 'build':
         docs_command(args)
+    elif args.command == 'lookup':
+        lookup_command(args)
     elif args.command == 'skills':
         if not getattr(args, 'skills_command', None):
             skills_parser.print_help()

--- a/tests/test_dx.py
+++ b/tests/test_dx.py
@@ -115,6 +115,7 @@ def test_top_level_help_shows_all_public_commands_with_usage(monkeypatch, capsys
         "appraise",
         "promote",
         "docs",
+        "lookup",
         "skills",
     ]:
         assert command in output
@@ -147,6 +148,26 @@ def test_promote_label_override_is_not_available(monkeypatch):
     with pytest.raises(SystemExit) as exc:
         run_cli(monkeypatch, ["promote", "web-search", "--label", "3★"])
     assert exc.value.code == 2
+
+
+def test_lookup_lists_named_implementation_roles(tmp_path, monkeypatch, capsys):
+    registry = tmp_path / "registry"
+    registry.mkdir()
+    (registry / "gaia.json").write_text(
+        '{"skills":[{"id":"web-search","name":"Web Search","type":"basic","level":"1★","description":"Find web pages.","prerequisites":[]}]}',
+        encoding="utf-8",
+    )
+    (registry / "named-skills.json").write_text(
+        '{"buckets":{"web-search":[{"id":"alice/search","name":"Alice Search","origin":true,"role":"origin"},{"id":"bob/search","name":"Bob Search","origin":false,"role":"variant"}]}}',
+        encoding="utf-8",
+    )
+
+    run_cli(monkeypatch, ["--registry", str(tmp_path), "lookup", "web-search"])
+
+    output = capsys.readouterr().out
+    assert "/web-search - Web Search" in output
+    assert "[origin] Alice Search (alice/search)" in output
+    assert "[variant] Bob Search (bob/search)" in output
 
 
 def parse_config(path):

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -10,7 +10,7 @@ VALIDATE_INTAKE_SCRIPT = os.path.join(REPO_ROOT, "scripts", "validate_intake.py"
 GRAPH_PATH = os.path.join(REPO_ROOT, "registry", "gaia.json")
 
 
-def run_validate_intake(intake_dir):
+def run_validate_intake(intake_dir, *extra_args):
     env = os.environ.copy()
     env["PYTHONIOENCODING"] = "utf-8"
     result = subprocess.run(
@@ -21,6 +21,7 @@ def run_validate_intake(intake_dir):
             intake_dir,
             "--graph",
             GRAPH_PATH,
+            *extra_args,
         ],
         capture_output=True,
         text=True,
@@ -68,12 +69,21 @@ class TestIntakeValidation(unittest.TestCase):
             self.assertEqual(code, 0, out)
             self.assertIn("All intake checks passed.", out)
 
-    def test_duplicate_proposed_id_against_canonical_fails(self):
+    def test_duplicate_proposed_id_against_canonical_warns(self):
         with tempfile.TemporaryDirectory() as tmp:
             write_batch(tmp, "batch-one", proposed_id="web-search")
             code, out = run_validate_intake(tmp)
+            self.assertEqual(code, 0, out)
+            self.assertIn("already exists as a generic skill", out)
+            self.assertIn("Treating this proposal as a named-skill submission", out)
+            self.assertIn("All intake checks passed.", out)
+
+    def test_strict_duplicate_proposed_id_against_canonical_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            write_batch(tmp, "batch-one", proposed_id="web-search")
+            code, out = run_validate_intake(tmp, "--strict")
             self.assertEqual(code, 1)
-            self.assertIn("duplicates canonical skill", out)
+            self.assertIn("already exists as a generic skill", out)
 
     def test_duplicate_proposed_ids_across_batches_fail(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_named_skills.py
+++ b/tests/test_named_skills.py
@@ -95,6 +95,8 @@ class TestNamedSkillIndexGeneration(unittest.TestCase):
         self.assertEqual(errors, [])
         self.assertIn("web-search", buckets)
         self.assertEqual(len(buckets["web-search"]), 2)
+        self.assertEqual(buckets["web-search"][0]["role"], "origin")
+        self.assertEqual(buckets["web-search"][1]["role"], "variant")
         self.assertIn("code-generation", buckets)
         self.assertEqual(len(buckets["code-generation"]), 1)
 

--- a/uv.lock
+++ b/uv.lock
@@ -349,7 +349,7 @@ wheels = [
 
 [[package]]
 name = "gaia-cli"
-version = "3.1.1"
+version = "3.1.10"
 source = { editable = "." }
 dependencies = [
     { name = "jsonschema" },


### PR DESCRIPTION
This PR adds a new \gaia lookup\ command to the CLI, allowing users to inspect canonical skills and their named implementations directly. It also introduces a \ole\ attribute for named skills to distinguish between 'origin' and 'variant' implementations, and updates the intake validation to be more flexible with duplicate IDs.