### PR TITLE
cli: prioritize local pet names and fix scan render crash

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,82 @@
+# Gaia AI Agent Skill Registry - Project Context
+
+This file provides critical context and instructions for the Gaia project. Adhere to these guidelines for all development and research tasks.
+
+## Project Overview
+Gaia is an open, evidence-backed skill graph for AI agents. It tracks capabilities (Basic, Extra, Ultimate), their evolution (0★ to 6★), and fusion into complex workflows.
+
+- **Primary Technologies:** Python (CLI), Node.js (MCP server, npm wrapper), JSON/YAML (Registry data), Markdown (Skill cards/Docs).
+- **Core Concept:** Skills level up through evidence. Tiers: ○ Basic (indivisible), ◇ Extra (combination), ◆ Ultimate (high complexity).
+- **Architecture:**
+    - `registry/`: Canonical graph (`gaia.json`), named skills, and schemas. **Source of Truth.**
+    - `src/gaia_cli/`: Core Python CLI logic.
+    - `packages/mcp/`: Model Context Protocol (MCP) server for agent-native integration.
+    - `scripts/`: Essential utilities for validation, building, and registry maintenance.
+    - `docs/`: Documentation site and generated graph assets.
+    - `registry-for-review/`: Intake area for proposed skills (`gaia push`).
+
+## Development Workflows
+
+### Setup
+```bash
+# Install editable with all extras
+pip install -e ".[embeddings,interactive,dev]"
+
+# (Optional) Install npm wrapper for local testing
+cd packages/cli-npm && npm install
+```
+
+### Key Commands
+- **Scan/Appraise:** `gaia scan` (detect skills), `gaia appraise <skillId>` (inspect).
+- **Validation:** 
+    - `python3 scripts/validate.py` (canonical graph check).
+    - `python3 scripts/validate_intake.py` (intake batch check).
+- **Documentation:** `gaia docs build` (regenerates site and artifacts).
+- **Testing:** `pytest` (Python test suite).
+- **MCP Server:** `npx @gaia-registry/mcp-server` (or `node packages/mcp/bin/mcp-server.js`).
+
+### Branch Naming Conventions (Strict)
+| Prefix | Scope |
+|---|---|
+| `schema/` | `registry/schema/` changes only |
+| `cli/` | `src/gaia_cli/`, `packages/`, `tests/` |
+| `docs/` | `docs/`, `*.md` |
+| `review/gaia-push/` | Intake PRs (`registry-for-review/`) |
+| `review/meta/` | Registry curation (`registry/` except schema) |
+| `infra/` | CI, scripts, `.github/` |
+
+## Technical Guidelines
+
+### Source of Truth
+- **NEVER** hand-edit files in `docs/` or generated artifacts like `registry/gaia.svg`.
+- **Edit Only:** `registry/gaia.json`, `registry/named/*.json`, or `registry-for-review/skill-batches/*.json`.
+
+### Python Internal Modules
+- `src/gaia_cli/formatting.py`: Centralized slash-naming formatters, RANK_COLORS, and tier colors.
+- `src/gaia_cli/localContext.py`: Manages `LocalContext`, merging user trees, scan results, and named skill maps.
+
+### Versioning & Pre-commit
+- The following files **MUST** be kept in lockstep: `pyproject.toml`, `packages/cli-npm/package.json`, `packages/mcp/package.json`, and `registry/gaia.json`.
+- A pre-commit hook (`scripts/install-git-hooks.sh`) enforces this. Do not manually repair version drift without investigation.
+
+### Skill Leveling (Evidence Floor)
+- `2★` (Named): ≥ 1 Tier C evidence.
+- `3★` (Evolved): ≥ 1 Tier B evidence.
+- `4★+` (Hardened/Transcendent): ≥ 1 Tier B/A evidence.
+- `6★` (Transcendent ★): Tier A + peer review.
+
+### Coding Style
+- **Python:** Follow idiomatic patterns; use `jsonschema` for data validation.
+- **Node.js:** TypeScript for the MCP server.
+- **Registry:** Skills use `kebab-case` IDs. Display names are Title Case.
+
+### CLI Design Philosophy
+- **Local-First Skill Names:** The CLI must prioritize the developer's local workspace context. "Pet names" (e.g. `/gaia-curate` or `gaiabot/gaia-triage`) are considered the *actual*, real skill names for a local developer.
+- **Slashes and Colors:** Do NOT remove the slash from local skill IDs. Real/local skill names should be displayed with their slash and colored green to distinguish them from generic canonical concepts. The generic canonical names ("Human Readable Names") are strictly for the state of all skills in the global graph, but developers using the CLI should see their own local skill names.
+
+## Important Files
+- `registry/gaia.json`: The core Directed Acyclic Graph (DAG) of skills.
+- `registry/schema/skill.schema.json`: Validation rules for skills.
+- `scripts/build_docs.py`: Orchestrates the entire documentation and artifact build process.
+- `DESIGN.md`: Visual language and design tokens for the graph and UI.
+- `CONTRIBUTING.md`: Detailed contribution workflows.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Skills level up through evidence, not declaration. Each demerit lowers effective
 ## Install
 
 <!-- gaia:version-start -->
