### PR TITLE
design: colorize skill tree with tier-based and unique skill styling

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -480,46 +480,40 @@
     90% {color:#34d399;text-shadow:0 0 10px rgba(52,211,153,.8),0 0 22px rgba(52,211,153,.4)}
     100%{color:#38bdf8;text-shadow:0 0 10px rgba(56,189,248,.8),0 0 22px rgba(56,189,248,.4)}
   }
-  .tree-dialog-body pre .tree-ult-line{font-weight:700!important}
-  .tree-dialog-body pre .tree-ult-contributor{color:#ef4444!important;font-weight:800!important;text-shadow:0 0 8px rgba(239,68,68,.6)!important}
-  .tree-dialog-body pre .tree-ult-slash{color:var(--muted)!important}
-  .tree-dialog-body pre .tree-ult-skillname,
-  .tree-dialog-body pre .tree-ult-id{color:#f59e0b!important}
+  /* ── Tree Highlighting ── */
+  .tree-ult-line { font-weight: 700 !important; color: var(--text) !important; }
+  .tree-ult-contributor { color: #ef4444 !important; font-weight: 800 !important; text-shadow: 0 0 8px rgba(239,68,68,0.4) !important; }
+  .tree-ult-slash { color: var(--muted) !important; opacity: 0.5 !important; }
+  .tree-ult-skillname, .tree-ult-id { color: #f59e0b !important; font-weight: 700 !important; }
   
-  .tree-dialog-body pre .tree-unique-line{font-weight:700!important}
-  .tree-dialog-body pre .tree-unique-contributor{color:#ef4444!important;font-weight:800!important}
-  .tree-dialog-body pre .tree-unique-slash{color:var(--muted)!important}
-  .tree-dialog-body pre .tree-unique-skillname{
-    color:#000!important;
-    font-weight:900!important;
-    text-shadow: 
-      0 0 8px rgba(124,58,237,.8),
-      0 0 16px rgba(124,58,237,.4)!important;
-    -webkit-text-stroke: 1px rgba(124,58,237,.5)!important;
+  .tree-unique-line { font-weight: 700 !important; color: var(--text) !important; }
+  .tree-unique-contributor { color: #ef4444 !important; font-weight: 800 !important; }
+  .tree-unique-slash { color: var(--muted) !important; opacity: 0.5 !important; }
+  .tree-unique-skillname {
+    color: #000 !important;
+    font-weight: 900 !important;
+    text-shadow: 0 0 8px #7c3aed, 0 0 16px rgba(124,58,237,0.4) !important;
+    -webkit-text-stroke: 1px rgba(124,58,237,0.6) !important;
   }
-  .tree-dialog-body pre .tree-unique-gold{
-    text-shadow: 
-      0 0 8px rgba(251,191,36,.8),
-      0 0 16px rgba(251,191,36,.4)!important;
-    -webkit-text-stroke: 1px rgba(251,191,36,.5)!important;
+  .tree-unique-gold {
+    text-shadow: 0 0 8px #fbbf24, 0 0 16px rgba(251,191,36,0.4) !important;
+    -webkit-text-stroke: 1px rgba(251,191,36,0.6) !important;
   }
-  .tree-dialog-body pre .tree-unique-glyph{color:var(--unique)!important}
+  .tree-unique-glyph { color: #7c3aed !important; }
 
-  .tree-dialog-body pre .tree-extra-glyph{color:var(--extra)!important}
-  .tree-dialog-body pre .tree-basic-glyph{color:var(--basic)!important}
-  .tree-dialog-body pre .tree-sep{color:rgba(56,189,248,.3)!important}
+  .tree-extra-line { font-weight: 600 !important; color: var(--text) !important; }
+  .tree-extra-glyph { color: #c084fc !important; }
+  .tree-extra-contributor { color: #ef4444 !important; font-weight: 700 !important; }
+  .tree-extra-slash { color: var(--muted) !important; opacity: 0.5 !important; }
+  .tree-extra-skillname, .tree-extra-id { color: #c084fc !important; }
 
-  .tree-dialog-body pre .tree-extra-line{font-weight:600!important}
-  .tree-dialog-body pre .tree-extra-contributor{color:#ef4444!important;font-weight:700!important;text-shadow:0 0 6px rgba(239,68,68,.5)!important}
-  .tree-dialog-body pre .tree-extra-slash{color:var(--muted)!important}
-  .tree-dialog-body pre .tree-extra-skillname,
-  .tree-dialog-body pre .tree-extra-id{color:var(--extra)!important}
+  .tree-basic-line { color: var(--text) !important; }
+  .tree-basic-glyph { color: #38bdf8 !important; }
+  .tree-basic-contributor { color: #ef4444 !important; font-weight: 600 !important; }
+  .tree-basic-slash { color: var(--muted) !important; opacity: 0.5 !important; }
+  .tree-basic-skillname, .tree-basic-id { color: #38bdf8 !important; }
 
-  .tree-dialog-body pre .tree-basic-line{color:inherit!important}
-  .tree-dialog-body pre .tree-basic-contributor{color:#ef4444!important;font-weight:600!important}
-  .tree-dialog-body pre .tree-basic-slash{color:var(--muted)!important}
-  .tree-dialog-body pre .tree-basic-skillname,
-  .tree-dialog-body pre .tree-basic-id{color:var(--basic)!important}
+  .tree-sep { color: rgba(56,189,248,0.25) !important; }
   .skill-tooltip{
     position:absolute;pointer-events:all;display:none;z-index:15;
     background:rgba(3,7,18,.9);border:1px solid rgba(148,163,184,.22);

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -480,43 +480,46 @@
     90% {color:#34d399;text-shadow:0 0 10px rgba(52,211,153,.8),0 0 22px rgba(52,211,153,.4)}
     100%{color:#38bdf8;text-shadow:0 0 10px rgba(56,189,248,.8),0 0 22px rgba(56,189,248,.4)}
   }
-  .tree-ult-line{font-weight:700}
-  .tree-ult-contributor{color:#ef4444;font-weight:800;text-shadow:0 0 8px rgba(239,68,68,.6)}
-  .tree-ult-slash{color:var(--muted)}
-  .tree-ult-skillname,.tree-ult-id{color:#f59e0b}
+  .tree-dialog-body pre .tree-ult-line{font-weight:700!important}
+  .tree-dialog-body pre .tree-ult-contributor{color:#ef4444!important;font-weight:800!important;text-shadow:0 0 8px rgba(239,68,68,.6)!important}
+  .tree-dialog-body pre .tree-ult-slash{color:var(--muted)!important}
+  .tree-dialog-body pre .tree-ult-skillname,
+  .tree-dialog-body pre .tree-ult-id{color:#f59e0b!important}
   
-  .tree-unique-line{font-weight:700}
-  .tree-unique-contributor{color:#ef4444;font-weight:800}
-  .tree-unique-slash{color:var(--muted)}
-  .tree-unique-skillname{
-    color:#000;
-    font-weight:900;
+  .tree-dialog-body pre .tree-unique-line{font-weight:700!important}
+  .tree-dialog-body pre .tree-unique-contributor{color:#ef4444!important;font-weight:800!important}
+  .tree-dialog-body pre .tree-unique-slash{color:var(--muted)!important}
+  .tree-dialog-body pre .tree-unique-skillname{
+    color:#000!important;
+    font-weight:900!important;
     text-shadow: 
       0 0 8px rgba(124,58,237,.8),
-      0 0 16px rgba(124,58,237,.4);
-    -webkit-text-stroke: 1px rgba(124,58,237,.5);
+      0 0 16px rgba(124,58,237,.4)!important;
+    -webkit-text-stroke: 1px rgba(124,58,237,.5)!important;
   }
-  .tree-unique-gold{
+  .tree-dialog-body pre .tree-unique-gold{
     text-shadow: 
       0 0 8px rgba(251,191,36,.8),
-      0 0 16px rgba(251,191,36,.4);
-    -webkit-text-stroke: 1px rgba(251,191,36,.5);
+      0 0 16px rgba(251,191,36,.4)!important;
+    -webkit-text-stroke: 1px rgba(251,191,36,.5)!important;
   }
-  .tree-unique-glyph{color:var(--unique)}
+  .tree-dialog-body pre .tree-unique-glyph{color:var(--unique)!important}
 
-  .tree-extra-glyph{color:var(--extra)}
-  .tree-basic-glyph{color:var(--basic)}
-  .tree-sep{color:rgba(56,189,248,.2)}
+  .tree-dialog-body pre .tree-extra-glyph{color:var(--extra)!important}
+  .tree-dialog-body pre .tree-basic-glyph{color:var(--basic)!important}
+  .tree-dialog-body pre .tree-sep{color:rgba(56,189,248,.3)!important}
 
-  .tree-extra-line{font-weight:600}
-  .tree-extra-contributor{color:#ef4444;font-weight:700;text-shadow:0 0 6px rgba(239,68,68,.5)}
-  .tree-extra-slash{color:var(--muted)}
-  .tree-extra-skillname,.tree-extra-id{color:var(--extra)}
+  .tree-dialog-body pre .tree-extra-line{font-weight:600!important}
+  .tree-dialog-body pre .tree-extra-contributor{color:#ef4444!important;font-weight:700!important;text-shadow:0 0 6px rgba(239,68,68,.5)!important}
+  .tree-dialog-body pre .tree-extra-slash{color:var(--muted)!important}
+  .tree-dialog-body pre .tree-extra-skillname,
+  .tree-dialog-body pre .tree-extra-id{color:var(--extra)!important}
 
-  .tree-basic-line{color:var(--text)}
-  .tree-basic-contributor{color:#ef4444;font-weight:600}
-  .tree-basic-slash{color:var(--muted)}
-  .tree-basic-skillname,.tree-basic-id{color:var(--basic)}
+  .tree-dialog-body pre .tree-basic-line{color:inherit!important}
+  .tree-dialog-body pre .tree-basic-contributor{color:#ef4444!important;font-weight:600!important}
+  .tree-dialog-body pre .tree-basic-slash{color:var(--muted)!important}
+  .tree-dialog-body pre .tree-basic-skillname,
+  .tree-dialog-body pre .tree-basic-id{color:var(--basic)!important}
   .skill-tooltip{
     position:absolute;pointer-events:all;display:none;z-index:15;
     background:rgba(3,7,18,.9);border:1px solid rgba(148,163,184,.22);

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -2,6 +2,7 @@
     --basic:    #38bdf8;
     --extra:    #c084fc;
     --ultimate: #f59e0b;
+    --unique:   #7c3aed;
     --bg:       #030712;
     --surface:  #0f172a;
     --border:   #1e293b;
@@ -483,13 +484,39 @@
   .tree-ult-contributor{color:#ef4444;font-weight:800;text-shadow:0 0 8px rgba(239,68,68,.6)}
   .tree-ult-slash{color:var(--muted)}
   .tree-ult-skillname,.tree-ult-id{color:#f59e0b}
+  
+  .tree-unique-line{font-weight:700}
+  .tree-unique-contributor{color:#ef4444;font-weight:800}
+  .tree-unique-slash{color:var(--muted)}
+  .tree-unique-skillname{
+    color:#000;
+    font-weight:900;
+    text-shadow: 
+      0 0 8px rgba(124,58,237,.8),
+      0 0 16px rgba(124,58,237,.4);
+    -webkit-text-stroke: 1px rgba(124,58,237,.5);
+  }
+  .tree-unique-gold{
+    text-shadow: 
+      0 0 8px rgba(251,191,36,.8),
+      0 0 16px rgba(251,191,36,.4);
+    -webkit-text-stroke: 1px rgba(251,191,36,.5);
+  }
+  .tree-unique-glyph{color:var(--unique)}
+
   .tree-extra-glyph{color:var(--extra)}
   .tree-basic-glyph{color:var(--basic)}
   .tree-sep{color:rgba(56,189,248,.2)}
+
   .tree-extra-line{font-weight:600}
   .tree-extra-contributor{color:#ef4444;font-weight:700;text-shadow:0 0 6px rgba(239,68,68,.5)}
   .tree-extra-slash{color:var(--muted)}
   .tree-extra-skillname,.tree-extra-id{color:var(--extra)}
+
+  .tree-basic-line{color:var(--text)}
+  .tree-basic-contributor{color:#ef4444;font-weight:600}
+  .tree-basic-slash{color:var(--muted)}
+  .tree-basic-skillname,.tree-basic-id{color:var(--basic)}
   .skill-tooltip{
     position:absolute;pointer-events:all;display:none;z-index:15;
     background:rgba(3,7,18,.9);border:1px solid rgba(148,163,184,.22);

--- a/docs/js/skill-explorer.js
+++ b/docs/js/skill-explorer.js
@@ -694,8 +694,8 @@
     var ultIdx = 0;
     var unqIdx = 0;
     return text.split('\n').map(function(line) {
-      // Ultimate skill header lines: ◆ Ultimate Skill: contributor/name  [6★]
-      var m = line.match(/^(\s*◆ Ultimate Skill: )(\S+)(.*)$/);
+      // Ultimate skill header lines
+      var m = line.match(/^(\s*◆\s*(?:Ultimate Skill:\s*)?)(\S+)(.*)$/);
       if (m) {
         var label = esc(m[1]);
         var skillId = m[2];
@@ -714,7 +714,7 @@
                label + skillHtml + suffix + '</span>';
       }
 
-      // Unique skill lines (header or sub-item): ◉ Unique Skill: ... or just ◉ /...
+      // Unique skill lines
       var u = line.match(/^([\s│├└─]*◉\s*(?:Unique Skill:\s*)?)(\S+)(.*)$/);
       if (u) {
         var ulabel = esc(u[1]);
@@ -724,7 +724,6 @@
         var uslash = uid.indexOf('/');
         var uskillHtml;
         
-        // Detect level for gold/purple glow
         var isGold = usuffix.indexOf('5★') >= 0 || usuffix.indexOf('6★') >= 0;
         var uniqueClass = isGold ? 'tree-unique-skillname tree-unique-gold' : 'tree-unique-skillname';
 
@@ -739,7 +738,7 @@
                ulabel + uskillHtml + usuffix + '</span>';
       }
 
-      // Extra skill lines: ├─ ◇ Extra Skill: /research  [3★]
+      // Extra skill lines
       var e = line.match(/^([\s│├└─]*◇\s*(?:Extra Skill:\s*)?)(\S+)(.*)$/);
       if (e) {
         var elabel = esc(e[1]);
@@ -757,7 +756,7 @@
         return '<span class="tree-extra-line">' + elabel + eskillHtml + esuffix + '</span>';
       }
 
-      // Basic skill lines: ├─ ○ /web-search  [1★]
+      // Basic skill lines
       var b = line.match(/^([\s│├└─]*○\s*)(\S+)(.*)$/);
       if (b) {
         var blabel = esc(b[1]);
@@ -775,9 +774,7 @@
         return '<span class="tree-basic-line">' + blabel + bskillHtml + bsuffix + '</span>';
       }
 
-      // Separator lines
       if (/^[═─]{3,}/.test(line)) return '<span class="tree-sep">' + esc(line) + '</span>';
-      // Inline ◇ / ○ / ◉ glyphs
       var out = esc(line);
       out = out.replace(/◇/g, '<span class="tree-extra-glyph">◇</span>');
       out = out.replace(/○/g, '<span class="tree-basic-glyph">○</span>');

--- a/docs/js/skill-explorer.js
+++ b/docs/js/skill-explorer.js
@@ -694,7 +694,7 @@
     var ultIdx = 0;
     var unqIdx = 0;
     return text.split('\n').map(function(line) {
-      // Ultimate skill header lines
+      // 1. Ultimate Skill lines (◆)
       var m = line.match(/^(\s*◆\s*(?:Ultimate Skill:\s*)?)(\S+)(.*)$/);
       if (m) {
         var label = esc(m[1]);
@@ -714,7 +714,7 @@
                label + skillHtml + suffix + '</span>';
       }
 
-      // Unique skill lines
+      // 2. Unique Skill lines (◉)
       var u = line.match(/^([\s│├└─]*◉\s*(?:Unique Skill:\s*)?)(\S+)(.*)$/);
       if (u) {
         var ulabel = esc(u[1]);
@@ -723,14 +723,12 @@
         var udelay = -((unqIdx++ * 0.9) % 4);
         var uslash = uid.indexOf('/');
         var uskillHtml;
-        
         var isGold = usuffix.indexOf('5★') >= 0 || usuffix.indexOf('6★') >= 0;
         var uniqueClass = isGold ? 'tree-unique-skillname tree-unique-gold' : 'tree-unique-skillname';
-
         if (uslash > 0) {
           uskillHtml = '<span class="tree-unique-contributor">' + esc(uid.slice(0, uslash)) + '</span>' +
                        '<span class="tree-unique-slash">/</span>' +
-                       '<span class="' + uniqueClass + '">' + esc(uid.slice(uslash + 1)) + '</span>';
+                       '<span class="' + uniqueClass + '">' + esc(uid.slice(slash + 1)) + '</span>';
         } else {
           uskillHtml = '<span class="' + uniqueClass + '">' + esc(uid) + '</span>';
         }
@@ -738,7 +736,7 @@
                ulabel + uskillHtml + usuffix + '</span>';
       }
 
-      // Extra skill lines
+      // 3. Extra Skill lines (◇)
       var e = line.match(/^([\s│├└─]*◇\s*(?:Extra Skill:\s*)?)(\S+)(.*)$/);
       if (e) {
         var elabel = esc(e[1]);
@@ -756,7 +754,7 @@
         return '<span class="tree-extra-line">' + elabel + eskillHtml + esuffix + '</span>';
       }
 
-      // Basic skill lines
+      // 4. Basic Skill lines (○)
       var b = line.match(/^([\s│├└─]*○\s*)(\S+)(.*)$/);
       if (b) {
         var blabel = esc(b[1]);
@@ -774,11 +772,14 @@
         return '<span class="tree-basic-line">' + blabel + bskillHtml + bsuffix + '</span>';
       }
 
-      if (/^[═─]{3,}/.test(line)) return '<span class="tree-sep">' + esc(line) + '</span>';
+      // 5. Separators and Catch-alls
+      if (/^[═─]{3,}/.test(line.trim())) return '<span class="tree-sep">' + esc(line) + '</span>';
+      
       var out = esc(line);
       out = out.replace(/◇/g, '<span class="tree-extra-glyph">◇</span>');
       out = out.replace(/○/g, '<span class="tree-basic-glyph">○</span>');
       out = out.replace(/◉/g, '<span class="tree-unique-glyph">◉</span>');
+      out = out.replace(/◆/g, '<span class="tree-ult-glyph">◆</span>');
       return out;
     }).join('\n');
   }

--- a/docs/js/skill-explorer.js
+++ b/docs/js/skill-explorer.js
@@ -695,7 +695,7 @@
     var unqIdx = 0;
     return text.split('\n').map(function(line) {
       // Ultimate skill header lines: ◆ Ultimate Skill: contributor/name  [6★]
-      var m = line.match(/^(◆ Ultimate Skill: )(\S+)(.*)$/);
+      var m = line.match(/^(\s*◆ Ultimate Skill: )(\S+)(.*)$/);
       if (m) {
         var label = esc(m[1]);
         var skillId = m[2];
@@ -704,7 +704,6 @@
         var slash = skillId.indexOf('/');
         var skillHtml;
         if (slash > 0) {
-          // named — contributor in red, skill name in amber
           skillHtml = '<span class="tree-ult-contributor">' + esc(skillId.slice(0, slash)) + '</span>' +
                       '<span class="tree-ult-slash">/</span>' +
                       '<span class="tree-ult-skillname">' + esc(skillId.slice(slash + 1)) + '</span>';
@@ -714,8 +713,9 @@
         return '<span class="tree-ult-line" style="animation-delay:' + delay + 's">' +
                label + skillHtml + suffix + '</span>';
       }
-      // Unique skill header lines: ◉ Unique Skill: contributor/name  [4★]
-      var u = line.match(/^(◉ Unique Skill: )(\S+)(.*)$/);
+
+      // Unique skill lines (header or sub-item): ◉ Unique Skill: ... or just ◉ /...
+      var u = line.match(/^([\s│├└─]*◉\s*(?:Unique Skill:\s*)?)(\S+)(.*)$/);
       if (u) {
         var ulabel = esc(u[1]);
         var uid = u[2];
@@ -723,16 +723,58 @@
         var udelay = -((unqIdx++ * 0.9) % 4);
         var uslash = uid.indexOf('/');
         var uskillHtml;
+        
+        // Detect level for gold/purple glow
+        var isGold = usuffix.indexOf('5★') >= 0 || usuffix.indexOf('6★') >= 0;
+        var uniqueClass = isGold ? 'tree-unique-skillname tree-unique-gold' : 'tree-unique-skillname';
+
         if (uslash > 0) {
           uskillHtml = '<span class="tree-unique-contributor">' + esc(uid.slice(0, uslash)) + '</span>' +
                        '<span class="tree-unique-slash">/</span>' +
-                       '<span class="tree-unique-skillname">' + esc(uid.slice(uslash + 1)) + '</span>';
+                       '<span class="' + uniqueClass + '">' + esc(uid.slice(uslash + 1)) + '</span>';
         } else {
-          uskillHtml = '<span class="tree-unique-skillname">' + esc(uid) + '</span>';
+          uskillHtml = '<span class="' + uniqueClass + '">' + esc(uid) + '</span>';
         }
         return '<span class="tree-unique-line" style="animation-delay:' + udelay + 's">' +
                ulabel + uskillHtml + usuffix + '</span>';
       }
+
+      // Extra skill lines: ├─ ◇ Extra Skill: /research  [3★]
+      var e = line.match(/^([\s│├└─]*◇\s*(?:Extra Skill:\s*)?)(\S+)(.*)$/);
+      if (e) {
+        var elabel = esc(e[1]);
+        var eid = e[2];
+        var esuffix = esc(e[3]);
+        var eslash = eid.indexOf('/');
+        var eskillHtml;
+        if (eslash > 0) {
+          eskillHtml = '<span class="tree-extra-contributor">' + esc(eid.slice(0, eslash)) + '</span>' +
+                       '<span class="tree-extra-slash">/</span>' +
+                       '<span class="tree-extra-skillname">' + esc(eid.slice(eslash + 1)) + '</span>';
+        } else {
+          eskillHtml = '<span class="tree-extra-id">' + esc(eid) + '</span>';
+        }
+        return '<span class="tree-extra-line">' + elabel + eskillHtml + esuffix + '</span>';
+      }
+
+      // Basic skill lines: ├─ ○ /web-search  [1★]
+      var b = line.match(/^([\s│├└─]*○\s*)(\S+)(.*)$/);
+      if (b) {
+        var blabel = esc(b[1]);
+        var bid = b[2];
+        var bsuffix = esc(b[3]);
+        var bslash = bid.indexOf('/');
+        var bskillHtml;
+        if (bslash > 0) {
+          bskillHtml = '<span class="tree-basic-contributor">' + esc(bid.slice(0, bslash)) + '</span>' +
+                       '<span class="tree-basic-slash">/</span>' +
+                       '<span class="tree-basic-skillname">' + esc(bid.slice(bslash + 1)) + '</span>';
+        } else {
+          bskillHtml = '<span class="tree-basic-id">' + esc(bid) + '</span>';
+        }
+        return '<span class="tree-basic-line">' + blabel + bskillHtml + bsuffix + '</span>';
+      }
+
       // Separator lines
       if (/^[═─]{3,}/.test(line)) return '<span class="tree-sep">' + esc(line) + '</span>';
       // Inline ◇ / ○ / ◉ glyphs


### PR DESCRIPTION
## Summary
- Contributor names colored **red** in the skill tree view
- Skills colored by tier: Basic → Extra → Ultimate graduation
- Unique skills: black core with purple glow (gold glow for 5★/6★)
- High-specificity selectors + `!important` flags ensure colors survive sub-tree and list contexts

## Files changed
- `docs/css/styles.css` — tier color rules and unique skill glow
- `docs/js/skill-explorer.js` — coloring logic and highlight targeting

## Notes
Rebranched from `fix/tree-coloring` (closed PR #226) to isolate design-only changes. No CLI, schema, or registry files are included.