### PR TITLE
feat(cli): comprehensive Local-First audit and platform fixes

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -480,46 +480,40 @@
     90% {color:#34d399;text-shadow:0 0 10px rgba(52,211,153,.8),0 0 22px rgba(52,211,153,.4)}
     100%{color:#38bdf8;text-shadow:0 0 10px rgba(56,189,248,.8),0 0 22px rgba(56,189,248,.4)}
   }
-  .tree-dialog-body pre .tree-ult-line{font-weight:700!important}
-  .tree-dialog-body pre .tree-ult-contributor{color:#ef4444!important;font-weight:800!important;text-shadow:0 0 8px rgba(239,68,68,.6)!important}
-  .tree-dialog-body pre .tree-ult-slash{color:var(--muted)!important}
-  .tree-dialog-body pre .tree-ult-skillname,
-  .tree-dialog-body pre .tree-ult-id{color:#f59e0b!important}
+  /* ── Tree Highlighting ── */
+  .tree-ult-line { font-weight: 700 !important; color: var(--text) !important; }
+  .tree-ult-contributor { color: #ef4444 !important; font-weight: 800 !important; text-shadow: 0 0 8px rgba(239,68,68,0.4) !important; }
+  .tree-ult-slash { color: var(--muted) !important; opacity: 0.5 !important; }
+  .tree-ult-skillname, .tree-ult-id { color: #f59e0b !important; font-weight: 700 !important; }
   
-  .tree-dialog-body pre .tree-unique-line{font-weight:700!important}
-  .tree-dialog-body pre .tree-unique-contributor{color:#ef4444!important;font-weight:800!important}
-  .tree-dialog-body pre .tree-unique-slash{color:var(--muted)!important}
-  .tree-dialog-body pre .tree-unique-skillname{
-    color:#000!important;
-    font-weight:900!important;
-    text-shadow: 
-      0 0 8px rgba(124,58,237,.8),
-      0 0 16px rgba(124,58,237,.4)!important;
-    -webkit-text-stroke: 1px rgba(124,58,237,.5)!important;
+  .tree-unique-line { font-weight: 700 !important; color: var(--text) !important; }
+  .tree-unique-contributor { color: #ef4444 !important; font-weight: 800 !important; }
+  .tree-unique-slash { color: var(--muted) !important; opacity: 0.5 !important; }
+  .tree-unique-skillname {
+    color: #000 !important;
+    font-weight: 900 !important;
+    text-shadow: 0 0 8px #7c3aed, 0 0 16px rgba(124,58,237,0.4) !important;
+    -webkit-text-stroke: 1px rgba(124,58,237,0.6) !important;
   }
-  .tree-dialog-body pre .tree-unique-gold{
-    text-shadow: 
-      0 0 8px rgba(251,191,36,.8),
-      0 0 16px rgba(251,191,36,.4)!important;
-    -webkit-text-stroke: 1px rgba(251,191,36,.5)!important;
+  .tree-unique-gold {
+    text-shadow: 0 0 8px #fbbf24, 0 0 16px rgba(251,191,36,0.4) !important;
+    -webkit-text-stroke: 1px rgba(251,191,36,0.6) !important;
   }
-  .tree-dialog-body pre .tree-unique-glyph{color:var(--unique)!important}
+  .tree-unique-glyph { color: #7c3aed !important; }
 
-  .tree-dialog-body pre .tree-extra-glyph{color:var(--extra)!important}
-  .tree-dialog-body pre .tree-basic-glyph{color:var(--basic)!important}
-  .tree-dialog-body pre .tree-sep{color:rgba(56,189,248,.3)!important}
+  .tree-extra-line { font-weight: 600 !important; color: var(--text) !important; }
+  .tree-extra-glyph { color: #c084fc !important; }
+  .tree-extra-contributor { color: #ef4444 !important; font-weight: 700 !important; }
+  .tree-extra-slash { color: var(--muted) !important; opacity: 0.5 !important; }
+  .tree-extra-skillname, .tree-extra-id { color: #c084fc !important; }
 
-  .tree-dialog-body pre .tree-extra-line{font-weight:600!important}
-  .tree-dialog-body pre .tree-extra-contributor{color:#ef4444!important;font-weight:700!important;text-shadow:0 0 6px rgba(239,68,68,.5)!important}
-  .tree-dialog-body pre .tree-extra-slash{color:var(--muted)!important}
-  .tree-dialog-body pre .tree-extra-skillname,
-  .tree-dialog-body pre .tree-extra-id{color:var(--extra)!important}
+  .tree-basic-line { color: var(--text) !important; }
+  .tree-basic-glyph { color: #38bdf8 !important; }
+  .tree-basic-contributor { color: #ef4444 !important; font-weight: 600 !important; }
+  .tree-basic-slash { color: var(--muted) !important; opacity: 0.5 !important; }
+  .tree-basic-skillname, .tree-basic-id { color: #38bdf8 !important; }
 
-  .tree-dialog-body pre .tree-basic-line{color:inherit!important}
-  .tree-dialog-body pre .tree-basic-contributor{color:#ef4444!important;font-weight:600!important}
-  .tree-dialog-body pre .tree-basic-slash{color:var(--muted)!important}
-  .tree-dialog-body pre .tree-basic-skillname,
-  .tree-dialog-body pre .tree-basic-id{color:var(--basic)!important}
+  .tree-sep { color: rgba(56,189,248,0.25) !important; }
   .skill-tooltip{
     position:absolute;pointer-events:all;display:none;z-index:15;
     background:rgba(3,7,18,.9);border:1px solid rgba(148,163,184,.22);

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -480,43 +480,46 @@
     90% {color:#34d399;text-shadow:0 0 10px rgba(52,211,153,.8),0 0 22px rgba(52,211,153,.4)}
     100%{color:#38bdf8;text-shadow:0 0 10px rgba(56,189,248,.8),0 0 22px rgba(56,189,248,.4)}
   }
-  .tree-ult-line{font-weight:700}
-  .tree-ult-contributor{color:#ef4444;font-weight:800;text-shadow:0 0 8px rgba(239,68,68,.6)}
-  .tree-ult-slash{color:var(--muted)}
-  .tree-ult-skillname,.tree-ult-id{color:#f59e0b}
+  .tree-dialog-body pre .tree-ult-line{font-weight:700!important}
+  .tree-dialog-body pre .tree-ult-contributor{color:#ef4444!important;font-weight:800!important;text-shadow:0 0 8px rgba(239,68,68,.6)!important}
+  .tree-dialog-body pre .tree-ult-slash{color:var(--muted)!important}
+  .tree-dialog-body pre .tree-ult-skillname,
+  .tree-dialog-body pre .tree-ult-id{color:#f59e0b!important}
   
-  .tree-unique-line{font-weight:700}
-  .tree-unique-contributor{color:#ef4444;font-weight:800}
-  .tree-unique-slash{color:var(--muted)}
-  .tree-unique-skillname{
-    color:#000;
-    font-weight:900;
+  .tree-dialog-body pre .tree-unique-line{font-weight:700!important}
+  .tree-dialog-body pre .tree-unique-contributor{color:#ef4444!important;font-weight:800!important}
+  .tree-dialog-body pre .tree-unique-slash{color:var(--muted)!important}
+  .tree-dialog-body pre .tree-unique-skillname{
+    color:#000!important;
+    font-weight:900!important;
     text-shadow: 
       0 0 8px rgba(124,58,237,.8),
-      0 0 16px rgba(124,58,237,.4);
-    -webkit-text-stroke: 1px rgba(124,58,237,.5);
+      0 0 16px rgba(124,58,237,.4)!important;
+    -webkit-text-stroke: 1px rgba(124,58,237,.5)!important;
   }
-  .tree-unique-gold{
+  .tree-dialog-body pre .tree-unique-gold{
     text-shadow: 
       0 0 8px rgba(251,191,36,.8),
-      0 0 16px rgba(251,191,36,.4);
-    -webkit-text-stroke: 1px rgba(251,191,36,.5);
+      0 0 16px rgba(251,191,36,.4)!important;
+    -webkit-text-stroke: 1px rgba(251,191,36,.5)!important;
   }
-  .tree-unique-glyph{color:var(--unique)}
+  .tree-dialog-body pre .tree-unique-glyph{color:var(--unique)!important}
 
-  .tree-extra-glyph{color:var(--extra)}
-  .tree-basic-glyph{color:var(--basic)}
-  .tree-sep{color:rgba(56,189,248,.2)}
+  .tree-dialog-body pre .tree-extra-glyph{color:var(--extra)!important}
+  .tree-dialog-body pre .tree-basic-glyph{color:var(--basic)!important}
+  .tree-dialog-body pre .tree-sep{color:rgba(56,189,248,.3)!important}
 
-  .tree-extra-line{font-weight:600}
-  .tree-extra-contributor{color:#ef4444;font-weight:700;text-shadow:0 0 6px rgba(239,68,68,.5)}
-  .tree-extra-slash{color:var(--muted)}
-  .tree-extra-skillname,.tree-extra-id{color:var(--extra)}
+  .tree-dialog-body pre .tree-extra-line{font-weight:600!important}
+  .tree-dialog-body pre .tree-extra-contributor{color:#ef4444!important;font-weight:700!important;text-shadow:0 0 6px rgba(239,68,68,.5)!important}
+  .tree-dialog-body pre .tree-extra-slash{color:var(--muted)!important}
+  .tree-dialog-body pre .tree-extra-skillname,
+  .tree-dialog-body pre .tree-extra-id{color:var(--extra)!important}
 
-  .tree-basic-line{color:var(--text)}
-  .tree-basic-contributor{color:#ef4444;font-weight:600}
-  .tree-basic-slash{color:var(--muted)}
-  .tree-basic-skillname,.tree-basic-id{color:var(--basic)}
+  .tree-dialog-body pre .tree-basic-line{color:inherit!important}
+  .tree-dialog-body pre .tree-basic-contributor{color:#ef4444!important;font-weight:600!important}
+  .tree-dialog-body pre .tree-basic-slash{color:var(--muted)!important}
+  .tree-dialog-body pre .tree-basic-skillname,
+  .tree-dialog-body pre .tree-basic-id{color:var(--basic)!important}
   .skill-tooltip{
     position:absolute;pointer-events:all;display:none;z-index:15;
     background:rgba(3,7,18,.9);border:1px solid rgba(148,163,184,.22);

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -2,6 +2,7 @@
     --basic:    #38bdf8;
     --extra:    #c084fc;
     --ultimate: #f59e0b;
+    --unique:   #7c3aed;
     --bg:       #030712;
     --surface:  #0f172a;
     --border:   #1e293b;
@@ -483,13 +484,39 @@
   .tree-ult-contributor{color:#ef4444;font-weight:800;text-shadow:0 0 8px rgba(239,68,68,.6)}
   .tree-ult-slash{color:var(--muted)}
   .tree-ult-skillname,.tree-ult-id{color:#f59e0b}
+  
+  .tree-unique-line{font-weight:700}
+  .tree-unique-contributor{color:#ef4444;font-weight:800}
+  .tree-unique-slash{color:var(--muted)}
+  .tree-unique-skillname{
+    color:#000;
+    font-weight:900;
+    text-shadow: 
+      0 0 8px rgba(124,58,237,.8),
+      0 0 16px rgba(124,58,237,.4);
+    -webkit-text-stroke: 1px rgba(124,58,237,.5);
+  }
+  .tree-unique-gold{
+    text-shadow: 
+      0 0 8px rgba(251,191,36,.8),
+      0 0 16px rgba(251,191,36,.4);
+    -webkit-text-stroke: 1px rgba(251,191,36,.5);
+  }
+  .tree-unique-glyph{color:var(--unique)}
+
   .tree-extra-glyph{color:var(--extra)}
   .tree-basic-glyph{color:var(--basic)}
   .tree-sep{color:rgba(56,189,248,.2)}
+
   .tree-extra-line{font-weight:600}
   .tree-extra-contributor{color:#ef4444;font-weight:700;text-shadow:0 0 6px rgba(239,68,68,.5)}
   .tree-extra-slash{color:var(--muted)}
   .tree-extra-skillname,.tree-extra-id{color:var(--extra)}
+
+  .tree-basic-line{color:var(--text)}
+  .tree-basic-contributor{color:#ef4444;font-weight:600}
+  .tree-basic-slash{color:var(--muted)}
+  .tree-basic-skillname,.tree-basic-id{color:var(--basic)}
   .skill-tooltip{
     position:absolute;pointer-events:all;display:none;z-index:15;
     background:rgba(3,7,18,.9);border:1px solid rgba(148,163,184,.22);

--- a/docs/js/skill-explorer.js
+++ b/docs/js/skill-explorer.js
@@ -694,8 +694,8 @@
     var ultIdx = 0;
     var unqIdx = 0;
     return text.split('\n').map(function(line) {
-      // Ultimate skill header lines: ◆ Ultimate Skill: contributor/name  [6★]
-      var m = line.match(/^(\s*◆ Ultimate Skill: )(\S+)(.*)$/);
+      // Ultimate skill header lines
+      var m = line.match(/^(\s*◆\s*(?:Ultimate Skill:\s*)?)(\S+)(.*)$/);
       if (m) {
         var label = esc(m[1]);
         var skillId = m[2];
@@ -714,7 +714,7 @@
                label + skillHtml + suffix + '</span>';
       }
 
-      // Unique skill lines (header or sub-item): ◉ Unique Skill: ... or just ◉ /...
+      // Unique skill lines
       var u = line.match(/^([\s│├└─]*◉\s*(?:Unique Skill:\s*)?)(\S+)(.*)$/);
       if (u) {
         var ulabel = esc(u[1]);
@@ -724,7 +724,6 @@
         var uslash = uid.indexOf('/');
         var uskillHtml;
         
-        // Detect level for gold/purple glow
         var isGold = usuffix.indexOf('5★') >= 0 || usuffix.indexOf('6★') >= 0;
         var uniqueClass = isGold ? 'tree-unique-skillname tree-unique-gold' : 'tree-unique-skillname';
 
@@ -739,7 +738,7 @@
                ulabel + uskillHtml + usuffix + '</span>';
       }
 
-      // Extra skill lines: ├─ ◇ Extra Skill: /research  [3★]
+      // Extra skill lines
       var e = line.match(/^([\s│├└─]*◇\s*(?:Extra Skill:\s*)?)(\S+)(.*)$/);
       if (e) {
         var elabel = esc(e[1]);
@@ -757,7 +756,7 @@
         return '<span class="tree-extra-line">' + elabel + eskillHtml + esuffix + '</span>';
       }
 
-      // Basic skill lines: ├─ ○ /web-search  [1★]
+      // Basic skill lines
       var b = line.match(/^([\s│├└─]*○\s*)(\S+)(.*)$/);
       if (b) {
         var blabel = esc(b[1]);
@@ -775,9 +774,7 @@
         return '<span class="tree-basic-line">' + blabel + bskillHtml + bsuffix + '</span>';
       }
 
-      // Separator lines
       if (/^[═─]{3,}/.test(line)) return '<span class="tree-sep">' + esc(line) + '</span>';
-      // Inline ◇ / ○ / ◉ glyphs
       var out = esc(line);
       out = out.replace(/◇/g, '<span class="tree-extra-glyph">◇</span>');
       out = out.replace(/○/g, '<span class="tree-basic-glyph">○</span>');

--- a/docs/js/skill-explorer.js
+++ b/docs/js/skill-explorer.js
@@ -694,7 +694,7 @@
     var ultIdx = 0;
     var unqIdx = 0;
     return text.split('\n').map(function(line) {
-      // Ultimate skill header lines
+      // 1. Ultimate Skill lines (◆)
       var m = line.match(/^(\s*◆\s*(?:Ultimate Skill:\s*)?)(\S+)(.*)$/);
       if (m) {
         var label = esc(m[1]);
@@ -714,7 +714,7 @@
                label + skillHtml + suffix + '</span>';
       }
 
-      // Unique skill lines
+      // 2. Unique Skill lines (◉)
       var u = line.match(/^([\s│├└─]*◉\s*(?:Unique Skill:\s*)?)(\S+)(.*)$/);
       if (u) {
         var ulabel = esc(u[1]);
@@ -723,14 +723,12 @@
         var udelay = -((unqIdx++ * 0.9) % 4);
         var uslash = uid.indexOf('/');
         var uskillHtml;
-        
         var isGold = usuffix.indexOf('5★') >= 0 || usuffix.indexOf('6★') >= 0;
         var uniqueClass = isGold ? 'tree-unique-skillname tree-unique-gold' : 'tree-unique-skillname';
-
         if (uslash > 0) {
           uskillHtml = '<span class="tree-unique-contributor">' + esc(uid.slice(0, uslash)) + '</span>' +
                        '<span class="tree-unique-slash">/</span>' +
-                       '<span class="' + uniqueClass + '">' + esc(uid.slice(uslash + 1)) + '</span>';
+                       '<span class="' + uniqueClass + '">' + esc(uid.slice(slash + 1)) + '</span>';
         } else {
           uskillHtml = '<span class="' + uniqueClass + '">' + esc(uid) + '</span>';
         }
@@ -738,7 +736,7 @@
                ulabel + uskillHtml + usuffix + '</span>';
       }
 
-      // Extra skill lines
+      // 3. Extra Skill lines (◇)
       var e = line.match(/^([\s│├└─]*◇\s*(?:Extra Skill:\s*)?)(\S+)(.*)$/);
       if (e) {
         var elabel = esc(e[1]);
@@ -756,7 +754,7 @@
         return '<span class="tree-extra-line">' + elabel + eskillHtml + esuffix + '</span>';
       }
 
-      // Basic skill lines
+      // 4. Basic Skill lines (○)
       var b = line.match(/^([\s│├└─]*○\s*)(\S+)(.*)$/);
       if (b) {
         var blabel = esc(b[1]);
@@ -774,11 +772,14 @@
         return '<span class="tree-basic-line">' + blabel + bskillHtml + bsuffix + '</span>';
       }
 
-      if (/^[═─]{3,}/.test(line)) return '<span class="tree-sep">' + esc(line) + '</span>';
+      // 5. Separators and Catch-alls
+      if (/^[═─]{3,}/.test(line.trim())) return '<span class="tree-sep">' + esc(line) + '</span>';
+      
       var out = esc(line);
       out = out.replace(/◇/g, '<span class="tree-extra-glyph">◇</span>');
       out = out.replace(/○/g, '<span class="tree-basic-glyph">○</span>');
       out = out.replace(/◉/g, '<span class="tree-unique-glyph">◉</span>');
+      out = out.replace(/◆/g, '<span class="tree-ult-glyph">◆</span>');
       return out;
     }).join('\n');
   }

--- a/docs/js/skill-explorer.js
+++ b/docs/js/skill-explorer.js
@@ -695,7 +695,7 @@
     var unqIdx = 0;
     return text.split('\n').map(function(line) {
       // Ultimate skill header lines: ◆ Ultimate Skill: contributor/name  [6★]
-      var m = line.match(/^(◆ Ultimate Skill: )(\S+)(.*)$/);
+      var m = line.match(/^(\s*◆ Ultimate Skill: )(\S+)(.*)$/);
       if (m) {
         var label = esc(m[1]);
         var skillId = m[2];
@@ -704,7 +704,6 @@
         var slash = skillId.indexOf('/');
         var skillHtml;
         if (slash > 0) {
-          // named — contributor in red, skill name in amber
           skillHtml = '<span class="tree-ult-contributor">' + esc(skillId.slice(0, slash)) + '</span>' +
                       '<span class="tree-ult-slash">/</span>' +
                       '<span class="tree-ult-skillname">' + esc(skillId.slice(slash + 1)) + '</span>';
@@ -714,8 +713,9 @@
         return '<span class="tree-ult-line" style="animation-delay:' + delay + 's">' +
                label + skillHtml + suffix + '</span>';
       }
-      // Unique skill header lines: ◉ Unique Skill: contributor/name  [4★]
-      var u = line.match(/^(◉ Unique Skill: )(\S+)(.*)$/);
+
+      // Unique skill lines (header or sub-item): ◉ Unique Skill: ... or just ◉ /...
+      var u = line.match(/^([\s│├└─]*◉\s*(?:Unique Skill:\s*)?)(\S+)(.*)$/);
       if (u) {
         var ulabel = esc(u[1]);
         var uid = u[2];
@@ -723,16 +723,58 @@
         var udelay = -((unqIdx++ * 0.9) % 4);
         var uslash = uid.indexOf('/');
         var uskillHtml;
+        
+        // Detect level for gold/purple glow
+        var isGold = usuffix.indexOf('5★') >= 0 || usuffix.indexOf('6★') >= 0;
+        var uniqueClass = isGold ? 'tree-unique-skillname tree-unique-gold' : 'tree-unique-skillname';
+
         if (uslash > 0) {
           uskillHtml = '<span class="tree-unique-contributor">' + esc(uid.slice(0, uslash)) + '</span>' +
                        '<span class="tree-unique-slash">/</span>' +
-                       '<span class="tree-unique-skillname">' + esc(uid.slice(uslash + 1)) + '</span>';
+                       '<span class="' + uniqueClass + '">' + esc(uid.slice(uslash + 1)) + '</span>';
         } else {
-          uskillHtml = '<span class="tree-unique-skillname">' + esc(uid) + '</span>';
+          uskillHtml = '<span class="' + uniqueClass + '">' + esc(uid) + '</span>';
         }
         return '<span class="tree-unique-line" style="animation-delay:' + udelay + 's">' +
                ulabel + uskillHtml + usuffix + '</span>';
       }
+
+      // Extra skill lines: ├─ ◇ Extra Skill: /research  [3★]
+      var e = line.match(/^([\s│├└─]*◇\s*(?:Extra Skill:\s*)?)(\S+)(.*)$/);
+      if (e) {
+        var elabel = esc(e[1]);
+        var eid = e[2];
+        var esuffix = esc(e[3]);
+        var eslash = eid.indexOf('/');
+        var eskillHtml;
+        if (eslash > 0) {
+          eskillHtml = '<span class="tree-extra-contributor">' + esc(eid.slice(0, eslash)) + '</span>' +
+                       '<span class="tree-extra-slash">/</span>' +
+                       '<span class="tree-extra-skillname">' + esc(eid.slice(eslash + 1)) + '</span>';
+        } else {
+          eskillHtml = '<span class="tree-extra-id">' + esc(eid) + '</span>';
+        }
+        return '<span class="tree-extra-line">' + elabel + eskillHtml + esuffix + '</span>';
+      }
+
+      // Basic skill lines: ├─ ○ /web-search  [1★]
+      var b = line.match(/^([\s│├└─]*○\s*)(\S+)(.*)$/);
+      if (b) {
+        var blabel = esc(b[1]);
+        var bid = b[2];
+        var bsuffix = esc(b[3]);
+        var bslash = bid.indexOf('/');
+        var bskillHtml;
+        if (bslash > 0) {
+          bskillHtml = '<span class="tree-basic-contributor">' + esc(bid.slice(0, bslash)) + '</span>' +
+                       '<span class="tree-basic-slash">/</span>' +
+                       '<span class="tree-basic-skillname">' + esc(bid.slice(bslash + 1)) + '</span>';
+        } else {
+          bskillHtml = '<span class="tree-basic-id">' + esc(bid) + '</span>';
+        }
+        return '<span class="tree-basic-line">' + blabel + bskillHtml + bsuffix + '</span>';
+      }
+
       // Separator lines
       if (/^[═─]{3,}/.test(line)) return '<span class="tree-sep">' + esc(line) + '</span>';
       // Inline ◇ / ○ / ◉ glyphs

--- a/registry-for-review/skill-batches/20260512012647-mbtiongson1-gaia-skill-tree.json
+++ b/registry-for-review/skill-batches/20260512012647-mbtiongson1-gaia-skill-tree.json
@@ -1,0 +1,23879 @@
+{
+  "batchId": "20260512012647-mbtiongson1-gaia-skill-tree",
+  "userId": "mbtiongson1",
+  "sourceRepo": "mbtiongson1/gaia-skill-tree",
+  "generatedAt": "2026-05-12T01:26:47Z",
+  "knownSkills": [
+    {
+      "skillId": "chain-of-thought"
+    },
+    {
+      "skillId": "classify"
+    },
+    {
+      "skillId": "gaia-audit"
+    },
+    {
+      "skillId": "gaia-meta-audit"
+    },
+    {
+      "skillId": "gaia-triage"
+    },
+    {
+      "skillId": "rank"
+    },
+    {
+      "skillId": "research"
+    },
+    {
+      "skillId": "web-search"
+    }
+  ],
+  "proposedSkills": [
+    {
+      "id": "a-z",
+      "name": "A-z",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: A-z.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "a-z0-9",
+      "name": "A-z0-9",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: A-z0-9.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "abbreviations",
+      "name": "Abbreviations",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Abbreviations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/parallel-execution",
+          "score": 0.452
+        }
+      ]
+    },
+    {
+      "id": "above",
+      "name": "Above",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Above.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "abs",
+      "name": "Abs",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Abs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "abstract",
+      "name": "Abstract",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Abstract.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "anthropic/pptx",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "accept",
+      "name": "Accept",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Accept.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "acceptable",
+      "name": "Acceptable",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Acceptable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.485
+        }
+      ]
+    },
+    {
+      "id": "acceptance",
+      "name": "Acceptance",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Acceptance.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.485
+        }
+      ]
+    },
+    {
+      "id": "accepted",
+      "name": "Accepted",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Accepted.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/tdd",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "accepting",
+      "name": "Accepting",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Accepting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "accordingly",
+      "name": "Accordingly",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Accordingly.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "accurate",
+      "name": "Accurate",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Accurate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "action",
+      "name": "Action",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Action.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/parallel-execution",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "actions",
+      "name": "Actions",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Actions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/parallel-execution",
+          "score": 0.48
+        },
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "actual",
+      "name": "Actual",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Actual.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "add",
+      "name": "Add",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Add.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/tdd",
+          "score": 0.667
+        }
+      ]
+    },
+    {
+      "id": "added",
+      "name": "Added",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Added.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/tdd",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "adding",
+      "name": "Adding",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Adding.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "additions",
+      "name": "Additions",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Additions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "addressed",
+      "name": "Addressed",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Addressed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "affected",
+      "name": "Affected",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Affected.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "affected-skill",
+      "name": "Affected-skill",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Affected-skill.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.64
+        },
+        {
+          "namedSkillId": "mattpocock/write-a-skill",
+          "score": 0.593
+        }
+      ]
+    },
+    {
+      "id": "after",
+      "name": "After",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: After.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "against",
+      "name": "Against",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Against.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.533
+        }
+      ]
+    },
+    {
+      "id": "agent",
+      "name": "Agent",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Agent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.545
+        },
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "glincker/readme-generator",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "agents",
+      "name": "Agents",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Agents.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.476
+        },
+        {
+          "namedSkillId": "glincker/readme-generator",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "all",
+      "name": "All",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: All.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "alone",
+      "name": "Alone",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Alone.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "alongside",
+      "name": "Alongside",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Alongside.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "already-fixed",
+      "name": "Already-fixed",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Already-fixed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "always",
+      "name": "Always",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Always.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "amend",
+      "name": "Amend",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Amend.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "any",
+      "name": "Any",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Any.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "api",
+      "name": "Api",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Api.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "appear",
+      "name": "Appear",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Appear.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "appears",
+      "name": "Appears",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Appears.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "append",
+      "name": "Append",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Append.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "applied",
+      "name": "Applied",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Applied.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "apply",
+      "name": "Apply",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Apply.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "appraise",
+      "name": "Appraise",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Appraise.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "approval",
+      "name": "Approval",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Approval.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "approve",
+      "name": "Approve",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Approve.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "arg",
+      "name": "Arg",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Arg.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "argument",
+      "name": "Argument",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Argument.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "around",
+      "name": "Around",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Around.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "arrays",
+      "name": "Arrays",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Arrays.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "artifact",
+      "name": "Artifact",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Artifact.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "artifacts",
+      "name": "Artifacts",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Artifacts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "arxiv",
+      "name": "Arxiv",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Arxiv.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ask",
+      "name": "Ask",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ask.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "asks",
+      "name": "Asks",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Asks.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "atomic",
+      "name": "Atomic",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Atomic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "anthropic/pptx",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "attempt",
+      "name": "Attempt",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Attempt.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/tdd",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "audit",
+      "name": "Audit",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Audit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "auditing",
+      "name": "Auditing",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Auditing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "gaiabot/gaia-triage",
+          "score": 0.526
+        }
+      ]
+    },
+    {
+      "id": "audits",
+      "name": "Audits",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Audits.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "auth",
+      "name": "Auth",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Auth.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "authenticated",
+      "name": "Authenticated",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Authenticated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "authoritative",
+      "name": "Authoritative",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Authoritative.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.526
+        },
+        {
+          "namedSkillId": "gaiabot/gaia-triage",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "auto-merged",
+      "name": "Auto-merged",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Auto-merged.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/to-prd",
+          "score": 0.588
+        },
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.522
+        },
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.48
+        }
+      ]
+    },
+    {
+      "id": "auto-triage",
+      "name": "Auto-triage",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Auto-triage.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "gaiabot/gaia-triage",
+          "score": 0.727
+        },
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.706
+        },
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.522
+        }
+      ]
+    },
+    {
+      "id": "automation",
+      "name": "Automation",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Automation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "available",
+      "name": "Available",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Available.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/grill-me",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "avoid",
+      "name": "Avoid",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Avoid.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "awesome",
+      "name": "Awesome",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Awesome.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "huggingface/transformers-js",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "back",
+      "name": "Back",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Back.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "based",
+      "name": "Based",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Based.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "bash",
+      "name": "Bash",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bash.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "basic",
+      "name": "Basic",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Basic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "batch",
+      "name": "Batch",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Batch.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "batches",
+      "name": "Batches",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Batches.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "because",
+      "name": "Because",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Because.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.571
+        }
+      ]
+    },
+    {
+      "id": "becomes",
+      "name": "Becomes",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Becomes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "been",
+      "name": "Been",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Been.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "before",
+      "name": "Before",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Before.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "gaiabot/repo-docs-before-pr",
+          "score": 0.48
+        }
+      ]
+    },
+    {
+      "id": "behavior",
+      "name": "Behavior",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Behavior.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "being",
+      "name": "Being",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Being.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "below",
+      "name": "Below",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Below.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "benchmark",
+      "name": "Benchmark",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Benchmark.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "benchmarks",
+      "name": "Benchmarks",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Benchmarks.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "better",
+      "name": "Better",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Better.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.588
+        },
+        {
+          "namedSkillId": "0xdarkmatter/pytest-patterns",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "beyond",
+      "name": "Beyond",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Beyond.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bin",
+      "name": "Bin",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bin.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "blob",
+      "name": "Blob",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Blob.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "block",
+      "name": "Block",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Block.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "blocked",
+      "name": "Blocked",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Blocked.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "blocks",
+      "name": "Blocks",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Blocks.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "body",
+      "name": "Body",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Body.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bot",
+      "name": "Bot",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bot.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "both",
+      "name": "Both",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Both.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bottom",
+      "name": "Bottom",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bottom.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "branch",
+      "name": "Branch",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Branch.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "branches",
+      "name": "Branches",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Branches.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "yonatangross/orchestkit-rag",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "brief",
+      "name": "Brief",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Brief.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.545
+        },
+        {
+          "namedSkillId": "mattpocock/grill-me",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "broad",
+      "name": "Broad",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Broad.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "broader",
+      "name": "Broader",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Broader.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "gooseworks/notte-browser",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.462
+        },
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "broken",
+      "name": "Broken",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Broken.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "browse",
+      "name": "Browse",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Browse.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "gooseworks/notte-browser",
+          "score": 0.632
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "bucket",
+      "name": "Bucket",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bucket.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "buckets",
+      "name": "Buckets",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Buckets.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bug",
+      "name": "Bug",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bug.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "build",
+      "name": "Build",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Build.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "builds",
+      "name": "Builds",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Builds.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bullet",
+      "name": "Bullet",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bullet.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "bump",
+      "name": "Bump",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Bump.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "but",
+      "name": "But",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: But.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "call",
+      "name": "Call",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Call.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "calling",
+      "name": "Calling",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Calling.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.471
+        },
+        {
+          "namedSkillId": "huggingface/hf-cli",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "calls",
+      "name": "Calls",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Calls.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "can",
+      "name": "Can",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Can.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "candidate",
+      "name": "Candidate",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Candidate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "gaiabot/gaia-triage",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.476
+        },
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "candidates",
+      "name": "Candidates",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Candidates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "gaiabot/gaia-triage",
+          "score": 0.476
+        },
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "canonical",
+      "name": "Canonical",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Canonical.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "capability",
+      "name": "Capability",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Capability.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "card",
+      "name": "Card",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Card.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "case",
+      "name": "Case",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Case.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.545
+        },
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "cat",
+      "name": "Cat",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cat.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "catalog",
+      "name": "Catalog",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Catalog.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "catch",
+      "name": "Catch",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Catch.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "cause",
+      "name": "Cause",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cause.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        },
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "centrally",
+      "name": "Centrally",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Centrally.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "change",
+      "name": "Change",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Change.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "changed",
+      "name": "Changed",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Changed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "changes",
+      "name": "Changes",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Changes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "changing",
+      "name": "Changing",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Changing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "channels",
+      "name": "Channels",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Channels.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "check",
+      "name": "Check",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Check.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "checked",
+      "name": "Checked",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Checked.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "checklist",
+      "name": "Checklist",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Checklist.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.526
+        }
+      ]
+    },
+    {
+      "id": "checkout",
+      "name": "Checkout",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Checkout.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "yonatangross/orchestkit-rag",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "choose",
+      "name": "Choose",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Choose.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "churn",
+      "name": "Churn",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Churn.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "claim",
+      "name": "Claim",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Claim.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "huggingface/hf-cli",
+          "score": 0.545
+        }
+      ]
+    },
+    {
+      "id": "claimed",
+      "name": "Claimed",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Claimed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.471
+        },
+        {
+          "namedSkillId": "huggingface/hf-cli",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "claiming",
+      "name": "Claiming",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Claiming.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "claims",
+      "name": "Claims",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Claims.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "huggingface/hf-cli",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "classification",
+      "name": "Classification",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Classification.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "classified",
+      "name": "Classified",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Classified.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "classifies",
+      "name": "Classifies",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Classifies.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "claude",
+      "name": "Claude",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Claude.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "clean",
+      "name": "Clean",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Clean.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.533
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "cleanup",
+      "name": "Cleanup",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cleanup.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "clear",
+      "name": "Clear",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Clear.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "clearly",
+      "name": "Clearly",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Clearly.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cli",
+      "name": "Cli",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cli.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "huggingface/hf-cli",
+          "score": 0.667
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "clone",
+      "name": "Clone",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Clone.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cloned",
+      "name": "Cloned",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cloned.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "close",
+      "name": "Close",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Close.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "close-resolved",
+      "name": "Close-resolved",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Close-resolved.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.48
+        }
+      ]
+    },
+    {
+      "id": "closing",
+      "name": "Closing",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Closing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.471
+        },
+        {
+          "namedSkillId": "huggingface/hf-cli",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "code",
+      "name": "Code",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Code.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "codebase",
+      "name": "Codebase",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Codebase.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.533
+        },
+        {
+          "namedSkillId": "gooseworks/notte-browser",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "codex",
+      "name": "Codex",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Codex.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "collection",
+      "name": "Collection",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Collection.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/parallel-execution",
+          "score": 0.571
+        }
+      ]
+    },
+    {
+      "id": "com",
+      "name": "Com",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Com.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "combination",
+      "name": "Combination",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Combination.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "combinations",
+      "name": "Combinations",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Combinations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "command",
+      "name": "Command",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Command.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "commands",
+      "name": "Commands",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Commands.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "comment",
+      "name": "Comment",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Comment.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "comments",
+      "name": "Comments",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Comments.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "commit",
+      "name": "Commit",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Commit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "commits",
+      "name": "Commits",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Commits.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "committed",
+      "name": "Committed",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Committed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "committing",
+      "name": "Committing",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Committing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "common",
+      "name": "Common",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Common.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "community",
+      "name": "Community",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Community.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/zoom-out",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "compact",
+      "name": "Compact",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Compact.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "completed",
+      "name": "Completed",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Completed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.526
+        }
+      ]
+    },
+    {
+      "id": "completely",
+      "name": "Completely",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Completely.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "composite",
+      "name": "Composite",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Composite.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/zoom-out",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "concrete",
+      "name": "Concrete",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Concrete.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "config",
+      "name": "Config",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Config.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "confirm",
+      "name": "Confirm",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Confirm.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "confirmation",
+      "name": "Confirmation",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Confirmation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "connectors",
+      "name": "Connectors",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Connectors.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "consideration",
+      "name": "Consideration",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Consideration.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "upsonic/unittest-generator",
+          "score": 0.452
+        }
+      ]
+    },
+    {
+      "id": "consolidation",
+      "name": "Consolidation",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Consolidation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "constraint",
+      "name": "Constraint",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Constraint.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "constraints",
+      "name": "Constraints",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Constraints.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "consumed",
+      "name": "Consumed",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Consumed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/to-issues",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "contains",
+      "name": "Contains",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Contains.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "content",
+      "name": "Content",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Content.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "contents",
+      "name": "Contents",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Contents.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "contexts",
+      "name": "Contexts",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Contexts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "contributing",
+      "name": "Contributing",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Contributing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "contribution",
+      "name": "Contribution",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Contribution.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "contributor",
+      "name": "Contributor",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Contributor.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "contributors",
+      "name": "Contributors",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Contributors.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "copies",
+      "name": "Copies",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Copies.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/to-issues",
+          "score": 0.533
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "copy",
+      "name": "Copy",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Copy.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "core",
+      "name": "Core",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Core.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "corequisite",
+      "name": "Corequisite",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Corequisite.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/requirements-engineer",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "yonatangross/orchestkit-rag",
+          "score": 0.48
+        }
+      ]
+    },
+    {
+      "id": "correction",
+      "name": "Correction",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Correction.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/parallel-execution",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "correspond",
+      "name": "Correspond",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Correspond.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "corresponding",
+      "name": "Corresponding",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Corresponding.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "could",
+      "name": "Could",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Could.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "couldn",
+      "name": "Couldn",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Couldn.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "count",
+      "name": "Count",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Count.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/zoom-out",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "counts",
+      "name": "Counts",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Counts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "coverage",
+      "name": "Coverage",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Coverage.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.571
+        },
+        {
+          "namedSkillId": "yonatangross/orchestkit-rag",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "covered",
+      "name": "Covered",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Covered.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/to-prd",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "covers",
+      "name": "Covers",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Covers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "crawl",
+      "name": "Crawl",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Crawl.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "crawler",
+      "name": "Crawler",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Crawler.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "create",
+      "name": "Create",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Create.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.615
+        },
+        {
+          "namedSkillId": "anthropic/skill-creator",
+          "score": 0.526
+        },
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "credentials",
+      "name": "Credentials",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Credentials.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.556
+        },
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "criteria",
+      "name": "Criteria",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Criteria.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.571
+        },
+        {
+          "namedSkillId": "gaiabot/gaia-triage",
+          "score": 0.526
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/security-engineer",
+          "score": 0.48
+        }
+      ]
+    },
+    {
+      "id": "cross-check",
+      "name": "Cross-check",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cross-check.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "curate",
+      "name": "Curate",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Curate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.471
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "curated",
+      "name": "Curated",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Curated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "curation",
+      "name": "Curation",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Curation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/security-engineer",
+          "score": 0.48
+        },
+        {
+          "namedSkillId": "anthropic/skill-creator",
+          "score": 0.476
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/parallel-execution",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "curation-only",
+      "name": "Curation-only",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Curation-only.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "current",
+      "name": "Current",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Current.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "currently",
+      "name": "Currently",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Currently.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cursor",
+      "name": "Cursor",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cursor.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "cutoff",
+      "name": "Cutoff",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cutoff.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "cycles",
+      "name": "Cycles",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Cycles.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "data",
+      "name": "Data",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Data.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "date",
+      "name": "Date",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Date.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "day",
+      "name": "Day",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Day.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "decision",
+      "name": "Decision",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Decision.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "decisions",
+      "name": "Decisions",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Decisions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "deduplicated",
+      "name": "Deduplicated",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Deduplicated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "default",
+      "name": "Default",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Default.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "deferred",
+      "name": "Deferred",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Deferred.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "definitions",
+      "name": "Definitions",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Definitions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.529
+        },
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "deleted",
+      "name": "Deleted",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Deleted.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.571
+        },
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "deletion",
+      "name": "Deletion",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Deletion.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/parallel-execution",
+          "score": 0.538
+        }
+      ]
+    },
+    {
+      "id": "demerit",
+      "name": "Demerit",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Demerit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "demo",
+      "name": "Demo",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Demo.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "demonstrations",
+      "name": "Demonstrations",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Demonstrations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "glincker/readme-generator",
+          "score": 0.467
+        }
+      ]
+    },
+    {
+      "id": "dependency",
+      "name": "Dependency",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dependency.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/devops-engineer",
+          "score": 0.48
+        }
+      ]
+    },
+    {
+      "id": "dependency-policy",
+      "name": "Dependency-policy",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dependency-policy.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dependency-related",
+      "name": "Dependency-related",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dependency-related.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.545
+        },
+        {
+          "namedSkillId": "glincker/readme-generator",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "derivative",
+      "name": "Derivative",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Derivative.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.48
+        },
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "derivatives",
+      "name": "Derivatives",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Derivatives.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.471
+        },
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.462
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "derived",
+      "name": "Derived",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Derived.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "describe",
+      "name": "Describe",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Describe.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "described",
+      "name": "Described",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Described.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "description",
+      "name": "Description",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Description.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/security-engineer",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "deserve",
+      "name": "Deserve",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Deserve.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/devops-engineer",
+          "score": 0.455
+        },
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "designed",
+      "name": "Designed",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Designed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.625
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/devops-engineer",
+          "score": 0.522
+        }
+      ]
+    },
+    {
+      "id": "desired",
+      "name": "Desired",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Desired.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/devops-engineer",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "detection",
+      "name": "Detection",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Detection.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/parallel-execution",
+          "score": 0.519
+        }
+      ]
+    },
+    {
+      "id": "determine",
+      "name": "Determine",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Determine.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/devops-engineer",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/database-engineer",
+          "score": 0.462
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/security-engineer",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "dev",
+      "name": "Dev",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dev.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "diff",
+      "name": "Diff",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Diff.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "direct",
+      "name": "Direct",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Direct.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "directly",
+      "name": "Directly",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Directly.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "directories",
+      "name": "Directories",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Directories.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "anthropic/skill-creator",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "mattpocock/to-issues",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "directory",
+      "name": "Directory",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Directory.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "anthropic/skill-creator",
+          "score": 0.545
+        }
+      ]
+    },
+    {
+      "id": "discover",
+      "name": "Discover",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Discover.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "discovered",
+      "name": "Discovered",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Discovered.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "discovery",
+      "name": "Discovery",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Discovery.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "discussion",
+      "name": "Discussion",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Discussion.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "display",
+      "name": "Display",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Display.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "display-style",
+      "name": "Display-style",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Display-style.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.48
+        }
+      ]
+    },
+    {
+      "id": "displaying",
+      "name": "Displaying",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Displaying.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "distinct",
+      "name": "Distinct",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Distinct.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "docs",
+      "name": "Docs",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Docs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "docs-build",
+      "name": "Docs-build",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Docs-build.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "document",
+      "name": "Document",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Document.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "documentation",
+      "name": "Documentation",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Documentation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "glincker/readme-generator",
+          "score": 0.483
+        }
+      ]
+    },
+    {
+      "id": "documented",
+      "name": "Documented",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Documented.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.48
+        }
+      ]
+    },
+    {
+      "id": "documents",
+      "name": "Documents",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Documents.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "does",
+      "name": "Does",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Does.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "mattpocock/to-issues",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "doing",
+      "name": "Doing",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Doing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "don",
+      "name": "Don",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Don.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "done",
+      "name": "Done",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Done.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "downgrade",
+      "name": "Downgrade",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Downgrade.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "draft",
+      "name": "Draft",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Draft.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "draft-skills",
+      "name": "Draft-skills",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Draft-skills.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.696
+        },
+        {
+          "namedSkillId": "mattpocock/write-a-skill",
+          "score": 0.64
+        }
+      ]
+    },
+    {
+      "id": "drafts",
+      "name": "Drafts",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Drafts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "drift",
+      "name": "Drift",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Drift.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "drop",
+      "name": "Drop",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Drop.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dropped",
+      "name": "Dropped",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dropped.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dry",
+      "name": "Dry",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dry.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "dry-run",
+      "name": "Dry-run",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Dry-run.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "duplicate",
+      "name": "Duplicate",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Duplicate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "duplicated",
+      "name": "Duplicated",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Duplicated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "duplicates",
+      "name": "Duplicates",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Duplicates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "duplication",
+      "name": "Duplication",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Duplication.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "each",
+      "name": "Each",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Each.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "echo",
+      "name": "Echo",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Echo.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "edge",
+      "name": "Edge",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Edge.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "edges",
+      "name": "Edges",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Edges.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "edit",
+      "name": "Edit",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Edit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "edits",
+      "name": "Edits",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Edits.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.471
+        },
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "effective",
+      "name": "Effective",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Effective.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "effective-level",
+      "name": "Effective-level",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Effective-level.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "addy-osmani/test-driven-development",
+          "score": 0.526
+        }
+      ]
+    },
+    {
+      "id": "effort",
+      "name": "Effort",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Effort.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "else",
+      "name": "Else",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Else.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.727
+        }
+      ]
+    },
+    {
+      "id": "em-dash",
+      "name": "Em-dash",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Em-dash.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "email",
+      "name": "Email",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Email.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "embeddings",
+      "name": "Embeddings",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Embeddings.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "empty",
+      "name": "Empty",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Empty.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "encoding",
+      "name": "Encoding",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Encoding.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "end",
+      "name": "End",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: End.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "endpoints",
+      "name": "Endpoints",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Endpoints.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "enforcement",
+      "name": "Enforcement",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Enforcement.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "huggingface/transformers-js",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "enhancement",
+      "name": "Enhancement",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Enhancement.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "enhances",
+      "name": "Enhances",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Enhances.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "enough",
+      "name": "Enough",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Enough.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "enrichment",
+      "name": "Enrichment",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Enrichment.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "ensures",
+      "name": "Ensures",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ensures.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/to-issues",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "huggingface/transformers-js",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "entirely",
+      "name": "Entirely",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Entirely.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "entries",
+      "name": "Entries",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Entries.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.615
+        },
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.526
+        },
+        {
+          "namedSkillId": "mattpocock/to-issues",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "entry",
+      "name": "Entry",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Entry.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "env",
+      "name": "Env",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Env.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "epic",
+      "name": "Epic",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Epic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "equivalent",
+      "name": "Equivalent",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Equivalent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.455
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/requirements-engineer",
+          "score": 0.452
+        }
+      ]
+    },
+    {
+      "id": "error",
+      "name": "Error",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Error.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "errors",
+      "name": "Errors",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Errors.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "esac",
+      "name": "Esac",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Esac.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "euo",
+      "name": "Euo",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Euo.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "evaluate",
+      "name": "Evaluate",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Evaluate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "every",
+      "name": "Every",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Every.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "everything",
+      "name": "Everything",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Everything.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "evidence",
+      "name": "Evidence",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Evidence.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "evidence-check",
+      "name": "Evidence-check",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Evidence-check.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "evidenced",
+      "name": "Evidenced",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Evidenced.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "exact",
+      "name": "Exact",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exact.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "exactly",
+      "name": "Exactly",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exactly.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "examples",
+      "name": "Examples",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Examples.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.533
+        }
+      ]
+    },
+    {
+      "id": "exist",
+      "name": "Exist",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exist.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "existing",
+      "name": "Existing",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Existing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "yonatangross/orchestkit-rag",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "existing-id",
+      "name": "Existing-id",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Existing-id.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "existing-skill",
+      "name": "Existing-skill",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Existing-skill.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.64
+        },
+        {
+          "namedSkillId": "mattpocock/write-a-skill",
+          "score": 0.519
+        }
+      ]
+    },
+    {
+      "id": "exists",
+      "name": "Exists",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exists.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "exit",
+      "name": "Exit",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "expand",
+      "name": "Expand",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Expand.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "expected",
+      "name": "Expected",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Expected.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "experimental-feature",
+      "name": "Experimental-feature",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Experimental-feature.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "explicit",
+      "name": "Explicit",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Explicit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "explicitly",
+      "name": "Explicitly",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Explicitly.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "exposes",
+      "name": "Exposes",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Exposes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/to-issues",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "extend",
+      "name": "Extend",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Extend.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "extensions",
+      "name": "Extensions",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Extensions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "external",
+      "name": "External",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: External.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "extra",
+      "name": "Extra",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Extra.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.545
+        }
+      ]
+    },
+    {
+      "id": "failing",
+      "name": "Failing",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Failing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "huggingface/hf-cli",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "fails",
+      "name": "Fails",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fails.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "fallback",
+      "name": "Fallback",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fallback.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "family",
+      "name": "Family",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Family.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "favored",
+      "name": "Favored",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Favored.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/to-prd",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "feat",
+      "name": "Feat",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Feat.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "feature",
+      "name": "Feature",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Feature.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "features",
+      "name": "Features",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Features.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "mattpocock/to-issues",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "fetch",
+      "name": "Fetch",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fetch.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ff-only",
+      "name": "Ff-only",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ff-only.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "huggingface/hf-cli",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "fields",
+      "name": "Fields",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fields.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.471
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "file",
+      "name": "File",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: File.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/grill-me",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "files",
+      "name": "Files",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Files.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "mattpocock/grill-me",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "final",
+      "name": "Final",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Final.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "finalized",
+      "name": "Finalized",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Finalized.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "find",
+      "name": "Find",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Find.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.533
+        }
+      ]
+    },
+    {
+      "id": "finding",
+      "name": "Finding",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Finding.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.556
+        }
+      ]
+    },
+    {
+      "id": "findings",
+      "name": "Findings",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Findings.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.632
+        },
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "first",
+      "name": "First",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: First.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fix",
+      "name": "Fix",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fix.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fixed",
+      "name": "Fixed",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fixed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "flagged",
+      "name": "Flagged",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Flagged.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "flags",
+      "name": "Flags",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Flags.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "floor",
+      "name": "Floor",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Floor.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "focused",
+      "name": "Focused",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Focused.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "follow-up",
+      "name": "Follow-up",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Follow-up.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "ruvnet/flow-nexus-swarm",
+          "score": 0.48
+        },
+        {
+          "namedSkillId": "mattpocock/zoom-out",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "following",
+      "name": "Following",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Following.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "follows",
+      "name": "Follows",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Follows.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "for-each-ref",
+      "name": "For-each-ref",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: For-each-ref.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "yonatangross/orchestkit-rag",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "format",
+      "name": "Format",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Format.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "formatting",
+      "name": "Formatting",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Formatting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "found",
+      "name": "Found",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Found.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fresh",
+      "name": "Fresh",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fresh.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "full",
+      "name": "Full",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Full.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fully",
+      "name": "Fully",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fully.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "fuzzy-match",
+      "name": "Fuzzy-match",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Fuzzy-match.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gaia",
+      "name": "Gaia",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaia.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "gaiabot/gaia-triage",
+          "score": 0.533
+        }
+      ]
+    },
+    {
+      "id": "gaia-bot-crawl-skill-names",
+      "name": "Gaia-bot-crawl-skill-names",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaia-bot-crawl-skill-names.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "gaiabot/gaia-triage",
+          "score": 0.486
+        },
+        {
+          "namedSkillId": "mattpocock/grill-me",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "gaia-bot-curate",
+      "name": "Gaia-bot-curate",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaia-bot-curate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "gaiabot/gaia-triage",
+          "score": 0.692
+        },
+        {
+          "namedSkillId": "gaiabot/repo-docs-before-pr",
+          "score": 0.524
+        },
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.45
+        }
+      ]
+    },
+    {
+      "id": "gaia-curate",
+      "name": "Gaia-curate",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaia-curate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "gaiabot/gaia-triage",
+          "score": 0.727
+        },
+        {
+          "namedSkillId": "anthropic/skill-creator",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "gaia-draft-curate",
+      "name": "Gaia-draft-curate",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaia-draft-curate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "gaiabot/gaia-triage",
+          "score": 0.571
+        }
+      ]
+    },
+    {
+      "id": "gaia-registry",
+      "name": "Gaia-registry",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaia-registry.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "gaiabot/gaia-triage",
+          "score": 0.583
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/database-engineer",
+          "score": 0.467
+        },
+        {
+          "namedSkillId": "anthropic/skill-creator",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "gaia-skill-tree",
+      "name": "Gaia-skill-tree",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaia-skill-tree.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "gaiabot/gaia-triage",
+          "score": 0.615
+        },
+        {
+          "namedSkillId": "anthropic/skill-creator",
+          "score": 0.571
+        },
+        {
+          "namedSkillId": "mattpocock/write-a-skill",
+          "score": 0.571
+        }
+      ]
+    },
+    {
+      "id": "gaia-wiki-sync",
+      "name": "Gaia-wiki-sync",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gaia-wiki-sync.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/grill-with-docs",
+          "score": 0.483
+        },
+        {
+          "namedSkillId": "gaiabot/gaia-triage",
+          "score": 0.48
+        }
+      ]
+    },
+    {
+      "id": "gather",
+      "name": "Gather",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gather.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "gaiabot/gaia-triage",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "generate",
+      "name": "Generate",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Generate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.696
+        },
+        {
+          "namedSkillId": "glincker/readme-generator",
+          "score": 0.583
+        },
+        {
+          "namedSkillId": "upsonic/unittest-generator",
+          "score": 0.538
+        }
+      ]
+    },
+    {
+      "id": "generated",
+      "name": "Generated",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Generated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.667
+        },
+        {
+          "namedSkillId": "glincker/readme-generator",
+          "score": 0.56
+        },
+        {
+          "namedSkillId": "upsonic/unittest-generator",
+          "score": 0.519
+        }
+      ]
+    },
+    {
+      "id": "generated-output",
+      "name": "Generated-output",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Generated-output.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.516
+        },
+        {
+          "namedSkillId": "glincker/readme-generator",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "upsonic/unittest-generator",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "generating",
+      "name": "Generating",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Generating.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.56
+        },
+        {
+          "namedSkillId": "glincker/readme-generator",
+          "score": 0.538
+        },
+        {
+          "namedSkillId": "upsonic/unittest-generator",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "generation",
+      "name": "Generation",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Generation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "glincker/readme-generator",
+          "score": 0.615
+        },
+        {
+          "namedSkillId": "upsonic/unittest-generator",
+          "score": 0.571
+        },
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.56
+        }
+      ]
+    },
+    {
+      "id": "generic",
+      "name": "Generic",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Generic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "get",
+      "name": "Get",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Get.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gexf",
+      "name": "Gexf",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gexf.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "git",
+      "name": "Git",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Git.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "github",
+      "name": "Github",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Github.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "gitkeep",
+      "name": "Gitkeep",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Gitkeep.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "glob",
+      "name": "Glob",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Glob.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "graph",
+      "name": "Graph",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Graph.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "grouped",
+      "name": "Grouped",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Grouped.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "grows",
+      "name": "Grows",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Grows.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "guessing",
+      "name": "Guessing",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Guessing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "hand",
+      "name": "Hand",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hand.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "happens",
+      "name": "Happens",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Happens.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "hardcode",
+      "name": "Hardcode",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hardcode.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "hardening",
+      "name": "Hardening",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hardening.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "has",
+      "name": "Has",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Has.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "have",
+      "name": "Have",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Have.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "head",
+      "name": "Head",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Head.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "heading",
+      "name": "Heading",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Heading.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "heads",
+      "name": "Heads",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Heads.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "heavyweight-dependency",
+      "name": "Heavyweight-dependency",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Heavyweight-dependency.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "held",
+      "name": "Held",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Held.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "help",
+      "name": "Help",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Help.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "helps",
+      "name": "Helps",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Helps.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "hf-cli",
+      "name": "Hf-cli",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hf-cli.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "huggingface/hf-cli",
+          "score": 1.0
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "hierarchy",
+      "name": "Hierarchy",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hierarchy.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "high-level",
+      "name": "High-level",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: High-level.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "hints",
+      "name": "Hints",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hints.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "history",
+      "name": "History",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: History.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/to-prd",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "hold",
+      "name": "Hold",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hold.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "homepages",
+      "name": "Homepages",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Homepages.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "hooks",
+      "name": "Hooks",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Hooks.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "https",
+      "name": "Https",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Https.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "huggingface",
+      "name": "Huggingface",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Huggingface.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "huggingface/hf-cli",
+          "score": 0.759
+        },
+        {
+          "namedSkillId": "huggingface/huggingface-papers",
+          "score": 0.759
+        },
+        {
+          "namedSkillId": "huggingface/huggingface-datasets",
+          "score": 0.71
+        }
+      ]
+    },
+    {
+      "id": "human",
+      "name": "Human",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Human.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "identified",
+      "name": "Identified",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Identified.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "identify",
+      "name": "Identify",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Identify.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "identity",
+      "name": "Identity",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Identity.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "immediately",
+      "name": "Immediately",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Immediately.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.522
+        }
+      ]
+    },
+    {
+      "id": "immutable",
+      "name": "Immutable",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Immutable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "implementation",
+      "name": "Implementation",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Implementation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/parallel-execution",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "glincker/readme-generator",
+          "score": 0.467
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/requirements-engineer",
+          "score": 0.457
+        }
+      ]
+    },
+    {
+      "id": "implementations",
+      "name": "Implementations",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Implementations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/parallel-execution",
+          "score": 0.485
+        },
+        {
+          "namedSkillId": "0xdarkmatter/pytest-patterns",
+          "score": 0.467
+        },
+        {
+          "namedSkillId": "glincker/readme-generator",
+          "score": 0.452
+        }
+      ]
+    },
+    {
+      "id": "implemented",
+      "name": "Implemented",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Implemented.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "implementing",
+      "name": "Implementing",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Implementing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/requirements-engineer",
+          "score": 0.485
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/parallel-execution",
+          "score": 0.467
+        }
+      ]
+    },
+    {
+      "id": "include",
+      "name": "Include",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Include.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "includes",
+      "name": "Includes",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Includes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/to-issues",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "incorrectly",
+      "name": "Incorrectly",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Incorrectly.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "independently",
+      "name": "Independently",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Independently.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "individual",
+      "name": "Individual",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Individual.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "info",
+      "name": "Info",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Info.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "information",
+      "name": "Information",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Information.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "informational",
+      "name": "Informational",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Informational.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "informed",
+      "name": "Informed",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Informed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "huggingface/transformers-js",
+          "score": 0.522
+        },
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "input",
+      "name": "Input",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Input.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "inside",
+      "name": "Inside",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Inside.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.571
+        },
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "inspect",
+      "name": "Inspect",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Inspect.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.533
+        }
+      ]
+    },
+    {
+      "id": "install",
+      "name": "Install",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Install.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.556
+        }
+      ]
+    },
+    {
+      "id": "installability",
+      "name": "Installability",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Installability.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.465
+        }
+      ]
+    },
+    {
+      "id": "instead",
+      "name": "Instead",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Instead.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.533
+        }
+      ]
+    },
+    {
+      "id": "intake",
+      "name": "Intake",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Intake.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "gaiabot/gaia-triage",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "into",
+      "name": "Into",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Into.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "inventory",
+      "name": "Inventory",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Inventory.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "anthropic/skill-creator",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "invoke",
+      "name": "Invoke",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Invoke.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.571
+        }
+      ]
+    },
+    {
+      "id": "issue",
+      "name": "Issue",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Issue.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/to-issues",
+          "score": 0.714
+        },
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "issue-number",
+      "name": "Issue-number",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Issue-number.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/to-issues",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "issues",
+      "name": "Issues",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Issues.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/to-issues",
+          "score": 0.8
+        }
+      ]
+    },
+    {
+      "id": "item",
+      "name": "Item",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Item.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "items",
+      "name": "Items",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Items.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "its",
+      "name": "Its",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Its.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "itself",
+      "name": "Itself",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Itself.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "job",
+      "name": "Job",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Job.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "json",
+      "name": "Json",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Json.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "just",
+      "name": "Just",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Just.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "justifies",
+      "name": "Justifies",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Justifies.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "justify",
+      "name": "Justify",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Justify.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "keep",
+      "name": "Keep",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Keep.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "keys",
+      "name": "Keys",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Keys.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "known",
+      "name": "Known",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Known.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "label",
+      "name": "Label",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Label.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "labels",
+      "name": "Labels",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Labels.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "larger",
+      "name": "Larger",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Larger.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "gaiabot/gaia-triage",
+          "score": 0.471
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "last",
+      "name": "Last",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Last.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.545
+        }
+      ]
+    },
+    {
+      "id": "latest",
+      "name": "Latest",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Latest.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.471
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "layout",
+      "name": "Layout",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Layout.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "layouts",
+      "name": "Layouts",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Layouts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "least",
+      "name": "Least",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Least.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.667
+        }
+      ]
+    },
+    {
+      "id": "leave",
+      "name": "Leave",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Leave.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.667
+        }
+      ]
+    },
+    {
+      "id": "left",
+      "name": "Left",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Left.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "legendaries",
+      "name": "Legendaries",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Legendaries.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.486
+        },
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "legendary",
+      "name": "Legendary",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Legendary.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "glincker/readme-generator",
+          "score": 0.48
+        }
+      ]
+    },
+    {
+      "id": "level",
+      "name": "Level",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Level.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "lexical",
+      "name": "Lexical",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lexical.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "license",
+      "name": "License",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: License.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.571
+        },
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.533
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "lifecycle",
+      "name": "Lifecycle",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lifecycle.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "like",
+      "name": "Like",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Like.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "likely",
+      "name": "Likely",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Likely.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "limit",
+      "name": "Limit",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Limit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "limitation",
+      "name": "Limitation",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Limitation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "link",
+      "name": "Link",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Link.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "linked",
+      "name": "Linked",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Linked.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "links",
+      "name": "Links",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Links.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "list",
+      "name": "List",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: List.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "listed",
+      "name": "Listed",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Listed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "listing",
+      "name": "Listing",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Listing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "listings",
+      "name": "Listings",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Listings.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lists",
+      "name": "Lists",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lists.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "load",
+      "name": "Load",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Load.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "local",
+      "name": "Local",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Local.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "locally",
+      "name": "Locally",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Locally.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "location",
+      "name": "Location",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Location.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "anthropic/skill-creator",
+          "score": 0.476
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/parallel-execution",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "locations",
+      "name": "Locations",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Locations.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "anthropic/skill-creator",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "lock",
+      "name": "Lock",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lock.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "log",
+      "name": "Log",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Log.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "login",
+      "name": "Login",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Login.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "longer",
+      "name": "Longer",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Longer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/devops-engineer",
+          "score": 0.476
+        },
+        {
+          "namedSkillId": "ruvnet/flow-nexus-swarm",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "looks",
+      "name": "Looks",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Looks.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lookup",
+      "name": "Lookup",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lookup.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "lowercase",
+      "name": "Lowercase",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lowercase.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.625
+        }
+      ]
+    },
+    {
+      "id": "lowercase-dash",
+      "name": "Lowercase-dash",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Lowercase-dash.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "ls-remote",
+      "name": "Ls-remote",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ls-remote.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "anthropic/skill-creator",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "made",
+      "name": "Made",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Made.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "main",
+      "name": "Main",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Main.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "maintainer",
+      "name": "Maintainer",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Maintainer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/database-engineer",
+          "score": 0.519
+        },
+        {
+          "namedSkillId": "huggingface/huggingface-llm-trainer",
+          "score": 0.485
+        },
+        {
+          "namedSkillId": "gaiabot/gaia-triage",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "maintainers",
+      "name": "Maintainers",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Maintainers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/database-engineer",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "huggingface/huggingface-llm-trainer",
+          "score": 0.471
+        },
+        {
+          "namedSkillId": "gaiabot/gaia-triage",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "make",
+      "name": "Make",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Make.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "manage",
+      "name": "Manage",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Manage.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "gaiabot/gaia-triage",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "manual",
+      "name": "Manual",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Manual.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "many",
+      "name": "Many",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Many.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "map",
+      "name": "Map",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Map.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mapped",
+      "name": "Mapped",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mapped.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mapping",
+      "name": "Mapping",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mapping.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "mappings",
+      "name": "Mappings",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mappings.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mark",
+      "name": "Mark",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mark.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "markdown",
+      "name": "Markdown",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Markdown.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "marker",
+      "name": "Marker",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Marker.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "marketing",
+      "name": "Marketing",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Marketing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "marketplace",
+      "name": "Marketplace",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Marketplace.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "marketplaces",
+      "name": "Marketplaces",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Marketplaces.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "master",
+      "name": "Master",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Master.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.471
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "match",
+      "name": "Match",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Match.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "matches",
+      "name": "Matches",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Matches.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "matching",
+      "name": "Matching",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Matching.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.48
+        }
+      ]
+    },
+    {
+      "id": "matters",
+      "name": "Matters",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Matters.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "0xdarkmatter/pytest-patterns",
+          "score": 0.545
+        },
+        {
+          "namedSkillId": "gooseworks/notte-browser",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "may",
+      "name": "May",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: May.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mbtiongson1",
+      "name": "Mbtiongson1",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mbtiongson1.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mcp",
+      "name": "Mcp",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mcp.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "mcp-server",
+      "name": "Mcp-server",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mcp-server.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "measurable",
+      "name": "Measurable",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Measurable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.471
+        },
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "memory",
+      "name": "Memory",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Memory.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mental",
+      "name": "Mental",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mental.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "merge",
+      "name": "Merge",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Merge.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.545
+        }
+      ]
+    },
+    {
+      "id": "merge-base",
+      "name": "Merge-base",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Merge-base.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.588
+        },
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.48
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "merged",
+      "name": "Merged",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Merged.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "merges",
+      "name": "Merges",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Merges.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.471
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "merits",
+      "name": "Merits",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Merits.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "message",
+      "name": "Message",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Message.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "meta",
+      "name": "Meta",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Meta.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "method",
+      "name": "Method",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Method.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/to-prd",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "minimal",
+      "name": "Minimal",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Minimal.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "minimum",
+      "name": "Minimum",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Minimum.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "missing",
+      "name": "Missing",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Missing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "mode",
+      "name": "Mode",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Mode.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "model",
+      "name": "Model",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Model.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "modify",
+      "name": "Modify",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Modify.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "module",
+      "name": "Module",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Module.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "move",
+      "name": "Move",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Move.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "much",
+      "name": "Much",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Much.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "multiple",
+      "name": "Multiple",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Multiple.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "must",
+      "name": "Must",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Must.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/zoom-out",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "name",
+      "name": "Name",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Name.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "name-only",
+      "name": "Name-only",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Name-only.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "named",
+      "name": "Named",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Named.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "named-origin",
+      "name": "Named-origin",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Named-origin.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "named-skill",
+      "name": "Named-skill",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Named-skill.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.727
+        },
+        {
+          "namedSkillId": "mattpocock/write-a-skill",
+          "score": 0.583
+        }
+      ]
+    },
+    {
+      "id": "named-skills",
+      "name": "Named-skills",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Named-skills.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.783
+        },
+        {
+          "namedSkillId": "mattpocock/write-a-skill",
+          "score": 0.56
+        }
+      ]
+    },
+    {
+      "id": "names",
+      "name": "Names",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Names.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "naming",
+      "name": "Naming",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Naming.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "narrow",
+      "name": "Narrow",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Narrow.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "narrowed",
+      "name": "Narrowed",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Narrowed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "gooseworks/notte-browser",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "narrower",
+      "name": "Narrower",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Narrower.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "gooseworks/notte-browser",
+          "score": 0.571
+        }
+      ]
+    },
+    {
+      "id": "need",
+      "name": "Need",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Need.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "needed",
+      "name": "Needed",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Needed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "needs",
+      "name": "Needs",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Needs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "needs-evidence",
+      "name": "Needs-evidence",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Needs-evidence.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "needs-review",
+      "name": "Needs-review",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Needs-review.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "needs-specific-url",
+      "name": "Needs-specific-url",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Needs-specific-url.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "never",
+      "name": "Never",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Never.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "new",
+      "name": "New",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: New.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "new-id",
+      "name": "New-id",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: New-id.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "next",
+      "name": "Next",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Next.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "niche-integration",
+      "name": "Niche-integration",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Niche-integration.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "upsonic/unittest-generator",
+          "score": 0.514
+        },
+        {
+          "namedSkillId": "glincker/readme-generator",
+          "score": 0.485
+        }
+      ]
+    },
+    {
+      "id": "no-merges",
+      "name": "No-merges",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: No-merges.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "huggingface/transformers-js",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "gooseworks/notte-browser",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "no-verify",
+      "name": "No-verify",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: No-verify.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "gooseworks/notte-browser",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "node",
+      "name": "Node",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Node.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "nodes",
+      "name": "Nodes",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Nodes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "nomenclature",
+      "name": "Nomenclature",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Nomenclature.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "noreply",
+      "name": "Noreply",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Noreply.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "normalized",
+      "name": "Normalized",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Normalized.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "not",
+      "name": "Not",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Not.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "notation",
+      "name": "Notation",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Notation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "gooseworks/notte-browser",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "note",
+      "name": "Note",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Note.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "gooseworks/notte-browser",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "notes",
+      "name": "Notes",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Notes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "gooseworks/notte-browser",
+          "score": 0.556
+        },
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "nothing",
+      "name": "Nothing",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Nothing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "now",
+      "name": "Now",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Now.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "npm",
+      "name": "Npm",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Npm.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "null",
+      "name": "Null",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Null.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "number",
+      "name": "Number",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Number.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "numerals",
+      "name": "Numerals",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Numerals.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "observed",
+      "name": "Observed",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Observed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "gooseworks/notte-browser",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "occurrence",
+      "name": "Occurrence",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Occurrence.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "off",
+      "name": "Off",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Off.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "often",
+      "name": "Often",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Often.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "old",
+      "name": "Old",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Old.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "old-id",
+      "name": "Old-id",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Old-id.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "omit",
+      "name": "Omit",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Omit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/zoom-out",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "one",
+      "name": "One",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: One.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "oneline",
+      "name": "Oneline",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Oneline.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/devops-engineer",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "only",
+      "name": "Only",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Only.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "open",
+      "name": "Open",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Open.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "open-source",
+      "name": "Open-source",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Open-source.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "opened",
+      "name": "Opened",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Opened.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/to-prd",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/devops-engineer",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "opens",
+      "name": "Opens",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Opens.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "optional",
+      "name": "Optional",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Optional.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "options",
+      "name": "Options",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Options.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "order",
+      "name": "Order",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Order.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/to-prd",
+          "score": 0.545
+        },
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "org",
+      "name": "Org",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Org.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "orgs",
+      "name": "Orgs",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Orgs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "origin",
+      "name": "Origin",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Origin.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "original",
+      "name": "Original",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Original.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "originating",
+      "name": "Originating",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Originating.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "orphaned",
+      "name": "Orphaned",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Orphaned.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "other",
+      "name": "Other",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Other.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "out-of-scope",
+      "name": "Out-of-scope",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Out-of-scope.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "gooseworks/notte-browser",
+          "score": 0.48
+        }
+      ]
+    },
+    {
+      "id": "outcomes",
+      "name": "Outcomes",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Outcomes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "mattpocock/to-issues",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "outdated",
+      "name": "Outdated",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Outdated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/tdd",
+          "score": 0.545
+        }
+      ]
+    },
+    {
+      "id": "output",
+      "name": "Output",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Output.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "outputs",
+      "name": "Outputs",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Outputs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "outside",
+      "name": "Outside",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Outside.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "over",
+      "name": "Over",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Over.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "overlaps",
+      "name": "Overlaps",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Overlaps.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.533
+        }
+      ]
+    },
+    {
+      "id": "overpromoted",
+      "name": "Overpromoted",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Overpromoted.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/zoom-out",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "overwritten",
+      "name": "Overwritten",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Overwritten.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "own",
+      "name": "Own",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Own.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "owner",
+      "name": "Owner",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Owner.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "ruvnet/flow-nexus-swarm",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "package",
+      "name": "Package",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Package.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "packages",
+      "name": "Packages",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Packages.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.48
+        }
+      ]
+    },
+    {
+      "id": "packaging",
+      "name": "Packaging",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Packaging.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "packaging-only",
+      "name": "Packaging-only",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Packaging-only.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "page",
+      "name": "Page",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Page.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.6
+        },
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "pages",
+      "name": "Pages",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pages.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.545
+        },
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "paper",
+      "name": "Paper",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Paper.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "papers",
+      "name": "Papers",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Papers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "huggingface/huggingface-papers",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "0xdarkmatter/pytest-patterns",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "parse",
+      "name": "Parse",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Parse.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "part",
+      "name": "Part",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Part.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "anthropic/pptx",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "partially",
+      "name": "Partially",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Partially.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.476
+        },
+        {
+          "namedSkillId": "mattpocock/grill-me",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "pass",
+      "name": "Pass",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pass.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "passes",
+      "name": "Passes",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Passes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/to-issues",
+          "score": 0.533
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "passing",
+      "name": "Passing",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Passing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "patched",
+      "name": "Patched",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Patched.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "patches",
+      "name": "Patches",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Patches.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "0xdarkmatter/pytest-patterns",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "path",
+      "name": "Path",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Path.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "anthropic/pptx",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "paths",
+      "name": "Paths",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Paths.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "payload",
+      "name": "Payload",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Payload.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "payloads",
+      "name": "Payloads",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Payloads.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pending",
+      "name": "Pending",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pending.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/devops-engineer",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "per",
+      "name": "Per",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Per.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "perform",
+      "name": "Perform",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Perform.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "huggingface/transformers-js",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "permanently",
+      "name": "Permanently",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Permanently.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "person",
+      "name": "Person",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Person.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "phase",
+      "name": "Phase",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Phase.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "pip",
+      "name": "Pip",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pip.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "anthropic/pptx",
+          "score": 0.571
+        }
+      ]
+    },
+    {
+      "id": "pipefail",
+      "name": "Pipefail",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pipefail.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/write-a-skill",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "place",
+      "name": "Place",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Place.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "playbook",
+      "name": "Playbook",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Playbook.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "please",
+      "name": "Please",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Please.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.769
+        }
+      ]
+    },
+    {
+      "id": "plus",
+      "name": "Plus",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Plus.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "point",
+      "name": "Point",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Point.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.533
+        }
+      ]
+    },
+    {
+      "id": "points",
+      "name": "Points",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Points.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "policy",
+      "name": "Policy",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Policy.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "polish",
+      "name": "Polish",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Polish.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "popular",
+      "name": "Popular",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Popular.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "possible",
+      "name": "Possible",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Possible.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/to-issues",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "post",
+      "name": "Post",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Post.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "anthropic/pptx",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "pre-populating",
+      "name": "Pre-populating",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pre-populating.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/parallel-execution",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "0xdarkmatter/pytest-patterns",
+          "score": 0.483
+        }
+      ]
+    },
+    {
+      "id": "prereqs",
+      "name": "Prereqs",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prereqs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.571
+        }
+      ]
+    },
+    {
+      "id": "prerequisite",
+      "name": "Prerequisite",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prerequisite.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.526
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/requirements-engineer",
+          "score": 0.485
+        }
+      ]
+    },
+    {
+      "id": "prerequisites",
+      "name": "Prerequisites",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prerequisites.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/requirements-engineer",
+          "score": 0.471
+        },
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.452
+        }
+      ]
+    },
+    {
+      "id": "presence",
+      "name": "Presence",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Presence.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.533
+        },
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "present",
+      "name": "Present",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Present.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.571
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.471
+        },
+        {
+          "namedSkillId": "0xdarkmatter/pytest-patterns",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "previously",
+      "name": "Previously",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Previously.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "print",
+      "name": "Print",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Print.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.533
+        }
+      ]
+    },
+    {
+      "id": "printf",
+      "name": "Printf",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Printf.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "prints",
+      "name": "Prints",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prints.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "prioritized",
+      "name": "Prioritized",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prioritized.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "priority",
+      "name": "Priority",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Priority.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "problems",
+      "name": "Problems",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Problems.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.533
+        }
+      ]
+    },
+    {
+      "id": "proceed",
+      "name": "Proceed",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Proceed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/to-prd",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "process",
+      "name": "Process",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Process.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "huggingface/transformers-js",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "produced",
+      "name": "Produced",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Produced.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "project",
+      "name": "Project",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Project.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "projection",
+      "name": "Projection",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Projection.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/parallel-execution",
+          "score": 0.571
+        }
+      ]
+    },
+    {
+      "id": "promote",
+      "name": "Promote",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Promote.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/zoom-out",
+          "score": 0.533
+        }
+      ]
+    },
+    {
+      "id": "promoted",
+      "name": "Promoted",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Promoted.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/zoom-out",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "mattpocock/tdd",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "promotion",
+      "name": "Promotion",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Promotion.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/zoom-out",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "proposal",
+      "name": "Proposal",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Proposal.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "proposals",
+      "name": "Proposals",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Proposals.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "propose",
+      "name": "Propose",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Propose.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "proposed",
+      "name": "Proposed",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Proposed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "proposed-skill-id",
+      "name": "Proposed-skill-id",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Proposed-skill-id.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/write-a-skill",
+          "score": 0.533
+        },
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.514
+        },
+        {
+          "namedSkillId": "anthropic/skill-creator",
+          "score": 0.45
+        }
+      ]
+    },
+    {
+      "id": "proposed-skill-name",
+      "name": "Proposed-skill-name",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Proposed-skill-name.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/grill-me",
+          "score": 0.519
+        },
+        {
+          "namedSkillId": "mattpocock/write-a-skill",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.486
+        }
+      ]
+    },
+    {
+      "id": "proposing",
+      "name": "Proposing",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Proposing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "provides",
+      "name": "Provides",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Provides.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/to-issues",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "provisional",
+      "name": "Provisional",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Provisional.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "prune",
+      "name": "Prune",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Prune.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pruning",
+      "name": "Pruning",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pruning.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "public",
+      "name": "Public",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Public.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "publish",
+      "name": "Publish",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Publish.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "published",
+      "name": "Published",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Published.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pull",
+      "name": "Pull",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pull.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "push",
+      "name": "Push",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Push.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pushing",
+      "name": "Pushing",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pushing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "pyproject",
+      "name": "Pyproject",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pyproject.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "anthropic/pptx",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "pytest",
+      "name": "Pytest",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Pytest.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "0xdarkmatter/pytest-patterns",
+          "score": 0.571
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "python",
+      "name": "Python",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Python.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "python3",
+      "name": "Python3",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Python3.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "qualifying",
+      "name": "Qualifying",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Qualifying.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "questions",
+      "name": "Questions",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Questions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "queue",
+      "name": "Queue",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Queue.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "quick",
+      "name": "Quick",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Quick.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "quickstart",
+      "name": "Quickstart",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Quickstart.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "rare",
+      "name": "Rare",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rare.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.6
+        }
+      ]
+    },
+    {
+      "id": "rarity",
+      "name": "Rarity",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rarity.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rather",
+      "name": "Rather",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rather.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "raw",
+      "name": "Raw",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Raw.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "re-resolve",
+      "name": "Re-resolve",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Re-resolve.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.588
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "read",
+      "name": "Read",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Read.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.545
+        }
+      ]
+    },
+    {
+      "id": "read-only",
+      "name": "Read-only",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Read-only.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "glincker/readme-generator",
+          "score": 0.48
+        },
+        {
+          "namedSkillId": "mattpocock/write-a-skill",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "readily",
+      "name": "Readily",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Readily.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/write-a-skill",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "readme",
+      "name": "Readme",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Readme.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.615
+        },
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.571
+        },
+        {
+          "namedSkillId": "glincker/readme-generator",
+          "score": 0.545
+        }
+      ]
+    },
+    {
+      "id": "ready",
+      "name": "Ready",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ready.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "real",
+      "name": "Real",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Real.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.545
+        },
+        {
+          "namedSkillId": "mattpocock/write-a-skill",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "real-skill",
+      "name": "Real-skill",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Real-skill.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/write-a-skill",
+          "score": 0.783
+        },
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.643
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "real-skills",
+      "name": "Real-skills",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Real-skills.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/write-a-skill",
+          "score": 0.75
+        },
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.69
+        }
+      ]
+    },
+    {
+      "id": "real-world",
+      "name": "Real-world",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Real-world.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "glincker/readme-generator",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "reason",
+      "name": "Reason",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reason.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.615
+        }
+      ]
+    },
+    {
+      "id": "reasons",
+      "name": "Reasons",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reasons.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.571
+        }
+      ]
+    },
+    {
+      "id": "recent",
+      "name": "Recent",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Recent.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.476
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "recorded",
+      "name": "Recorded",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Recorded.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "records",
+      "name": "Records",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Records.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/to-prd",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "red",
+      "name": "Red",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Red.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reference",
+      "name": "Reference",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reference.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "references",
+      "name": "References",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: References.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.471
+        },
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "reframe",
+      "name": "Reframe",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reframe.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.571
+        },
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "refresh",
+      "name": "Refresh",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Refresh.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.571
+        }
+      ]
+    },
+    {
+      "id": "refs",
+      "name": "Refs",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Refs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.545
+        }
+      ]
+    },
+    {
+      "id": "registered",
+      "name": "Registered",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Registered.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.571
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.471
+        },
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "registries",
+      "name": "Registries",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Registries.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "gaiabot/gaia-triage",
+          "score": 0.571
+        },
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "registry",
+      "name": "Registry",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Registry.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.526
+        },
+        {
+          "namedSkillId": "yonatangross/orchestkit-rag",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "registry-for-review",
+      "name": "Registry-for-review",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Registry-for-review.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "gaiabot/repo-docs-before-pr",
+          "score": 0.474
+        }
+      ]
+    },
+    {
+      "id": "regression",
+      "name": "Regression",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Regression.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.471
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/requirements-engineer",
+          "score": 0.452
+        }
+      ]
+    },
+    {
+      "id": "regressions",
+      "name": "Regressions",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Regressions.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reject",
+      "name": "Reject",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reject.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "rejected",
+      "name": "Rejected",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rejected.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.533
+        }
+      ]
+    },
+    {
+      "id": "related",
+      "name": "Related",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Related.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.714
+        },
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "release",
+      "name": "Release",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Release.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 1.0
+        },
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "release-process",
+      "name": "Release-process",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Release-process.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.636
+        },
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.467
+        },
+        {
+          "namedSkillId": "mattpocock/improve-codebase-architecture",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "relevance",
+      "name": "Relevance",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Relevance.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.75
+        },
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "relevant",
+      "name": "Relevant",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Relevant.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.667
+        }
+      ]
+    },
+    {
+      "id": "relies",
+      "name": "Relies",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Relies.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.769
+        }
+      ]
+    },
+    {
+      "id": "remaining",
+      "name": "Remaining",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Remaining.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "remains",
+      "name": "Remains",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Remains.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.571
+        }
+      ]
+    },
+    {
+      "id": "remote",
+      "name": "Remote",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Remote.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.476
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "remote-only",
+      "name": "Remote-only",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Remote-only.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "remotes",
+      "name": "Remotes",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Remotes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.571
+        },
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "remove",
+      "name": "Remove",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Remove.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "removed",
+      "name": "Removed",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Removed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rename",
+      "name": "Rename",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rename.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.615
+        },
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.476
+        },
+        {
+          "namedSkillId": "glincker/readme-generator",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "renamed",
+      "name": "Renamed",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Renamed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.571
+        },
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "rendering",
+      "name": "Rendering",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rendering.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reopen",
+      "name": "Reopen",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reopen.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/devops-engineer",
+          "score": 0.476
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "replaced",
+      "name": "Replaced",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Replaced.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.667
+        }
+      ]
+    },
+    {
+      "id": "repo",
+      "name": "Repo",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Repo.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "repo-level",
+      "name": "Repo-level",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Repo-level.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.588
+        },
+        {
+          "namedSkillId": "gaiabot/repo-docs-before-pr",
+          "score": 0.483
+        },
+        {
+          "namedSkillId": "laravel/upgrade-laravel-v13",
+          "score": 0.483
+        }
+      ]
+    },
+    {
+      "id": "repo-root",
+      "name": "Repo-root",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Repo-root.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "report",
+      "name": "Report",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Report.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reports",
+      "name": "Reports",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reports.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "repos",
+      "name": "Repos",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Repos.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "repository",
+      "name": "Repository",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Repository.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "yonatangross/orchestkit-rag",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "gaiabot/repo-docs-before-pr",
+          "score": 0.483
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "reproduce",
+      "name": "Reproduce",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reproduce.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reproducible",
+      "name": "Reproducible",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reproducible.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "reproduction",
+      "name": "Reproduction",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reproduction.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/parallel-execution",
+          "score": 0.467
+        }
+      ]
+    },
+    {
+      "id": "reputable",
+      "name": "Reputable",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reputable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "request",
+      "name": "Request",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Request.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.571
+        }
+      ]
+    },
+    {
+      "id": "requests",
+      "name": "Requests",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Requests.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.533
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/requirements-engineer",
+          "score": 0.483
+        }
+      ]
+    },
+    {
+      "id": "require",
+      "name": "Require",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Require.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/requirements-engineer",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "required",
+      "name": "Required",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Required.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/requirements-engineer",
+          "score": 0.483
+        }
+      ]
+    },
+    {
+      "id": "requires",
+      "name": "Requires",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Requires.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/requirements-engineer",
+          "score": 0.552
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.533
+        }
+      ]
+    },
+    {
+      "id": "rerun",
+      "name": "Rerun",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rerun.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "resolution",
+      "name": "Resolution",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Resolution.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/parallel-execution",
+          "score": 0.571
+        }
+      ]
+    },
+    {
+      "id": "resolvable",
+      "name": "Resolvable",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Resolvable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "resolved",
+      "name": "Resolved",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Resolved.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.533
+        }
+      ]
+    },
+    {
+      "id": "resolves",
+      "name": "Resolves",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Resolves.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.533
+        }
+      ]
+    },
+    {
+      "id": "respect",
+      "name": "Respect",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Respect.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.571
+        },
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.526
+        }
+      ]
+    },
+    {
+      "id": "restore",
+      "name": "Restore",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Restore.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.571
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.556
+        },
+        {
+          "namedSkillId": "anthropic/skill-creator",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "restructure",
+      "name": "Restructure",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Restructure.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.455
+        },
+        {
+          "namedSkillId": "mattpocock/improve-codebase-architecture",
+          "score": 0.45
+        }
+      ]
+    },
+    {
+      "id": "result",
+      "name": "Result",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Result.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.471
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "results",
+      "name": "Results",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Results.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "retitle",
+      "name": "Retitle",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Retitle.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.571
+        },
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.526
+        },
+        {
+          "namedSkillId": "yonatangross/orchestkit-rag",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "return",
+      "name": "Return",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Return.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "returns",
+      "name": "Returns",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Returns.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "0xdarkmatter/pytest-patterns",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "review",
+      "name": "Review",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Review.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "reviewed",
+      "name": "Reviewed",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reviewed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.533
+        }
+      ]
+    },
+    {
+      "id": "reviewer",
+      "name": "Reviewer",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reviewer.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.533
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/devops-engineer",
+          "score": 0.522
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/security-engineer",
+          "score": 0.48
+        }
+      ]
+    },
+    {
+      "id": "reviewers",
+      "name": "Reviewers",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Reviewers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/devops-engineer",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/security-engineer",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "rewrite",
+      "name": "Rewrite",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rewrite.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/write-a-skill",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.462
+        },
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "rewriting",
+      "name": "Rewriting",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rewriting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/security-engineer",
+          "score": 0.462
+        },
+        {
+          "namedSkillId": "mattpocock/write-a-skill",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "root",
+      "name": "Root",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Root.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/zoom-out",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "route-review",
+      "name": "Route-review",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Route-review.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "gooseworks/notte-browser",
+          "score": 0.48
+        }
+      ]
+    },
+    {
+      "id": "routed",
+      "name": "Routed",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Routed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "row",
+      "name": "Row",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Row.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "rule",
+      "name": "Rule",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rule.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.545
+        },
+        {
+          "namedSkillId": "mattpocock/grill-me",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "rules",
+      "name": "Rules",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Rules.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.667
+        },
+        {
+          "namedSkillId": "mattpocock/grill-me",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "run",
+      "name": "Run",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Run.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "running",
+      "name": "Running",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Running.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "runs",
+      "name": "Runs",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Runs.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "same",
+      "name": "Same",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Same.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "says",
+      "name": "Says",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Says.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scan",
+      "name": "Scan",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scan.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scans",
+      "name": "Scans",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scans.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "schema",
+      "name": "Schema",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Schema.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scope",
+      "name": "Scope",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scope.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "score",
+      "name": "Score",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Score.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "screenshot",
+      "name": "Screenshot",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Screenshot.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "script",
+      "name": "Script",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Script.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "scripts",
+      "name": "Scripts",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Scripts.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "search",
+      "name": "Search",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Search.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.667
+        }
+      ]
+    },
+    {
+      "id": "section",
+      "name": "Section",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Section.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/security-engineer",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/parallel-execution",
+          "score": 0.48
+        }
+      ]
+    },
+    {
+      "id": "sections",
+      "name": "Sections",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sections.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/security-engineer",
+          "score": 0.48
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/parallel-execution",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "see",
+      "name": "See",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: See.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "separate",
+      "name": "Separate",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Separate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.526
+        },
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.522
+        },
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "separately",
+      "name": "Separately",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Separately.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "spring-ai/readme-generate",
+          "score": 0.48
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.476
+        },
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "server",
+      "name": "Server",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Server.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.588
+        }
+      ]
+    },
+    {
+      "id": "servers",
+      "name": "Servers",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Servers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.556
+        },
+        {
+          "namedSkillId": "huggingface/transformers-js",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "set",
+      "name": "Set",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Set.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "setuptools",
+      "name": "Setuptools",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Setuptools.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "several",
+      "name": "Several",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Several.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "shape",
+      "name": "Shape",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Shape.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "short-crawl-slug",
+      "name": "Short-crawl-slug",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Short-crawl-slug.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/write-a-skill",
+          "score": 0.483
+        },
+        {
+          "namedSkillId": "yonatangross/orchestkit-rag",
+          "score": 0.467
+        }
+      ]
+    },
+    {
+      "id": "should",
+      "name": "Should",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Should.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "show",
+      "name": "Show",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Show.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "signal",
+      "name": "Signal",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Signal.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "signatures",
+      "name": "Signatures",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Signatures.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "since",
+      "name": "Since",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Since.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "single",
+      "name": "Single",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Single.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "site",
+      "name": "Site",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Site.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "skill",
+      "name": "Skill",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skill.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.625
+        },
+        {
+          "namedSkillId": "anthropic/skill-creator",
+          "score": 0.556
+        },
+        {
+          "namedSkillId": "mattpocock/write-a-skill",
+          "score": 0.556
+        }
+      ]
+    },
+    {
+      "id": "skill-batches",
+      "name": "Skill-batches",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skill-batches.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "anthropic/skill-creator",
+          "score": 0.615
+        },
+        {
+          "namedSkillId": "mattpocock/grill-with-docs",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "skill-id",
+      "name": "Skill-id",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skill-id.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "anthropic/skill-creator",
+          "score": 0.571
+        },
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.526
+        },
+        {
+          "namedSkillId": "mattpocock/grill-with-docs",
+          "score": 0.522
+        }
+      ]
+    },
+    {
+      "id": "skill-name",
+      "name": "Skill-name",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skill-name.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/grill-me",
+          "score": 0.667
+        },
+        {
+          "namedSkillId": "anthropic/skill-creator",
+          "score": 0.609
+        },
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "skill-shaped",
+      "name": "Skill-shaped",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skill-shaped.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "anthropic/skill-creator",
+          "score": 0.56
+        },
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.522
+        },
+        {
+          "namedSkillId": "mattpocock/grill-me",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "skill-sources",
+      "name": "Skill-sources",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skill-sources.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "anthropic/skill-creator",
+          "score": 0.615
+        },
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "mattpocock/grill-me",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "skill-topic",
+      "name": "Skill-topic",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skill-topic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "anthropic/skill-creator",
+          "score": 0.667
+        },
+        {
+          "namedSkillId": "mattpocock/grill-with-docs",
+          "score": 0.538
+        },
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "skill-tree",
+      "name": "Skill-tree",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skill-tree.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "anthropic/skill-creator",
+          "score": 0.696
+        },
+        {
+          "namedSkillId": "mattpocock/grill-me",
+          "score": 0.556
+        },
+        {
+          "namedSkillId": "gaiabot/gaia-triage",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "skill-trees",
+      "name": "Skill-trees",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skill-trees.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "anthropic/skill-creator",
+          "score": 0.667
+        },
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.545
+        },
+        {
+          "namedSkillId": "mattpocock/grill-me",
+          "score": 0.526
+        }
+      ]
+    },
+    {
+      "id": "skills",
+      "name": "Skills",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skills.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.706
+        },
+        {
+          "namedSkillId": "anthropic/skill-creator",
+          "score": 0.526
+        },
+        {
+          "namedSkillId": "mattpocock/write-a-skill",
+          "score": 0.526
+        }
+      ]
+    },
+    {
+      "id": "skills-dir",
+      "name": "Skills-dir",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skills-dir.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "anthropic/skill-creator",
+          "score": 0.609
+        },
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.571
+        }
+      ]
+    },
+    {
+      "id": "skillsmp",
+      "name": "Skillsmp",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skillsmp.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.632
+        },
+        {
+          "namedSkillId": "mattpocock/grill-me",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "anthropic/skill-creator",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "skip",
+      "name": "Skip",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Skip.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "slash",
+      "name": "Slash",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Slash.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "slug",
+      "name": "Slug",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Slug.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "smaller",
+      "name": "Smaller",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Smaller.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "anthropic/skill-creator",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "smallest",
+      "name": "Smallest",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Smallest.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "anthropic/skill-creator",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "snapshot",
+      "name": "Snapshot",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Snapshot.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "snapshots",
+      "name": "Snapshots",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Snapshots.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sort",
+      "name": "Sort",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sort.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "source",
+      "name": "Source",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Source.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "source-directory",
+      "name": "Source-directory",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Source-directory.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "anthropic/skill-creator",
+          "score": 0.483
+        }
+      ]
+    },
+    {
+      "id": "source-level",
+      "name": "Source-level",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Source-level.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.526
+        },
+        {
+          "namedSkillId": "laravel/upgrade-laravel-v13",
+          "score": 0.516
+        },
+        {
+          "namedSkillId": "addy-osmani/test-driven-development",
+          "score": 0.457
+        }
+      ]
+    },
+    {
+      "id": "source-of-truth",
+      "name": "Source-of-truth",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Source-of-truth.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sourced",
+      "name": "Sourced",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sourced.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/to-prd",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "sources",
+      "name": "Sources",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sources.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/to-issues",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "yonatangross/orchestkit-rag",
+          "score": 0.476
+        },
+        {
+          "namedSkillId": "huggingface/transformers-js",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "specific",
+      "name": "Specific",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Specific.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "split",
+      "name": "Split",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Split.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.533
+        }
+      ]
+    },
+    {
+      "id": "src",
+      "name": "Src",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Src.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "stable",
+      "name": "Stable",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "stale",
+      "name": "Stale",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stale.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.545
+        },
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "standardized",
+      "name": "Standardized",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Standardized.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "standards",
+      "name": "Standards",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Standards.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/tdd",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "star",
+      "name": "Star",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Star.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "star-tiers",
+      "name": "Star-tiers",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Star-tiers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.571
+        },
+        {
+          "namedSkillId": "0xdarkmatter/pytest-patterns",
+          "score": 0.56
+        },
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.545
+        }
+      ]
+    },
+    {
+      "id": "stars",
+      "name": "Stars",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stars.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "0xdarkmatter/pytest-patterns",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "starting",
+      "name": "Starting",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Starting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "state",
+      "name": "State",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: State.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.545
+        },
+        {
+          "namedSkillId": "0xdarkmatter/pytest-patterns",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "stats",
+      "name": "Stats",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stats.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "0xdarkmatter/pytest-patterns",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "status",
+      "name": "Status",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Status.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "0xdarkmatter/pytest-patterns",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "stay",
+      "name": "Stay",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stay.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "step",
+      "name": "Step",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Step.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "steps",
+      "name": "Steps",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Steps.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "still",
+      "name": "Still",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Still.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "mattpocock/grill-me",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "stop",
+      "name": "Stop",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stop.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/to-prd",
+          "score": 0.6
+        }
+      ]
+    },
+    {
+      "id": "stored",
+      "name": "Stored",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stored.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/to-prd",
+          "score": 0.667
+        },
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "stronger",
+      "name": "Stronger",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Stronger.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.571
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/security-engineer",
+          "score": 0.48
+        },
+        {
+          "namedSkillId": "gooseworks/notte-browser",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "structure",
+      "name": "Structure",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Structure.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "style",
+      "name": "Style",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Style.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "subcommand",
+      "name": "Subcommand",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Subcommand.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "subdirectories",
+      "name": "Subdirectories",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Subdirectories.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "anthropic/skill-creator",
+          "score": 0.519
+        },
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "subdirectory",
+      "name": "Subdirectory",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Subdirectory.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "anthropic/skill-creator",
+          "score": 0.56
+        }
+      ]
+    },
+    {
+      "id": "subjects",
+      "name": "Subjects",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Subjects.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/to-issues",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "submit",
+      "name": "Submit",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Submit.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "subparsers",
+      "name": "Subparsers",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Subparsers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "0xdarkmatter/pytest-patterns",
+          "score": 0.48
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "subset",
+      "name": "Subset",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Subset.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "substantive",
+      "name": "Substantive",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Substantive.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "such",
+      "name": "Such",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Such.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sufficient",
+      "name": "Sufficient",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sufficient.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/mcp-client",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "suggested",
+      "name": "Suggested",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Suggested.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "suite",
+      "name": "Suite",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Suite.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/security-engineer",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "summarized",
+      "name": "Summarized",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Summarized.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "summarizing",
+      "name": "Summarizing",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Summarizing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "summary",
+      "name": "Summary",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Summary.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "superseded",
+      "name": "Superseded",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Superseded.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "supplementary",
+      "name": "Supplementary",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Supplementary.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "supplied",
+      "name": "Supplied",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Supplied.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "supports",
+      "name": "Supports",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Supports.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "anthropic/pptx",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "surfaces",
+      "name": "Surfaces",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Surfaces.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/to-issues",
+          "score": 0.471
+        },
+        {
+          "namedSkillId": "huggingface/huggingface-papers",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "survey",
+      "name": "Survey",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Survey.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "symbols",
+      "name": "Symbols",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Symbols.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "sync",
+      "name": "Sync",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Sync.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "system",
+      "name": "System",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: System.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "table",
+      "name": "Table",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Table.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.545
+        },
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "tally",
+      "name": "Tally",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tally.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "target",
+      "name": "Target",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Target.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.667
+        },
+        {
+          "namedSkillId": "gaiabot/gaia-triage",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "targeting",
+      "name": "Targeting",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Targeting.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.533
+        },
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "telling",
+      "name": "Telling",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Telling.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "templates",
+      "name": "Templates",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Templates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "test",
+      "name": "Test",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Test.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.533
+        },
+        {
+          "namedSkillId": "mattpocock/to-issues",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "tests",
+      "name": "Tests",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tests.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "0xdarkmatter/pytest-patterns",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "than",
+      "name": "Than",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Than.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "thanked",
+      "name": "Thanked",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Thanked.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "their",
+      "name": "Their",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Their.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "them",
+      "name": "Them",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Them.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "then",
+      "name": "Then",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Then.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "there",
+      "name": "There",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: There.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "these",
+      "name": "These",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: These.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "they",
+      "name": "They",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: They.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "this",
+      "name": "This",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: This.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/to-issues",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "those",
+      "name": "Those",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Those.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/to-issues",
+          "score": 0.571
+        },
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        },
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "three",
+      "name": "Three",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Three.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.545
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "through",
+      "name": "Through",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Through.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "tier",
+      "name": "Tier",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tier.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.6
+        },
+        {
+          "namedSkillId": "mattpocock/to-issues",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "time",
+      "name": "Time",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Time.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.6
+        },
+        {
+          "namedSkillId": "mattpocock/grill-me",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "mattpocock/to-issues",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "title",
+      "name": "Title",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Title.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.545
+        },
+        {
+          "namedSkillId": "mattpocock/edit-article",
+          "score": 0.471
+        },
+        {
+          "namedSkillId": "mattpocock/grill-me",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "tmp",
+      "name": "Tmp",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tmp.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tokens",
+      "name": "Tokens",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tokens.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/to-issues",
+          "score": 0.533
+        }
+      ]
+    },
+    {
+      "id": "toml",
+      "name": "Toml",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Toml.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tool",
+      "name": "Tool",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tool.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "tools",
+      "name": "Tools",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tools.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "topic",
+      "name": "Topic",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Topic.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/to-prd",
+          "score": 0.545
+        },
+        {
+          "namedSkillId": "anthropic/pptx",
+          "score": 0.526
+        }
+      ]
+    },
+    {
+      "id": "touch",
+      "name": "Touch",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Touch.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "touching",
+      "name": "Touching",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Touching.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "yonatangross/orchestkit-rag",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "tracks",
+      "name": "Tracks",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tracks.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "treated",
+      "name": "Treated",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Treated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.571
+        },
+        {
+          "namedSkillId": "mattpocock/to-prd",
+          "score": 0.462
+        },
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "tree",
+      "name": "Tree",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Tree.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.6
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.545
+        },
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "triage",
+      "name": "Triage",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Triage.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 1.0
+        },
+        {
+          "namedSkillId": "gaiabot/gaia-triage",
+          "score": 0.706
+        },
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.571
+        }
+      ]
+    },
+    {
+      "id": "triggered",
+      "name": "Triggered",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Triggered.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.667
+        },
+        {
+          "namedSkillId": "gaiabot/gaia-triage",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "triggers",
+      "name": "Triggers",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Triggers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.714
+        },
+        {
+          "namedSkillId": "gaiabot/gaia-triage",
+          "score": 0.526
+        },
+        {
+          "namedSkillId": "mattpocock/to-issues",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "type",
+      "name": "Type",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Type.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "types",
+      "name": "Types",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Types.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "ultimate",
+      "name": "Ultimate",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Ultimate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.571
+        }
+      ]
+    },
+    {
+      "id": "unauthenticated",
+      "name": "Unauthenticated",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unauthenticated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unavailable",
+      "name": "Unavailable",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unavailable.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "uncommon",
+      "name": "Uncommon",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Uncommon.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "under-sourced",
+      "name": "Under-sourced",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Under-sourced.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "understand",
+      "name": "Understand",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Understand.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "understood",
+      "name": "Understood",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Understood.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "undocumented",
+      "name": "Undocumented",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Undocumented.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "uninstall",
+      "name": "Uninstall",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Uninstall.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "uniqueness",
+      "name": "Uniqueness",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Uniqueness.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unittest",
+      "name": "Unittest",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unittest.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "upsonic/unittest-generator",
+          "score": 0.615
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.526
+        },
+        {
+          "namedSkillId": "gooseworks/notte-browser",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "universally",
+      "name": "Universally",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Universally.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "unless",
+      "name": "Unless",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unless.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "unproposed",
+      "name": "Unproposed",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unproposed.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "devin-ai/autonomous-swe",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "unrelated",
+      "name": "Unrelated",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unrelated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.625
+        }
+      ]
+    },
+    {
+      "id": "unsupported",
+      "name": "Unsupported",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Unsupported.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "until",
+      "name": "Until",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Until.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "untouched",
+      "name": "Untouched",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Untouched.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "update",
+      "name": "Update",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Update.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "updated",
+      "name": "Updated",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Updated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "updates",
+      "name": "Updates",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Updates.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "updating",
+      "name": "Updating",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Updating.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "upgrade",
+      "name": "Upgrade",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Upgrade.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "laravel/upgrade-laravel-v13",
+          "score": 0.538
+        },
+        {
+          "namedSkillId": "mattpocock/to-prd",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "upgrading",
+      "name": "Upgrading",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Upgrading.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "url",
+      "name": "Url",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Url.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "usage",
+      "name": "Usage",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Usage.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.545
+        },
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "use",
+      "name": "Use",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Use.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "used",
+      "name": "Used",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Used.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "user",
+      "name": "User",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: User.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.533
+        },
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "username",
+      "name": "Username",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Username.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.526
+        }
+      ]
+    },
+    {
+      "id": "users",
+      "name": "Users",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Users.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.625
+        },
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "using",
+      "name": "Using",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Using.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "usr",
+      "name": "Usr",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Usr.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "utf-8",
+      "name": "Utf-8",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Utf-8.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "valid",
+      "name": "Valid",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Valid.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "validate",
+      "name": "Validate",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Validate.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "gaiabot/gaia-triage",
+          "score": 0.526
+        }
+      ]
+    },
+    {
+      "id": "validated",
+      "name": "Validated",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Validated.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "gaiabot/gaia-triage",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "validation",
+      "name": "Validation",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Validation.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "gaiabot/gaia-triage",
+          "score": 0.476
+        }
+      ]
+    },
+    {
+      "id": "values",
+      "name": "Values",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Values.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "variant",
+      "name": "Variant",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Variant.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "variants",
+      "name": "Variants",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Variants.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.5
+        }
+      ]
+    },
+    {
+      "id": "vendor",
+      "name": "Vendor",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Vendor.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "venv",
+      "name": "Venv",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Venv.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "verbatim",
+      "name": "Verbatim",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Verbatim.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "verification",
+      "name": "Verification",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Verification.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "verified",
+      "name": "Verified",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Verified.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "verify",
+      "name": "Verify",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Verify.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "version",
+      "name": "Version",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Version.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "via",
+      "name": "Via",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Via.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "vscode-marketplace",
+      "name": "Vscode-marketplace",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Vscode-marketplace.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "intelligentcode-ai/release",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "mattpocock/improve-codebase-architecture",
+          "score": 0.468
+        }
+      ]
+    },
+    {
+      "id": "warranted",
+      "name": "Warranted",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Warranted.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "watch",
+      "name": "Watch",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Watch.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "karpathy/autoresearch",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "weak",
+      "name": "Weak",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Weak.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/write-a-skill",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "weakly",
+      "name": "Weakly",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Weakly.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/write-a-skill",
+          "score": 0.526
+        }
+      ]
+    },
+    {
+      "id": "what",
+      "name": "What",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: What.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "wheel",
+      "name": "Wheel",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Wheel.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "when",
+      "name": "When",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: When.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "where",
+      "name": "Where",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Where.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "whether",
+      "name": "Whether",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Whether.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "while",
+      "name": "While",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: While.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/grill-me",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "who",
+      "name": "Who",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Who.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "whose",
+      "name": "Whose",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Whose.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/diagnose",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "wider",
+      "name": "Wider",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Wider.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "wiki",
+      "name": "Wiki",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Wiki.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/write-a-skill",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "will",
+      "name": "Will",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Will.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/grill-me",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "mattpocock/write-a-skill",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "window",
+      "name": "Window",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Window.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "without",
+      "name": "Without",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Without.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/grill-with-docs",
+          "score": 0.455
+        }
+      ]
+    },
+    {
+      "id": "words",
+      "name": "Words",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Words.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/to-prd",
+          "score": 0.545
+        }
+      ]
+    },
+    {
+      "id": "work",
+      "name": "Work",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Work.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "workflow",
+      "name": "Workflow",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Workflow.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "working",
+      "name": "Working",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Working.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "yonatangross/orchestkit-rag",
+          "score": 0.476
+        },
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "worth",
+      "name": "Worth",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Worth.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "would",
+      "name": "Would",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Would.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "wrappers",
+      "name": "Wrappers",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Wrappers.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "huggingface/huggingface-papers",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "write",
+      "name": "Write",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Write.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/write-a-skill",
+          "score": 0.556
+        },
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.545
+        },
+        {
+          "namedSkillId": "mattpocock/grill-me",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "writes",
+      "name": "Writes",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Writes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/write-a-skill",
+          "score": 0.632
+        },
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "intelligentcode-ai/user-tester",
+          "score": 0.471
+        }
+      ]
+    },
+    {
+      "id": "writing",
+      "name": "Writing",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Writing.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "mattpocock/write-a-skill",
+          "score": 0.5
+        },
+        {
+          "namedSkillId": "mattpocock/triage",
+          "score": 0.462
+        }
+      ]
+    },
+    {
+      "id": "wrong",
+      "name": "Wrong",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Wrong.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "year",
+      "name": "Year",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Year.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "yes",
+      "name": "Yes",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Yes.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "yet",
+      "name": "Yet",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Yet.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "you",
+      "name": "You",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: You.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "your",
+      "name": "Your",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Your.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": []
+    },
+    {
+      "id": "your-findings",
+      "name": "Your-findings",
+      "type": "basic",
+      "description": "Candidate skill detected from mbtiongson1/gaia-skill-tree usage: Your-findings.",
+      "sourceRepo": "mbtiongson1/gaia-skill-tree",
+      "lifecycle": "pending",
+      "namedSuggestions": [
+        {
+          "namedSkillId": "vercel/find-skills",
+          "score": 0.5
+        }
+      ]
+    }
+  ],
+  "similarity": [
+    {
+      "sourceSkillId": "abbreviations",
+      "targetSkillId": "agent-eval",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "abbreviations",
+      "targetSkillId": "tool-creation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "abbreviations",
+      "targetSkillId": "image-caption",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "abstract",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "acceptable",
+      "targetSkillId": "agent-eval",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "acceptance",
+      "targetSkillId": "score-relevance",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accepted",
+      "targetSkillId": "parse-pdf",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accepting",
+      "targetSkillId": "image-caption",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accepting",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accepting",
+      "targetSkillId": "e2e-testing",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accordingly",
+      "targetSkillId": "grounding",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accordingly",
+      "targetSkillId": "guardrails",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accordingly",
+      "targetSkillId": "skill-authoring",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accurate",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accurate",
+      "targetSkillId": "security-audit",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "accurate",
+      "targetSkillId": "image-generate",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "action",
+      "targetSkillId": "image-caption",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "action",
+      "targetSkillId": "tool-creation",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "action",
+      "targetSkillId": "prd-generation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "actions",
+      "targetSkillId": "image-caption",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "actions",
+      "targetSkillId": "tool-creation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "actions",
+      "targetSkillId": "parallel-execution",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "actual",
+      "targetSkillId": "api-call",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "actual",
+      "targetSkillId": "data-visualize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "actual",
+      "targetSkillId": "agent-eval",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "adding",
+      "targetSkillId": "reward-modeling",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "adding",
+      "targetSkillId": "grounding",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "adding",
+      "targetSkillId": "document-editing",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "additions",
+      "targetSkillId": "document-editing",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "additions",
+      "targetSkillId": "ux-audit",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "additions",
+      "targetSkillId": "document-digitization",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "addressed",
+      "targetSkillId": "parse-pdf",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "addressed",
+      "targetSkillId": "research",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "affected",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "affected",
+      "targetSkillId": "fine-tune",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "affected",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "affected-skill",
+      "targetSkillId": "generate-sql",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "affected-skill",
+      "targetSkillId": "execute-bash",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "affected-skill",
+      "targetSkillId": "automated-testing",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "against",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "against",
+      "targetSkillId": "image-caption",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "against",
+      "targetSkillId": "guardrails",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agent",
+      "targetSkillId": "agent-eval",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agent",
+      "targetSkillId": "voice-agent",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agent",
+      "targetSkillId": "image-generate",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agents",
+      "targetSkillId": "agent-eval",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agents",
+      "targetSkillId": "voice-agent",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "agents",
+      "targetSkillId": "generate-sql",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "all",
+      "targetSkillId": "api-call",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "alone",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "alone",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "alongside",
+      "targetSkillId": "self-consistency",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "alongside",
+      "targetSkillId": "autonomous-debug",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "alongside",
+      "targetSkillId": "tokenize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "already-fixed",
+      "targetSkillId": "parse-pdf",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "any",
+      "targetSkillId": "rank",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "api",
+      "targetSkillId": "api-call",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "appears",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "appears",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "appears",
+      "targetSkillId": "parse-html",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "append",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "append",
+      "targetSkillId": "ml-pipeline",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "applied",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "applied",
+      "targetSkillId": "ml-pipeline",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "apply",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "apply",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "appraise",
+      "targetSkillId": "guardrails",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "appraise",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "appraise",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "approval",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "approve",
+      "targetSkillId": "humanize-prose",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "argument",
+      "targetSkillId": "agent-eval",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "argument",
+      "targetSkillId": "voice-agent",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "argument",
+      "targetSkillId": "route-intent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "around",
+      "targetSkillId": "grounding",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "around",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "around",
+      "targetSkillId": "math-reason",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "arrays",
+      "targetSkillId": "guardrails",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "arrays",
+      "targetSkillId": "math-reason",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "artifact",
+      "targetSkillId": "refactor-code",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "artifact",
+      "targetSkillId": "semantic-cache",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "artifacts",
+      "targetSkillId": "refactor-code",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "arxiv",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ask",
+      "targetSkillId": "rank",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "asks",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "asks",
+      "targetSkillId": "classify",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attempt",
+      "targetSkillId": "generate-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attempt",
+      "targetSkillId": "generate-test",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "attempt",
+      "targetSkillId": "format-output",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "audit",
+      "targetSkillId": "ux-audit",
+      "score": 0.769,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "audit",
+      "targetSkillId": "gaia-audit",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "audit",
+      "targetSkillId": "security-audit",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "auditing",
+      "targetSkillId": "ux-audit",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "auditing",
+      "targetSkillId": "grounding",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "auditing",
+      "targetSkillId": "document-editing",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "audits",
+      "targetSkillId": "ux-audit",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "audits",
+      "targetSkillId": "gaia-audit",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "audits",
+      "targetSkillId": "security-audit",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "auth",
+      "targetSkillId": "ux-audit",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "authenticated",
+      "targetSkillId": "extract-entities",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "authenticated",
+      "targetSkillId": "semantic-cache",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "authenticated",
+      "targetSkillId": "audience-model",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "authoritative",
+      "targetSkillId": "ghostwrite",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "authoritative",
+      "targetSkillId": "skill-authoring",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "authoritative",
+      "targetSkillId": "gaia-triage",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "auto-merged",
+      "targetSkillId": "autonomous-debug",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "auto-merged",
+      "targetSkillId": "autonomous-research-agent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "auto-merged",
+      "targetSkillId": "automated-testing",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "auto-triage",
+      "targetSkillId": "gaia-triage",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "auto-triage",
+      "targetSkillId": "issue-triage",
+      "score": 0.696,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "auto-triage",
+      "targetSkillId": "automated-testing",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "automation",
+      "targetSkillId": "release-automation",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "automation",
+      "targetSkillId": "browser-automation",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "automation",
+      "targetSkillId": "workflow-automation",
+      "score": 0.69,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "available",
+      "targetSkillId": "api-call",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "awesome",
+      "targetSkillId": "plan-decompose",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "awesome",
+      "targetSkillId": "web-search",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "awesome",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "back",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "based",
+      "targetSkillId": "parse-pdf",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "bash",
+      "targetSkillId": "execute-bash",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "basic",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "basic",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "batch",
+      "targetSkillId": "web-search",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "batch",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "batches",
+      "targetSkillId": "math-reason",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "batches",
+      "targetSkillId": "semantic-cache",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "batches",
+      "targetSkillId": "web-search",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "becomes",
+      "targetSkillId": "computer-use",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "becomes",
+      "targetSkillId": "plan-decompose",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "becomes",
+      "targetSkillId": "context-compression",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "before",
+      "targetSkillId": "refactor-code",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "being",
+      "targetSkillId": "e2e-testing",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "benchmark",
+      "targetSkillId": "skill-performance-benchmarking",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "benchmarks",
+      "targetSkillId": "skill-performance-benchmarking",
+      "score": 0.45,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "better",
+      "targetSkillId": "embed-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "block",
+      "targetSkillId": "ocr",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "branch",
+      "targetSkillId": "rank",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "branch",
+      "targetSkillId": "research",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "branch",
+      "targetSkillId": "web-search",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "branches",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "branches",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "branches",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "brief",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "broader",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "broken",
+      "targetSkillId": "tokenize",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "browse",
+      "targetSkillId": "browser-automation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "builds",
+      "targetSkillId": "guardrails",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "bullet",
+      "targetSkillId": "tool-select",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "call",
+      "targetSkillId": "api-call",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "calling",
+      "targetSkillId": "function-calling",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "calling",
+      "targetSkillId": "api-call",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "calling",
+      "targetSkillId": "tool-chaining",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "calls",
+      "targetSkillId": "api-call",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "calls",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "can",
+      "targetSkillId": "rank",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "candidate",
+      "targetSkillId": "translate",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "candidate",
+      "targetSkillId": "gaia-triage",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "candidate",
+      "targetSkillId": "ux-audit",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "candidates",
+      "targetSkillId": "translate",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "candidates",
+      "targetSkillId": "gaia-triage",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "candidates",
+      "targetSkillId": "extract-entities",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "canonical",
+      "targetSkillId": "api-call",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "canonical",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "canonical",
+      "targetSkillId": "function-calling",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "capability",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "card",
+      "targetSkillId": "ocr",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "card",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "case",
+      "targetSkillId": "classify",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "case",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "case",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "catalog",
+      "targetSkillId": "agent-eval",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "catch",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cause",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cause",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cause",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "centrally",
+      "targetSkillId": "document-analyst",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "centrally",
+      "targetSkillId": "agent-eval",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "centrally",
+      "targetSkillId": "generate-sql",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "change",
+      "targetSkillId": "tool-chaining",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "change",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "change",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "changed",
+      "targetSkillId": "tool-chaining",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "changes",
+      "targetSkillId": "tool-chaining",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "changes",
+      "targetSkillId": "schema-design",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "changes",
+      "targetSkillId": "humanize-prose",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "changing",
+      "targetSkillId": "tool-chaining",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "changing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "changing",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "channels",
+      "targetSkillId": "tool-chaining",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "channels",
+      "targetSkillId": "humanize-prose",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "checkout",
+      "targetSkillId": "code-execution",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "choose",
+      "targetSkillId": "tool-use",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "choose",
+      "targetSkillId": "plan-decompose",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "choose",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "churn",
+      "targetSkillId": "ocr",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "claim",
+      "targetSkillId": "classify",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "claim",
+      "targetSkillId": "code-explain",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "claimed",
+      "targetSkillId": "classify",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "claimed",
+      "targetSkillId": "gaia-meta-audit",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "claiming",
+      "targetSkillId": "tool-chaining",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "claiming",
+      "targetSkillId": "code-explain",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "claiming",
+      "targetSkillId": "classify",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "claims",
+      "targetSkillId": "classify",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "classification",
+      "targetSkillId": "classify",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "classification",
+      "targetSkillId": "scientific-visualization",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "classification",
+      "targetSkillId": "image-caption",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "classified",
+      "targetSkillId": "classify",
+      "score": 0.778,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "classifies",
+      "targetSkillId": "classify",
+      "score": 0.778,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "clean",
+      "targetSkillId": "voice-agent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "clean",
+      "targetSkillId": "score-relevance",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "clean",
+      "targetSkillId": "code-explain",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cleanup",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "clear",
+      "targetSkillId": "ocr",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "clear",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "clear",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "clearly",
+      "targetSkillId": "classify",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "cli",
+      "targetSkillId": "classify",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "clone",
+      "targetSkillId": "diff-content",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "clone",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "close",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "close",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "close",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "close-resolved",
+      "targetSkillId": "score-relevance",
+      "score": 0.621,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "close-resolved",
+      "targetSkillId": "context-compression",
+      "score": 0.485,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "close-resolved",
+      "targetSkillId": "code-review-pipeline",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "closing",
+      "targetSkillId": "classify",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "closing",
+      "targetSkillId": "grounding",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "closing",
+      "targetSkillId": "skill-authoring",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "code",
+      "targetSkillId": "code-explain",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "code",
+      "targetSkillId": "refactor-code",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "codebase",
+      "targetSkillId": "execute-bash",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "codebase",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "codebase",
+      "targetSkillId": "code-explain",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "codex",
+      "targetSkillId": "code-explain",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "codex",
+      "targetSkillId": "code-execution",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "collection",
+      "targetSkillId": "code-execution",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "collection",
+      "targetSkillId": "tool-creation",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "collection",
+      "targetSkillId": "tool-select",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combination",
+      "targetSkillId": "mcp-integration",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combination",
+      "targetSkillId": "code-generation",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combination",
+      "targetSkillId": "content-moderation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combinations",
+      "targetSkillId": "mcp-integration",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combinations",
+      "targetSkillId": "code-generation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "combinations",
+      "targetSkillId": "content-moderation",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comment",
+      "targetSkillId": "chunk-document",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comment",
+      "targetSkillId": "diff-content",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comment",
+      "targetSkillId": "code-generation",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comments",
+      "targetSkillId": "chunk-document",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comments",
+      "targetSkillId": "document-analyst",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "comments",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "commits",
+      "targetSkillId": "computer-use",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "committed",
+      "targetSkillId": "computer-use",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "committing",
+      "targetSkillId": "document-editing",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "committing",
+      "targetSkillId": "automated-testing",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "committing",
+      "targetSkillId": "scientific-writing",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "community",
+      "targetSkillId": "self-consistency",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "community",
+      "targetSkillId": "computer-use",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "compact",
+      "targetSkillId": "computer-use",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "completed",
+      "targetSkillId": "computer-use",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "completed",
+      "targetSkillId": "document-editing",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "completely",
+      "targetSkillId": "computer-use",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "completely",
+      "targetSkillId": "document-analyst",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "composite",
+      "targetSkillId": "plan-decompose",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "composite",
+      "targetSkillId": "computer-use",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "composite",
+      "targetSkillId": "ghostwrite",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "concrete",
+      "targetSkillId": "ocr",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "concrete",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "concrete",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "config",
+      "targetSkillId": "grounding",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "config",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "config",
+      "targetSkillId": "function-calling",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "confirmation",
+      "targetSkillId": "code-generation",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "confirmation",
+      "targetSkillId": "content-moderation",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "confirmation",
+      "targetSkillId": "mcp-integration",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "connectors",
+      "targetSkillId": "content-moderation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "connectors",
+      "targetSkillId": "code-execution",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "connectors",
+      "targetSkillId": "code-generation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "consideration",
+      "targetSkillId": "code-generation",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "consideration",
+      "targetSkillId": "content-moderation",
+      "score": 0.71,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "consideration",
+      "targetSkillId": "mcp-integration",
+      "score": 0.643,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "consolidation",
+      "targetSkillId": "content-moderation",
+      "score": 0.645,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "consolidation",
+      "targetSkillId": "tool-creation",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "consolidation",
+      "targetSkillId": "code-generation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "constraint",
+      "targetSkillId": "ghostwrite",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "constraint",
+      "targetSkillId": "content-moderation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "constraint",
+      "targetSkillId": "code-generation",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "constraints",
+      "targetSkillId": "ghostwrite",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "constraints",
+      "targetSkillId": "content-moderation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "constraints",
+      "targetSkillId": "code-generation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "consumed",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "consumed",
+      "targetSkillId": "chunk-document",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contains",
+      "targetSkillId": "content-moderation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contains",
+      "targetSkillId": "code-generation",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contains",
+      "targetSkillId": "function-calling",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "content",
+      "targetSkillId": "diff-content",
+      "score": 0.737,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "content",
+      "targetSkillId": "route-intent",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "content",
+      "targetSkillId": "content-moderation",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contents",
+      "targetSkillId": "diff-content",
+      "score": 0.7,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contents",
+      "targetSkillId": "route-intent",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contents",
+      "targetSkillId": "content-moderation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contexts",
+      "targetSkillId": "diff-content",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contexts",
+      "targetSkillId": "context-compression",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contexts",
+      "targetSkillId": "speech-to-text",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contributing",
+      "targetSkillId": "scientific-writing",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contributing",
+      "targetSkillId": "document-editing",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contributing",
+      "targetSkillId": "content-moderation",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contribution",
+      "targetSkillId": "content-moderation",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contribution",
+      "targetSkillId": "mcp-integration",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contribution",
+      "targetSkillId": "code-generation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contributor",
+      "targetSkillId": "content-moderation",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contributor",
+      "targetSkillId": "ghostwrite",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contributor",
+      "targetSkillId": "context-compression",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contributors",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contributors",
+      "targetSkillId": "content-moderation",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "contributors",
+      "targetSkillId": "ghostwrite",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "copies",
+      "targetSkillId": "computer-use",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "core",
+      "targetSkillId": "ocr",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "core",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "core",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "corequisite",
+      "targetSkillId": "ghostwrite",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "corequisite",
+      "targetSkillId": "code-review-pipeline",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "correction",
+      "targetSkillId": "code-execution",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "correction",
+      "targetSkillId": "tool-creation",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "correction",
+      "targetSkillId": "code-generation",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "correspond",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "correspond",
+      "targetSkillId": "context-compression",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "correspond",
+      "targetSkillId": "score-relevance",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "corresponding",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "corresponding",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "corresponding",
+      "targetSkillId": "grounding",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "couldn",
+      "targetSkillId": "grounding",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "count",
+      "targetSkillId": "route-intent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "count",
+      "targetSkillId": "diff-content",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "count",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "counts",
+      "targetSkillId": "computer-use",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "counts",
+      "targetSkillId": "document-analyst",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "coverage",
+      "targetSkillId": "conversational-agent",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "coverage",
+      "targetSkillId": "voice-agent",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "coverage",
+      "targetSkillId": "issue-triage",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "covered",
+      "targetSkillId": "computer-use",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "covered",
+      "targetSkillId": "skill-discovery",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "covers",
+      "targetSkillId": "computer-use",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "covers",
+      "targetSkillId": "skill-discovery",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "covers",
+      "targetSkillId": "conversational-agent",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "crawl",
+      "targetSkillId": "ocr",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "crawl",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "crawler",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "crawler",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "create",
+      "targetSkillId": "retrieve",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "create",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "create",
+      "targetSkillId": "tool-creation",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "credentials",
+      "targetSkillId": "document-analyst",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "credentials",
+      "targetSkillId": "requirements-analysis",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "credentials",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "criteria",
+      "targetSkillId": "gaia-triage",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "criteria",
+      "targetSkillId": "mcp-integration",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "criteria",
+      "targetSkillId": "write-report",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "curate",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "curate",
+      "targetSkillId": "web-scrape",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "curate",
+      "targetSkillId": "security-audit",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "curated",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "curated",
+      "targetSkillId": "security-audit",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "curated",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "curation",
+      "targetSkillId": "tool-creation",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "curation",
+      "targetSkillId": "registry-curation",
+      "score": 0.64,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "curation",
+      "targetSkillId": "mcp-integration",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "curation-only",
+      "targetSkillId": "conversational-agent",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "curation-only",
+      "targetSkillId": "tool-creation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "curation-only",
+      "targetSkillId": "registry-curation",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "current",
+      "targetSkillId": "chunk-document",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "currently",
+      "targetSkillId": "document-analyst",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "currently",
+      "targetSkillId": "requirements-analysis",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "data",
+      "targetSkillId": "data-analysis",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "date",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decision",
+      "targetSkillId": "vision-qa",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decision",
+      "targetSkillId": "code-execution",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decision",
+      "targetSkillId": "object-detection",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decisions",
+      "targetSkillId": "vision-qa",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decisions",
+      "targetSkillId": "code-execution",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "decisions",
+      "targetSkillId": "question-answer",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "definitions",
+      "targetSkillId": "prd-generation",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "definitions",
+      "targetSkillId": "code-generation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "definitions",
+      "targetSkillId": "document-editing",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deletion",
+      "targetSkillId": "prd-generation",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deletion",
+      "targetSkillId": "code-execution",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deletion",
+      "targetSkillId": "code-generation",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "demerit",
+      "targetSkillId": "prd-generation",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "demerit",
+      "targetSkillId": "embed-text",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "demerit",
+      "targetSkillId": "code-generation",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "demonstrations",
+      "targetSkillId": "prd-generation",
+      "score": 0.643,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "demonstrations",
+      "targetSkillId": "code-generation",
+      "score": 0.621,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "demonstrations",
+      "targetSkillId": "error-interpretation",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dependency",
+      "targetSkillId": "code-generation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dependency",
+      "targetSkillId": "self-consistency",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dependency-policy",
+      "targetSkillId": "audience-model",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dependency-related",
+      "targetSkillId": "image-generate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dependency-related",
+      "targetSkillId": "code-generation",
+      "score": 0.485,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "dependency-related",
+      "targetSkillId": "generate-sql",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "derivative",
+      "targetSkillId": "retrieve",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "derivative",
+      "targetSkillId": "self-critique",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "derivative",
+      "targetSkillId": "prd-generation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "derivatives",
+      "targetSkillId": "retrieve",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "derivatives",
+      "targetSkillId": "generate-sql",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "derivatives",
+      "targetSkillId": "extract-entities",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "derived",
+      "targetSkillId": "retrieve",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "derived",
+      "targetSkillId": "design-review",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "describe",
+      "targetSkillId": "design-review",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "describe",
+      "targetSkillId": "web-scrape",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "describe",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "described",
+      "targetSkillId": "design-review",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "described",
+      "targetSkillId": "web-scrape",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "described",
+      "targetSkillId": "retrieve",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "description",
+      "targetSkillId": "image-caption",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "description",
+      "targetSkillId": "registry-curation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "description",
+      "targetSkillId": "prd-generation",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deserve",
+      "targetSkillId": "design-review",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deserve",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "deserve",
+      "targetSkillId": "research",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "designed",
+      "targetSkillId": "design-review",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "designed",
+      "targetSkillId": "schema-design",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "desired",
+      "targetSkillId": "design-review",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "desired",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detection",
+      "targetSkillId": "object-detection",
+      "score": 0.72,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detection",
+      "targetSkillId": "code-execution",
+      "score": 0.696,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "detection",
+      "targetSkillId": "prd-generation",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "determine",
+      "targetSkillId": "prd-generation",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "determine",
+      "targetSkillId": "e2e-testing",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "determine",
+      "targetSkillId": "code-generation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "diff",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directly",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directly",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directories",
+      "targetSkillId": "retrieve",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directories",
+      "targetSkillId": "refactor-code",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directories",
+      "targetSkillId": "issue-triage",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directory",
+      "targetSkillId": "refactor-code",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directory",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "directory",
+      "targetSkillId": "write-report",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "discover",
+      "targetSkillId": "skill-discovery",
+      "score": 0.696,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "discover",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "discover",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "discovered",
+      "targetSkillId": "skill-discovery",
+      "score": 0.64,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "discovered",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "discovered",
+      "targetSkillId": "issue-triage",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "discovery",
+      "targetSkillId": "skill-discovery",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "discovery",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.621,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "discovery",
+      "targetSkillId": "diff-content",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "discussion",
+      "targetSkillId": "vision-qa",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "discussion",
+      "targetSkillId": "registry-curation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "discussion",
+      "targetSkillId": "code-execution",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "display-style",
+      "targetSkillId": "translate",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "displaying",
+      "targetSkillId": "code-explain",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "displaying",
+      "targetSkillId": "vertical-slice-planning",
+      "score": 0.485,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "displaying",
+      "targetSkillId": "skill-authoring",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "distinct",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "distinct",
+      "targetSkillId": "vision-qa",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "docs",
+      "targetSkillId": "ocr",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "docs-build",
+      "targetSkillId": "knowledge-graph-build",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "document",
+      "targetSkillId": "chunk-document",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "document",
+      "targetSkillId": "document-editing",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "document",
+      "targetSkillId": "document-analyst",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documentation",
+      "targetSkillId": "document-digitization",
+      "score": 0.765,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documentation",
+      "targetSkillId": "document-editing",
+      "score": 0.759,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documentation",
+      "targetSkillId": "document-analyst",
+      "score": 0.69,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documented",
+      "targetSkillId": "document-editing",
+      "score": 0.769,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documented",
+      "targetSkillId": "chunk-document",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documented",
+      "targetSkillId": "document-analyst",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documents",
+      "targetSkillId": "document-analyst",
+      "score": 0.72,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documents",
+      "targetSkillId": "chunk-document",
+      "score": 0.696,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "documents",
+      "targetSkillId": "document-editing",
+      "score": 0.64,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "doing",
+      "targetSkillId": "grounding",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "doing",
+      "targetSkillId": "reward-modeling",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "doing",
+      "targetSkillId": "feed-monitoring",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "done",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "done",
+      "targetSkillId": "diff-content",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "downgrade",
+      "targetSkillId": "framework-upgrade",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "draft-skills",
+      "targetSkillId": "data-analysis",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "draft-skills",
+      "targetSkillId": "guardrails",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "draft-skills",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "drafts",
+      "targetSkillId": "guardrails",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "drift",
+      "targetSkillId": "diff-content",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "drift",
+      "targetSkillId": "ux-audit",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "duplicate",
+      "targetSkillId": "diff-content",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "duplicate",
+      "targetSkillId": "api-call",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "duplicated",
+      "targetSkillId": "diff-content",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "duplicates",
+      "targetSkillId": "diff-content",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "duplication",
+      "targetSkillId": "tool-creation",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "duplication",
+      "targetSkillId": "image-caption",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "duplication",
+      "targetSkillId": "mcp-integration",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "each",
+      "targetSkillId": "research",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "each",
+      "targetSkillId": "web-search",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "each",
+      "targetSkillId": "wiki-search",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "echo",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "edges",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "edit",
+      "targetSkillId": "ux-audit",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "edits",
+      "targetSkillId": "ux-audit",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "effective",
+      "targetSkillId": "self-critique",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "effective",
+      "targetSkillId": "execute-bash",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "effective",
+      "targetSkillId": "retrieve",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "effective-level",
+      "targetSkillId": "test-driven-development",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "effective-level",
+      "targetSkillId": "retrieve",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "effective-level",
+      "targetSkillId": "agent-eval",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "else",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "else",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "em-dash",
+      "targetSkillId": "execute-bash",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "em-dash",
+      "targetSkillId": "schema-design",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "em-dash",
+      "targetSkillId": "semantic-cache",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "email",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "embeddings",
+      "targetSkillId": "embed-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "embeddings",
+      "targetSkillId": "reward-modeling",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "embeddings",
+      "targetSkillId": "feed-monitoring",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "encoding",
+      "targetSkillId": "grounding",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "encoding",
+      "targetSkillId": "e2e-testing",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "encoding",
+      "targetSkillId": "reward-modeling",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enforcement",
+      "targetSkillId": "chunk-document",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enforcement",
+      "targetSkillId": "voice-agent",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enforcement",
+      "targetSkillId": "refactor-code",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enhancement",
+      "targetSkillId": "generate-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enhancement",
+      "targetSkillId": "generate-test",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enhancement",
+      "targetSkillId": "chunk-document",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enhances",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enhances",
+      "targetSkillId": "generate-test",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enhances",
+      "targetSkillId": "semantic-cache",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enough",
+      "targetSkillId": "tree-of-thought",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enough",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enrichment",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enrichment",
+      "targetSkillId": "semantic-cache",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "enrichment",
+      "targetSkillId": "chunk-document",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ensures",
+      "targetSkillId": "cite-sources",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ensures",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ensures",
+      "targetSkillId": "generate-test",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entirely",
+      "targetSkillId": "agent-eval",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entirely",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entirely",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entries",
+      "targetSkillId": "retrieve",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entries",
+      "targetSkillId": "tokenize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entries",
+      "targetSkillId": "issue-triage",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "entry",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "env",
+      "targetSkillId": "agent-eval",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "epic",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "equivalent",
+      "targetSkillId": "evaluate-output",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "equivalent",
+      "targetSkillId": "voice-agent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "equivalent",
+      "targetSkillId": "conversational-agent",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "error",
+      "targetSkillId": "write-report",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "esac",
+      "targetSkillId": "research",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "esac",
+      "targetSkillId": "web-search",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluate",
+      "targetSkillId": "evaluate-output",
+      "score": 0.696,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluate",
+      "targetSkillId": "translate",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evaluate",
+      "targetSkillId": "agent-eval",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "every",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "every",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "everything",
+      "targetSkillId": "e2e-testing",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "everything",
+      "targetSkillId": "prd-generation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "everything",
+      "targetSkillId": "mcp-server-creation",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evidence",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evidence-check",
+      "targetSkillId": "semantic-cache",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evidence-check",
+      "targetSkillId": "audience-model",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evidence-check",
+      "targetSkillId": "voice-agent",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "evidenced",
+      "targetSkillId": "audience-model",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "exact",
+      "targetSkillId": "extract-entities",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "exact",
+      "targetSkillId": "ux-audit",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "exact",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "exactly",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "exist",
+      "targetSkillId": "ux-audit",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "existing",
+      "targetSkillId": "e2e-testing",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "existing",
+      "targetSkillId": "feed-monitoring",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "existing",
+      "targetSkillId": "issue-triage",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "existing-id",
+      "targetSkillId": "e2e-testing",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "existing-id",
+      "targetSkillId": "vision-qa",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "existing-id",
+      "targetSkillId": "question-answer",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "existing-skill",
+      "targetSkillId": "question-answer",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "existing-skill",
+      "targetSkillId": "e2e-testing",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "exit",
+      "targetSkillId": "ux-audit",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "expand",
+      "targetSkillId": "code-explain",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "expected",
+      "targetSkillId": "execute-bash",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "expected",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "expected",
+      "targetSkillId": "text-to-speech",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "experimental-feature",
+      "targetSkillId": "multi-agent-debate",
+      "score": 0.474,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "experimental-feature",
+      "targetSkillId": "gaia-meta-audit",
+      "score": 0.457,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "explicit",
+      "targetSkillId": "code-explain",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "explicit",
+      "targetSkillId": "self-critique",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "explicitly",
+      "targetSkillId": "code-explain",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "exposes",
+      "targetSkillId": "plan-decompose",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "exposes",
+      "targetSkillId": "humanize-prose",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "exposes",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extend",
+      "targetSkillId": "e2e-testing",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extend",
+      "targetSkillId": "extract-entities",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extensions",
+      "targetSkillId": "context-compression",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extensions",
+      "targetSkillId": "code-execution",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extensions",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "external",
+      "targetSkillId": "agent-eval",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "external",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "external",
+      "targetSkillId": "execute-bash",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extra",
+      "targetSkillId": "extract-entities",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extra",
+      "targetSkillId": "issue-triage",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "extra",
+      "targetSkillId": "execute-bash",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "failing",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "failing",
+      "targetSkillId": "function-calling",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "failing",
+      "targetSkillId": "tool-chaining",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "fails",
+      "targetSkillId": "guardrails",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "fails",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "favored",
+      "targetSkillId": "refactor-code",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "feat",
+      "targetSkillId": "fine-tune",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "feature",
+      "targetSkillId": "fine-tune",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "feature",
+      "targetSkillId": "literature-review",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "feature",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "features",
+      "targetSkillId": "fine-tune",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "features",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "features",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "fetch",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ff-only",
+      "targetSkillId": "diff-content",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "file",
+      "targetSkillId": "fine-tune",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "final",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "finalized",
+      "targetSkillId": "data-visualize",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "finalized",
+      "targetSkillId": "tokenize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "find",
+      "targetSkillId": "fine-tune",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "finding",
+      "targetSkillId": "grounding",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "finding",
+      "targetSkillId": "function-calling",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "finding",
+      "targetSkillId": "tool-chaining",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "findings",
+      "targetSkillId": "grounding",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "findings",
+      "targetSkillId": "function-calling",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "findings",
+      "targetSkillId": "tool-chaining",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "flags",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "floor",
+      "targetSkillId": "ocr",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "focused",
+      "targetSkillId": "tool-use",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "follow-up",
+      "targetSkillId": "tool-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "follow-up",
+      "targetSkillId": "format-output",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "following",
+      "targetSkillId": "function-calling",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "following",
+      "targetSkillId": "skill-authoring",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "following",
+      "targetSkillId": "feed-monitoring",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "for-each-ref",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "for-each-ref",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "for-each-ref",
+      "targetSkillId": "web-search",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "format",
+      "targetSkillId": "format-output",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "formatting",
+      "targetSkillId": "format-output",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "formatting",
+      "targetSkillId": "automated-testing",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "formatting",
+      "targetSkillId": "document-editing",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "found",
+      "targetSkillId": "grounding",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "fresh",
+      "targetSkillId": "research",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia",
+      "targetSkillId": "gaia-audit",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia",
+      "targetSkillId": "gaia-triage",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-bot-crawl-skill-names",
+      "targetSkillId": "gaia-triage",
+      "score": 0.486,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-bot-curate",
+      "targetSkillId": "gaia-triage",
+      "score": 0.692,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-bot-curate",
+      "targetSkillId": "gaia-meta-audit",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-bot-curate",
+      "targetSkillId": "registry-curation",
+      "score": 0.562,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-curate",
+      "targetSkillId": "gaia-triage",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-curate",
+      "targetSkillId": "gaia-audit",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-curate",
+      "targetSkillId": "registry-curation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-draft-curate",
+      "targetSkillId": "gaia-triage",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-draft-curate",
+      "targetSkillId": "registry-curation",
+      "score": 0.529,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-draft-curate",
+      "targetSkillId": "gaia-audit",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-registry",
+      "targetSkillId": "gaia-audit",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-registry",
+      "targetSkillId": "gaia-triage",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-registry",
+      "targetSkillId": "gaia-meta-audit",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-skill-tree",
+      "targetSkillId": "gaia-triage",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-skill-tree",
+      "targetSkillId": "gaia-audit",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-skill-tree",
+      "targetSkillId": "skill-authoring",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-wiki-sync",
+      "targetSkillId": "wiki-search",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-wiki-sync",
+      "targetSkillId": "gaia-audit",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gaia-wiki-sync",
+      "targetSkillId": "gaia-triage",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gather",
+      "targetSkillId": "math-reason",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gather",
+      "targetSkillId": "gaia-triage",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generate",
+      "targetSkillId": "generate-sql",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generate",
+      "targetSkillId": "generate-text",
+      "score": 0.762,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generate",
+      "targetSkillId": "generate-test",
+      "score": 0.762,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generated",
+      "targetSkillId": "generate-sql",
+      "score": 0.762,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generated",
+      "targetSkillId": "generate-text",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generated",
+      "targetSkillId": "generate-test",
+      "score": 0.727,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generated-output",
+      "targetSkillId": "generate-text",
+      "score": 0.759,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generated-output",
+      "targetSkillId": "generate-test",
+      "score": 0.759,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generated-output",
+      "targetSkillId": "evaluate-output",
+      "score": 0.71,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generating",
+      "targetSkillId": "prd-generation",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generating",
+      "targetSkillId": "code-generation",
+      "score": 0.72,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generating",
+      "targetSkillId": "generate-sql",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generation",
+      "targetSkillId": "prd-generation",
+      "score": 0.833,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generation",
+      "targetSkillId": "code-generation",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generation",
+      "targetSkillId": "agent-eval",
+      "score": 0.692,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generic",
+      "targetSkillId": "prd-generation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generic",
+      "targetSkillId": "code-generation",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "generic",
+      "targetSkillId": "research",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "get",
+      "targetSkillId": "agent-eval",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "git",
+      "targetSkillId": "ghostwrite",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "git",
+      "targetSkillId": "gaia-audit",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gitkeep",
+      "targetSkillId": "tokenize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gitkeep",
+      "targetSkillId": "write-report",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "gitkeep",
+      "targetSkillId": "ghostwrite",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "graph",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "grouped",
+      "targetSkillId": "grounding",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "guessing",
+      "targetSkillId": "grounding",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "guessing",
+      "targetSkillId": "e2e-testing",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "guessing",
+      "targetSkillId": "automated-testing",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hand",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "happens",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hardcode",
+      "targetSkillId": "refactor-code",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hardcode",
+      "targetSkillId": "audience-model",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hardcode",
+      "targetSkillId": "reward-modeling",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hardening",
+      "targetSkillId": "reward-modeling",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hardening",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hardening",
+      "targetSkillId": "grounding",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "head",
+      "targetSkillId": "schema-design",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "heading",
+      "targetSkillId": "schema-design",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "heading",
+      "targetSkillId": "reward-modeling",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "heading",
+      "targetSkillId": "tool-chaining",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "heads",
+      "targetSkillId": "schema-design",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "heads",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hf-cli",
+      "targetSkillId": "function-calling",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hierarchy",
+      "targetSkillId": "wiki-search",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hierarchy",
+      "targetSkillId": "research",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hierarchy",
+      "targetSkillId": "web-search",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "high-level",
+      "targetSkillId": "design-review",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "high-level",
+      "targetSkillId": "agent-eval",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "history",
+      "targetSkillId": "ghostwrite",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "history",
+      "targetSkillId": "skill-discovery",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "homepages",
+      "targetSkillId": "voice-agent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "homepages",
+      "targetSkillId": "schema-design",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "homepages",
+      "targetSkillId": "memory-manage",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "hooks",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "human",
+      "targetSkillId": "humanize-prose",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "identified",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "identified",
+      "targetSkillId": "scientific-writing",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "identified",
+      "targetSkillId": "extract-entities",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "identify",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "identify",
+      "targetSkillId": "scientific-writing",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "identify",
+      "targetSkillId": "prd-generation",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "identity",
+      "targetSkillId": "document-editing",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "identity",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "identity",
+      "targetSkillId": "scientific-writing",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "immediately",
+      "targetSkillId": "image-generate",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "immediately",
+      "targetSkillId": "embed-text",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "immediately",
+      "targetSkillId": "gaia-meta-audit",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "immutable",
+      "targetSkillId": "issue-triage",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "implementation",
+      "targetSkillId": "deployment-automation",
+      "score": 0.629,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "implementation",
+      "targetSkillId": "prd-generation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "implementation",
+      "targetSkillId": "mcp-integration",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "implementations",
+      "targetSkillId": "deployment-automation",
+      "score": 0.611,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "implementations",
+      "targetSkillId": "prd-generation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "implementations",
+      "targetSkillId": "mcp-integration",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "implemented",
+      "targetSkillId": "image-generate",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "implemented",
+      "targetSkillId": "embed-text",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "implemented",
+      "targetSkillId": "voice-agent",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "implementing",
+      "targetSkillId": "e2e-testing",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "implementing",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "implementing",
+      "targetSkillId": "document-editing",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "include",
+      "targetSkillId": "fine-tune",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "include",
+      "targetSkillId": "audience-model",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "includes",
+      "targetSkillId": "fine-tune",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "includes",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "incorrectly",
+      "targetSkillId": "audience-model",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "incorrectly",
+      "targetSkillId": "score-relevance",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "individual",
+      "targetSkillId": "data-visualize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "individual",
+      "targetSkillId": "scientific-visualization",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "information",
+      "targetSkillId": "mcp-integration",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "information",
+      "targetSkillId": "tool-creation",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "information",
+      "targetSkillId": "image-caption",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "informational",
+      "targetSkillId": "mcp-integration",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "informational",
+      "targetSkillId": "conversational-agent",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "informational",
+      "targetSkillId": "tool-creation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "inspect",
+      "targetSkillId": "fine-tune",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "inspect",
+      "targetSkillId": "speech-to-text",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "install",
+      "targetSkillId": "api-call",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "install",
+      "targetSkillId": "agent-eval",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "instead",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "instead",
+      "targetSkillId": "fine-tune",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "instead",
+      "targetSkillId": "agent-eval",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intake",
+      "targetSkillId": "fine-tune",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "intake",
+      "targetSkillId": "gaia-triage",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "into",
+      "targetSkillId": "fine-tune",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "inventory",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "inventory",
+      "targetSkillId": "route-intent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "inventory",
+      "targetSkillId": "diff-content",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "issue",
+      "targetSkillId": "issue-triage",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "issue-number",
+      "targetSkillId": "issue-triage",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "issue-number",
+      "targetSkillId": "fine-tune",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "issue-number",
+      "targetSkillId": "image-generate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "issues",
+      "targetSkillId": "issue-triage",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "issues",
+      "targetSkillId": "cite-sources",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "item",
+      "targetSkillId": "fine-tune",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "items",
+      "targetSkillId": "cite-sources",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "itself",
+      "targetSkillId": "tool-select",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "json",
+      "targetSkillId": "parse-json",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "json",
+      "targetSkillId": "vision-qa",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "justify",
+      "targetSkillId": "classify",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "keep",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "larger",
+      "targetSkillId": "gaia-triage",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "last",
+      "targetSkillId": "classify",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "last",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "latest",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "latest",
+      "targetSkillId": "generate-test",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "latest",
+      "targetSkillId": "evaluate-output",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "layout",
+      "targetSkillId": "evaluate-output",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "layouts",
+      "targetSkillId": "evaluate-output",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "least",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "least",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "leave",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "leave",
+      "targetSkillId": "literature-review",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "leave",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "legendaries",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "legendaries",
+      "targetSkillId": "generate-sql",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "legendaries",
+      "targetSkillId": "generate-test",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "legendary",
+      "targetSkillId": "research",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "legendary",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "level",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lexical",
+      "targetSkillId": "api-call",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "license",
+      "targetSkillId": "logical-inference",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "license",
+      "targetSkillId": "fine-tune",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lifecycle",
+      "targetSkillId": "classify",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lifecycle",
+      "targetSkillId": "logical-inference",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "limitation",
+      "targetSkillId": "image-caption",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "limitation",
+      "targetSkillId": "mcp-integration",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "limitation",
+      "targetSkillId": "prompt-optimization",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "link",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "linked",
+      "targetSkillId": "ml-pipeline",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "listed",
+      "targetSkillId": "self-consistency",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "listing",
+      "targetSkillId": "e2e-testing",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "listing",
+      "targetSkillId": "issue-triage",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "listing",
+      "targetSkillId": "vision-qa",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "listings",
+      "targetSkillId": "e2e-testing",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "listings",
+      "targetSkillId": "issue-triage",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "listings",
+      "targetSkillId": "tool-chaining",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "local",
+      "targetSkillId": "ocr",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "local",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "local",
+      "targetSkillId": "logical-inference",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "locally",
+      "targetSkillId": "api-call",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "location",
+      "targetSkillId": "tool-creation",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "location",
+      "targetSkillId": "image-caption",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "location",
+      "targetSkillId": "code-execution",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "locations",
+      "targetSkillId": "tool-creation",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "locations",
+      "targetSkillId": "image-caption",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "locations",
+      "targetSkillId": "code-execution",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lock",
+      "targetSkillId": "ocr",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "login",
+      "targetSkillId": "logical-inference",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "looks",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lowercase",
+      "targetSkillId": "web-scrape",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lowercase",
+      "targetSkillId": "computer-use",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lowercase",
+      "targetSkillId": "logical-inference",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lowercase-dash",
+      "targetSkillId": "execute-bash",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lowercase-dash",
+      "targetSkillId": "generate-sql",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "lowercase-dash",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ls-remote",
+      "targetSkillId": "write-report",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ls-remote",
+      "targetSkillId": "retrieve",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ls-remote",
+      "targetSkillId": "tool-creation",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "made",
+      "targetSkillId": "schema-design",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "made",
+      "targetSkillId": "summarize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "main",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "main",
+      "targetSkillId": "schema-design",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "main",
+      "targetSkillId": "image-caption",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "maintainer",
+      "targetSkillId": "mcp-integration",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "maintainer",
+      "targetSkillId": "semantic-cache",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "maintainer",
+      "targetSkillId": "ml-pipeline",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "maintainers",
+      "targetSkillId": "mcp-integration",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "maintainers",
+      "targetSkillId": "semantic-cache",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "maintainers",
+      "targetSkillId": "humanize-prose",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "make",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "make",
+      "targetSkillId": "summarize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "manage",
+      "targetSkillId": "memory-manage",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "manage",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "manage",
+      "targetSkillId": "semantic-cache",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "manual",
+      "targetSkillId": "agent-eval",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "manual",
+      "targetSkillId": "document-analyst",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "many",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mapped",
+      "targetSkillId": "ml-pipeline",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mapping",
+      "targetSkillId": "image-caption",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mapping",
+      "targetSkillId": "mcp-integration",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mappings",
+      "targetSkillId": "image-caption",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mark",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mark",
+      "targetSkillId": "summarize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "markdown",
+      "targetSkillId": "math-reason",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marker",
+      "targetSkillId": "summarize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marker",
+      "targetSkillId": "math-reason",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marketing",
+      "targetSkillId": "image-caption",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marketing",
+      "targetSkillId": "automated-testing",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marketing",
+      "targetSkillId": "reward-modeling",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marketplace",
+      "targetSkillId": "semantic-cache",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marketplace",
+      "targetSkillId": "parse-html",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marketplace",
+      "targetSkillId": "math-reason",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marketplaces",
+      "targetSkillId": "math-reason",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marketplaces",
+      "targetSkillId": "semantic-cache",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "marketplaces",
+      "targetSkillId": "parse-html",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "master",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "match",
+      "targetSkillId": "semantic-cache",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "match",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "match",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "matches",
+      "targetSkillId": "math-reason",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "matches",
+      "targetSkillId": "semantic-cache",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "matching",
+      "targetSkillId": "tool-chaining",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "matching",
+      "targetSkillId": "math-reason",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "matching",
+      "targetSkillId": "skill-authoring",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "matters",
+      "targetSkillId": "math-reason",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "matters",
+      "targetSkillId": "computer-use",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "matters",
+      "targetSkillId": "generate-test",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mbtiongson1",
+      "targetSkillId": "math-reason",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mbtiongson1",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mcp-server",
+      "targetSkillId": "mcp-server-creation",
+      "score": 0.69,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mcp-server",
+      "targetSkillId": "mcp-integration",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mcp-server",
+      "targetSkillId": "computer-use",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "measurable",
+      "targetSkillId": "web-scrape",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "measurable",
+      "targetSkillId": "data-visualize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "measurable",
+      "targetSkillId": "issue-triage",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "memory",
+      "targetSkillId": "memory-manage",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mental",
+      "targetSkillId": "agent-eval",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mental",
+      "targetSkillId": "document-analyst",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "mental",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "merge",
+      "targetSkillId": "memory-manage",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "merge",
+      "targetSkillId": "issue-triage",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "merge",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "merge-base",
+      "targetSkillId": "execute-bash",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "merge-base",
+      "targetSkillId": "computer-use",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "merge-base",
+      "targetSkillId": "multi-agent-debate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "merged",
+      "targetSkillId": "memory-manage",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "merges",
+      "targetSkillId": "memory-manage",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "merits",
+      "targetSkillId": "extract-entities",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "message",
+      "targetSkillId": "issue-triage",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "message",
+      "targetSkillId": "memory-manage",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "message",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "method",
+      "targetSkillId": "math-reason",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "missing",
+      "targetSkillId": "issue-triage",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "missing",
+      "targetSkillId": "vision-qa",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "missing",
+      "targetSkillId": "feed-monitoring",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "model",
+      "targetSkillId": "audience-model",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "model",
+      "targetSkillId": "reward-modeling",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "model",
+      "targetSkillId": "code-explain",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multiple",
+      "targetSkillId": "ml-pipeline",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multiple",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "multiple",
+      "targetSkillId": "multi-agent-debate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "name",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "name-only",
+      "targetSkillId": "parse-json",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "name-only",
+      "targetSkillId": "generate-sql",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "name-only",
+      "targetSkillId": "image-caption",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "named-origin",
+      "targetSkillId": "feed-monitoring",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "named-origin",
+      "targetSkillId": "automated-testing",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "named-skill",
+      "targetSkillId": "generate-sql",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "named-skill",
+      "targetSkillId": "automated-testing",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "named-skills",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "named-skills",
+      "targetSkillId": "automated-testing",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "named-skills",
+      "targetSkillId": "guardrails",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "names",
+      "targetSkillId": "generate-sql",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "naming",
+      "targetSkillId": "grounding",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "naming",
+      "targetSkillId": "reward-modeling",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "naming",
+      "targetSkillId": "function-calling",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "narrowed",
+      "targetSkillId": "parse-pdf",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "need",
+      "targetSkillId": "fine-tune",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "needed",
+      "targetSkillId": "embed-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "needs",
+      "targetSkillId": "generate-sql",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "needs-evidence",
+      "targetSkillId": "score-relevance",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "needs-evidence",
+      "targetSkillId": "code-review-pipeline",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "needs-evidence",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "needs-review",
+      "targetSkillId": "design-review",
+      "score": 0.64,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "needs-review",
+      "targetSkillId": "literature-review",
+      "score": 0.621,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "needs-review",
+      "targetSkillId": "code-review-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "never",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "never",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "next",
+      "targetSkillId": "generate-text",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "next",
+      "targetSkillId": "fine-tune",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "niche-integration",
+      "targetSkillId": "mcp-integration",
+      "score": 0.812,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "niche-integration",
+      "targetSkillId": "code-generation",
+      "score": 0.688,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "niche-integration",
+      "targetSkillId": "error-interpretation",
+      "score": 0.649,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "no-merges",
+      "targetSkillId": "generate-sql",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "no-merges",
+      "targetSkillId": "computer-use",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "no-merges",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "nodes",
+      "targetSkillId": "knowledge-harvest",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "nomenclature",
+      "targetSkillId": "translate",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "nomenclature",
+      "targetSkillId": "fine-tune",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "nomenclature",
+      "targetSkillId": "image-generate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "normalized",
+      "targetSkillId": "summarize",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "normalized",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "notation",
+      "targetSkillId": "mcp-integration",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "notation",
+      "targetSkillId": "agent-eval",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "notation",
+      "targetSkillId": "tool-creation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "note",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "note",
+      "targetSkillId": "fine-tune",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "notes",
+      "targetSkillId": "generate-sql",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "notes",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "nothing",
+      "targetSkillId": "grounding",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "nothing",
+      "targetSkillId": "e2e-testing",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "nothing",
+      "targetSkillId": "skill-authoring",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "numerals",
+      "targetSkillId": "guardrails",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "numerals",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "numerals",
+      "targetSkillId": "document-analyst",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "observed",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "occurrence",
+      "targetSkillId": "logical-inference",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "occurrence",
+      "targetSkillId": "score-relevance",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "occurrence",
+      "targetSkillId": "ocr",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "often",
+      "targetSkillId": "route-intent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "often",
+      "targetSkillId": "diff-content",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "often",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "one",
+      "targetSkillId": "tokenize",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "oneline",
+      "targetSkillId": "ml-pipeline",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "oneline",
+      "targetSkillId": "route-intent",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "oneline",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "open",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "open-source",
+      "targetSkillId": "cite-sources",
+      "score": 0.696,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "open-source",
+      "targetSkillId": "computer-use",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "open-source",
+      "targetSkillId": "web-search",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "opened",
+      "targetSkillId": "tokenize",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "opened",
+      "targetSkillId": "ml-pipeline",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "opened",
+      "targetSkillId": "document-editing",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "opens",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "opens",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "optional",
+      "targetSkillId": "function-calling",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "optional",
+      "targetSkillId": "conversational-agent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "optional",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "options",
+      "targetSkillId": "tool-creation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "options",
+      "targetSkillId": "image-caption",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "options",
+      "targetSkillId": "prd-generation",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "order",
+      "targetSkillId": "ocr",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "order",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "order",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "org",
+      "targetSkillId": "ocr",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "orgs",
+      "targetSkillId": "ocr",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "origin",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "originating",
+      "targetSkillId": "prd-generation",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "originating",
+      "targetSkillId": "error-interpretation",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "originating",
+      "targetSkillId": "tool-creation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "orphaned",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "orphaned",
+      "targetSkillId": "memory-manage",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "orphaned",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "other",
+      "targetSkillId": "ocr",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "other",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "out-of-scope",
+      "targetSkillId": "text-to-speech",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "out-of-scope",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "out-of-scope",
+      "targetSkillId": "web-scrape",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outcomes",
+      "targetSkillId": "context-compression",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outcomes",
+      "targetSkillId": "computer-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outcomes",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outdated",
+      "targetSkillId": "route-intent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outdated",
+      "targetSkillId": "automated-testing",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outdated",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "output",
+      "targetSkillId": "format-output",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "output",
+      "targetSkillId": "evaluate-output",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "output",
+      "targetSkillId": "structured-output",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outputs",
+      "targetSkillId": "format-output",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outputs",
+      "targetSkillId": "evaluate-output",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outputs",
+      "targetSkillId": "computer-use",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outside",
+      "targetSkillId": "tool-use",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outside",
+      "targetSkillId": "route-intent",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "outside",
+      "targetSkillId": "computer-use",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "over",
+      "targetSkillId": "ocr",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "overwritten",
+      "targetSkillId": "ghostwrite",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "overwritten",
+      "targetSkillId": "route-intent",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "overwritten",
+      "targetSkillId": "error-interpretation",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "owner",
+      "targetSkillId": "ocr",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "owner",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "packaging",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "page",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pages",
+      "targetSkillId": "parse-json",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "papers",
+      "targetSkillId": "parse-pdf",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "papers",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "papers",
+      "targetSkillId": "parse-html",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parse",
+      "targetSkillId": "parse-pdf",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parse",
+      "targetSkillId": "parse-json",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "parse",
+      "targetSkillId": "parse-html",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "part",
+      "targetSkillId": "parse-html",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "part",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "partially",
+      "targetSkillId": "api-call",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "partially",
+      "targetSkillId": "parse-html",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "partially",
+      "targetSkillId": "statistical-analysis",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pass",
+      "targetSkillId": "parse-json",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pass",
+      "targetSkillId": "classify",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pass",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "passes",
+      "targetSkillId": "parse-json",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "passes",
+      "targetSkillId": "parse-pdf",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "passes",
+      "targetSkillId": "parse-html",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "passing",
+      "targetSkillId": "parse-json",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "passing",
+      "targetSkillId": "classify",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "passing",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "patched",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "patched",
+      "targetSkillId": "semantic-cache",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "patches",
+      "targetSkillId": "math-reason",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "patches",
+      "targetSkillId": "semantic-cache",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "patches",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "paths",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pending",
+      "targetSkillId": "grounding",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pending",
+      "targetSkillId": "document-editing",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pending",
+      "targetSkillId": "e2e-testing",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "permanently",
+      "targetSkillId": "requirements-analysis",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "permanently",
+      "targetSkillId": "memory-manage",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "permanently",
+      "targetSkillId": "agent-eval",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "person",
+      "targetSkillId": "parse-json",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "person",
+      "targetSkillId": "prd-generation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "person",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "phase",
+      "targetSkillId": "parse-pdf",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "phase",
+      "targetSkillId": "parse-json",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "phase",
+      "targetSkillId": "parse-html",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pipefail",
+      "targetSkillId": "ml-pipeline",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pipefail",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pipefail",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "place",
+      "targetSkillId": "plan-decompose",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "place",
+      "targetSkillId": "plan-and-execute",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "playbook",
+      "targetSkillId": "plan-decompose",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "please",
+      "targetSkillId": "parse-pdf",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "please",
+      "targetSkillId": "plan-decompose",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "please",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "plus",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "point",
+      "targetSkillId": "voice-agent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "point",
+      "targetSkillId": "route-intent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "points",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pre-populating",
+      "targetSkillId": "reward-modeling",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pre-populating",
+      "targetSkillId": "prompt-optimization",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pre-populating",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prereqs",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prereqs",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prereqs",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prerequisite",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prerequisites",
+      "targetSkillId": "execute-bash",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prerequisites",
+      "targetSkillId": "retrieve",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prerequisites",
+      "targetSkillId": "requirements-analysis",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "presence",
+      "targetSkillId": "research",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "presence",
+      "targetSkillId": "parse-json",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "presence",
+      "targetSkillId": "score-relevance",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "present",
+      "targetSkillId": "parse-json",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "present",
+      "targetSkillId": "parse-html",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "present",
+      "targetSkillId": "research",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "print",
+      "targetSkillId": "route-intent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prioritized",
+      "targetSkillId": "ghostwrite",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proceed",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "project",
+      "targetSkillId": "parse-html",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "project",
+      "targetSkillId": "prompt-injection-defense",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "projection",
+      "targetSkillId": "object-detection",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "projection",
+      "targetSkillId": "prompt-injection-defense",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "projection",
+      "targetSkillId": "prd-generation",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "promote",
+      "targetSkillId": "plan-decompose",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "promote",
+      "targetSkillId": "prompt-optimization",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "promoted",
+      "targetSkillId": "parse-pdf",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "promoted",
+      "targetSkillId": "plan-decompose",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "promotion",
+      "targetSkillId": "prompt-optimization",
+      "score": 0.643,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "promotion",
+      "targetSkillId": "prd-generation",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "promotion",
+      "targetSkillId": "release-automation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposal",
+      "targetSkillId": "plan-decompose",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "propose",
+      "targetSkillId": "plan-decompose",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "propose",
+      "targetSkillId": "tool-use",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "propose",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposed",
+      "targetSkillId": "parse-pdf",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposed",
+      "targetSkillId": "plan-decompose",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposed",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposed-skill-name",
+      "targetSkillId": "parse-json",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposed-skill-name",
+      "targetSkillId": "route-intent",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposing",
+      "targetSkillId": "grounding",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposing",
+      "targetSkillId": "prompt-optimization",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "proposing",
+      "targetSkillId": "tool-chaining",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "provisional",
+      "targetSkillId": "vision-qa",
+      "score": 0.7,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "provisional",
+      "targetSkillId": "parse-json",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "provisional",
+      "targetSkillId": "prompt-optimization",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prune",
+      "targetSkillId": "route-intent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "prune",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pruning",
+      "targetSkillId": "grounding",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pruning",
+      "targetSkillId": "prd-generation",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pruning",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pull",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pushing",
+      "targetSkillId": "grounding",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pushing",
+      "targetSkillId": "skill-authoring",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "pytest",
+      "targetSkillId": "e2e-testing",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "python",
+      "targetSkillId": "math-reason",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "qualifying",
+      "targetSkillId": "function-calling",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "questions",
+      "targetSkillId": "question-answer",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "questions",
+      "targetSkillId": "vision-qa",
+      "score": 0.529,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "questions",
+      "targetSkillId": "e2e-testing",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "queue",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "quickstart",
+      "targetSkillId": "question-answer",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "quickstart",
+      "targetSkillId": "wiki-search",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rare",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rare",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rare",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rather",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rather",
+      "targetSkillId": "math-reason",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "raw",
+      "targetSkillId": "rank",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "re-resolve",
+      "targetSkillId": "retrieve",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "re-resolve",
+      "targetSkillId": "score-relevance",
+      "score": 0.64,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "re-resolve",
+      "targetSkillId": "write-report",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "read",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "read",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "read",
+      "targetSkillId": "refactor-code",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "read-only",
+      "targetSkillId": "reward-modeling",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "read-only",
+      "targetSkillId": "parse-json",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "read-only",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "readily",
+      "targetSkillId": "guardrails",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "readily",
+      "targetSkillId": "reward-modeling",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "readme",
+      "targetSkillId": "reward-modeling",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "readme",
+      "targetSkillId": "refactor-code",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ready",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "real",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "real",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "real-skill",
+      "targetSkillId": "generate-sql",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "real-skills",
+      "targetSkillId": "guardrails",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "real-skills",
+      "targetSkillId": "skill-discovery",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "real-world",
+      "targetSkillId": "refactor-code",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reason",
+      "targetSkillId": "math-reason",
+      "score": 0.706,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reason",
+      "targetSkillId": "parse-json",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reason",
+      "targetSkillId": "rank",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reasons",
+      "targetSkillId": "math-reason",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reasons",
+      "targetSkillId": "parse-json",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reasons",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "recent",
+      "targetSkillId": "route-intent",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "recent",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "recent",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "recorded",
+      "targetSkillId": "refactor-code",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "recorded",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "recorded",
+      "targetSkillId": "framework-upgrade",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "records",
+      "targetSkillId": "refactor-code",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "red",
+      "targetSkillId": "parse-pdf",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reference",
+      "targetSkillId": "research",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reference",
+      "targetSkillId": "score-relevance",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reference",
+      "targetSkillId": "logical-inference",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "references",
+      "targetSkillId": "score-relevance",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "references",
+      "targetSkillId": "research",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "references",
+      "targetSkillId": "generate-test",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reframe",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reframe",
+      "targetSkillId": "refactor-code",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reframe",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refresh",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refresh",
+      "targetSkillId": "research",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refresh",
+      "targetSkillId": "refactor-code",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refs",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "refs",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registered",
+      "targetSkillId": "retrieve",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registered",
+      "targetSkillId": "research",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registered",
+      "targetSkillId": "registry-curation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registries",
+      "targetSkillId": "retrieve",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registries",
+      "targetSkillId": "ghostwrite",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registries",
+      "targetSkillId": "registry-curation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registry",
+      "targetSkillId": "registry-curation",
+      "score": 0.64,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registry",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registry",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registry-for-review",
+      "targetSkillId": "design-review",
+      "score": 0.562,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registry-for-review",
+      "targetSkillId": "registry-curation",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "registry-for-review",
+      "targetSkillId": "retrieve",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "regression",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "regression",
+      "targetSkillId": "context-compression",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "regression",
+      "targetSkillId": "registry-curation",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "regressions",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "regressions",
+      "targetSkillId": "context-compression",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "regressions",
+      "targetSkillId": "requirements-analysis",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reject",
+      "targetSkillId": "research",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reject",
+      "targetSkillId": "tool-select",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rejected",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rejected",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rejected",
+      "targetSkillId": "execute-bash",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "related",
+      "targetSkillId": "translate",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "related",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "related",
+      "targetSkillId": "refactor-code",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "release",
+      "targetSkillId": "release-automation",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "release",
+      "targetSkillId": "score-relevance",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "release",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "release-process",
+      "targetSkillId": "release-automation",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "release-process",
+      "targetSkillId": "research",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "release-process",
+      "targetSkillId": "recursive-self-improvement",
+      "score": 0.488,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relevance",
+      "targetSkillId": "score-relevance",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relevance",
+      "targetSkillId": "retrieve",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relevance",
+      "targetSkillId": "research",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relevant",
+      "targetSkillId": "score-relevance",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relevant",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relevant",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relies",
+      "targetSkillId": "retrieve",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relies",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "relies",
+      "targetSkillId": "ml-pipeline",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "remaining",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "remaining",
+      "targetSkillId": "grounding",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "remaining",
+      "targetSkillId": "tool-chaining",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "remains",
+      "targetSkillId": "rank",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "remains",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "remains",
+      "targetSkillId": "tool-creation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "remote",
+      "targetSkillId": "retrieve",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "remote",
+      "targetSkillId": "embed-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "remote",
+      "targetSkillId": "reward-modeling",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "remote-only",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "remote-only",
+      "targetSkillId": "route-intent",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "remote-only",
+      "targetSkillId": "requirements-analysis",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "remotes",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "remotes",
+      "targetSkillId": "generate-test",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "remotes",
+      "targetSkillId": "embed-text",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "remove",
+      "targetSkillId": "retrieve",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "remove",
+      "targetSkillId": "reward-modeling",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "removed",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "removed",
+      "targetSkillId": "embed-text",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "removed",
+      "targetSkillId": "reward-modeling",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "renamed",
+      "targetSkillId": "embed-text",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rendering",
+      "targetSkillId": "grounding",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rendering",
+      "targetSkillId": "prd-generation",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rendering",
+      "targetSkillId": "reward-modeling",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reopen",
+      "targetSkillId": "parse-json",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reopen",
+      "targetSkillId": "reward-modeling",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reopen",
+      "targetSkillId": "math-reason",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "replaced",
+      "targetSkillId": "score-relevance",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "replaced",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "replaced",
+      "targetSkillId": "refactor-code",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repo",
+      "targetSkillId": "write-report",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repo",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repo-level",
+      "targetSkillId": "score-relevance",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repo-level",
+      "targetSkillId": "retrieve",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repo-level",
+      "targetSkillId": "agent-eval",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repo-root",
+      "targetSkillId": "write-report",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repo-root",
+      "targetSkillId": "tree-of-thought",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repo-root",
+      "targetSkillId": "refactor-code",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "report",
+      "targetSkillId": "write-report",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reports",
+      "targetSkillId": "write-report",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repos",
+      "targetSkillId": "write-report",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repos",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repository",
+      "targetSkillId": "feed-monitoring",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repository",
+      "targetSkillId": "self-consistency",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "repository",
+      "targetSkillId": "write-report",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reproduce",
+      "targetSkillId": "refactor-code",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reproduce",
+      "targetSkillId": "reward-modeling",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reproduce",
+      "targetSkillId": "retrieve",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reproducible",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reproducible",
+      "targetSkillId": "refactor-code",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reproduction",
+      "targetSkillId": "registry-curation",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reproduction",
+      "targetSkillId": "prd-generation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reproduction",
+      "targetSkillId": "code-execution",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reputable",
+      "targetSkillId": "retrieve",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "request",
+      "targetSkillId": "generate-test",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "request",
+      "targetSkillId": "question-answer",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "requests",
+      "targetSkillId": "question-answer",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "requests",
+      "targetSkillId": "requirements-analysis",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "requests",
+      "targetSkillId": "generate-test",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "require",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "require",
+      "targetSkillId": "requirements-analysis",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "required",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "required",
+      "targetSkillId": "requirements-analysis",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "requires",
+      "targetSkillId": "requirements-analysis",
+      "score": 0.552,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "requires",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rerun",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rerun",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rerun",
+      "targetSkillId": "registry-curation",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolution",
+      "targetSkillId": "registry-curation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolution",
+      "targetSkillId": "release-automation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolution",
+      "targetSkillId": "parallel-execution",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolvable",
+      "targetSkillId": "score-relevance",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolved",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolved",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolves",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "resolves",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "respect",
+      "targetSkillId": "research",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "respect",
+      "targetSkillId": "text-to-speech",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "respect",
+      "targetSkillId": "speech-to-text",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "restore",
+      "targetSkillId": "retrieve",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "restore",
+      "targetSkillId": "refactor-code",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "restore",
+      "targetSkillId": "research",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "restructure",
+      "targetSkillId": "structured-output",
+      "score": 0.643,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "restructure",
+      "targetSkillId": "registry-curation",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "restructure",
+      "targetSkillId": "retrieve",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retitle",
+      "targetSkillId": "retrieve",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retitle",
+      "targetSkillId": "extract-entities",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "retitle",
+      "targetSkillId": "parse-html",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "return",
+      "targetSkillId": "retrieve",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "return",
+      "targetSkillId": "fine-tune",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "return",
+      "targetSkillId": "registry-curation",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "returns",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "returns",
+      "targetSkillId": "registry-curation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "returns",
+      "targetSkillId": "fine-tune",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "review",
+      "targetSkillId": "design-review",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "review",
+      "targetSkillId": "retrieve",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "review",
+      "targetSkillId": "literature-review",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reviewed",
+      "targetSkillId": "retrieve",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reviewed",
+      "targetSkillId": "design-review",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reviewed",
+      "targetSkillId": "code-review-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reviewer",
+      "targetSkillId": "retrieve",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reviewer",
+      "targetSkillId": "design-review",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reviewer",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reviewers",
+      "targetSkillId": "retrieve",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reviewers",
+      "targetSkillId": "design-review",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "reviewers",
+      "targetSkillId": "code-review-pipeline",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rewrite",
+      "targetSkillId": "retrieve",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rewrite",
+      "targetSkillId": "ghostwrite",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rewrite",
+      "targetSkillId": "write-report",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rewriting",
+      "targetSkillId": "scientific-writing",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rewriting",
+      "targetSkillId": "reward-modeling",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rewriting",
+      "targetSkillId": "prd-generation",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "route-review",
+      "targetSkillId": "literature-review",
+      "score": 0.69,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "route-review",
+      "targetSkillId": "design-review",
+      "score": 0.64,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "route-review",
+      "targetSkillId": "route-intent",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "routed",
+      "targetSkillId": "route-intent",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "routed",
+      "targetSkillId": "grounding",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "routed",
+      "targetSkillId": "document-editing",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rule",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "rules",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "run",
+      "targetSkillId": "rank",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "run",
+      "targetSkillId": "grounding",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "running",
+      "targetSkillId": "grounding",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "running",
+      "targetSkillId": "function-calling",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "running",
+      "targetSkillId": "re-act-reasoning",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "runs",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "runs",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "runs",
+      "targetSkillId": "grounding",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "same",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "same",
+      "targetSkillId": "summarize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scan",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scan",
+      "targetSkillId": "schema-design",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "schema",
+      "targetSkillId": "schema-design",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scope",
+      "targetSkillId": "web-scrape",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scope",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "score",
+      "targetSkillId": "web-scrape",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "score",
+      "targetSkillId": "score-relevance",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "score",
+      "targetSkillId": "ocr",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "screenshot",
+      "targetSkillId": "speech-to-text",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "screenshot",
+      "targetSkillId": "tree-of-thought",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "screenshot",
+      "targetSkillId": "score-relevance",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "script",
+      "targetSkillId": "self-critique",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "script",
+      "targetSkillId": "web-scrape",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "script",
+      "targetSkillId": "security-audit",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scripts",
+      "targetSkillId": "self-critique",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scripts",
+      "targetSkillId": "security-audit",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "scripts",
+      "targetSkillId": "web-scrape",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "search",
+      "targetSkillId": "research",
+      "score": 0.857,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "search",
+      "targetSkillId": "web-search",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "search",
+      "targetSkillId": "wiki-search",
+      "score": 0.706,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "section",
+      "targetSkillId": "image-caption",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "section",
+      "targetSkillId": "code-execution",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "section",
+      "targetSkillId": "mcp-server-creation",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sections",
+      "targetSkillId": "image-caption",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sections",
+      "targetSkillId": "code-execution",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sections",
+      "targetSkillId": "question-answer",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "separate",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "separate",
+      "targetSkillId": "generate-sql",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "separate",
+      "targetSkillId": "self-critique",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "separately",
+      "targetSkillId": "generate-sql",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "separately",
+      "targetSkillId": "parse-html",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "server",
+      "targetSkillId": "retrieve",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "server",
+      "targetSkillId": "mcp-server-creation",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "server",
+      "targetSkillId": "score-relevance",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "servers",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "servers",
+      "targetSkillId": "mcp-server-creation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "servers",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "set",
+      "targetSkillId": "parse-html",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "setuptools",
+      "targetSkillId": "tool-use",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "setuptools",
+      "targetSkillId": "tool-select",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "several",
+      "targetSkillId": "generate-sql",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "several",
+      "targetSkillId": "agent-eval",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "several",
+      "targetSkillId": "mcp-server-creation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "shape",
+      "targetSkillId": "web-scrape",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "short-crawl-slug",
+      "targetSkillId": "vertical-slice-planning",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "signal",
+      "targetSkillId": "vision-qa",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "signal",
+      "targetSkillId": "agent-eval",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "signatures",
+      "targetSkillId": "generate-sql",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "signatures",
+      "targetSkillId": "fine-tune",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "signatures",
+      "targetSkillId": "generate-test",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "single",
+      "targetSkillId": "e2e-testing",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "site",
+      "targetSkillId": "ghostwrite",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "site",
+      "targetSkillId": "self-critique",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "site",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill",
+      "targetSkillId": "skill-discovery",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill",
+      "targetSkillId": "skill-authoring",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill-batches",
+      "targetSkillId": "skill-authoring",
+      "score": 0.643,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill-batches",
+      "targetSkillId": "skill-discovery",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill-batches",
+      "targetSkillId": "semantic-cache",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill-id",
+      "targetSkillId": "skill-discovery",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill-id",
+      "targetSkillId": "skill-authoring",
+      "score": 0.609,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill-id",
+      "targetSkillId": "skill-security-analysis",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill-name",
+      "targetSkillId": "skill-discovery",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill-name",
+      "targetSkillId": "skill-authoring",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill-name",
+      "targetSkillId": "skill-security-analysis",
+      "score": 0.485,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill-shaped",
+      "targetSkillId": "skill-discovery",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill-shaped",
+      "targetSkillId": "skill-authoring",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill-shaped",
+      "targetSkillId": "skill-security-analysis",
+      "score": 0.457,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill-sources",
+      "targetSkillId": "cite-sources",
+      "score": 0.72,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill-sources",
+      "targetSkillId": "skill-discovery",
+      "score": 0.643,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill-sources",
+      "targetSkillId": "skill-authoring",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill-topic",
+      "targetSkillId": "skill-authoring",
+      "score": 0.692,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill-topic",
+      "targetSkillId": "skill-discovery",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill-topic",
+      "targetSkillId": "skill-security-analysis",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill-tree",
+      "targetSkillId": "skill-authoring",
+      "score": 0.64,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill-tree",
+      "targetSkillId": "skill-discovery",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill-tree",
+      "targetSkillId": "design-review",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill-trees",
+      "targetSkillId": "skill-authoring",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill-trees",
+      "targetSkillId": "skill-discovery",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skill-trees",
+      "targetSkillId": "design-review",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skills",
+      "targetSkillId": "skill-discovery",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skills",
+      "targetSkillId": "skill-authoring",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skills-dir",
+      "targetSkillId": "skill-discovery",
+      "score": 0.72,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skills-dir",
+      "targetSkillId": "skill-authoring",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skills-dir",
+      "targetSkillId": "skill-security-analysis",
+      "score": 0.485,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "skillsmp",
+      "targetSkillId": "skill-discovery",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "slash",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "slash",
+      "targetSkillId": "classify",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "smaller",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "smaller",
+      "targetSkillId": "skill-discovery",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "smallest",
+      "targetSkillId": "schema-design",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "smallest",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "snapshot",
+      "targetSkillId": "speech-to-text",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sort",
+      "targetSkillId": "ocr",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "source",
+      "targetSkillId": "cite-sources",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "source",
+      "targetSkillId": "summarize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "source",
+      "targetSkillId": "score-relevance",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "source-directory",
+      "targetSkillId": "write-report",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "source-directory",
+      "targetSkillId": "scientific-discovery",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "source-directory",
+      "targetSkillId": "route-intent",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "source-level",
+      "targetSkillId": "score-relevance",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "source-level",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "source-level",
+      "targetSkillId": "cite-sources",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "source-of-truth",
+      "targetSkillId": "tree-of-thought",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "source-of-truth",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sourced",
+      "targetSkillId": "cite-sources",
+      "score": 0.632,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sourced",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sourced",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sources",
+      "targetSkillId": "cite-sources",
+      "score": 0.737,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sources",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sources",
+      "targetSkillId": "score-relevance",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specific",
+      "targetSkillId": "self-critique",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specific",
+      "targetSkillId": "scientific-writing",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "specific",
+      "targetSkillId": "security-audit",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "src",
+      "targetSkillId": "research",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "src",
+      "targetSkillId": "web-search",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stale",
+      "targetSkillId": "issue-triage",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "standardized",
+      "targetSkillId": "summarize",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "standardized",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "standardized",
+      "targetSkillId": "translate",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "standards",
+      "targetSkillId": "data-analysis",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "star",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "star",
+      "targetSkillId": "summarize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "star-tiers",
+      "targetSkillId": "extract-entities",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "star-tiers",
+      "targetSkillId": "summarize",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "star-tiers",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stars",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "starting",
+      "targetSkillId": "few-shot-learning",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "starting",
+      "targetSkillId": "scientific-writing",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "starting",
+      "targetSkillId": "e2e-testing",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "state",
+      "targetSkillId": "translate",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "state",
+      "targetSkillId": "ghostwrite",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "state",
+      "targetSkillId": "issue-triage",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "step",
+      "targetSkillId": "translate",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "step",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "still",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stored",
+      "targetSkillId": "ghostwrite",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stronger",
+      "targetSkillId": "question-answer",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stronger",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "stronger",
+      "targetSkillId": "issue-triage",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "structure",
+      "targetSkillId": "structured-output",
+      "score": 0.692,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "structure",
+      "targetSkillId": "ghostwrite",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "structure",
+      "targetSkillId": "registry-curation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "subcommand",
+      "targetSkillId": "summarize",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "subdirectories",
+      "targetSkillId": "retrieve",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "subdirectories",
+      "targetSkillId": "issue-triage",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "subdirectories",
+      "targetSkillId": "refactor-code",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "subdirectory",
+      "targetSkillId": "refactor-code",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "subdirectory",
+      "targetSkillId": "detect-anomaly",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "subdirectory",
+      "targetSkillId": "audience-model",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "submit",
+      "targetSkillId": "summarize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "subparsers",
+      "targetSkillId": "parse-json",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "subparsers",
+      "targetSkillId": "summarize",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "subparsers",
+      "targetSkillId": "parse-pdf",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "substantive",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "substantive",
+      "targetSkillId": "summarize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "substantive",
+      "targetSkillId": "semantic-cache",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "such",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sufficient",
+      "targetSkillId": "diff-content",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sufficient",
+      "targetSkillId": "voice-agent",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "sufficient",
+      "targetSkillId": "route-intent",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "suite",
+      "targetSkillId": "summarize",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "suite",
+      "targetSkillId": "ghostwrite",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "suite",
+      "targetSkillId": "issue-triage",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summarized",
+      "targetSkillId": "summarize",
+      "score": 0.947,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summarized",
+      "targetSkillId": "humanize-prose",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summarized",
+      "targetSkillId": "data-visualize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summarizing",
+      "targetSkillId": "summarize",
+      "score": 0.8,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summarizing",
+      "targetSkillId": "skill-authoring",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "summary",
+      "targetSkillId": "summarize",
+      "score": 0.75,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "superseded",
+      "targetSkillId": "parse-pdf",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "superseded",
+      "targetSkillId": "issue-triage",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "superseded",
+      "targetSkillId": "computer-use",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "supplementary",
+      "targetSkillId": "sentiment-analysis",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "supplementary",
+      "targetSkillId": "document-analyst",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "supplementary",
+      "targetSkillId": "requirements-analysis",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "supplied",
+      "targetSkillId": "ml-pipeline",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "supplied",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "supplied",
+      "targetSkillId": "summarize",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "surfaces",
+      "targetSkillId": "cite-sources",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "surfaces",
+      "targetSkillId": "issue-triage",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "surfaces",
+      "targetSkillId": "refactor-code",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "survey",
+      "targetSkillId": "summarize",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "table",
+      "targetSkillId": "translate",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "table",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tally",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "target",
+      "targetSkillId": "parse-html",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "target",
+      "targetSkillId": "agent-eval",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "target",
+      "targetSkillId": "voice-agent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "targeting",
+      "targetSkillId": "e2e-testing",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "targeting",
+      "targetSkillId": "image-caption",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "targeting",
+      "targetSkillId": "automated-testing",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "telling",
+      "targetSkillId": "e2e-testing",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "telling",
+      "targetSkillId": "function-calling",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "telling",
+      "targetSkillId": "tool-chaining",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "templates",
+      "targetSkillId": "translate",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "templates",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "templates",
+      "targetSkillId": "generate-sql",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "test",
+      "targetSkillId": "e2e-testing",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "test",
+      "targetSkillId": "generate-test",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tests",
+      "targetSkillId": "e2e-testing",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tests",
+      "targetSkillId": "cite-sources",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "than",
+      "targetSkillId": "math-reason",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "than",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "than",
+      "targetSkillId": "tool-chaining",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "thanked",
+      "targetSkillId": "rank",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "thanked",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "their",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "then",
+      "targetSkillId": "math-reason",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "then",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "there",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "there",
+      "targetSkillId": "write-report",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "there",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "these",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "these",
+      "targetSkillId": "computer-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "these",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "those",
+      "targetSkillId": "tool-use",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "those",
+      "targetSkillId": "ghostwrite",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "those",
+      "targetSkillId": "tool-select",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "three",
+      "targetSkillId": "math-reason",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "three",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "three",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "through",
+      "targetSkillId": "tree-of-thought",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "through",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "through",
+      "targetSkillId": "grounding",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tier",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tier",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "time",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "time",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "title",
+      "targetSkillId": "ghostwrite",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "title",
+      "targetSkillId": "route-intent",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "title",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tokens",
+      "targetSkillId": "tokenize",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "toml",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tool",
+      "targetSkillId": "tool-use",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tool",
+      "targetSkillId": "tool-select",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tool",
+      "targetSkillId": "tool-creation",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tools",
+      "targetSkillId": "tool-use",
+      "score": 0.769,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tools",
+      "targetSkillId": "tool-select",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "topic",
+      "targetSkillId": "ocr",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "topic",
+      "targetSkillId": "tokenize",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "topic",
+      "targetSkillId": "api-call",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "touch",
+      "targetSkillId": "ocr",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "touch",
+      "targetSkillId": "cite-sources",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "touch",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "touching",
+      "targetSkillId": "tool-chaining",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "touching",
+      "targetSkillId": "grounding",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "touching",
+      "targetSkillId": "function-calling",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tracks",
+      "targetSkillId": "rank",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tracks",
+      "targetSkillId": "translate",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tracks",
+      "targetSkillId": "math-reason",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "treated",
+      "targetSkillId": "translate",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "treated",
+      "targetSkillId": "retrieve",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "treated",
+      "targetSkillId": "tool-creation",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tree",
+      "targetSkillId": "retrieve",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tree",
+      "targetSkillId": "tokenize",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "tree",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "triage",
+      "targetSkillId": "gaia-triage",
+      "score": 0.706,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "triage",
+      "targetSkillId": "issue-triage",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "triage",
+      "targetSkillId": "retrieve",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "triggered",
+      "targetSkillId": "retrieve",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "triggered",
+      "targetSkillId": "gaia-triage",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "triggered",
+      "targetSkillId": "write-report",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "triggers",
+      "targetSkillId": "gaia-triage",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "triggers",
+      "targetSkillId": "retrieve",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "triggers",
+      "targetSkillId": "issue-triage",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ultimate",
+      "targetSkillId": "multi-agent-debate",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ultimate",
+      "targetSkillId": "multimodal-reasoning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "ultimate",
+      "targetSkillId": "issue-triage",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "unauthenticated",
+      "targetSkillId": "extract-entities",
+      "score": 0.516,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "unauthenticated",
+      "targetSkillId": "multi-agent-debate",
+      "score": 0.485,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "unauthenticated",
+      "targetSkillId": "semantic-cache",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "unavailable",
+      "targetSkillId": "guardrails",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "uncommon",
+      "targetSkillId": "plan-decompose",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "uncommon",
+      "targetSkillId": "chunk-document",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "uncommon",
+      "targetSkillId": "audience-model",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "under-sourced",
+      "targetSkillId": "cite-sources",
+      "score": 0.64,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "under-sourced",
+      "targetSkillId": "computer-use",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "understand",
+      "targetSkillId": "conversational-agent",
+      "score": 0.467,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "undocumented",
+      "targetSkillId": "chunk-document",
+      "score": 0.769,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "undocumented",
+      "targetSkillId": "document-editing",
+      "score": 0.714,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "undocumented",
+      "targetSkillId": "document-analyst",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "uninstall",
+      "targetSkillId": "function-calling",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "uninstall",
+      "targetSkillId": "api-call",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "unittest",
+      "targetSkillId": "generate-test",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "unittest",
+      "targetSkillId": "automated-testing",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "unittest",
+      "targetSkillId": "e2e-testing",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "universally",
+      "targetSkillId": "humanize-prose",
+      "score": 0.48,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "universally",
+      "targetSkillId": "conversational-agent",
+      "score": 0.452,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "unproposed",
+      "targetSkillId": "humanize-prose",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "unproposed",
+      "targetSkillId": "parse-pdf",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "unproposed",
+      "targetSkillId": "plan-decompose",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "unrelated",
+      "targetSkillId": "translate",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "unrelated",
+      "targetSkillId": "generate-sql",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "unrelated",
+      "targetSkillId": "retrieve",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "until",
+      "targetSkillId": "function-calling",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "untouched",
+      "targetSkillId": "cite-sources",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "untouched",
+      "targetSkillId": "tool-use",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "updates",
+      "targetSkillId": "parse-json",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "updates",
+      "targetSkillId": "guardrails",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "updating",
+      "targetSkillId": "grounding",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "updating",
+      "targetSkillId": "prd-generation",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "updating",
+      "targetSkillId": "document-editing",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "upgrade",
+      "targetSkillId": "framework-upgrade",
+      "score": 0.583,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "upgrading",
+      "targetSkillId": "grounding",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "upgrading",
+      "targetSkillId": "prd-generation",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "upgrading",
+      "targetSkillId": "reward-modeling",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "url",
+      "targetSkillId": "guardrails",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "usage",
+      "targetSkillId": "issue-triage",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "usage",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "use",
+      "targetSkillId": "tool-use",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "used",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "used",
+      "targetSkillId": "parse-pdf",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "user",
+      "targetSkillId": "tool-use",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "user",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "username",
+      "targetSkillId": "issue-triage",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "username",
+      "targetSkillId": "memory-manage",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "username",
+      "targetSkillId": "semantic-cache",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "users",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "users",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "using",
+      "targetSkillId": "grounding",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "using",
+      "targetSkillId": "e2e-testing",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "using",
+      "targetSkillId": "automated-testing",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validate",
+      "targetSkillId": "translate",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validate",
+      "targetSkillId": "gaia-triage",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validate",
+      "targetSkillId": "evaluate-output",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validated",
+      "targetSkillId": "translate",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validated",
+      "targetSkillId": "gaia-triage",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validated",
+      "targetSkillId": "evaluate-output",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validation",
+      "targetSkillId": "agent-eval",
+      "score": 0.615,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validation",
+      "targetSkillId": "scientific-visualization",
+      "score": 0.529,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "validation",
+      "targetSkillId": "vision-qa",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "values",
+      "targetSkillId": "evaluate-output",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "variant",
+      "targetSkillId": "rank",
+      "score": 0.545,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "variant",
+      "targetSkillId": "translate",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "variant",
+      "targetSkillId": "gaia-audit",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "variants",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "variants",
+      "targetSkillId": "translate",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "verbatim",
+      "targetSkillId": "prd-generation",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "verification",
+      "targetSkillId": "mcp-server-creation",
+      "score": 0.581,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "verification",
+      "targetSkillId": "image-caption",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "verification",
+      "targetSkillId": "scientific-visualization",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "verified",
+      "targetSkillId": "self-critique",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "version",
+      "targetSkillId": "vision-qa",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "version",
+      "targetSkillId": "conversational-agent",
+      "score": 0.519,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "version",
+      "targetSkillId": "prd-generation",
+      "score": 0.476,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "via",
+      "targetSkillId": "vision-qa",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "vscode-marketplace",
+      "targetSkillId": "code-explain",
+      "score": 0.6,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "vscode-marketplace",
+      "targetSkillId": "code-review-pipeline",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "vscode-marketplace",
+      "targetSkillId": "semantic-cache",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "warranted",
+      "targetSkillId": "translate",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "warranted",
+      "targetSkillId": "rank",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "watch",
+      "targetSkillId": "web-search",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "watch",
+      "targetSkillId": "wiki-search",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "watch",
+      "targetSkillId": "research",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "weak",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "where",
+      "targetSkillId": "web-scrape",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "where",
+      "targetSkillId": "write-report",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "whose",
+      "targetSkillId": "ghostwrite",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "whose",
+      "targetSkillId": "tool-use",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "wider",
+      "targetSkillId": "wiki-search",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "wider",
+      "targetSkillId": "write-report",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "wiki",
+      "targetSkillId": "wiki-search",
+      "score": 0.533,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "will",
+      "targetSkillId": "api-call",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "without",
+      "targetSkillId": "write-report",
+      "score": 0.526,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "without",
+      "targetSkillId": "chain-of-thought",
+      "score": 0.522,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "without",
+      "targetSkillId": "tree-of-thought",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "words",
+      "targetSkillId": "ocr",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "work",
+      "targetSkillId": "ocr",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "work",
+      "targetSkillId": "rank",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "workflow",
+      "targetSkillId": "workflow-automation",
+      "score": 0.593,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "working",
+      "targetSkillId": "grounding",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "working",
+      "targetSkillId": "few-shot-learning",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "working",
+      "targetSkillId": "workflow-automation",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "worth",
+      "targetSkillId": "ocr",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "worth",
+      "targetSkillId": "write-report",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "wrappers",
+      "targetSkillId": "web-scrape",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "wrappers",
+      "targetSkillId": "rag-pipeline",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "write",
+      "targetSkillId": "ghostwrite",
+      "score": 0.667,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "write",
+      "targetSkillId": "write-report",
+      "score": 0.588,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "write",
+      "targetSkillId": "retrieve",
+      "score": 0.462,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "writes",
+      "targetSkillId": "ghostwrite",
+      "score": 0.625,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "writes",
+      "targetSkillId": "write-report",
+      "score": 0.556,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "writes",
+      "targetSkillId": "extract-entities",
+      "score": 0.455,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "writing",
+      "targetSkillId": "scientific-writing",
+      "score": 0.56,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "writing",
+      "targetSkillId": "grounding",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "writing",
+      "targetSkillId": "ghostwrite",
+      "score": 0.471,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "wrong",
+      "targetSkillId": "grounding",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "wrong",
+      "targetSkillId": "reward-modeling",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "year",
+      "targetSkillId": "research",
+      "score": 0.5,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "your",
+      "targetSkillId": "ocr",
+      "score": 0.571,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "your-findings",
+      "targetSkillId": "grounding",
+      "score": 0.636,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "your-findings",
+      "targetSkillId": "tool-chaining",
+      "score": 0.538,
+      "reason": "Lexical similarity from Gaia push scan."
+    },
+    {
+      "sourceSkillId": "your-findings",
+      "targetSkillId": "document-editing",
+      "score": 0.483,
+      "reason": "Lexical similarity from Gaia push scan."
+    }
+  ]
+}