-Current Gaia CLI version: `3.2.2`.
+Current Gaia CLI version: `3.2.3`.
 
 Python install:
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Skills level up through evidence, not declaration. Each demerit lowers effective
 ## Install
 
 <!-- gaia:version-start -->
-Current Gaia CLI version: `3.2.1`.
+Current Gaia CLI version: `3.2.2`.
 
 Python install:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -572,5 +572,5 @@
 </html>
 
 <!-- gaia:stats-start -->
-<!-- skills=133; namedSkills=37; uniqueSkills=1; version=3.2.1 -->
+<!-- skills=133; namedSkills=37; uniqueSkills=1; version=3.2.2 -->
 <!-- gaia:stats-end -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -572,5 +572,5 @@
 </html>
 
 <!-- gaia:stats-start -->
-<!-- skills=133; namedSkills=37; uniqueSkills=1; version=3.2.2 -->
+<!-- skills=133; namedSkills=37; uniqueSkills=1; version=3.2.3 -->
 <!-- gaia:stats-end -->

--- a/packages/cli-npm/package.json
+++ b/packages/cli-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia-registry/cli",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Gaia CLI - Integrate your AI agent skills with the Gaia registry",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli-npm/package.json
+++ b/packages/cli-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia-registry/cli",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Gaia CLI - Integrate your AI agent skills with the Gaia registry",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia-registry/mcp-server",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "MCP server for the Gaia Skill Registry \u2014 agent-native skill detection, fusion, and progression",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia-registry/mcp-server",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "MCP server for the Gaia Skill Registry \u2014 agent-native skill detection, fusion, and progression",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gaia-cli"
-version = "3.2.2"
+version = "3.2.3"
 description = "Gaia AI Agent Skill Registry CLI"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gaia-cli"
-version = "3.2.1"
+version = "3.2.2"
 description = "Gaia AI Agent Skill Registry CLI"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/registry/gaia.json
