### PR TITLE
feat(agent): add gaia-docs-sync skill to manage cross-repo documentation updates

### DIFF
--- a/.agents/skills/gaia-docs-sync/SKILL.md
+++ b/.agents/skills/gaia-docs-sync/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: gaia-docs-sync
+description: Sync documentation updates across the main repository and the adjacent wiki repository. Use when updating crucial documentation (like README.md, docs/index.html, or wiki pages) to ensure all surfaces stay in sync efficiently, especially from a docs branch.
+---
+
+# gaia-docs-sync
+
+Ensure documentation changes are accurately applied to both the main repository (`README.md`, `docs/index.html`) and the adjacent wiki repository (`../gaia-wiki`), and pushed via PR and direct push respectively.
+
+## What this skill does
+
+1. Validates the current branch is appropriate for docs (e.g., `docs/*`).
+2. Updates primary documentation files in the main repository (e.g., `README.md`, `docs/index.html`).
+3. Commits and pushes the changes, then creates a PR for the main repo.
+4. Manuevers to the adjacent wiki repository.
+5. Applies the exact same documentation updates to the corresponding wiki pages (e.g., `Getting-Started.md`, `CLI-Reference.md`).
+6. Commits and pushes the wiki updates directly to the wiki's `master` branch.
+
+## Workflow
+
+### 1. Update Main Repository Documentation
+
+Make the requested changes to the main repository documentation files (e.g., `README.md`, `docs/index.html`).
+
+Once complete:
+```bash
+git add <files>
+git commit -m "docs: <summary of changes>"
+```
+
+### 2. Push and PR Main Repository
+
+Push the documentation branch and create a PR to merge into `main`.
+
+```bash
+git push -u origin <branch-name>
+gh pr create --title "docs: <summary of changes>" --body "<detailed description>"
+```
+
+### 3. Update Adjacent Wiki Repository
+
+Clone or pull the wiki repository into an adjacent folder if it's not already up to date.
+
+```bash
+# If not cloned yet:
+git clone https://github.com/mbtiongson1/gaia-skill-tree.wiki.git ../gaia-wiki
+
+# If already cloned:
+cd ../gaia-wiki
+git pull origin master
+```
+
+### 4. Apply Changes to Wiki Pages
+
+Identify which wiki pages correspond to the changes made in the main repository (e.g., `Getting-Started.md`, `Home.md`, `CLI-Reference.md`). 
+
+Apply the identical logic or content updates to these wiki pages.
+
+### 5. Commit and Push Wiki Updates
+
+Commit and push the wiki repository directly to `master`.
+
+```bash
+cd ../gaia-wiki
+git add <updated-files>.md
+git commit -m "docs: <summary of changes>"
+git push origin master
+```
+
+## Constraints
+- **Use Docs Branches:** Always use a `docs/*` branch for main repo documentation updates to avoid triggering unnecessary CI/CD branch checks intended for `cli/*` or `schema/*` branches.
+- **Maintainer Hooks:** Note that the main repo has a pre-commit hook that generates docs automatically. Ensure this hook succeeds.
+- **Wiki Location:** The wiki must remain adjacent to the main repo (i.e. `../gaia-wiki`) to allow easy cross-repo synchronization.
+- **Accuracy:** The wiki and the main repo documentation must reflect the exact same technical capabilities, such as CLI command options, schema requirements, or rank nomenclature.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Skills level up through evidence, not declaration. Each demerit lowers effective
 ## Install
 
 <!-- gaia:version-start -->
-Current Gaia CLI version: `3.3.0`.
+Current Gaia CLI version: `3.4.0`.
 
 Python install:
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Skills level up through evidence, not declaration. Each demerit lowers effective
 ## Install
 
 <!-- gaia:version-start -->
-Current Gaia CLI version: `3.2.8`.
+Current Gaia CLI version: `3.3.0`.
 
 Python install:
 

