### PR TITLE
Skip packaging tests when build is unavailable

### DIFF
--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,3 +1,4 @@
+import importlib.util
 import json
 import os
 import shutil
@@ -12,6 +13,15 @@ import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def require_build_package():
+    if importlib.util.find_spec("build") is None:
+        pytest.skip(
+            'packaging tests require the "build" package; install developer '
+            'dependencies with `pip install -e ".[dev]"` or '
+            '`pip install -e ".[embeddings,dev]"`.'
+        )
 
 
 def run_python(args, *, cwd=None, env=None):
@@ -276,6 +286,8 @@ def test_install_cache_honors_gaia_home(tmp_path, monkeypatch):
 
 @pytest.mark.packaging
 def test_built_wheel_contains_only_python_package_data(tmp_path):
+    require_build_package()
+
     dist_dir = tmp_path / "dist"
     result = build_wheel(dist_dir)
     assert result.returncode == 0, result.stderr
@@ -305,6 +317,8 @@ def test_built_wheel_contains_only_python_package_data(tmp_path):
 
 @pytest.mark.packaging
 def test_wheel_install_smoke_tests_console_script(tmp_path):
+    require_build_package()
+
     dist_dir = tmp_path / "dist"
     build_result = build_wheel(dist_dir)
     assert build_result.returncode == 0, build_result.stderr


### PR DESCRIPTION
### Motivation
- Issue 181 notes that running the documented `pip install -e ".[embeddings]"` can cause packaging tests to fail with `No module named build` because the `build` tool is declared only in the `dev` extra; tests should not hard-fail for contributors who intentionally install a smaller extra set. 
- The change aims to make the packaging test behavior more resilient and provide an actionable message so contributors understand how to run the packaging checks.

### Description
- Add a `require_build_package()` helper in `tests/test_packaging.py` that uses `importlib.util.find_spec("build")` and calls `pytest.skip()` with an actionable install message if `build` is not importable. 
- Call `require_build_package()` at the start of the packaging wheel-building tests `test_built_wheel_contains_only_python_package_data` and `test_wheel_install_smoke_tests_console_script` so they skip cleanly when `build` is missing and recommend `pip install -e ".[dev]"` or `pip install -e ".[embeddings,dev]"`.

### Testing
- Ran `python -m pytest tests/test_packaging.py -q`, which completed with `16 passed, 2 skipped` indicating the helper correctly skips when `build` is unavailable. 
- Ran the docs and generation commands `uv run python scripts/build_docs.py --check && uv run python scripts/generateProjections.py && uv run python scripts/exportGexf.py`, which reported documentation up to date and generated indexes. 
- Ran the full test suite with `uv run pytest`, which completed with `378 passed, 2 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a026012fc3c8327be081fbf489cb898)