--- a/src/gaia_cli/cardRenderer.py
+++ b/src/gaia_cli/cardRenderer.py
@@ -241,13 +241,16 @@ def _bottom_border(width: int = CARD_WIDTH) -> str:
 # ─── Main rendering ─────────────────────────────────────────────────────────
 
 
-def render_card(skill: dict, *, width: int = CARD_WIDTH) -> str:
+def render_card(skill: dict, *, width: int = CARD_WIDTH, canon: bool = False, display_name: str | None = None, ctx: Optional["LocalContext"] = None) -> str:
     """
     Render a single skill as an ASCII card.
 
     Args:
         skill: A skill dict (from gaia.json skills array).
         width: Card width in characters (default 48).
+        canon: If True, show canonical slash-prefixed IDs.
+        display_name: Optional override for the skill name.
+        ctx: Optional LocalContext for nickname resolution of prereqs/derivatives.
 
     Returns:
         Multi-line string representing the card.
@@ -257,7 +260,12 @@ def render_card(skill: dict, *, width: int = CARD_WIDTH) -> str:
     tier = skill.get("type", "basic")
     glyph = TIER_GLYPHS.get(tier, "○")
     skill_id = skill.get("id", "unknown")
-    name = f"/{skill_id}"
+    
+    if canon:
+        name = f"/{skill_id}"
+    else:
+        name = display_name or (ctx.display_name(skill_id) if ctx else None) or skill.get("name") or _name_from_slug(skill_id)
+    
     rarity = skill.get("rarity", "common")
     rarity_label = RARITY_LABELS.get(rarity, rarity.capitalize())
     level = skill.get("level", "0★")
@@ -310,17 +318,17 @@ def render_card(skill: dict, *, width: int = CARD_WIDTH) -> str:
     # Separator
     lines.append(_separator(width))
 
-    # Prerequisites (slash-named)
+    # Prerequisites (Local-First or slash-named)
     if prereqs:
-        prereq_list = [f"/{p}" for p in prereqs]
+        prereq_list = [(ctx.display_name(p, canon=canon) if ctx else f"/{p}") for p in prereqs]
         prereq_str = _fit_list(prereq_list, inner, prefix="Prereqs: ")
         lines.append(_line(prereq_str, width))
     else:
         lines.append(_line("Prereqs: (none)", width))
 
-    # Derivatives (slash-named)
+    # Derivatives (Local-First or slash-named)
     if derivatives:
-        deriv_list = [f"/{d}" for d in derivatives]
+        deriv_list = [(ctx.display_name(d, canon=canon) if ctx else f"/{d}") for d in derivatives]
         deriv_str = _fit_list(deriv_list, inner, prefix="Unlocks: ")
         lines.append(_line(deriv_str, width))
     else:
@@ -341,7 +349,7 @@ def render_card(skill: dict, *, width: int = CARD_WIDTH) -> str:
     return "\n".join(lines)
 
 
-def render_card_compact(skill: dict) -> str:
+def render_card_compact(skill: dict, canon: bool = False, ctx: Optional["LocalContext"] = None) -> str:
     """
     Render a compact single-line card summary.
 