+++ b/registry/gaia.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./schema/skill.schema.json",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "generatedAt": "2026-05-06T00:00:00Z",
   "meta": {
     "typeLabels": {

--- a/registry/gaia.json
+++ b/registry/gaia.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./schema/skill.schema.json",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "generatedAt": "2026-05-06T00:00:00Z",
   "meta": {
     "typeLabels": {

--- a/src/gaia_cli/cardRenderer.py
+++ b/src/gaia_cli/cardRenderer.py
@@ -481,12 +481,25 @@ def render_appraise_card(
 
     # Header line: glyph + name + level (rank-colored)
     level_str = f"Level {level}"
-    header_left = f"{glyph} {name}"
-    space = inner - len(header_left) - len(level_str)
+    header_left_plain = f"{glyph} {name}"
+    space = inner - len(header_left_plain) - len(level_str)
     if space < 1:
-        header_left = header_left[: inner - len(level_str) - 2] + "…"
+        # truncating name if too long
+        name_plain = name[: inner - len(level_str) - 4] + "…"
         space = 1
-    lines.append(f"{bc}{V}{r} {bold()}{fg(*tc)}{header_left}{r}{' ' * space}{fg(*rc)}{level_str}{r} {bc}{V}{r}")
+    else:
+        name_plain = name
+        
+    if "/" in name_plain:
+        parts = name_plain.split("/", 1)
+        if parts[0] == "": # starts with /
+            name_colored = f"{fg(*COLOR_LOCAL_USER)}{name_plain}{r}"
+        else:
+            name_colored = f"{fg(*COLOR_CONTRIBUTOR)}{parts[0]}{r}/{fg(*rc)}{parts[1]}{r}"
+    else:
+        name_colored = f"{fg(*tc)}{name_plain}{r}"
+
+    lines.append(f"{bc}{V}{r} {bold()}{fg(*tc)}{glyph}{r} {name_colored}{' ' * space}{fg(*rc)}{level_str}{r} {bc}{V}{r}")
 
     # Thin divider
     lines.append(f"{bc}{V}{r} {fg(*COLOR_MUTED)}{H * inner}{r} {bc}{V}{r}")
@@ -593,6 +606,15 @@ def render_unlock_card(skill_data: dict, new_paths: list, canon: bool = False, c
     r = reset()
     b = bold()
 
+    if "/" in name:
+        parts = name.split("/", 1)
+        if parts[0] == "":
+            name_colored = f"{fg(*COLOR_LOCAL_USER)}{name}{r}"
+        else:
+            name_colored = f"{fg(*COLOR_CONTRIBUTOR)}{parts[0]}{r}/{fg(*RANK_COLORS.get(level, RANK_COLORS['0★']))}{parts[1]}{r}"
+    else:
+        name_colored = f"{tc_fg}{name}{r}"
+
     art = [
         f"{gc}        ✦  ·  ✦        {r}",
         f"{gc}     ·  ╱────╲  ·     {r}",
@@ -602,7 +624,7 @@ def render_unlock_card(skill_data: dict, new_paths: list, canon: bool = False, c
         f"",
         f"    {b}{gc}═══ SKILL UNLOCKED ═══{r}",
         f"",
-        f"    {tc_fg}{b}{glyph} {name}{r}",
+        f"    {tc_fg}{b}{glyph}{r} {name_colored}",
         f"    {fg(*COLOR_MUTED)}Level {level} • {tier.capitalize()} • {rarity}{r}",
     ]
 
@@ -672,9 +694,18 @@ def render_promotion_prompt(skill_data: dict, proposed_level: str, canon: bool =
     
     display = (ctx.display_name(skill_id, canon=canon) if ctx else f"/{skill_id}")
     
+    if "/" in display:
+        parts = display.split("/", 1)
+        if parts[0] == "":
+            display_colored = f"{fg(*COLOR_LOCAL_USER)}{display}{r}"
+        else:
+            display_colored = f"{fg(*COLOR_CONTRIBUTOR)}{parts[0]}{r}/{tc}{b}{parts[1]}{r}"
+    else:
+        display_colored = f"{tc}{b}{display}{r}"
+    
     lines.extend([
         f"  {gc}┌─ Fusion ──────────────────────────────┐{r}",
-        f"  {gc}│{r}  {tc}{b}{display}{r} can advance to {b}Level {proposed_level}{r} ({level_name})",
+        f"  {gc}│{r}  {display_colored} can advance to {b}Level {proposed_level}{r} ({level_name})",
         f"  {gc}│{r}  Run: {b}gaia fuse {skill_id}{r}",
         f"  {gc}└───────────────────────────────────────────┘{r}",
         "",
@@ -696,30 +727,50 @@ def render_fusion_diagram(prereqs: list[str], result: str, result_type: str = "e
     r = reset()
 
     # Format skill names with slash prefix or nickname
-    prereq_names = [(ctx.display_name(p, canon=canon) if ctx else f"/{p}") for p in prereqs]
-    result_name = (ctx.display_name(result, canon=canon) if ctx else f"/{result}")
+    prereq_raw = [(ctx.display_name(p, canon=canon) if ctx else f"/{p}") for p in prereqs]
+    result_raw = (ctx.display_name(result, canon=canon) if ctx else f"/{result}")
+
+    def _color_name(n: str, is_result: bool = False) -> str:
+        # returns the colored string and its plain length
+        if "/" in n:
+            parts = n.split("/", 1)
+            if parts[0] == "":
+                colored = f"{fg(*COLOR_LOCAL_USER)}{n}{r}"
+            else:
+                colored = f"{fg(*COLOR_CONTRIBUTOR)}{parts[0]}{r}/{tb if is_result else mc}{parts[1]}{r}"
+        else:
+            colored = f"{tb if is_result else mc}{n}{r}"
+        return colored, len(n)
+
+    result_colored, _ = _color_name(result_raw, is_result=True)
 
     # Single prereq: simple arrow
     if len(prereqs) == 1:
-        return f"  {mc}{prereq_names[0]} ────▶{r} {tb}{result_name} {glyph}{r}"
+        p_col, _ = _color_name(prereq_raw[0])
+        return f"  {p_col} {mc}────▶{r} {result_colored} {tc}{glyph}{r}"
 
     # Pad prereq names to equal width
-    max_len = max(len(n) for n in prereq_names)
-    padded = [n.ljust(max_len) for n in prereq_names]
+    max_len = max(len(n) for n in prereq_raw)
+    
+    padded_colored = []
+    for n in prereq_raw:
+        c, length = _color_name(n)
+        pad = " " * (max_len - length)
+        padded_colored.append(f"{c}{pad}")
 
-    n = len(padded)
+    n = len(padded_colored)
     lines = []
 
     if n == 2:
         # Two prereqs: bracket rows with a connector row in between
         padding = " " * max_len
-        lines.append(f"  {mc}{padded[0]} ─┐{r}")
-        lines.append(f"  {mc}{padding}  {r}{tc}├──▶{r} {tb}{result_name} {glyph}{r}")
-        lines.append(f"  {mc}{padded[1]} ─┘{r}")
+        lines.append(f"  {padded_colored[0]} {mc}─┐{r}")
+        lines.append(f"  {padding}  {tc}├──▶{r} {result_colored} {tc}{glyph}{r}")
+        lines.append(f"  {padded_colored[1]} {mc}─┘{r}")
     else:
         # 3+ prereqs: arrow on the vertical midpoint row
         mid = n // 2
-        for i, name in enumerate(padded):
+        for i, colored_n in enumerate(padded_colored):
             if i == 0:
                 bracket = "─┐"
             elif i == n - 1:
@@ -730,9 +781,9 @@ def render_fusion_diagram(prereqs: list[str], result: str, result_type: str = "e
                 bracket = "─┤"
 
             if i == mid:
-                line = f"  {mc}{name} {r}{tc}─┼──▶{r} {tb}{result_name} {glyph}{r}"
+                line = f"  {colored_n} {tc}{bracket}{r} {result_colored} {tc}{glyph}{r}"
             else:
-                line = f"  {mc}{name} {bracket}{r}"
+                line = f"  {colored_n} {mc}{bracket}{r}"
             lines.append(line)
 
     return "\n".join(lines)

--- a/src/gaia_cli/cardRenderer.py
+++ b/src/gaia_cli/cardRenderer.py
@@ -574,7 +574,7 @@ def render_appraise_card(
 # ─── Unlock celebration ────────────────────────────────────────────────────
 
 
-def render_unlock_card(skill_data: dict, new_paths: list, canon: bool = False) -> str:
+def render_unlock_card(skill_data: dict, new_paths: list, canon: bool = False, ctx: Optional["LocalContext"] = None) -> str:
     """Celebratory unlock card with ASCII art."""
     tier = skill_data.get("type", "basic")
     tc = TIER_COLORS.get(tier, (56, 189, 248))
@@ -582,7 +582,7 @@ def render_unlock_card(skill_data: dict, new_paths: list, canon: bool = False) -
     if canon:
         name = f"/{skill_id}"
     else:
-        name = skill_data.get("name") or _name_from_slug(skill_id)
+        name = ctx.display_name(skill_id, canon=canon) if ctx else (skill_data.get("name") or _name_from_slug(skill_id))
     
     glyph = TIER_GLYPHS.get(tier, "○")
     level = skill_data.get("level", "0★")

--- a/src/gaia_cli/formatting.py
+++ b/src/gaia_cli/formatting.py
@@ -68,8 +68,8 @@ def format_skill_plain(skill_id: str, *, named_contributor: str | None = None,
     """Return plain display string without ANSI codes."""
     if named_contributor:
         return f"{named_contributor}/{skill_id}"
-    if is_local and local_user:
-        return f"{local_user}/{skill_id}"
+    if is_local:
+        return f"/{skill_id}"
     return f"/{skill_id}"
 
 
@@ -79,7 +79,7 @@ def format_skill_colored(skill_id: str, level: str = "0★", *,
     """Return ANSI-colored display string.
 
     - Named: RED contributor + rank-colored skill name
-    - Local: GREEN username + rank-colored skill name
+    - Local: GREEN slash and skill name
     - Canon: rank-colored /skill-id
     """
     r = _reset()
@@ -89,9 +89,10 @@ def format_skill_colored(skill_id: str, level: str = "0★", *,
     if named_contributor:
         contrib_colored = f"{_fg(*COLOR_CONTRIBUTOR)}{named_contributor}{r}"
         return f"{contrib_colored}/{skill_colored}"
-    if is_local and local_user:
-        user_colored = f"{_fg(*COLOR_LOCAL_USER)}{local_user}{r}"
-        return f"{user_colored}/{skill_colored}"
+    if is_local:
+        # Philosophy: Real/local skill names should be displayed with their slash and colored green
+        # to distinguish them from generic canonical concepts.
+        return f"{_fg(*COLOR_LOCAL_USER)}/{skill_id}{r}"
     return f"{_fg(*rank_color)}/{skill_id}{r}"
 
 

--- a/src/gaia_cli/localContext.py
+++ b/src/gaia_cli/localContext.py
@@ -172,7 +172,7 @@ class LocalContext:
 
         # 2. Check for local novel skill
         if skill_id in self.novel_ids:
-            return f"{self.username}/{skill_id}"
+            return f"/{skill_id}"
 
         # 3. Fallback to generic slash ID
         return f"/{skill_id}"

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -35,7 +35,7 @@ class TestFormatSkillPlain:
 
     def test_local_user(self):
         result = format_skill_plain("my-tool", is_local=True, local_user="bob")
-        assert result == "bob/my-tool"
+        assert result == "/my-tool"
 
     def test_local_without_user_falls_to_canon(self):
         # is_local=True but no local_user -> fallback to canon display
@@ -73,7 +73,7 @@ class TestFormatSkillColoredNoColor:
     def test_local_no_color(self, monkeypatch):
         monkeypatch.setenv("NO_COLOR", "1")
         result = format_skill_colored("my-tool", "3★", is_local=True, local_user="bob")
-        assert result == "bob/my-tool"
+        assert result == "/my-tool"
         assert "\033" not in result
 
 
@@ -113,10 +113,7 @@ class TestFormatSkillColoredTruecolor:
         result = format_skill_colored("my-tool", "3★", is_local=True, local_user="bob")
         r, g, b = COLOR_LOCAL_USER
         assert f"\033[38;2;{r};{g};{b}m" in result
-        assert "bob" in result
-        sr, sg, sb = RANK_COLORS["3★"]
-        assert f"\033[38;2;{sr};{sg};{sb}m" in result
-        assert "my-tool" in result
+        assert "/my-tool" in result
 
     def test_unknown_level_falls_to_zero(self):
         result = format_skill_colored("foo", "IX")

--- a/tests/test_local_context.py
+++ b/tests/test_local_context.py
@@ -258,12 +258,12 @@ class TestDisplayName:
         assert ctx.display_name("web-frameworks") == "alice/flask-mastery"
 
     def test_display_novel_skill(self, mock_registry, monkeypatch):
-        """Novel/local skills display as username/id."""
+        """Novel/local skills display as /id."""
         monkeypatch.chdir(mock_registry)
         # Manually inject a novel skill
         ctx = LocalContext.load(mock_registry, "testuser", include_scan=False)
         ctx.novel_ids.add("my-experiment")
-        assert ctx.display_name("my-experiment") == "testuser/my-experiment"
+        assert ctx.display_name("my-experiment") == "/my-experiment"
 
     def test_display_canon_skill(self, mock_registry, monkeypatch):
         """Canon skills without named impl display as /id."""


### PR DESCRIPTION
This PR fixes a `TypeError` in `gaia scan` and updates the CLI design philosophy to natively prioritize user's local skill implementations ('pet names') such as `/gaia-curate` or `gaiabot/gaia-triage` by preserving their slashes and rendering them in green.