--- a/docs/graph/gaia.json
+++ b/docs/graph/gaia.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./schema/skill.schema.json",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "generatedAt": "2026-05-13T21:50:25.987654Z",
   "meta": {
     "typeLabels": {

--- a/docs/graph/gaia.json
+++ b/docs/graph/gaia.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./schema/skill.schema.json",
-  "version": "3.2.8",
+  "version": "3.3.0",
   "generatedAt": "2026-05-13T21:50:25.987654Z",
   "meta": {
     "typeLabels": {

--- a/docs/index.html
+++ b/docs/index.html
@@ -573,5 +573,5 @@
 </html>
 
 <!-- gaia:stats-start -->
-<!-- skills=133; namedSkills=37; uniqueSkills=1; version=3.2.8 -->
+<!-- skills=133; namedSkills=37; uniqueSkills=1; version=3.3.0 -->
 <!-- gaia:stats-end -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -573,5 +573,5 @@
 </html>
 
 <!-- gaia:stats-start -->
-<!-- skills=133; namedSkills=37; uniqueSkills=1; version=3.3.0 -->
+<!-- skills=133; namedSkills=37; uniqueSkills=1; version=3.4.0 -->
 <!-- gaia:stats-end -->

--- a/docs/tree.md
+++ b/docs/tree.md
@@ -1,7 +1,7 @@
 # Gaia Skill Tree
 
 ```
-GAIA SKILL TREE  v3.2.8  ·  generated 2026-05-13
+GAIA SKILL TREE  v3.3.0  ·  generated 2026-05-13
 ══════════════════════════════════════════════════════════════════════
 Upgrade paths — each legendary shows its full prerequisite chain.
 Shared prerequisites marked (↑ see above) on second occurrence.

--- a/docs/tree.md
+++ b/docs/tree.md
@@ -1,7 +1,7 @@
 # Gaia Skill Tree
 
 ```
-GAIA SKILL TREE  v3.3.0  ·  generated 2026-05-13
+GAIA SKILL TREE  v3.4.0  ·  generated 2026-05-13
 ══════════════════════════════════════════════════════════════════════
 Upgrade paths — each legendary shows its full prerequisite chain.
 Shared prerequisites marked (↑ see above) on second occurrence.

--- a/packages/cli-npm/package.json
+++ b/packages/cli-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia-registry/cli",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Gaia CLI - Integrate your AI agent skills with the Gaia registry",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli-npm/package.json
+++ b/packages/cli-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia-registry/cli",
-  "version": "3.2.8",
+  "version": "3.3.0",
   "description": "Gaia CLI - Integrate your AI agent skills with the Gaia registry",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia-registry/mcp-server",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "MCP server for the Gaia Skill Registry \u2014 agent-native skill detection, fusion, and progression",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaia-registry/mcp-server",
-  "version": "3.2.8",
+  "version": "3.3.0",
   "description": "MCP server for the Gaia Skill Registry \u2014 agent-native skill detection, fusion, and progression",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gaia-cli"
-version = "3.3.0"
+version = "3.4.0"
 description = "Gaia AI Agent Skill Registry CLI"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gaia-cli"
-version = "3.2.8"
+version = "3.3.0"
 description = "Gaia AI Agent Skill Registry CLI"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/registry/gaia.json
+++ b/registry/gaia.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./schema/skill.schema.json",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "generatedAt": "2026-05-13T21:50:25.987654Z",
   "meta": {
     "typeLabels": {

--- a/registry/gaia.json
+++ b/registry/gaia.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./schema/skill.schema.json",
-  "version": "3.2.8",
+  "version": "3.3.0",
   "generatedAt": "2026-05-13T21:50:25.987654Z",
   "meta": {
     "typeLabels": {


### PR DESCRIPTION
Provides an agent skill to orchestrate documentation updates across the main registry repository and the adjacent wiki repository, ensuring structural documentation remains synchronized.