@@ -350,7 +358,9 @@ def render_card_compact(skill: dict) -> str:
     tier = skill.get("type", "basic")
     glyph = TIER_GLYPHS.get(tier, "○")
     skill_id = skill.get("id", skill.get("name", "unknown"))
-    name = f"/{skill_id}"
+    
+    name = (ctx.display_name(skill_id, canon=canon) if ctx else (f"/{skill_id}" if canon else skill.get("name", f"/{skill_id}")))
+    
     level = skill.get("level", "0★")
     effective = level_summary(skill)["effectiveLevel"]
     rarity = skill.get("rarity", "common")
@@ -361,7 +371,7 @@ def render_card_compact(skill: dict) -> str:
     return f"{glyph} {name} ({level}) [{rarity}] — {short_desc}"
 
 
-def render_cards(skills: list[dict], *, width: int = CARD_WIDTH, compact: bool = False) -> str:
+def render_cards(skills: list[dict], *, width: int = CARD_WIDTH, compact: bool = False, canon: bool = False, ctx: Optional["LocalContext"] = None) -> str:
     """
     Render multiple skills as cards.
 
@@ -369,13 +379,15 @@ def render_cards(skills: list[dict], *, width: int = CARD_WIDTH, compact: bool =
         skills: List of skill dicts.
         width: Card width (ignored in compact mode).
         compact: If True, render one-line summaries instead of full cards.
+        canon: If True, show canonical IDs.
+        ctx: Optional LocalContext for nickname resolution.
 
     Returns:
         Multi-line string with all cards.
     """
     if compact:
-        return "\n".join(render_card_compact(s) for s in skills)
-    return "\n\n".join(render_card(s, width=width) for s in skills)
+        return "\n".join(render_card_compact(s, canon=canon, ctx=ctx) for s in skills)
+    return "\n\n".join(render_card(s, width=width, canon=canon, ctx=ctx) for s in skills)
 
 
 def load_and_render(
@@ -384,6 +396,8 @@ def load_and_render(
     *,
     compact: bool = False,
     width: int = CARD_WIDTH,
+    canon: bool = False,
+    ctx: Optional["LocalContext"] = None,
 ) -> Optional[str]:
     """
     Load a skill by ID from the registry and render its card.
@@ -393,6 +407,8 @@ def load_and_render(
         registry_path: Path to the registry root.
         compact: Use compact rendering.
         width: Card width.
+        canon: Show canonical IDs.
+        ctx: Optional LocalContext for nickname resolution.
 
     Returns:
         Rendered card string, or None if skill not found.
@@ -410,8 +426,8 @@ def load_and_render(
         return None
 
     if compact:
-        return render_card_compact(skill)
-    return render_card(skill, width=width)
+        return render_card_compact(skill, canon=canon, ctx=ctx)
+    return render_card(skill, width=width, canon=canon, ctx=ctx)
 
 
 # ─── Appraise card (colored, with prereq status + actions) ─────────────────
@@ -423,6 +439,8 @@ def render_appraise_card(
     derivatives: list,
     actions: list[str],
     owned: bool = False,
+    canon: bool = False,
+    display_name: str | None = None,
 ) -> str:
     """
     Rich appraise card with ANSI color.
@@ -433,6 +451,8 @@ def render_appraise_card(
         derivatives: list of derivative skill dicts [{id, name, type}]
         actions: list of action labels (e.g. ["[F] Fuse", "[P] Promote"])
         owned: whether user owns this skill
+        canon: if True, show slash-prefixed IDs
+        display_name: optional override for skill name
     """
     width = CARD_WIDTH
     inner = width - 4
@@ -442,7 +462,11 @@ def render_appraise_card(
     rc = RANK_COLORS.get(skill_data.get("level", "0★"), (148, 163, 184))
     glyph = TIER_GLYPHS.get(tier, "○")
     skill_id = skill_data.get("id", "?")
-    name = f"/{skill_id}"
+    if canon:
+        name = f"/{skill_id}"
+    else:
+        name = display_name or skill_data.get("name") or _name_from_slug(skill_id)
+    
     level = skill_data.get("level", "0★")
     rarity = skill_data.get("rarity", "common")
     desc = skill_data.get("description", "")
@@ -490,7 +514,8 @@ def render_appraise_card(
         prereq_items = []
         for pid, has in prereq_status.items():
             icon = f"{fg(*COLOR_SUCCESS)}✓{r}" if has else f"{fg(*COLOR_MISSING)}○{r}"
-            prereq_items.append(f"  {icon} /{pid}")
+            pr_label = f"/{pid}" if canon else (skill_data.get("name") or _name_from_slug(pid))
+            prereq_items.append(f"  {icon} {pr_label}")
         # Two-column layout
         col_w = inner // 2
         for i in range(0, len(prereq_items), 2):
@@ -511,7 +536,15 @@ def render_appraise_card(
 
     # Derivatives (unlocks) — slash-named
     if derivatives:
-        deriv_line = "Unlocks: " + ", ".join("/" + (d.get("id", d) if isinstance(d, dict) else d) for d in derivatives[:4])
+        prefix = "Unlocks: "
+        deriv_items = []
+        for d in derivatives[:4]:
+            if isinstance(d, dict):
+                d_label = f"/{d['id']}" if canon else (d.get("name") or _name_from_slug(d["id"]))
+            else:
+                d_label = f"/{d}" if canon else _name_from_slug(d)
+            deriv_items.append(d_label)
+        deriv_line = prefix + ", ".join(deriv_items)
         if len(derivatives) > 4:
             deriv_line += f" +{len(derivatives) - 4} more"
         lines.append(f"{bc}{V}{r} {fg(*COLOR_MUTED)}{_pad(deriv_line, inner)}{r} {bc}{V}{r}")
@@ -541,12 +574,16 @@ def render_appraise_card(
 # ─── Unlock celebration ────────────────────────────────────────────────────
 
 
-def render_unlock_card(skill_data: dict, new_paths: list) -> str:
+def render_unlock_card(skill_data: dict, new_paths: list, canon: bool = False) -> str:
     """Celebratory unlock card with ASCII art."""
     tier = skill_data.get("type", "basic")
     tc = TIER_COLORS.get(tier, (56, 189, 248))
     skill_id = skill_data.get("id", "?")
-    name = f"/{skill_id}"
+    if canon:
+        name = f"/{skill_id}"
+    else:
+        name = skill_data.get("name") or _name_from_slug(skill_id)
+    
     glyph = TIER_GLYPHS.get(tier, "○")
     level = skill_data.get("level", "0★")
     rarity = skill_data.get("rarity", "common")
@@ -573,8 +610,12 @@ def render_unlock_card(skill_data: dict, new_paths: list) -> str:
         art.append(f"")
         art.append(f"    {fg(*COLOR_TEXT)}New paths opened:{r}")
         for p in new_paths[:4]:
-            pname = p.get("name", p.get("skillId", "?")) if isinstance(p, dict) else p
-            dist = p.get("distance", "?") if isinstance(p, dict) else "?"
+            if isinstance(p, dict):
+                pname = f"/{p['skillId']}" if canon else (p.get("name") or _name_from_slug(p["skillId"]))
+                dist = p.get("distance", "?")
+            else:
+                pname = f"/{p}" if canon else _name_from_slug(p)
+                dist = "?"
             art.append(f"      {fg(*COLOR_MUTED)}→{r} {pname} ({dist} away)")
 
     return "\n".join(art)
@@ -611,7 +652,7 @@ def render_path_summary(paths: dict) -> str:
 # ─── Promotion prompt ──────────────────────────────────────────────────────
 
 
-def render_promotion_prompt(skill_data: dict, proposed_level: str) -> str:
+def render_promotion_prompt(skill_data: dict, proposed_level: str, canon: bool = False, ctx: Optional["LocalContext"] = None) -> str:
     """Prompt shown when a skill is eligible for promotion."""
     skill_id = skill_data.get("id", "?")
     skill_type = skill_data.get("type", "extra")
@@ -627,10 +668,13 @@ def render_promotion_prompt(skill_data: dict, proposed_level: str) -> str:
     lines = [""]
     # Show fusion diagram if skill has prerequisites
     if prereqs:
-        lines.append(render_fusion_diagram(prereqs, skill_id, skill_type))
+        lines.append(render_fusion_diagram(prereqs, skill_id, skill_type, canon=canon, ctx=ctx))
+    
+    display = (ctx.display_name(skill_id, canon=canon) if ctx else f"/{skill_id}")
+    
     lines.extend([
         f"  {gc}┌─ Fusion ──────────────────────────────┐{r}",
-        f"  {gc}│{r}  {tc}{b}/{skill_id}{r} can advance to {b}Level {proposed_level}{r} ({level_name})",
+        f"  {gc}│{r}  {tc}{b}{display}{r} can advance to {b}Level {proposed_level}{r} ({level_name})",
         f"  {gc}│{r}  Run: {b}gaia fuse {skill_id}{r}",
         f"  {gc}└───────────────────────────────────────────┘{r}",
         "",
@@ -641,7 +685,7 @@ def render_promotion_prompt(skill_data: dict, proposed_level: str) -> str:
 # ─── Fusion diagram ───────────────────────────────────────────────────────
 
 
-def render_fusion_diagram(prereqs: list[str], result: str, result_type: str = "extra") -> str:
+def render_fusion_diagram(prereqs: list[str], result: str, result_type: str = "extra", canon: bool = False, ctx: Optional["LocalContext"] = None) -> str:
     """Render a Unicode fusion flow diagram showing skill combination."""
     tier_color = TIER_COLORS.get(result_type, TIER_COLORS["extra"])
     glyph = TIER_GLYPHS.get(result_type, "◇")
@@ -651,9 +695,9 @@ def render_fusion_diagram(prereqs: list[str], result: str, result_type: str = "e
     tb = bold() + fg(*tier_color)
     r = reset()
 
-    # Format skill names with slash prefix
-    prereq_names = [f"/{p}" for p in prereqs]
-    result_name = f"/{result}"
+    # Format skill names with slash prefix or nickname
+    prereq_names = [(ctx.display_name(p, canon=canon) if ctx else f"/{p}") for p in prereqs]
+    result_name = (ctx.display_name(result, canon=canon) if ctx else f"/{result}")
 
     # Single prereq: simple arrow
     if len(prereqs) == 1:

--- a/src/gaia_cli/localContext.py
+++ b/src/gaia_cli/localContext.py
@@ -147,15 +147,39 @@ class LocalContext:
                 })
         return skills
 
-    def display_name(self, skill_id: str) -> str:
-        """Return the best display name for a skill (plain text, no ANSI).
+    def display_name(self, skill_id: str, canon: bool = False) -> str:
+        """Return the best display name for a skill.
 
-        Priority: named ref > local user/id > /id
+        Priority (Local-First): 
+        - Nickname ID (e.g. /gaia-curate or karpathy/autoresearch)
+        - Human-readable Name (e.g. Research)
+        - Generic ID as fallback (/research)
+        
+        If canon=True, always returns /skill-id.
         """
+        if canon:
+            return f"/{skill_id}"
+
+        # 1. Check for named nickname (Pet Nickname)
         if skill_id in self.named_map:
-            return self.named_map[skill_id]
+            ref = self.named_map[skill_id]
+            if "/" in ref:
+                contrib, nickname = ref.split("/", 1)
+                if contrib == self.username:
+                    return f"/{nickname}"
+                return ref
+            return f"/{ref}"
+
+        # 2. Check for local novel skill
         if skill_id in self.novel_ids:
-            return f"{self.username}/{skill_id}"
+            return f"/{skill_id}"
+
+        # 3. Fallback to human-readable Real Skill Name (Dog Breed Name)
+        skill = self._skill_map.get(skill_id)
+        if skill and skill.get("name"):
+            return skill["name"]
+
+        # 4. Final fallback to generic ID
         return f"/{skill_id}"
 
 

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -249,9 +249,21 @@ def init_command(args):
         hook_script = os.path.join(registry_abs, "scripts", "install-git-hooks.sh")
         if os.path.exists(hook_script):
             try:
-                subprocess.run(["bash", hook_script], check=True)
-                print("  git hooks:  installed automatically")
-            except subprocess.CalledProcessError:
+                # Windows doesn't always have bash in PATH; skip or use sh if available
+                if sys.platform == "win32":
+                    # Check if 'sh' or 'bash' exists before running
+                    if subprocess.run(["where", "bash"], capture_output=True).returncode == 0:
+                        subprocess.run(["bash", hook_script], check=True)
+                        print("  git hooks:  installed automatically")
+                    elif subprocess.run(["where", "sh"], capture_output=True).returncode == 0:
+                        subprocess.run(["sh", hook_script], check=True)
+                        print("  git hooks:  installed automatically")
+                    else:
+                        print("  git hooks:  bash/sh not found, skipping auto-install")
+                else:
+                    subprocess.run(["bash", hook_script], check=True)
+                    print("  git hooks:  installed automatically")
+            except Exception:
                 print("  git hooks:  failed to install automatically")
 
 
@@ -267,6 +279,13 @@ def scan_command(args):
     raw_tokens = scan_result["tokens"]
     graph_path = registry_graph_path(args.registry)
     resolved = resolve_skills(raw_tokens, registry_path=graph_path)
+    
+    username = config.get('gaiaUser')
+    canon = getattr(args, 'canon', False)
+    
+    # Unified local context for display
+    ctx = LocalContext.load(args.registry, username or "", include_scan=False)
+
     if not quiet:
         print(
             f"Scanned {scan_result['files_scanned']} file(s) across "
@@ -282,20 +301,41 @@ def scan_command(args):
             with open(graph_path_file, 'r', encoding='utf-8') as gf:
                 gdata = json.load(gf)
             smap = {s['id']: s for s in gdata.get('skills', [])}
+            
             skill_parts = []
             for sid in sorted(resolved):
                 sk = smap.get(sid, {})
                 glyph = TYPE_SYMBOLS.get(sk.get('type', 'basic'), '○')
-                colored_name = format_skill_colored(sid, sk.get('level', '0★'))
+                
+                # Resolve display name via LocalContext
+                display = ctx.display_name(sid, canon=canon)
+                rank_color = RANK_COLORS.get(sk.get('level', '0★'), RANK_COLORS["0★"])
+                
+                # Apply nickname coloring if not canon and it's a nickname
+                if not canon and ("/" in display or sid in ctx.novel_ids):
+                    # Check if it's our own nickname (starts with /)
+                    if display.startswith("/"):
+                        colored_name = f"{_fg(*COLOR_LOCAL_USER)}{_bold()}{display}{_reset()}"
+                    else:
+                        # Other contributor nickname: contrib in red, rest in rank color
+                        parts = display.split("/", 1)
+                        if len(parts) == 2:
+                            colored_name = f"{_fg(*COLOR_CONTRIBUTOR)}{parts[0]}{_reset()}/{_fg(*rank_color)}{parts[1]}{_reset()}"
+                        else:
+                            colored_name = f"{_fg(*rank_color)}{display}{_reset()}"
+                else:
+                    colored_name = f"{_fg(*rank_color)}{display}{_reset()}"
+                
                 skill_parts.append(f"  {glyph} {colored_name}")
             print("\n".join(skill_parts))
         else:
             print('Tip: try `gaia skills search "code review"` or expand scanPaths.')
-    username = config.get('gaiaUser')
+
     tree = load_tree(username, registry_path=args.registry)
     if tree:
         with open(graph_path, 'r', encoding='utf-8') as f:
             graph_data = json.load(f)
+        skill_map = {s['id']: s for s in graph_data.get('skills', [])}
         unlocked = [s.get('skillId') for s in tree.get('unlockedSkills', [])]
         combos = get_combinations(graph_data, unlocked, resolved)
         if combos and not quiet:
@@ -304,7 +344,8 @@ def scan_command(args):
                 result_skill = skill_map.get(c['candidateResult'], {})
                 result_type = result_skill.get('type', 'extra')
                 print(render_fusion_diagram(
-                    c['detectedSkills'], c['candidateResult'], result_type
+                    c['detectedSkills'], c['candidateResult'], result_type,
+                    canon=canon, ctx=ctx
                 ))
             print("Run `gaia fuse <skill>` to confirm.")
 
@@ -317,14 +358,13 @@ def scan_command(args):
         save_paths(new_paths)
 
         # Show unlock cards for newly reachable skills
-        skill_map = {s['id']: s for s in graph_data.get('skills', [])}
         if changes.get("new_near_unlocks"):
             print()
             for sid in changes["new_near_unlocks"]:
                 skill = skill_map.get(sid)
                 if skill:
                     opened = [p for p in new_paths.get("availablePaths", []) if p.get("distance", 99) <= 2]
-                    print(render_unlock_card(skill, opened[:3]))
+                    print(render_unlock_card(skill, opened[:3], canon=canon, ctx=ctx))
                     print()
 
         # Path summary
@@ -343,7 +383,7 @@ def scan_command(args):
             for promo in eligible[:2]:
                 skill = skill_map.get(promo["skillId"])
                 if skill:
-                    print(render_promotion_prompt(skill, promo.get("suggestedLevel", "2★")))
+                    print(render_promotion_prompt(skill, promo.get("suggestedLevel", "2★"), canon=canon, ctx=ctx))
         if unique_eligible and not quiet:
             for uc in unique_eligible:
                 print(f"  ◉ {uc['name']} eligible for unique promotion (gaia promote {uc['skillId']} --unique)")
@@ -433,7 +473,15 @@ def lookup_command(args):
             sys.exit(1)
 
     skill_id = skill["id"]
-    print(f"/{skill_id} - {skill.get('name', skill_id)}")
+    canon = getattr(args, 'canon', False)
+    
+    config = load_config() or {}
+    username = config.get("gaiaUser")
+    ctx = LocalContext.load(args.registry, username or "", include_scan=False)
+    
+    display = ctx.display_name(skill_id, canon=canon)
+    print(f"{display}")
+    
     print(f"Type: {skill.get('type', 'unknown')}    Level: {skill.get('level', '?')}")
     if skill.get("description"):
         print(skill["description"])
@@ -561,7 +609,15 @@ def appraise_command(args):
     if derivatives:
         actions.append("[→] Paths")
 
-    print(render_appraise_card(skill, prereq_status, derivatives, actions, owned=owned))
+    # Local-first display name
+    canon = getattr(args, "canon", False)
+    ctx = LocalContext.load(args.registry, username or "", include_scan=False)
+    display_name = ctx.display_name(skill_id, canon=canon)
+
+    print(render_appraise_card(
+        skill, prereq_status, derivatives, actions, 
+        owned=owned, canon=canon, display_name=display_name
+    ))
     try:
         candidates = load_promotion_candidates(args.registry).get("candidates", [])
         matching = [c for c in candidates if c.get("skillId") == skill_id]
@@ -778,7 +834,8 @@ def tree_command(args):
             graph_data = json.load(f)
     tree = load_tree(config.get('gaiaUser'), registry_path=args.registry)
     mode = "named" if getattr(args, 'named', False) else ("title" if getattr(args, 'title', False) else "default")
-    show_tree(tree, graph_data=graph_data, registry_path=args.registry, mode=mode)
+    canon = getattr(args, 'canon', False)
+    show_tree(tree, graph_data=graph_data, registry_path=args.registry, mode=mode, canon=canon)
     if tree:
         render_user_tree_outputs(config.get('gaiaUser'), tree, graph_data, args.registry, quiet=False)
 
@@ -1229,6 +1286,7 @@ def get_parser():
     tree_parser = subparsers.add_parser('tree', help="Show your Gaia skill tree")
     tree_parser.add_argument('--named', action='store_true', help="Show only skills that have a named implementation")
     tree_parser.add_argument('--title', action='store_true', help="Show display name instead of slash command / contributor ID")
+    tree_parser.add_argument('--canon', action='store_true', help="Show canonical registry data instead of local-first view.")
     push_parser = subparsers.add_parser('push', help="Prepare detected skills for review")
     push_parser.add_argument('--dry-run', action='store_true', help="Print the skill batch without writing it")
     push_parser.add_argument('--no-pr', action='store_true', help="Write intake record without creating a PR")
@@ -1247,7 +1305,8 @@ def get_parser():
     graph_parser.add_argument('-o', '--output', help="Output path (default: registry/render/gaia.html)")
     graph_parser.add_argument('--open', dest='open', action='store_true', default=True, help="Open the generated graph (default)")
     graph_parser.add_argument('--no-open', dest='open', action='store_false', help="Do not open the generated graph")
-    subparsers.add_parser('stats', help="Show registry health at a glance")
+    stats_parser = subparsers.add_parser('stats', help="Show registry health at a glance")
+    stats_parser.add_argument('--canon', action='store_true', help="Show canonical registry data instead of local-first view.")
     appraise_parser = subparsers.add_parser('appraise', help="Inspect a skill card with status and actions")
     appraise_parser.add_argument('skillId', nargs='?', default=None, help="Skill ID to appraise (default: most recent)")
     promote_parser = subparsers.add_parser('promote', help="Promote a skill eligible for level-up")

--- a/src/gaia_cli/treeManager.py
+++ b/src/gaia_cli/treeManager.py
@@ -109,7 +109,7 @@ def _gradient_text(text, start_rgb, end_rgb):
     return "".join(parts) + reset()
 
 
-def _color_entry(symbol, plain_label, tier, is_named, level):
+def _color_entry(symbol, plain_label, tier, is_named, level, current_user=None):
     from gaia_cli.cardRenderer import fg, reset, bold, _use_color, TIER_COLORS, RANK_COLORS, COLOR_CONTRIBUTOR, COLOR_LOCAL_USER
     if not _use_color():
         return f"{symbol} {plain_label}"
@@ -117,16 +117,26 @@ def _color_entry(symbol, plain_label, tier, is_named, level):
         if level in _TRANSCENDENT_LEVELS:
             colored = _gradient_text(f"{symbol} {plain_label}", _GRAD_GOLD, _GRAD_RED)
             return f"{bold()}{colored}{reset()}"
-        # Named skills: contributor in red, rest in rank color
+        
+        # Named skills
         rc = RANK_COLORS.get(level, (148, 163, 184))
-        cr, cg, cb = COLOR_CONTRIBUTOR
-        # Check if label has contributor prefix (contains / before [)
-        if "/" in plain_label.split("[")[0]:
-            parts = plain_label.split("/", 1)
+        
+        # Check for contributor prefix
+        parts = plain_label.split("[")[0].strip().split("/", 1)
+        if len(parts) == 2 and parts[0]:
             contrib_part = parts[0]
             rest = parts[1]
-            return f"{fg(cr, cg, cb)}{symbol} {contrib_part}{reset()}/{fg(*rc)}{rest}{reset()}"
-        return f"{bold()}{fg(cr, cg, cb)}{symbol} {plain_label}{reset()}"
+            color = COLOR_LOCAL_USER if current_user and contrib_part == current_user else COLOR_CONTRIBUTOR
+            return f"{fg(*color)}{symbol} {contrib_part}{reset()}/{fg(*rc)}{rest}{reset()}"
+        
+        # No contributor part (or leading slash)
+        color = COLOR_CONTRIBUTOR
+        if plain_label.startswith("/"):
+            # If it starts with / but no contributor, it's a local/own nickname
+            color = COLOR_LOCAL_USER
+        
+        return f"{bold()}{fg(*color)}{symbol} {plain_label}{reset()}"
+    
     # Canon skills: rank color for entire label
     rc = RANK_COLORS.get(level, (148, 163, 184))
     return f"{fg(*rc)}{symbol} {plain_label}{reset()}"
@@ -142,17 +152,34 @@ def _dim(text):
 _TYPE_SYMBOL = {"basic": "○", "extra": "◇", "ultimate": "◆"}
 
 
-def _plain_label(skill_id, skill_map, named_by_ref, local_by_ref, mode):
+def _plain_label(skill_id, skill_map, named_by_ref, local_by_ref, mode, canon=False, current_user=None):
     level = skill_map.get(skill_id, {}).get("level", "?")
+    if canon:
+        return f"/{skill_id}  [{level}]"
+    
     if mode == "title":
         name = skill_map.get(skill_id, {}).get("name", skill_id)
         return f"{name}  [{level}]"
+    
     local = local_by_ref.get(skill_id)
     named = named_by_ref.get(skill_id)
-    if local:
-        return f"{local['id']}  [{level}]  (/{skill_id})"
-    if named:
-        return f"{named['id']}  [{level}]"
+    
+    specific = local or named
+    if specific:
+        full_id = specific.get("id")
+        if full_id:
+            if "/" in full_id:
+                contrib, nickname = full_id.split("/", 1)
+                if current_user and contrib == current_user:
+                    return f"/{nickname}  [{level}]"
+                return f"{full_id}  [{level}]"
+            return f"/{full_id}  [{level}]"
+
+    # Fallback to human name (Real Skill Name)
+    canon_name = skill_map.get(skill_id, {}).get("name")
+    if canon_name:
+        return f"{canon_name}  [{level}]"
+        
     return f"/{skill_id}  [{level}]"
 
 
@@ -162,15 +189,15 @@ def _is_named(skill_id, named_by_ref, local_by_ref):
 
 # ─── recursive renderer ───────────────────────────────────────────────────────
 
-def _render_subtree(skill_id, skill_map, display_ids, named_by_ref, local_by_ref, mode, prefix, is_last, seen):
+def _render_subtree(skill_id, skill_map, display_ids, named_by_ref, local_by_ref, mode, prefix, is_last, seen, canon=False, current_user=None):
     skill = skill_map.get(skill_id, {})
     tier = skill.get("type", "basic")
     level = skill.get("level", "?")
     symbol = _TYPE_SYMBOL.get(tier, "○")
     named = _is_named(skill_id, named_by_ref, local_by_ref)
-    label = _plain_label(skill_id, skill_map, named_by_ref, local_by_ref, mode)
+    label = _plain_label(skill_id, skill_map, named_by_ref, local_by_ref, mode, canon=canon, current_user=current_user)
     connector = "└── " if is_last else "├── "
-    lines = [_dim(prefix + connector) + _color_entry(symbol, label, tier, named, level)]
+    lines = [_dim(prefix + connector) + _color_entry(symbol, label, tier, named, level, current_user=current_user)]
     seen.add(skill_id)
 
     child_prefix = prefix + ("    " if is_last else "│   ")
@@ -182,18 +209,18 @@ def _render_subtree(skill_id, skill_map, display_ids, named_by_ref, local_by_ref
         child_level = child_skill.get("level", "?")
         child_sym = _TYPE_SYMBOL.get(child_tier, "○")
         child_named = _is_named(child_id, named_by_ref, local_by_ref)
-        child_label = _plain_label(child_id, skill_map, named_by_ref, local_by_ref, mode)
+        child_label = _plain_label(child_id, skill_map, named_by_ref, local_by_ref, mode, canon=canon, current_user=current_user)
         if child_id in seen:
             conn2 = "└── " if child_is_last else "├── "
             lines.append(
                 _dim(child_prefix + conn2)
-                + _color_entry(child_sym, child_label + " ...", child_tier, child_named, child_level)
+                + _color_entry(child_sym, child_label + " ...", child_tier, child_named, child_level, current_user=current_user)
             )
         else:
             lines.extend(
                 _render_subtree(
                     child_id, skill_map, display_ids, named_by_ref, local_by_ref,
-                    mode, child_prefix, child_is_last, seen,
+                    mode, child_prefix, child_is_last, seen, canon=canon, current_user=current_user
                 )
             )
     return lines
@@ -201,7 +228,7 @@ def _render_subtree(skill_id, skill_map, display_ids, named_by_ref, local_by_ref
 
 # ─── public entry point ───────────────────────────────────────────────────────
 
-def show_tree(tree_data, graph_data=None, registry_path=".", mode="default"):
+def show_tree(tree_data, graph_data=None, registry_path=".", mode="default", canon=False):
     if not tree_data:
         print("No skill tree found.")
         return
@@ -232,10 +259,13 @@ def show_tree(tree_data, graph_data=None, registry_path=".", mode="default"):
     tier_order = {"ultimate": 0, "extra": 1, "basic": 2}
     roots.sort(key=lambda s: (tier_order.get(skill_map.get(s["skillId"], {}).get("type", "basic"), 2), s["skillId"]))
 
-    print(username)
+    from gaia_cli.formatting import _fg, _reset, COLOR_CONTRIBUTOR
+    # Use a direct ANSI code to ensure color even if _use_color() fails in a subshell/pipe
+    username_colored = f"\033[38;2;{COLOR_CONTRIBUTOR[0]};{COLOR_CONTRIBUTOR[1]};{COLOR_CONTRIBUTOR[2]}m{username}\033[0m"
+    print(username_colored)
     seen: set[str] = set()
     for i, entry in enumerate(roots):
         sid = entry["skillId"]
         is_last = i == len(roots) - 1
-        for line in _render_subtree(sid, skill_map, display_ids, named_by_ref, local_by_ref, mode, "", is_last, seen):
+        for line in _render_subtree(sid, skill_map, display_ids, named_by_ref, local_by_ref, mode, "", is_last, seen, canon=canon, current_user=username):
             print(line)

--- a/tests/test_dx.py
+++ b/tests/test_dx.py
@@ -165,9 +165,15 @@ def test_lookup_lists_named_implementation_roles(tmp_path, monkeypatch, capsys):
     run_cli(monkeypatch, ["--registry", str(tmp_path), "lookup", "web-search"])
 
     output = capsys.readouterr().out
-    assert "/web-search - Web Search" in output
+    assert "Web Search" in output
+    assert "Type: basic    Level: 1★" in output
     assert "[origin] Alice Search (alice/search)" in output
     assert "[variant] Bob Search (bob/search)" in output
+
+    # Verify canon flag reveals slash ID
+    run_cli(monkeypatch, ["--registry", str(tmp_path), "--canon", "lookup", "web-search"])
+    output_canon = capsys.readouterr().out
+    assert "/web-search" in output_canon
 
 
 def parse_config(path):


### PR DESCRIPTION
This PR implements a full 'Local-First' behavior for the Gaia CLI, prioritizing user-specific nicknames and human-readable names over generic canonical IDs. It also includes several platform-specific fixes for Windows, resolves a scan-time crash, and ensures consistent UTF-8 rendering for box-drawing characters.