### PR TITLE
[extra] x-twitter-automation — add X/Twitter automation capability

### DIFF
--- a/docs/graph/gaia.gexf
+++ b/docs/graph/gaia.gexf
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <gexf xmlns="http://www.gexf.net/1.2draft" version="1.2">
-  <meta lastmodifieddate="2026-05-14">
+  <meta lastmodifieddate="2026-05-15">
     <creator>Gaia</creator>
     <description>Gaia Skill Registry Graph</description>
   </meta>
@@ -1180,6 +1180,14 @@
           <attvalue for="type" value="basic" />
         </attvalues>
       </node>
+      <node id="x-twitter-automation" label="X/Twitter Automation">
+        <attvalues>
+          <attvalue for="level" value="4★" />
+          <attvalue for="rarity" value="rare" />
+          <attvalue for="status" value="provisional" />
+          <attvalue for="type" value="extra" />
+        </attvalues>
+      </node>
     </nodes>
     <edges>
       <edge id="e0" source="evaluate-output" target="agent-eval" />
@@ -1375,6 +1383,9 @@
       <edge id="e190" source="plan-decompose" target="workflow-automation" />
       <edge id="e191" source="tool-use" target="workflow-automation" />
       <edge id="e192" source="api-call" target="workflow-automation" />
+      <edge id="e193" source="browser-automation" target="x-twitter-automation" />
+      <edge id="e194" source="web-scrape" target="x-twitter-automation" />
+      <edge id="e195" source="workflow-automation" target="x-twitter-automation" />
     </edges>
   </graph>
 </gexf>

--- a/docs/graph/gaia.json
+++ b/docs/graph/gaia.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/skill.schema.json",
   "version": "3.9.2",
-  "generatedAt": "2026-05-14T20:36:31.357434Z",
+  "generatedAt": "2026-05-15T09:39:30.366045Z",
   "meta": {
     "typeLabels": {
       "basic": "Basic Skill",
@@ -10,49 +10,49 @@
       "ultimate": "Ultimate Skill"
     },
     "levelLabels": {
-      "0\u2605": "Basic",
-      "1\u2605": "Awakened",
-      "2\u2605": "Named",
-      "3\u2605": "Evolved",
-      "4\u2605": "Hardened",
-      "5\u2605": "Transcendent",
-      "6\u2605": "Transcendent \u2605"
+      "0★": "Basic",
+      "1★": "Awakened",
+      "2★": "Named",
+      "3★": "Evolved",
+      "4★": "Hardened",
+      "5★": "Transcendent",
+      "6★": "Transcendent ★"
     },
     "rarityLabels": {
       "legendary": "Divine"
     },
     "levelColors": {
-      "0\u2605": {
+      "0★": {
         "hex": "#94a3b8",
         "bg": "rgba(148,163,184,.12)",
         "border": "rgba(148,163,184,.4)"
       },
-      "1\u2605": {
+      "1★": {
         "hex": "#38bdf8",
         "bg": "rgba(56,189,248,.12)",
         "border": "rgba(56,189,248,.4)"
       },
-      "2\u2605": {
+      "2★": {
         "hex": "#63cab7",
         "bg": "rgba(99,202,183,.15)",
         "border": "rgba(99,202,183,.4)"
       },
-      "3\u2605": {
+      "3★": {
         "hex": "#a78bfa",
         "bg": "rgba(167,139,250,.15)",
         "border": "rgba(167,139,250,.4)"
       },
-      "4\u2605": {
+      "4★": {
         "hex": "#e879f9",
         "bg": "rgba(232,121,249,.15)",
         "border": "rgba(232,121,249,.4)"
       },
-      "5\u2605": {
+      "5★": {
         "hex": "#fbbf24",
         "bg": "rgba(251,191,36,.15)",
         "border": "rgba(251,191,36,.4)"
       },
-      "6\u2605": {
+      "6★": {
         "hex": "#fbbf24",
         "bg": "rgba(251,191,36,.22)",
         "border": "rgba(251,191,36,.55)"
@@ -77,10 +77,10 @@
       }
     },
     "typeSymbols": {
-      "basic": "\u25cb",
-      "extra": "\u25c7",
-      "unique": "\u25c9",
-      "ultimate": "\u25c6"
+      "basic": "○",
+      "extra": "◇",
+      "unique": "◉",
+      "ultimate": "◆"
     },
     "demeritLabels": {
       "niche-integration": "Niche integrations",
@@ -93,7 +93,7 @@
       "id": "agent-eval",
       "name": "Agent Evaluation",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Holistically evaluates an AI agent's performance on multi-step tasks by running standardised benchmarks, scoring full interaction trajectories, and producing reproducible capability reports.",
       "prerequisites": [
@@ -137,7 +137,7 @@
       "id": "agentic-workflow-design",
       "name": "Agentic Workflow Design",
       "type": "extra",
-      "level": "5\u2605",
+      "level": "5★",
       "rarity": "rare",
       "description": "Autonomously designs, authors, and iterates on complex multi-step workflows by translating high-level goals into executable DAGs or playbooks, managing task dependencies and distributed execution environments.",
       "prerequisites": [
@@ -172,7 +172,7 @@
       "id": "api-call",
       "name": "API Call",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "common",
       "description": "Constructs, executes, and handles responses from HTTP APIs by interpreting documentation and selecting appropriate endpoints and parameters.",
       "prerequisites": [],
@@ -188,7 +188,7 @@
           "source": "https://arxiv.org/abs/2305.15334",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Gorilla (Patil et al.) \u00e2\u20ac\u201d LLM that generates accurate API calls across TorchHub, TensorFlow Hub, and HuggingFace; 20.43% AST accuracy improvement over GPT-4."
+          "notes": "Gorilla (Patil et al.) â€” LLM that generates accurate API calls across TorchHub, TensorFlow Hub, and HuggingFace; 20.43% AST accuracy improvement over GPT-4."
         }
       ],
       "knownAgents": [],
@@ -201,7 +201,7 @@
       "id": "architecture-diagram",
       "name": "Architecture Diagram",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "uncommon",
       "description": "Generates technical architecture, infrastructure, or cloud diagrams as structured visual artifacts from natural-language system descriptions.",
       "prerequisites": [
@@ -232,7 +232,7 @@
       "id": "audience-model",
       "name": "Audience Model",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Adapts tone, complexity, and framing of output to match a target audience profile.",
       "prerequisites": [],
@@ -261,7 +261,7 @@
       "id": "automated-testing",
       "name": "Automated Testing",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Generates test suites, executes them in a sandbox, interprets failures, and iterates until the target pass rate is reached.",
       "prerequisites": [
@@ -281,7 +281,7 @@
           "source": "https://github.com/princeton-nlp/SWE-bench",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SWE-bench Verified \u00e2\u20ac\u201d open-source evaluation harness where agents fix GitHub issues by generating and passing test suites; full execution logs archived."
+          "notes": "SWE-bench Verified â€” open-source evaluation harness where agents fix GitHub issues by generating and passing test suites; full execution logs archived."
         }
       ],
       "knownAgents": [],
@@ -294,7 +294,7 @@
       "id": "autonomous-data-scientist",
       "name": "Autonomous Data Scientist",
       "type": "ultimate",
-      "level": "5\u2605",
+      "level": "5★",
       "rarity": "legendary",
       "description": "Conducts end-to-end data science workflows autonomously: hypothesis generation, data analysis, statistical modeling, and insight reporting.",
       "prerequisites": [
@@ -310,21 +310,21 @@
           "source": "https://arxiv.org/abs/2210.12641",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "DS-1000 \u00e2\u20ac\u201d benchmark of 1000 data science problems across NumPy/Pandas/Scikit-learn; GPT-4 achieves 43.3% pass@1, establishing reproducible DS evaluation."
+          "notes": "DS-1000 â€” benchmark of 1000 data science problems across NumPy/Pandas/Scikit-learn; GPT-4 achieves 43.3% pass@1, establishing reproducible DS evaluation."
         },
         {
           "class": "A",
           "source": "https://arxiv.org/abs/2208.01756",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "AutoML Survey (He et al., ACM CSUR) \u00e2\u20ac\u201d systematic review of autonomous ML pipeline search; demonstrates automated feature engineering, model selection, and HPO."
+          "notes": "AutoML Survey (He et al., ACM CSUR) â€” systematic review of autonomous ML pipeline search; demonstrates automated feature engineering, model selection, and HPO."
         },
         {
           "class": "B",
           "source": "https://github.com/microsoft/autogen",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "AutoGen (Microsoft) \u00e2\u20ac\u201d multi-agent framework with reproducible data science notebooks; science agent achieves 44.3% on DS-1000 with full execution logs."
+          "notes": "AutoGen (Microsoft) â€” multi-agent framework with reproducible data science notebooks; science agent achieves 44.3% on DS-1000 with full execution logs."
         }
       ],
       "knownAgents": [],
@@ -338,7 +338,7 @@
       "id": "autonomous-debug",
       "name": "Autonomous Debug",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Independently identifies, diagnoses, and fixes software bugs through code generation and execution.",
       "prerequisites": [
@@ -367,7 +367,7 @@
       "id": "autonomous-research-agent",
       "name": "Autonomous Research Agent",
       "type": "ultimate",
-      "level": "6\u2605",
+      "level": "6★",
       "rarity": "legendary",
       "description": "Independently conducts end-to-end research cycles including hypothesis generation, evidence gathering, synthesis, and reporting.",
       "prerequisites": [
@@ -383,7 +383,7 @@
           "source": "https://github.com/gaia-registry/gaia/blob/main/docs/evidence/seed.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Seed evidence \u00e2\u20ac\u201d apex tier structural validation placeholder."
+          "notes": "Seed evidence â€” apex tier structural validation placeholder."
         },
         {
           "class": "B",
@@ -404,7 +404,7 @@
       "id": "autonomous-web-research",
       "name": "Autonomous Web Research",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Independently surveys, maps, and extracts structured information from the web by autonomously deciding which domains to crawl and synthesizing data into comprehensive research reports.",
       "prerequisites": [
@@ -436,7 +436,7 @@
       "id": "browser-automation",
       "name": "Browser Automation",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Navigates web pages, fills forms, clicks elements, and extracts information by combining web search with screenshot-based GUI control to complete multi-step web tasks.",
       "prerequisites": [
@@ -445,7 +445,8 @@
       ],
       "derivatives": [
         "autonomous-research-agent",
-        "e2e-testing"
+        "e2e-testing",
+        "x-twitter-automation"
       ],
       "conditions": "",
       "evidence": [
@@ -454,14 +455,14 @@
           "source": "https://arxiv.org/abs/2401.13919",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "WebVoyager (He et al., 2024) \u00e2\u20ac\u201d end-to-end web agent with GPT-4V; 59.1% task success on real-world web tasks across 15 popular websites."
+          "notes": "WebVoyager (He et al., 2024) â€” end-to-end web agent with GPT-4V; 59.1% task success on real-world web tasks across 15 popular websites."
         },
         {
           "class": "B",
           "source": "https://github.com/web-arena-x/webarena",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "WebArena \u00e2\u20ac\u201d self-hosted web environment with 812 realistic tasks; reproducible benchmark with ground-truth evaluation scripts."
+          "notes": "WebArena â€” self-hosted web environment with 812 realistic tasks; reproducible benchmark with ground-truth evaluation scripts."
         }
       ],
       "knownAgents": [],
@@ -474,7 +475,7 @@
       "id": "browser-control",
       "name": "Browser Control",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
       "description": "Directly controls a web browser via low-level protocols (like CDP) to manipulate DOM, manage cookies, and intercept network traffic.",
       "prerequisites": [],
@@ -501,7 +502,7 @@
       "id": "career-operations",
       "name": "Career Operations",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "legendary",
       "description": "Orchestrates an end-to-end job application pipeline, including automated search, fit evaluation, and tailored CV/cover letter generation.",
       "prerequisites": [
@@ -530,7 +531,7 @@
       "id": "chain-of-thought",
       "name": "Chain-of-Thought Reasoning",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "uncommon",
       "description": "Produces explicit intermediate reasoning steps before arriving at a final answer, dramatically improving accuracy on multi-step problems.",
       "prerequisites": [],
@@ -547,14 +548,14 @@
           "source": "https://arxiv.org/abs/2201.11903",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Wei et al. (2022) \u00e2\u20ac\u201d Chain-of-Thought Prompting; +18% on GSM8K and +14% on MATH with PaLM 540B vs standard prompting."
+          "notes": "Wei et al. (2022) â€” Chain-of-Thought Prompting; +18% on GSM8K and +14% on MATH with PaLM 540B vs standard prompting."
         },
         {
           "class": "B",
           "source": "https://github.com/princeton-nlp/chain-of-thought-hub",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Chain-of-Thought Hub \u00e2\u20ac\u201d reproducible evaluation suite covering 10+ reasoning benchmarks with CoT prompts and baselines."
+          "notes": "Chain-of-Thought Hub â€” reproducible evaluation suite covering 10+ reasoning benchmarks with CoT prompts and baselines."
         }
       ],
       "knownAgents": [],
@@ -567,7 +568,7 @@
       "id": "chunk-document",
       "name": "Chunk Document",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Splits a document into semantically meaningful segments optimized for embedding and retrieval.",
       "prerequisites": [],
@@ -594,7 +595,7 @@
       "id": "cite-sources",
       "name": "Cite Sources",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Attributes claims to specific sources with proper references, URLs, or bibliographic entries.",
       "prerequisites": [],
@@ -625,7 +626,7 @@
       "id": "classify",
       "name": "Classify",
       "type": "basic",
-      "level": "0\u2605",
+      "level": "0★",
       "rarity": "common",
       "description": "Assigns one or more categorical labels to an input based on learned or rule-based criteria.",
       "prerequisites": [],
@@ -653,7 +654,7 @@
       "id": "code-execution",
       "name": "Code Execution",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "common",
       "description": "Writes and executes code in a sandboxed environment, uses the runtime output to verify correctness, and iterates until the result is correct.",
       "prerequisites": [],
@@ -669,14 +670,14 @@
           "source": "https://arxiv.org/abs/2211.10435",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "PAL (Gao et al., 2023) \u00e2\u20ac\u201d Program-Aided Language Models; delegates computation to Python interpreter, achieving +7% on GSM8K over direct CoT."
+          "notes": "PAL (Gao et al., 2023) â€” Program-Aided Language Models; delegates computation to Python interpreter, achieving +7% on GSM8K over direct CoT."
         },
         {
           "class": "B",
           "source": "https://github.com/reasoning-machines/pal",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "PAL repo \u00e2\u20ac\u201d reproducible harness across 13 reasoning benchmarks; evaluation scripts and baseline comparisons included."
+          "notes": "PAL repo â€” reproducible harness across 13 reasoning benchmarks; evaluation scripts and baseline comparisons included."
         }
       ],
       "knownAgents": [],
@@ -689,7 +690,7 @@
       "id": "code-explain",
       "name": "Code Explain",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "common",
       "description": "Generates accurate natural-language explanations of source code, describing intent, logic flow, and key decisions at function or module level.",
       "prerequisites": [],
@@ -724,7 +725,7 @@
       "id": "code-generation",
       "name": "Code Generation",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Produces syntactically correct and functionally appropriate source code from specifications or prompts.",
       "prerequisites": [],
@@ -756,7 +757,7 @@
       "id": "code-review-pipeline",
       "name": "Code Review Pipeline",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Performs automated code review by generating, diffing, and evaluating code changes for correctness, style, security, and maintainability.",
       "prerequisites": [
@@ -775,7 +776,7 @@
           "source": "https://arxiv.org/abs/2203.09095",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "CodeReviewer (Microsoft) \u00e2\u20ac\u201d pre-trained model for code review tasks; 28.7% BLEU improvement on comment generation and change quality prediction."
+          "notes": "CodeReviewer (Microsoft) â€” pre-trained model for code review tasks; 28.7% BLEU improvement on comment generation and change quality prediction."
         }
       ],
       "knownAgents": [],
@@ -788,7 +789,7 @@
       "id": "computer-use",
       "name": "Computer Use",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "rare",
       "description": "Controls desktop GUIs and web browsers by interpreting screenshots, issuing mouse/keyboard actions, and verifying visual state to complete open-ended computer tasks.",
       "prerequisites": [],
@@ -802,14 +803,14 @@
           "source": "https://arxiv.org/abs/2307.13854",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "WebArena (Zhou et al., 2023) \u00e2\u20ac\u201d realistic 812-task benchmark for autonomous web agents; establishes controlled eval for GUI-based computer use."
+          "notes": "WebArena (Zhou et al., 2023) â€” realistic 812-task benchmark for autonomous web agents; establishes controlled eval for GUI-based computer use."
         },
         {
           "class": "B",
           "source": "https://github.com/xlang-ai/OSWorld",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "OSWorld \u00e2\u20ac\u201d 369 computer tasks across real OS environments (Windows, macOS, Ubuntu); reproducible VM-based evaluation harness."
+          "notes": "OSWorld â€” 369 computer tasks across real OS environments (Windows, macOS, Ubuntu); reproducible VM-based evaluation harness."
         }
       ],
       "knownAgents": [],
@@ -822,7 +823,7 @@
       "id": "content-moderation",
       "name": "Content Moderation",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Detects policy-violating content by combining intent classification, sentiment scoring, and entity extraction across text, images, and mixed media.",
       "prerequisites": [
@@ -838,7 +839,7 @@
           "source": "https://platform.openai.com/docs/guides/moderation",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "OpenAI Moderation API \u00e2\u20ac\u201d publicly documented multi-category content classifier with reproducible API calls, category scores, and evaluation methodology."
+          "notes": "OpenAI Moderation API â€” publicly documented multi-category content classifier with reproducible API calls, category scores, and evaluation methodology."
         }
       ],
       "knownAgents": [],
@@ -851,7 +852,7 @@
       "id": "context-compression",
       "name": "Context Compression",
       "type": "basic",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "common",
       "description": "Reduces the length of prompts or retrieved context to fit token limits while preserving semantic content, using techniques such as selective token removal, summarization, or token-classification-based pruning (e.g. LLMLingua).",
       "prerequisites": [],
@@ -863,14 +864,14 @@
           "source": "https://arxiv.org/abs/2403.12968",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "LLMLingua-2 (ACL 2024 Findings) \u2014 data-distillation for efficient task-agnostic prompt compression; 3x-6x speed-up, BERT-base token classifier; demonstrates measurable perplexity-based faithfulness."
+          "notes": "LLMLingua-2 (ACL 2024 Findings) — data-distillation for efficient task-agnostic prompt compression; 3x-6x speed-up, BERT-base token classifier; demonstrates measurable perplexity-based faithfulness."
         },
         {
           "class": "B",
           "source": "https://github.com/microsoft/LLMLingua",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "Microsoft LLMLingua \u2014 reproducible open-source implementation of LLMLingua-1/2/LongLLMLingua; CI, README, Apache-2.0 license."
+          "notes": "Microsoft LLMLingua — reproducible open-source implementation of LLMLingua-1/2/LongLLMLingua; CI, README, Apache-2.0 license."
         },
         {
           "class": "C",
@@ -890,7 +891,7 @@
       "id": "conversational-agent",
       "name": "Conversational Agent",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Manages coherent multi-turn dialogue by routing intent, maintaining memory across turns, and generating contextually appropriate responses.",
       "prerequisites": [
@@ -906,7 +907,7 @@
           "source": "https://github.com/langchain-ai/langchain/tree/master/libs/langchain/langchain/chains/conversation",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "LangChain ConversationChain \u00e2\u20ac\u201d reproducible open-source multi-turn conversational agent with buffer and summary memory backends."
+          "notes": "LangChain ConversationChain â€” reproducible open-source multi-turn conversational agent with buffer and summary memory backends."
         }
       ],
       "knownAgents": [],
@@ -919,7 +920,7 @@
       "id": "data-analysis",
       "name": "Data Analysis",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Conducts end-to-end quantitative analysis: queries data via SQL, computes statistics, generates visualizations, and summarizes findings.",
       "prerequisites": [
@@ -939,7 +940,7 @@
           "source": "https://github.com/Sinaptik-AI/pandas-ai",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "pandas-ai \u00e2\u20ac\u201d open-source agent for natural-language data analysis over pandas DataFrames; reproducible demos with logging and output artifacts."
+          "notes": "pandas-ai â€” open-source agent for natural-language data analysis over pandas DataFrames; reproducible demos with logging and output artifacts."
         }
       ],
       "knownAgents": [],
@@ -952,7 +953,7 @@
       "id": "data-visualize",
       "name": "Data Visualize",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "common",
       "description": "Generates charts, graphs, and visual summaries from datasets by selecting appropriate visualization types and mapping data dimensions.",
       "prerequisites": [],
@@ -967,7 +968,7 @@
           "source": "https://github.com/microsoft/lida",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "LIDA (Microsoft) \u00e2\u20ac\u201d open-source LLM-based data visualization tool with reproducible generation pipeline; evaluated on diverse real-world datasets."
+          "notes": "LIDA (Microsoft) â€” open-source LLM-based data visualization tool with reproducible generation pipeline; evaluated on diverse real-world datasets."
         }
       ],
       "knownAgents": [],
@@ -980,9 +981,9 @@
       "id": "deployment-automation",
       "name": "Deployment Automation",
       "type": "extra",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
-      "description": "Automate CI/CD pipeline execution and deployment to target environments \u2014 build, test, artifact publishing, environment promotion, and rollback strategies.",
+      "description": "Automate CI/CD pipeline execution and deployment to target environments — build, test, artifact publishing, environment promotion, and rollback strategies.",
       "prerequisites": [
         "workflow-automation",
         "execute-bash"
@@ -995,7 +996,7 @@
           "source": "https://github.com/intelligentcode-ai/skills/blob/main/skills/devops-engineer/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "intelligentcode-ai/skills devops-engineer \u2014 CI/CD pipeline design and deployment automation with build systems and release management."
+          "notes": "intelligentcode-ai/skills devops-engineer — CI/CD pipeline design and deployment automation with build systems and release management."
         }
       ],
       "knownAgents": [],
@@ -1011,7 +1012,7 @@
       "id": "design-generation",
       "name": "Design Generation",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "rare",
       "description": "Generates high-fidelity visual assets, prototypes, and UI components from design intent or discovery forms, adhering to brand and UX standards.",
       "prerequisites": [
@@ -1041,9 +1042,9 @@
       "id": "design-review",
       "name": "Design Review",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "rare",
-      "description": "Stress-tests a plan or design through relentless targeted questioning, walking the decision tree branch-by-branch, resolving concept dependencies, surfacing contradictions against the existing codebase, and crystallising ubiquitous language \u2014 optionally persisting resolved decisions to CONTEXT.md and ADRs.",
+      "description": "Stress-tests a plan or design through relentless targeted questioning, walking the decision tree branch-by-branch, resolving concept dependencies, surfacing contradictions against the existing codebase, and crystallising ubiquitous language — optionally persisting resolved decisions to CONTEXT.md and ADRs.",
       "prerequisites": [
         "evaluate-output",
         "plan-decompose"
@@ -1076,7 +1077,7 @@
       "id": "design-system-extraction",
       "name": "Design System Extraction",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "rare",
       "description": "Automates the discovery and extraction of design tokens, component architectures, and CSS configurations from live web applications or URLs.",
       "prerequisites": [
@@ -1106,7 +1107,7 @@
       "id": "detect-anomaly",
       "name": "Detect Anomaly",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
       "description": "Identifies statistical outliers, novel patterns, or deviations from expected behavior in structured or unstructured data.",
       "prerequisites": [],
@@ -1120,7 +1121,7 @@
           "source": "https://arxiv.org/abs/2007.02500",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Deep Learning for Anomaly Detection survey (Pang et al., ACM CSUR) \u00e2\u20ac\u201d comprehensive benchmark of 30+ methods across fraud, intrusion, and medical anomaly detection."
+          "notes": "Deep Learning for Anomaly Detection survey (Pang et al., ACM CSUR) â€” comprehensive benchmark of 30+ methods across fraud, intrusion, and medical anomaly detection."
         }
       ],
       "knownAgents": [],
@@ -1133,7 +1134,7 @@
       "id": "diff-content",
       "name": "Diff Content",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Compares two versions of content and produces a structured delta highlighting additions, deletions, and modifications.",
       "prerequisites": [],
@@ -1160,7 +1161,7 @@
       "id": "document-analyst",
       "name": "Document Analyst",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Parses, extracts entities from, summarizes, and formats structured documents.",
       "prerequisites": [
@@ -1190,7 +1191,7 @@
       "id": "document-digitization",
       "name": "Document Digitization",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Converts scanned or PDF documents into structured, machine-readable output by parsing layout, extracting entities, and formatting results.",
       "prerequisites": [
@@ -1206,7 +1207,7 @@
           "source": "https://github.com/VikParuchuri/marker",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Marker \u00e2\u20ac\u201d open-source PDF-to-markdown pipeline with reproducible benchmarks; outperforms Nougat on edit distance across 1000+ arXiv PDFs."
+          "notes": "Marker â€” open-source PDF-to-markdown pipeline with reproducible benchmarks; outperforms Nougat on edit distance across 1000+ arXiv PDFs."
         }
       ],
       "knownAgents": [],
@@ -1219,7 +1220,7 @@
       "id": "document-editing",
       "name": "Document Editing",
       "type": "basic",
-      "level": "0\u2605",
+      "level": "0★",
       "rarity": "common",
       "description": "Reads, edits, repacks, and applies styling or design principles to structured binary document formats such as PPTX, DOCX, and XLSX.",
       "prerequisites": [],
@@ -1246,7 +1247,7 @@
       "id": "e2e-testing",
       "name": "End-to-End Testing",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Execute full end-to-end user journey tests using browser automation frameworks (Playwright/Puppeteer), validating complete workflows from UI to backend across real environments.",
       "prerequisites": [
@@ -1261,14 +1262,14 @@
           "source": "https://github.com/zachblume/autospec",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "autospec \u2014 AI agent that takes a web app URL and autonomously QAs it, saving passing specs as E2E test code (59 stars, active)."
+          "notes": "autospec — AI agent that takes a web app URL and autonomously QAs it, saving passing specs as E2E test code (59 stars, active)."
         },
         {
           "class": "C",
           "source": "https://github.com/intelligentcode-ai/skills/blob/main/skills/user-tester/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "intelligentcode-ai/skills user-tester \u2014 E2E testing specialist with Puppeteer/Playwright automation and cross-browser user journey validation."
+          "notes": "intelligentcode-ai/skills user-tester — E2E testing specialist with Puppeteer/Playwright automation and cross-browser user journey validation."
         }
       ],
       "knownAgents": [],
@@ -1281,7 +1282,7 @@
       "id": "embed-text",
       "name": "Embed Text",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Converts text into dense vector representations suitable for similarity search and clustering.",
       "prerequisites": [],
@@ -1310,7 +1311,7 @@
       "id": "error-interpretation",
       "name": "Error Interpretation",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Diagnoses error messages, stack traces, and failure modes to identify root causes and suggest fixes.",
       "prerequisites": [],
@@ -1338,7 +1339,7 @@
       "id": "evaluate-output",
       "name": "Evaluate Output",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Assesses the quality, correctness, or safety of generated output against defined criteria.",
       "prerequisites": [],
@@ -1373,7 +1374,7 @@
       "id": "execute-bash",
       "name": "Execute Bash",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Runs shell commands in a sandboxed environment, captures stdout/stderr, and handles exit codes.",
       "prerequisites": [],
@@ -1404,7 +1405,7 @@
       "id": "extract-entities",
       "name": "Extract Entities",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Identifies and extracts named entities such as people, organizations, dates, and locations from text.",
       "prerequisites": [],
@@ -1436,7 +1437,7 @@
       "id": "feed-monitoring",
       "name": "Feed Monitoring",
       "type": "unique",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "common",
       "description": "Monitors RSS, Atom, blog, or other recurring content feeds, discovers updates, tracks read state, and surfaces new signals for downstream agent workflows.",
       "prerequisites": [],
@@ -1463,7 +1464,7 @@
       "id": "few-shot-learning",
       "name": "Few-Shot Learning",
       "type": "unique",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "common",
       "description": "Conditions a language model on a small number of input-output demonstrations within the prompt, enabling task adaptation without weight updates.",
       "prerequisites": [],
@@ -1478,7 +1479,7 @@
           "source": "https://arxiv.org/abs/2005.14165",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Brown et al. (2020) \u00e2\u20ac\u201d Language Models are Few-Shot Learners (GPT-3); in-context learning from 1-100 examples achieves near-SOTA on SuperGLUE, translation, and QA benchmarks."
+          "notes": "Brown et al. (2020) â€” Language Models are Few-Shot Learners (GPT-3); in-context learning from 1-100 examples achieves near-SOTA on SuperGLUE, translation, and QA benchmarks."
         }
       ],
       "knownAgents": [],
@@ -1491,7 +1492,7 @@
       "id": "fine-tune",
       "name": "Fine-Tune",
       "type": "unique",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "uncommon",
       "description": "Adapts a pre-trained model to a new task or domain by updating model weights using parameter-efficient methods such as LoRA, QLoRA, or full supervised fine-tuning, without retraining from scratch.",
       "prerequisites": [],
@@ -1530,7 +1531,7 @@
       "id": "format-output",
       "name": "Format Output",
       "type": "basic",
-      "level": "0\u2605",
+      "level": "0★",
       "rarity": "common",
       "description": "Structures raw output into a specified format such as markdown, JSON, CSV, or HTML.",
       "prerequisites": [],
@@ -1561,7 +1562,7 @@
       "id": "framework-upgrade",
       "name": "Framework Upgrade",
       "type": "basic",
-      "level": "0\u2605",
+      "level": "0★",
       "rarity": "common",
       "description": "Guides an agent through upgrading a project from one major framework version to another, including breaking-change detection, migration steps, and post-upgrade validation.",
       "prerequisites": [],
@@ -1586,7 +1587,7 @@
       "id": "full-stack-developer",
       "name": "Full-Stack Developer",
       "type": "ultimate",
-      "level": "5\u2605",
+      "level": "5★",
       "rarity": "legendary",
       "description": "Autonomously implements, reviews, tests, and refactors complete software features across the full development lifecycle from specification to merged PR.",
       "prerequisites": [
@@ -1602,21 +1603,21 @@
           "source": "https://arxiv.org/abs/2310.06770",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SWE-bench \u00e2\u20ac\u201d 2294 real GitHub issues; Claude 3.5 Sonnet (Cognition) resolves 49% on Verified, demonstrating full-cycle autonomous development."
+          "notes": "SWE-bench â€” 2294 real GitHub issues; Claude 3.5 Sonnet (Cognition) resolves 49% on Verified, demonstrating full-cycle autonomous development."
         },
         {
           "class": "B",
           "source": "https://github.com/princeton-nlp/SWE-agent",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SWE-agent \u00e2\u20ac\u201d open-source agent with AgentComputer Interface; reproducible harness achieving 12.5% on SWE-bench full with logs and eval scripts."
+          "notes": "SWE-agent â€” open-source agent with AgentComputer Interface; reproducible harness achieving 12.5% on SWE-bench full with logs and eval scripts."
         },
         {
           "class": "A",
           "source": "https://arxiv.org/abs/2402.01030",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "CodeAct \u00e2\u20ac\u201d executable code action space for LLM agents; +20% task completion vs JSON/text-based actions across 17 programming benchmarks."
+          "notes": "CodeAct â€” executable code action space for LLM agents; +20% task completion vs JSON/text-based actions across 17 programming benchmarks."
         }
       ],
       "knownAgents": [],
@@ -1630,7 +1631,7 @@
       "id": "function-calling",
       "name": "Function Calling",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Selects an external callable, emits schema-valid arguments, invokes the function or API, and integrates the returned result into the agent loop.",
       "prerequisites": [
@@ -1666,7 +1667,7 @@
       "id": "gaia-audit",
       "name": "Gaia Audit",
       "type": "extra",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
       "description": "Reviews one Gaia skill, named skill, or real-skill catalog item against current evidence, source URLs, taxonomy mapping, promotion status, and demotion criteria, then proposes the smallest source-of-truth correction.",
       "prerequisites": [
@@ -1697,7 +1698,7 @@
       "id": "gaia-meta-audit",
       "name": "Gaia Meta Audit",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "rare",
       "description": "Scans Gaia registry and real-skill catalog entries for review candidates whose evidence may be outdated, superseded, overpromoted, unmapped, stale, or insufficient for their current level or named-skill claim.",
       "prerequisites": [
@@ -1726,7 +1727,7 @@
       "id": "gaia-triage",
       "name": "Gaia Triage",
       "type": "extra",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
       "description": "Triage and audit GitHub issues for the Gaia Skill Tree project. Helps identify stale issues, gather evidence from the codebase, and manage issue lifecycle via GitHub CLI.",
       "prerequisites": [
@@ -1754,7 +1755,7 @@
       "id": "generate-sql",
       "name": "Generate SQL",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "common",
       "description": "Translates natural-language data questions into syntactically correct, executable SQL queries against a given schema.",
       "prerequisites": [],
@@ -1769,7 +1770,7 @@
           "source": "https://arxiv.org/abs/1809.08887",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Spider benchmark \u00e2\u20ac\u201d cross-domain text-to-SQL dataset; LLM baselines reach >85% exact match, establishing reproducible evaluation methodology."
+          "notes": "Spider benchmark â€” cross-domain text-to-SQL dataset; LLM baselines reach >85% exact match, establishing reproducible evaluation methodology."
         }
       ],
       "knownAgents": [],
@@ -1782,7 +1783,7 @@
       "id": "generate-test",
       "name": "Generate Test",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "common",
       "description": "Produces unit tests, integration tests, and edge-case test cases from source code or natural-language specifications.",
       "prerequisites": [],
@@ -1796,7 +1797,7 @@
           "source": "https://arxiv.org/abs/2107.03374",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Codex/HumanEval (Chen et al.) \u00e2\u20ac\u201d evaluates LLMs on writing Python functions that pass hand-crafted unit tests; pass@1 72.0% for GPT-4."
+          "notes": "Codex/HumanEval (Chen et al.) â€” evaluates LLMs on writing Python functions that pass hand-crafted unit tests; pass@1 72.0% for GPT-4."
         }
       ],
       "knownAgents": [],
@@ -1809,7 +1810,7 @@
       "id": "generate-text",
       "name": "Generate Text",
       "type": "basic",
-      "level": "0\u2605",
+      "level": "0★",
       "rarity": "common",
       "description": "Produces coherent natural language output given a prompt, instruction, or context window.",
       "prerequisites": [],
@@ -1838,7 +1839,7 @@
       "id": "ghostwrite",
       "name": "Ghostwrite",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Produces audience-tailored, research-backed long-form written content.",
       "prerequisites": [
@@ -1867,7 +1868,7 @@
       "id": "grill-me",
       "name": "Grill Me",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Conducts a relentless, one-question-at-a-time Socratic interview to stress-test designs and force the resolution of hidden assumptions before code is written.",
       "prerequisites": [
@@ -1897,7 +1898,7 @@
       "id": "grill-with-docs",
       "name": "Grill With Docs",
       "type": "ultimate",
-      "level": "5\u2605",
+      "level": "5★",
       "rarity": "legendary",
       "description": "The apex of agentic design alignment. Fuses relentless Socratic questioning with deep domain awareness, ensuring every decision is cross-referenced against a persistent ubiquitous language and documented via real-time ADR generation.",
       "prerequisites": [
@@ -1934,7 +1935,7 @@
       "id": "grounding",
       "name": "Grounding",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Verifies generated claims against retrieved evidence, identifies unsupported or contradicted assertions, and anchors outputs in traceable, cited sources.",
       "prerequisites": [
@@ -1970,7 +1971,7 @@
       "id": "guardrails",
       "name": "Guardrails",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Wraps LLM outputs with programmatic safety rules, content filters, and topical constraints that detect policy violations and enforce compliant, on-policy responses before they reach the user.",
       "prerequisites": [
@@ -2006,7 +2007,7 @@
       "id": "humanize-prose",
       "name": "Humanize Prose",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "uncommon",
       "description": "Audits and rewrites prose to remove generic AI-writing patterns, preserve author intent, and adapt tone toward a more natural human voice.",
       "prerequisites": [
@@ -2037,7 +2038,7 @@
       "id": "hypothesis-generate",
       "name": "Hypothesis Generation",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "rare",
       "description": "Formulates novel, testable scientific hypotheses by synthesising existing literature, identifying knowledge gaps, and proposing mechanistic explanations.",
       "prerequisites": [],
@@ -2051,21 +2052,21 @@
           "source": "https://arxiv.org/abs/2304.05376",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "ChemCrow (Bran et al., 2023) \u00e2\u20ac\u201d LLM augmented with 18 chemistry tools autonomously proposes and validates synthesis routes; GPT-4 outperforms on Chem. benchmark."
+          "notes": "ChemCrow (Bran et al., 2023) â€” LLM augmented with 18 chemistry tools autonomously proposes and validates synthesis routes; GPT-4 outperforms on Chem. benchmark."
         },
         {
           "class": "A",
           "source": "https://arxiv.org/abs/2304.05332",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Coscientist (Boiko et al., 2023) \u00e2\u20ac\u201d autonomous LLM system designs and executes chemistry experiments; independently re-derived Suzuki coupling conditions."
+          "notes": "Coscientist (Boiko et al., 2023) â€” autonomous LLM system designs and executes chemistry experiments; independently re-derived Suzuki coupling conditions."
         },
         {
           "class": "B",
           "source": "https://github.com/SakanaAI/AI-Scientist",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "The AI Scientist (Sakana AI) \u00e2\u20ac\u201d end-to-end pipeline generating ideas, running experiments, and writing ML papers; 50+ auto-generated manuscripts reviewed."
+          "notes": "The AI Scientist (Sakana AI) â€” end-to-end pipeline generating ideas, running experiments, and writing ML papers; 50+ auto-generated manuscripts reviewed."
         }
       ],
       "knownAgents": [],
@@ -2078,7 +2079,7 @@
       "id": "image-caption",
       "name": "Image Caption",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
       "description": "Generates accurate natural-language descriptions of images, capturing objects, actions, and spatial relationships.",
       "prerequisites": [],
@@ -2092,7 +2093,7 @@
           "source": "https://arxiv.org/abs/2301.12597",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "BLIP-2 \u00e2\u20ac\u201d bootstrapped language-image pre-training achieving SOTA on COCO Captions (CIDEr 145.8) and NoCaps benchmarks."
+          "notes": "BLIP-2 â€” bootstrapped language-image pre-training achieving SOTA on COCO Captions (CIDEr 145.8) and NoCaps benchmarks."
         }
       ],
       "knownAgents": [],
@@ -2105,7 +2106,7 @@
       "id": "image-generate",
       "name": "Image Generate",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
       "description": "Creates photorealistic or stylized images from text prompts using diffusion-based or autoregressive generative models.",
       "prerequisites": [],
@@ -2117,7 +2118,7 @@
           "source": "https://arxiv.org/abs/2112.10752",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Latent Diffusion Models (Rombach et al.) \u00e2\u20ac\u201d foundational paper for Stable Diffusion; achieves FID 5.11 on LSUN-Beds at 200\u00c3\u2014 less compute than pixel-space diffusion."
+          "notes": "Latent Diffusion Models (Rombach et al.) â€” foundational paper for Stable Diffusion; achieves FID 5.11 on LSUN-Beds at 200Ã— less compute than pixel-space diffusion."
         }
       ],
       "knownAgents": [],
@@ -2130,7 +2131,7 @@
       "id": "issue-triage",
       "name": "Issue Triage",
       "type": "basic",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "uncommon",
       "description": "Classifies incoming issue reports through a structured state machine, assigns triage roles (bug/enhancement, needs-info/ready-for-agent/wontfix), reproduces bugs, requests missing detail, and produces structured resolution briefs for agent or human handoff.",
       "prerequisites": [],
@@ -2169,7 +2170,7 @@
       "id": "knowledge-graph-build",
       "name": "Knowledge Graph Construction",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Extracts entities and relations from unstructured text, resolves co-references, and assembles them into a queryable graph structure with typed edges.",
       "prerequisites": [
@@ -2187,14 +2188,14 @@
           "source": "https://arxiv.org/abs/2306.08302",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Pan et al. (2024) \u00e2\u20ac\u201d Unifying Large Language Models and Knowledge Graphs: A Roadmap; comprehensive survey showing LLM-KG synergy improves downstream tasks by 5-15%."
+          "notes": "Pan et al. (2024) â€” Unifying Large Language Models and Knowledge Graphs: A Roadmap; comprehensive survey showing LLM-KG synergy improves downstream tasks by 5-15%."
         },
         {
           "class": "B",
           "source": "https://github.com/microsoft/graphrag",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Microsoft GraphRAG \u00e2\u20ac\u201d production KG construction pipeline; extracts community summaries and entity graphs from corpora, enabling global sensemaking queries."
+          "notes": "Microsoft GraphRAG â€” production KG construction pipeline; extracts community summaries and entity graphs from corpora, enabling global sensemaking queries."
         }
       ],
       "knownAgents": [],
@@ -2207,7 +2208,7 @@
       "id": "knowledge-harvest",
       "name": "Knowledge Harvest",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Extracts, structures, and embeds knowledge from web sources into a searchable corpus.",
       "prerequisites": [
@@ -2236,7 +2237,7 @@
       "id": "literature-review",
       "name": "Literature Review",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "uncommon",
       "description": "Conducts systematic multi-database academic literature searches following PRISMA/SWARM protocols, screens and synthesises findings, verifies all citations, and generates a structured review report.",
       "prerequisites": [
@@ -2252,14 +2253,14 @@
           "source": "https://arxiv.org/abs/2501.05468",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "Rouzrokh et al. (2025) \u2014 LatteReview: multi-agent framework for systematic review automation; modular agents for title/abstract screening, relevance scoring, and structured data extraction with RAG and multimodal support."
+          "notes": "Rouzrokh et al. (2025) — LatteReview: multi-agent framework for systematic review automation; modular agents for title/abstract screening, relevance scoring, and structured data extraction with RAG and multimodal support."
         },
         {
           "class": "B",
           "source": "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/scientific-skills/literature-review/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "K-Dense-AI scientific-agent-skills \u2014 reproducible literature-review skill: seven-phase workflow from research-question planning through multi-database search, screening, extraction, synthesis, citation verification to final PDF output."
+          "notes": "K-Dense-AI scientific-agent-skills — reproducible literature-review skill: seven-phase workflow from research-question planning through multi-database search, screening, extraction, synthesis, citation verification to final PDF output."
         }
       ],
       "knownAgents": [],
@@ -2272,7 +2273,7 @@
       "id": "logical-inference",
       "name": "Logical Inference",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "uncommon",
       "description": "Applies deductive, inductive, or abductive reasoning to derive valid conclusions from premises and structured knowledge.",
       "prerequisites": [],
@@ -2287,7 +2288,7 @@
           "source": "https://arxiv.org/abs/2201.11903",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Chain-of-Thought prompting (Wei et al.) \u00e2\u20ac\u201d few-shot CoT elicits multi-step reasoning; +18% on GSM8K and +15% on SVAMP over standard prompting."
+          "notes": "Chain-of-Thought prompting (Wei et al.) â€” few-shot CoT elicits multi-step reasoning; +18% on GSM8K and +15% on SVAMP over standard prompting."
         }
       ],
       "knownAgents": [],
@@ -2300,7 +2301,7 @@
       "id": "math-reason",
       "name": "Math Reason",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
       "description": "Solves multi-step mathematical problems including arithmetic, algebra, calculus, and competition mathematics through symbolic and numeric reasoning.",
       "prerequisites": [],
@@ -2315,7 +2316,7 @@
           "source": "https://arxiv.org/abs/2206.14858",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Minerva (Google) \u00e2\u20ac\u201d 50.3% on MATH and 78.5% on MMLU-STEM benchmarks using chain-of-thought over scientific literature."
+          "notes": "Minerva (Google) â€” 50.3% on MATH and 78.5% on MMLU-STEM benchmarks using chain-of-thought over scientific literature."
         }
       ],
       "knownAgents": [],
@@ -2328,7 +2329,7 @@
       "id": "mcp-debugger-control",
       "name": "MCP Debugger Control",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Exposes low-level debugger capabilities (breakpoints, stepping, stack inspection, variable evaluation) to AI agents via the Model Context Protocol, enabling real-time runtime diagnosis and autonomous bug fixing.",
       "prerequisites": [
@@ -2363,9 +2364,9 @@
       "id": "mcp-integration",
       "name": "MCP Integration",
       "type": "basic",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
-      "description": "Connect to and invoke tools exposed by Model Context Protocol (MCP) servers \u2014 enumerate available tools, execute calls, and handle responses across any MCP-compatible backend.",
+      "description": "Connect to and invoke tools exposed by Model Context Protocol (MCP) servers — enumerate available tools, execute calls, and handle responses across any MCP-compatible backend.",
       "prerequisites": [],
       "derivatives": [
         "mcp-server-creation"
@@ -2391,7 +2392,7 @@
           "source": "https://github.com/intelligentcode-ai/skills/blob/main/skills/mcp-client/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "intelligentcode-ai/skills mcp-client \u2014 portable CLI MCP client with server enumeration, tool display, and on-demand execution."
+          "notes": "intelligentcode-ai/skills mcp-client — portable CLI MCP client with server enumeration, tool display, and on-demand execution."
         }
       ],
       "knownAgents": [],
@@ -2407,7 +2408,7 @@
       "id": "mcp-server-creation",
       "name": "MCP Server Creation",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Designs and implements Model Context Protocol servers that expose external APIs, files, or services as well-typed tools with clear schemas, authentication, and testable agent workflows.",
       "prerequisites": [
@@ -2449,7 +2450,7 @@
       "id": "memory-manage",
       "name": "Memory Manage",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
       "description": "Maintains, indexes, and retrieves conversational and long-term memory across sessions, managing context window constraints.",
       "prerequisites": [],
@@ -2464,7 +2465,7 @@
           "source": "https://arxiv.org/abs/2310.08560",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "MemGPT \u00e2\u20ac\u201d virtual context management system enabling LLMs to handle unbounded memory; benchmarked on multi-session dialogue and document QA."
+          "notes": "MemGPT â€” virtual context management system enabling LLMs to handle unbounded memory; benchmarked on multi-session dialogue and document QA."
         }
       ],
       "knownAgents": [],
@@ -2477,7 +2478,7 @@
       "id": "ml-pipeline",
       "name": "ML Pipeline",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Designs and implements production ML pipelines with experiment tracking (MLflow, W&B), feature stores (Feast), orchestration (Kubeflow, Airflow), and automated retraining workflows including model evaluation gates and A/B deployment.",
       "prerequisites": [
@@ -2493,14 +2494,14 @@
           "source": "https://arxiv.org/abs/2502.18530",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "Xue et al. (2025) \u2014 IMPROVE: Iterative Model Pipeline Refinement and Optimization Leveraging LLM Experts; iterative component-level refinement consistently outperforms single-step zero-shot LLM-based ML pipeline optimization with theoretical convergence guarantees."
+          "notes": "Xue et al. (2025) — IMPROVE: Iterative Model Pipeline Refinement and Optimization Leveraging LLM Experts; iterative component-level refinement consistently outperforms single-step zero-shot LLM-based ML pipeline optimization with theoretical convergence guarantees."
         },
         {
           "class": "B",
           "source": "https://github.com/Jeffallan/claude-skills/blob/main/skills/ml-pipeline/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "Jeffallan/claude-skills \u2014 reproducible ml-pipeline skill: full lifecycle from data validation and feature engineering through distributed training, experiment tracking, model evaluation gates, A/B testing, and automated retraining with DVC/Feast/MLflow/Kubeflow."
+          "notes": "Jeffallan/claude-skills — reproducible ml-pipeline skill: full lifecycle from data validation and feature engineering through distributed training, experiment tracking, model evaluation gates, A/B testing, and automated retraining with DVC/Feast/MLflow/Kubeflow."
         }
       ],
       "knownAgents": [],
@@ -2513,7 +2514,7 @@
       "id": "multi-agent-debate",
       "name": "Multi-Agent Debate",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Runs multiple LLM agents that propose, critique, and iteratively refine answers across structured debate rounds, converging on more accurate and well-reasoned responses than any single agent achieves.",
       "prerequisites": [
@@ -2549,7 +2550,7 @@
       "id": "multi-agent-orchestration-v",
       "name": "Multi-Agent Orchestration",
       "type": "ultimate",
-      "level": "5\u2605",
+      "level": "5★",
       "rarity": "legendary",
       "description": "Coordinates multiple specialized agents across complex workflows with dynamic task allocation and conflict resolution.",
       "prerequisites": [
@@ -2565,7 +2566,7 @@
           "source": "https://github.com/gaia-registry/gaia/blob/main/docs/evidence/seed.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Seed evidence \u00e2\u20ac\u201d structural validation placeholder."
+          "notes": "Seed evidence â€” structural validation placeholder."
         }
       ],
       "knownAgents": [],
@@ -2579,7 +2580,7 @@
       "id": "multimodal-reasoning",
       "name": "Multimodal Reasoning",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "rare",
       "description": "Integrates information from images and text to answer questions requiring visual grounding and logical inference across modalities.",
       "prerequisites": [
@@ -2595,7 +2596,7 @@
           "source": "https://arxiv.org/abs/2304.08485",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "LLaVA \u00e2\u20ac\u201d large language and vision assistant; 85.1% on ScienceQA and 64.3% on TextVQA, establishing reproducible multimodal reasoning benchmark."
+          "notes": "LLaVA â€” large language and vision assistant; 85.1% on ScienceQA and 64.3% on TextVQA, establishing reproducible multimodal reasoning benchmark."
         }
       ],
       "knownAgents": [],
@@ -2611,7 +2612,7 @@
       "id": "object-detection",
       "name": "Object Detection",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
       "description": "Locates and classifies multiple objects within images by producing bounding boxes, confidence scores, and category labels in a single forward pass.",
       "prerequisites": [],
@@ -2646,7 +2647,7 @@
       "id": "ocr",
       "name": "OCR",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
       "description": "Extracts machine-readable text from raster images, scanned pages, and photo documents using optical character recognition, preserving layout and handling skew, noise, and varied fonts.",
       "prerequisites": [],
@@ -2680,7 +2681,7 @@
       "id": "parallel-execution",
       "name": "Parallel Execution",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
       "description": "Decompose a task into independent sub-tasks and execute them concurrently, merging results with configurable concurrency limits and queue-based state tracking.",
       "prerequisites": [],
@@ -2692,7 +2693,7 @@
           "source": "https://github.com/intelligentcode-ai/skills/blob/main/skills/parallel-execution/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "intelligentcode-ai/skills parallel-execution \u2014 concurrent work item execution with independence verification and configurable concurrency (default 5)."
+          "notes": "intelligentcode-ai/skills parallel-execution — concurrent work item execution with independence verification and configurable concurrency (default 5)."
         }
       ],
       "knownAgents": [],
@@ -2705,7 +2706,7 @@
       "id": "parse-html",
       "name": "Parse HTML",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Extracts structured content from raw HTML, navigating DOM trees and handling malformed markup.",
       "prerequisites": [],
@@ -2732,7 +2733,7 @@
       "id": "parse-json",
       "name": "Parse JSON",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Extracts structured data from JSON-formatted input, handling nested objects and arrays.",
       "prerequisites": [],
@@ -2760,7 +2761,7 @@
       "id": "parse-pdf",
       "name": "Parse PDF",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Extracts text, tables, equations, and structure from PDF documents, preserving layout and reading order.",
       "prerequisites": [],
@@ -2774,7 +2775,7 @@
           "source": "https://arxiv.org/abs/2308.13418",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Nougat (Meta AI) \u00e2\u20ac\u201d visual transformer for scientific PDF parsing; 7.6% edit distance on arXiv papers, handling LaTeX, tables, and equations."
+          "notes": "Nougat (Meta AI) â€” visual transformer for scientific PDF parsing; 7.6% edit distance on arXiv papers, handling LaTeX, tables, and equations."
         }
       ],
       "knownAgents": [],
@@ -2787,7 +2788,7 @@
       "id": "plan-and-execute",
       "name": "Plan and Execute",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Decomposes complex objectives into sub-tasks, selects tools, and orchestrates execution.",
       "prerequisites": [
@@ -2818,7 +2819,7 @@
       "id": "plan-decompose",
       "name": "Plan and Decompose",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Breaks a complex objective into an ordered sequence of executable sub-tasks.",
       "prerequisites": [],
@@ -2851,7 +2852,7 @@
       "id": "prd-generation",
       "name": "PRD Generation",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "uncommon",
       "description": "Synthesizes conversation context and codebase knowledge into a structured Product Requirements Document containing a problem statement, extensive user stories, implementation decisions, module boundaries, testing decisions, and out-of-scope items.",
       "prerequisites": [
@@ -2886,7 +2887,7 @@
       "id": "prediction-market-analysis",
       "name": "Prediction Market Analysis",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Queries prediction-market data, compares market probabilities and price history, and summarizes probabilistic signals for forecasting or decision-support workflows.",
       "prerequisites": [
@@ -2917,7 +2918,7 @@
       "id": "prompt-injection-defense",
       "name": "Prompt Injection Defense",
       "type": "basic",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Detects and neutralizes adversarial instructions injected into agent context from untrusted external sources (indirect prompt injection), using techniques such as context isolation, hierarchical intent verification, or semantic consistency checks.",
       "prerequisites": [],
@@ -2931,21 +2932,21 @@
           "source": "https://arxiv.org/abs/2604.10134",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "PlanGuard (2026) \u2014 training-free indirect prompt injection defense; planning-based consistency verification reduces InjecAgent attack success rate from 72.8% to 0%."
+          "notes": "PlanGuard (2026) — training-free indirect prompt injection defense; planning-based consistency verification reduces InjecAgent attack success rate from 72.8% to 0%."
         },
         {
           "class": "B",
           "source": "https://github.com/tldrsec/prompt-injection-defenses",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "tldrsec/prompt-injection-defenses (682 stars) \u2014 curated, reproducible catalog of defense techniques with implementation references; actively maintained."
+          "notes": "tldrsec/prompt-injection-defenses (682 stars) — curated, reproducible catalog of defense techniques with implementation references; actively maintained."
         },
         {
           "class": "C",
           "source": "https://skillsmp.com/api/v1/skills/search?q=prompt-injection-defense",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "SkillsMP top hit: openclaw/prompt-injection-defense (4,419 stars) \u2014 'Harden agent sessions against prompt injection from untrusted content'; references CaMeL benchmark."
+          "notes": "SkillsMP top hit: openclaw/prompt-injection-defense (4,419 stars) — 'Harden agent sessions against prompt injection from untrusted content'; references CaMeL benchmark."
         }
       ],
       "knownAgents": [],
@@ -2958,7 +2959,7 @@
       "id": "prompt-optimization",
       "name": "Prompt Optimization",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "uncommon",
       "description": "Automatically improves prompt instructions through iterative compilation, treating prompts as programs that can be optimized against a metric using LLM-driven feedback loops.",
       "prerequisites": [
@@ -2975,14 +2976,14 @@
           "source": "https://arxiv.org/abs/2310.03714",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Khattab et al. (2023) \u00e2\u20ac\u201d DSPy: Compiling Declarative Language Model Calls into Self-Improving Pipelines; automated prompt tuning matches or exceeds hand-crafted prompts on GSM8K, HotPotQA, and FEVER."
+          "notes": "Khattab et al. (2023) â€” DSPy: Compiling Declarative Language Model Calls into Self-Improving Pipelines; automated prompt tuning matches or exceeds hand-crafted prompts on GSM8K, HotPotQA, and FEVER."
         },
         {
           "class": "B",
           "source": "https://github.com/stanfordnlp/dspy",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "DSPy \u00e2\u20ac\u201d Stanford NLP library for programmable LM pipelines; 18k+ GitHub stars, supports multiple optimizers (BootstrapFewShot, MIPRO, COPRO) across any LM."
+          "notes": "DSPy â€” Stanford NLP library for programmable LM pipelines; 18k+ GitHub stars, supports multiple optimizers (BootstrapFewShot, MIPRO, COPRO) across any LM."
         }
       ],
       "knownAgents": [],
@@ -2995,7 +2996,7 @@
       "id": "question-answer",
       "name": "Question Answer",
       "type": "basic",
-      "level": "0\u2605",
+      "level": "0★",
       "rarity": "common",
       "description": "Produces accurate, context-grounded answers to natural-language questions, handling unanswerable cases.",
       "prerequisites": [],
@@ -3011,7 +3012,7 @@
           "source": "https://arxiv.org/abs/1806.03822",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SQuAD 2.0 \u00e2\u20ac\u201d reading comprehension benchmark with 150K questions; modern LLMs exceed human F1 (90.9), providing rigorous reproducible evaluation."
+          "notes": "SQuAD 2.0 â€” reading comprehension benchmark with 150K questions; modern LLMs exceed human F1 (90.9), providing rigorous reproducible evaluation."
         }
       ],
       "knownAgents": [],
@@ -3024,7 +3025,7 @@
       "id": "rag-pipeline",
       "name": "RAG Pipeline",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "End-to-end retrieval-augmented generation combining document chunking, embedding, retrieval, and relevance scoring.",
       "prerequisites": [
@@ -3063,7 +3064,7 @@
       "id": "rank",
       "name": "Rank",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Orders a set of candidate items by relevance, quality, or fitness for a given objective.",
       "prerequisites": [],
@@ -3090,7 +3091,7 @@
       "id": "re-act-reasoning",
       "name": "ReAct Reasoning",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Interleaves free-form reasoning traces with discrete tool actions in a single loop, enabling agents to plan, act, observe, and update beliefs step-by-step.",
       "prerequisites": [
@@ -3108,14 +3109,14 @@
           "source": "https://arxiv.org/abs/2210.03629",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "ReAct (Yao et al., 2023) \u00e2\u20ac\u201d reasoning+acting paradigm; +34% on HotpotQA and +10% on ALFWorld vs chain-of-thought-only baselines."
+          "notes": "ReAct (Yao et al., 2023) â€” reasoning+acting paradigm; +34% on HotpotQA and +10% on ALFWorld vs chain-of-thought-only baselines."
         },
         {
           "class": "B",
           "source": "https://github.com/ysymyth/ReAct",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "ReAct repo \u00e2\u20ac\u201d reproducible prompts and evaluation harness for HotpotQA, FEVER, ALFWorld, and WebShop benchmarks."
+          "notes": "ReAct repo â€” reproducible prompts and evaluation harness for HotpotQA, FEVER, ALFWorld, and WebShop benchmarks."
         }
       ],
       "knownAgents": [],
@@ -3128,7 +3129,7 @@
       "id": "real-time-voice-assistant",
       "name": "Real-Time Voice Assistant",
       "type": "ultimate",
-      "level": "5\u2605",
+      "level": "5★",
       "rarity": "legendary",
       "description": "Provides low-latency spoken interactions combining real-time speech I/O, persistent memory, and goal-directed task execution across multi-session conversations.",
       "prerequisites": [
@@ -3144,21 +3145,21 @@
           "source": "https://arxiv.org/abs/2312.11805",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "AudioPaLM (Google) \u00e2\u20ac\u201d unified audio language model supporting real-time spoken dialogue; SOTA on ASR and speech translation, demonstrating end-to-end voice assistant capability."
+          "notes": "AudioPaLM (Google) â€” unified audio language model supporting real-time spoken dialogue; SOTA on ASR and speech translation, demonstrating end-to-end voice assistant capability."
         },
         {
           "class": "A",
           "source": "https://arxiv.org/abs/2305.11206",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "VoiceBox (Meta AI) \u00e2\u20ac\u201d generative speech model with zero-shot TTS; enables real-time voice assistants with <100ms synthesis latency benchmarked on VCTK."
+          "notes": "VoiceBox (Meta AI) â€” generative speech model with zero-shot TTS; enables real-time voice assistants with <100ms synthesis latency benchmarked on VCTK."
         },
         {
           "class": "B",
           "source": "https://github.com/openai/whisper",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Whisper + LLM integration demos \u00e2\u20ac\u201d open-source real-time voice assistant pipelines combining Whisper STT, LLM reasoning, and TTS with documented latency benchmarks."
+          "notes": "Whisper + LLM integration demos â€” open-source real-time voice assistant pipelines combining Whisper STT, LLM reasoning, and TTS with documented latency benchmarks."
         }
       ],
       "knownAgents": [],
@@ -3172,7 +3173,7 @@
       "id": "recursive-self-improvement",
       "name": "Recursive Self-Improvement",
       "type": "ultimate",
-      "level": "5\u2605",
+      "level": "5★",
       "rarity": "legendary",
       "description": "Agent iteratively refines its own prompts, tools, or strategies based on performance feedback loops.",
       "prerequisites": [
@@ -3188,7 +3189,7 @@
           "source": "https://github.com/gaia-registry/gaia/blob/main/docs/evidence/seed.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Seed evidence \u00e2\u20ac\u201d structural validation placeholder."
+          "notes": "Seed evidence â€” structural validation placeholder."
         }
       ],
       "knownAgents": [],
@@ -3202,7 +3203,7 @@
       "id": "refactor-code",
       "name": "Refactor Code",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
       "description": "Restructures existing source code to improve readability, maintainability, or performance without changing observable behavior.",
       "prerequisites": [],
@@ -3216,7 +3217,7 @@
           "source": "https://arxiv.org/abs/2310.06770",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SWE-bench \u00e2\u20ac\u201d 2294 real GitHub issues benchmark; agents that resolve issues must safely refactor code while passing existing test suites."
+          "notes": "SWE-bench â€” 2294 real GitHub issues benchmark; agents that resolve issues must safely refactor code while passing existing test suites."
         }
       ],
       "knownAgents": [],
@@ -3229,7 +3230,7 @@
       "id": "registry-curation",
       "name": "Registry Curation",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Systematically discovers, evaluates, and ingests new skill definitions into a structured skill registry: researching capabilities, sourcing reproducible evidence, scripting graph updates, validating schema and DAG integrity, and publishing via pull request.",
       "prerequisites": [
@@ -3247,7 +3248,7 @@
           "source": "https://github.com/mbtiongson1/gaia-skill-tree/pull/2",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Reproducible demonstration: Claude Code agent researched 30 popular AI skills, sourced 22 peer-reviewed papers, generated gaia.json via script, passed all 6 validator checks, and submitted PR \u00e2\u20ac\u201d full inputs/outputs archived in the PR diff."
+          "notes": "Reproducible demonstration: Claude Code agent researched 30 popular AI skills, sourced 22 peer-reviewed papers, generated gaia.json via script, passed all 6 validator checks, and submitted PR â€” full inputs/outputs archived in the PR diff."
         },
         {
           "class": "B",
@@ -3261,7 +3262,7 @@
           "source": "https://github.com/mbtiongson1/gaia-skill-tree",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Batch 3 curation: 5 skills added (2 atomic, 3 composite) \u00e2\u20ac\u201d self-consistency, few-shot-learning, tree-of-thought, prompt-optimization, tool-creation."
+          "notes": "Batch 3 curation: 5 skills added (2 atomic, 3 composite) â€” self-consistency, few-shot-learning, tree-of-thought, prompt-optimization, tool-creation."
         },
         {
           "class": "B",
@@ -3288,7 +3289,7 @@
       "id": "release-automation",
       "name": "Release Automation",
       "type": "extra",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
       "description": "Automate the full software release cycle: determine semantic version bump, update CHANGELOG, commit, create a git tag, and publish a GitHub release with release notes.",
       "prerequisites": [
@@ -3304,7 +3305,7 @@
           "source": "https://github.com/intelligentcode-ai/skills/blob/main/skills/release/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "intelligentcode-ai/skills release \u2014 automates semantic versioning, CHANGELOG updates, PR merging, git tagging, and GitHub release creation with verification gates."
+          "notes": "intelligentcode-ai/skills release — automates semantic versioning, CHANGELOG updates, PR merging, git tagging, and GitHub release creation with verification gates."
         }
       ],
       "knownAgents": [],
@@ -3317,9 +3318,9 @@
       "id": "requirements-analysis",
       "name": "Requirements Analysis",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "common",
-      "description": "Elicit and structure requirements from stakeholder inputs into formal specifications \u2014 user stories, acceptance criteria, and traceability matrices.",
+      "description": "Elicit and structure requirements from stakeholder inputs into formal specifications — user stories, acceptance criteria, and traceability matrices.",
       "prerequisites": [],
       "derivatives": [],
       "conditions": "",
@@ -3329,7 +3330,7 @@
           "source": "https://github.com/intelligentcode-ai/skills/blob/main/skills/requirements-engineer/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "intelligentcode-ai/skills requirements-engineer \u2014 business analysis specialist bridging stakeholders and technical teams for full requirements lifecycle."
+          "notes": "intelligentcode-ai/skills requirements-engineer — business analysis specialist bridging stakeholders and technical teams for full requirements lifecycle."
         }
       ],
       "knownAgents": [],
@@ -3342,7 +3343,7 @@
       "id": "research",
       "name": "Research",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Conducts multi-source information gathering, synthesis, and citation for a given topic.",
       "prerequisites": [
@@ -3377,7 +3378,7 @@
       "id": "retrieve",
       "name": "Retrieve",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Fetches relevant documents or passages from an indexed corpus given a query.",
       "prerequisites": [],
@@ -3407,7 +3408,7 @@
       "id": "reward-modeling",
       "name": "Reward Modeling",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "rare",
       "description": "Learns a scalar reward signal from human preference comparisons between model outputs, enabling reinforcement learning from human feedback (RLHF) to align model behavior with human values.",
       "prerequisites": [],
@@ -3442,7 +3443,7 @@
       "id": "route-intent",
       "name": "Route Intent",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Classifies user intent and directs execution to the appropriate handler, tool, or sub-agent.",
       "prerequisites": [],
@@ -3471,9 +3472,9 @@
       "id": "schema-design",
       "name": "Schema Design",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "common",
-      "description": "Design database schemas across relational, NoSQL, graph, and time-series stores \u2014 entity modelling, normalization, indexing strategies, and migration planning.",
+      "description": "Design database schemas across relational, NoSQL, graph, and time-series stores — entity modelling, normalization, indexing strategies, and migration planning.",
       "prerequisites": [],
       "derivatives": [],
       "conditions": "",
@@ -3483,7 +3484,7 @@
           "source": "https://github.com/intelligentcode-ai/skills/blob/main/skills/database-engineer/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "intelligentcode-ai/skills database-engineer \u2014 schema design and query optimization expert across relational, NoSQL, graph, time-series, and data warehouses."
+          "notes": "intelligentcode-ai/skills database-engineer — schema design and query optimization expert across relational, NoSQL, graph, time-series, and data warehouses."
         }
       ],
       "knownAgents": [],
@@ -3496,9 +3497,9 @@
       "id": "scientific-discovery",
       "name": "Autonomous Scientific Discovery",
       "type": "ultimate",
-      "level": "5\u2605",
+      "level": "5★",
       "rarity": "legendary",
-      "description": "Autonomously generates novel scientific hypotheses, designs and executes experiments, analyses results, and produces a written report \u00e2\u20ac\u201d completing a full research cycle without human intervention.",
+      "description": "Autonomously generates novel scientific hypotheses, designs and executes experiments, analyses results, and produces a written report â€” completing a full research cycle without human intervention.",
       "prerequisites": [
         "hypothesis-generate",
         "research",
@@ -3512,21 +3513,21 @@
           "source": "https://arxiv.org/abs/2304.05376",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "ChemCrow (Bran et al., 2023) \u00e2\u20ac\u201d autonomous chemistry agent completes synthesis planning and molecular design tasks rated expert-level by human chemists."
+          "notes": "ChemCrow (Bran et al., 2023) â€” autonomous chemistry agent completes synthesis planning and molecular design tasks rated expert-level by human chemists."
         },
         {
           "class": "A",
           "source": "https://arxiv.org/abs/2304.05332",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Coscientist (Boiko et al., 2023) \u00e2\u20ac\u201d autonomously planned and executed real wet-lab chemistry experiments, confirmed by GC-MS analysis."
+          "notes": "Coscientist (Boiko et al., 2023) â€” autonomously planned and executed real wet-lab chemistry experiments, confirmed by GC-MS analysis."
         },
         {
           "class": "B",
           "source": "https://github.com/SakanaAI/AI-Scientist",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "AI Scientist (Lu et al., 2024) \u00e2\u20ac\u201d generates idea, writes code, runs experiments, and produces a full NeurIPS-style paper; 50+ manuscripts auto-generated."
+          "notes": "AI Scientist (Lu et al., 2024) â€” generates idea, writes code, runs experiments, and produces a full NeurIPS-style paper; 50+ manuscripts auto-generated."
         }
       ],
       "knownAgents": [],
@@ -3540,7 +3541,7 @@
       "id": "scientific-visualization",
       "name": "Scientific Visualization",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
       "description": "Creates publication-ready scientific figures with multi-panel layouts, statistical annotations, colorblind-safe palettes, and journal-specific formatting (Nature, Science, Cell) using matplotlib, seaborn, and plotly.",
       "prerequisites": [],
@@ -3554,7 +3555,7 @@
           "source": "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/scientific-skills/scientific-visualization/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "K-Dense-AI scientific-agent-skills \u2014 reproducible scientific-visualization skill orchestrating matplotlib, seaborn, and plotly for journal-quality multi-panel figures with PDF/EPS/TIFF/PNG export and accessibility annotations."
+          "notes": "K-Dense-AI scientific-agent-skills — reproducible scientific-visualization skill orchestrating matplotlib, seaborn, and plotly for journal-quality multi-panel figures with PDF/EPS/TIFF/PNG export and accessibility annotations."
         }
       ],
       "knownAgents": [],
@@ -3567,7 +3568,7 @@
       "id": "scientific-writing",
       "name": "Scientific Writing",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Composes research manuscripts in IMRAD structure with reporting-guideline compliance (CONSORT, STROBE, PRISMA), citation management, publication-quality figures, and LaTeX/PDF formatting.",
       "prerequisites": [
@@ -3583,14 +3584,14 @@
           "source": "https://arxiv.org/abs/2405.20477",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "Chamoun et al. (ACL 2024 Findings) \u2014 SWIFT: automated focused feedback for scientific writing; multi-component LLM system (planner, investigator, reviewer, controller) rated more specific and helpful than human reviewers on 300 peer-reviewed manuscripts."
+          "notes": "Chamoun et al. (ACL 2024 Findings) — SWIFT: automated focused feedback for scientific writing; multi-component LLM system (planner, investigator, reviewer, controller) rated more specific and helpful than human reviewers on 300 peer-reviewed manuscripts."
         },
         {
           "class": "B",
           "source": "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/scientific-skills/scientific-writing/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "K-Dense-AI scientific-agent-skills \u2014 reproducible scientific-writing skill: two-stage outline-to-prose pipeline with IMRAD structure, multi-style citation management, and reporting-guideline validation (CONSORT, STROBE, PRISMA, STARD, TRIPOD)."
+          "notes": "K-Dense-AI scientific-agent-skills — reproducible scientific-writing skill: two-stage outline-to-prose pipeline with IMRAD structure, multi-style citation management, and reporting-guideline validation (CONSORT, STROBE, PRISMA, STARD, TRIPOD)."
         }
       ],
       "knownAgents": [],
@@ -3603,7 +3604,7 @@
       "id": "score-relevance",
       "name": "Score Relevance",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Assigns a numerical relevance score to candidate items relative to a query or objective.",
       "prerequisites": [],
@@ -3631,7 +3632,7 @@
       "id": "security-audit",
       "name": "Security Audit",
       "type": "extra",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "rare",
       "description": "Systematically identify security vulnerabilities, assess attack surface, and produce actionable remediation guidance across code, dependencies, and infrastructure.",
       "prerequisites": [
@@ -3648,14 +3649,14 @@
           "source": "https://github.com/intelligentcode-ai/skills/blob/main/skills/security-engineer/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "intelligentcode-ai/skills security-engineer \u2014 vulnerability assessment and security architecture with zero-trust principles and compliance management."
+          "notes": "intelligentcode-ai/skills security-engineer — vulnerability assessment and security architecture with zero-trust principles and compliance management."
         },
         {
           "class": "C",
           "source": "https://github.com/microsoft/PromptKit",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "microsoft/PromptKit (42 stars) \u2014 composable prompt components for security audits, code review, and bug investigation with any LLM."
+          "notes": "microsoft/PromptKit (42 stars) — composable prompt components for security audits, code review, and bug investigation with any LLM."
         }
       ],
       "knownAgents": [],
@@ -3668,7 +3669,7 @@
       "id": "self-consistency",
       "name": "Self-Consistency",
       "type": "unique",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Samples multiple independent reasoning paths for the same problem and selects the answer by majority vote, improving robustness without any additional training.",
       "prerequisites": [],
@@ -3683,7 +3684,7 @@
           "source": "https://arxiv.org/abs/2203.11171",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Wang et al. (2022) \u00e2\u20ac\u201d Self-Consistency Improves Chain of Thought Reasoning in Language Models; +17.9% on GSM8K and +11.0% on MATH over greedy CoT decoding."
+          "notes": "Wang et al. (2022) â€” Self-Consistency Improves Chain of Thought Reasoning in Language Models; +17.9% on GSM8K and +11.0% on MATH over greedy CoT decoding."
         }
       ],
       "knownAgents": [],
@@ -3696,7 +3697,7 @@
       "id": "self-critique",
       "name": "Self-Critique",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "uncommon",
       "description": "Iteratively evaluates and refines its own outputs using self-generated feedback, improving quality without external supervision.",
       "prerequisites": [],
@@ -3711,14 +3712,14 @@
           "source": "https://arxiv.org/abs/2303.17651",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Self-Refine (Madaan et al., 2023) \u00e2\u20ac\u201d iterative self-feedback loop; +20% on code generation and +13% on math reasoning vs single-pass generation."
+          "notes": "Self-Refine (Madaan et al., 2023) â€” iterative self-feedback loop; +20% on code generation and +13% on math reasoning vs single-pass generation."
         },
         {
           "class": "B",
           "source": "https://github.com/madaan/self-refine",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Self-Refine repo \u00e2\u20ac\u201d reproducible demos across 7 tasks (code, math, dialogue, sentiment reversal) with evaluation scripts."
+          "notes": "Self-Refine repo â€” reproducible demos across 7 tasks (code, math, dialogue, sentiment reversal) with evaluation scripts."
         }
       ],
       "knownAgents": [],
@@ -3731,7 +3732,7 @@
       "id": "semantic-cache",
       "name": "Semantic Cache",
       "type": "unique",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Stores LLM responses keyed by embedding similarity so that semantically equivalent queries are served from cache, reducing inference latency and token cost without sacrificing answer quality.",
       "prerequisites": [],
@@ -3770,7 +3771,7 @@
       "id": "sentiment-analysis",
       "name": "Sentiment Analysis",
       "type": "basic",
-      "level": "0\u2605",
+      "level": "0★",
       "rarity": "common",
       "description": "Determines the emotional valence (positive, negative, neutral) and intensity of text input.",
       "prerequisites": [],
@@ -3785,7 +3786,7 @@
           "source": "https://arxiv.org/abs/1810.04805",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "BERT paper \u00e2\u20ac\u201d achieves SOTA on SST-2 sentiment benchmark (93.5% accuracy), foundational evidence for LLM-based sentiment analysis."
+          "notes": "BERT paper â€” achieves SOTA on SST-2 sentiment benchmark (93.5% accuracy), foundational evidence for LLM-based sentiment analysis."
         }
       ],
       "knownAgents": [],
@@ -3798,7 +3799,7 @@
       "id": "skill-authoring",
       "name": "Skill Authoring",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Designs, writes, packages, and iteratively improves reusable agent skill directories with metadata, progressive instructions, supporting assets, and measurable trigger criteria.",
       "prerequisites": [
@@ -3839,7 +3840,7 @@
       "id": "skill-discovery",
       "name": "Skill Discovery",
       "type": "basic",
-      "level": "0\u2605",
+      "level": "0★",
       "rarity": "common",
       "description": "Searches a skill or tool registry, ranks results by relevance and install count, and surfaces candidates for the agent to adopt or invoke.",
       "prerequisites": [],
@@ -3867,7 +3868,7 @@
       "id": "skill-performance-benchmarking",
       "name": "Skill Performance Benchmarking",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Builds and runs task suites that measure whether agents select, invoke, and complete installed skills correctly across artifact-rich workflows and repeated trials.",
       "prerequisites": [
@@ -3915,7 +3916,7 @@
       "id": "skill-security-analysis",
       "name": "Skill Security Analysis",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Assesses third-party agent skills for malicious behavior, unsafe permissions, prompt-injection exposure, repository-context mismatch, and supply-chain risk before installation or invocation.",
       "prerequisites": [
@@ -3961,7 +3962,7 @@
       "id": "speech-to-text",
       "name": "Speech to Text",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "common",
       "description": "Transcribes spoken audio into accurate text, handling diverse accents, noise conditions, and multiple languages.",
       "prerequisites": [],
@@ -3975,7 +3976,7 @@
           "source": "https://arxiv.org/abs/2212.04356",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Whisper (OpenAI) \u00e2\u20ac\u201d large-scale weak supervision across 680K hours of audio achieves near-human WER on LibriSpeech and multilingual benchmarks."
+          "notes": "Whisper (OpenAI) â€” large-scale weak supervision across 680K hours of audio achieves near-human WER on LibriSpeech and multilingual benchmarks."
         }
       ],
       "knownAgents": [],
@@ -3988,7 +3989,7 @@
       "id": "statistical-analysis",
       "name": "Statistical Analysis",
       "type": "basic",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Performs hypothesis testing, regression analysis, and Bayesian modelling with effect size calculation and APA-formatted statistical reporting using scipy, statsmodels, and PyMC.",
       "prerequisites": [],
@@ -4003,14 +4004,14 @@
           "source": "https://arxiv.org/abs/2511.06701",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "Sargsyan (2025) \u2014 Structural Enforcement of Statistical Rigor in AI-Driven Discovery; monadic architecture achieves 1.1% false discovery rate vs 41% for naive LLM approaches across automated hypothesis-testing pipelines."
+          "notes": "Sargsyan (2025) — Structural Enforcement of Statistical Rigor in AI-Driven Discovery; monadic architecture achieves 1.1% false discovery rate vs 41% for naive LLM approaches across automated hypothesis-testing pipelines."
         },
         {
           "class": "B",
           "source": "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/scientific-skills/statistical-analysis/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "K-Dense-AI scientific-agent-skills \u2014 reproducible statistical-analysis skill covering parametric, non-parametric, and Bayesian workflows with scipy/statsmodels/pingouin/PyMC and APA-formatted output."
+          "notes": "K-Dense-AI scientific-agent-skills — reproducible statistical-analysis skill covering parametric, non-parametric, and Bayesian workflows with scipy/statsmodels/pingouin/PyMC and APA-formatted output."
         }
       ],
       "knownAgents": [],
@@ -4023,7 +4024,7 @@
       "id": "stealth-browser-interaction",
       "name": "Stealth Browser Interaction",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "uncommon",
       "description": "Operates web browsers through an advanced stealth layer that handles bot-detection, fingerprinting, session rotation, and human-like interaction patterns to maintain resilient access to protected domains.",
       "prerequisites": [
@@ -4059,7 +4060,7 @@
       "id": "structured-output",
       "name": "Structured Output Generation",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Generates output guaranteed to conform to a given schema (JSON, YAML, Pydantic model, etc.) using constrained decoding or grammar-guided generation.",
       "prerequisites": [],
@@ -4077,14 +4078,14 @@
           "source": "https://arxiv.org/abs/2307.09702",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Willard & Louf (2023) \u00e2\u20ac\u201d Efficient Guided Generation for LLMs; finite-state machine approach guarantees schema-valid output with <1% throughput overhead."
+          "notes": "Willard & Louf (2023) â€” Efficient Guided Generation for LLMs; finite-state machine approach guarantees schema-valid output with <1% throughput overhead."
         },
         {
           "class": "B",
           "source": "https://github.com/outlines-dev/outlines",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Outlines library \u00e2\u20ac\u201d production-grade constrained decoding supporting JSON Schema, regex, and CFG grammars; 2k+ GitHub stars."
+          "notes": "Outlines library â€” production-grade constrained decoding supporting JSON Schema, regex, and CFG grammars; 2k+ GitHub stars."
         }
       ],
       "knownAgents": [],
@@ -4097,7 +4098,7 @@
       "id": "summarize",
       "name": "Summarize",
       "type": "basic",
-      "level": "0\u2605",
+      "level": "0★",
       "rarity": "common",
       "description": "Condenses longer input into a shorter representation that preserves key information and intent.",
       "prerequisites": [],
@@ -4128,7 +4129,7 @@
       "id": "test-driven-development",
       "name": "Test-Driven Development",
       "type": "basic",
-      "level": "0\u2605",
+      "level": "0★",
       "rarity": "uncommon",
       "description": "Enforces a strict red-green-refactor TDD loop: writes failing tests before implementation, blocks code generation that skips the test step, and validates coverage thresholds before marking tasks complete.",
       "prerequisites": [],
@@ -4153,7 +4154,7 @@
       "id": "text-to-speech",
       "name": "Text to Speech",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "common",
       "description": "Synthesizes natural-sounding speech audio from text input, supporting voice cloning and prosody control.",
       "prerequisites": [],
@@ -4167,7 +4168,7 @@
           "source": "https://arxiv.org/abs/2301.02111",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "VALL-E (Microsoft) \u00e2\u20ac\u201d neural codec language model achieving SOTA speech synthesis with 3-second voice cloning on LibriSpeech."
+          "notes": "VALL-E (Microsoft) â€” neural codec language model achieving SOTA speech synthesis with 3-second voice cloning on LibriSpeech."
         }
       ],
       "knownAgents": [],
@@ -4180,7 +4181,7 @@
       "id": "text-to-sql-pipeline",
       "name": "Text-to-SQL Pipeline",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Converts natural-language queries into validated, executable SQL against a target schema and returns formatted result sets.",
       "prerequisites": [
@@ -4196,7 +4197,7 @@
           "source": "https://arxiv.org/abs/2304.11015",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "DIN-SQL \u00e2\u20ac\u201d decomposed in-context learning for text-to-SQL; 82.8% execution accuracy on Spider dev, demonstrating end-to-end pipeline."
+          "notes": "DIN-SQL â€” decomposed in-context learning for text-to-SQL; 82.8% execution accuracy on Spider dev, demonstrating end-to-end pipeline."
         }
       ],
       "knownAgents": [],
@@ -4209,7 +4210,7 @@
       "id": "token-observability",
       "name": "Token Observability",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
       "description": "Tracks and analyzes token usage and cost across multiple AI models and agents, providing session-level and project-level spending metrics.",
       "prerequisites": [],
@@ -4236,7 +4237,7 @@
       "id": "tokenize",
       "name": "Tokenize",
       "type": "basic",
-      "level": "0\u2605",
+      "level": "0★",
       "rarity": "common",
       "description": "Splits input text into discrete tokens suitable for downstream processing by language models. MODIFIED FOR TESTING.",
       "prerequisites": [],
@@ -4263,7 +4264,7 @@
       "id": "tool-chaining",
       "name": "Tool Chaining",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Sequences multiple tool invocations into a dependency graph where the output of each tool feeds as structured input to the next, handling state propagation, intermediate result validation, and error recovery across multi-step execution pipelines.",
       "prerequisites": [
@@ -4278,7 +4279,7 @@
           "source": "https://arxiv.org/abs/2604.07223",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "TraceSafe (2026) \u2014 first benchmark with 1,000+ instances explicitly evaluating sequential multi-step tool-calling trajectories across 12 risk categories; establishes tool-chaining as a distinct, measurable capability surface."
+          "notes": "TraceSafe (2026) — first benchmark with 1,000+ instances explicitly evaluating sequential multi-step tool-calling trajectories across 12 risk categories; establishes tool-chaining as a distinct, measurable capability surface."
         },
         {
           "class": "C",
@@ -4298,7 +4299,7 @@
       "id": "tool-creation",
       "name": "Tool Creation",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Dynamically generates reusable tool functions (code) at runtime to solve novel sub-tasks, then invokes those tools to complete the overall objective without human-written APIs.",
       "prerequisites": [
@@ -4317,14 +4318,14 @@
           "source": "https://arxiv.org/abs/2305.17126",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Cai et al. (2023) \u00e2\u20ac\u201d Large Language Models as Tool Makers (LATM); LLM-generated tools reused across problem instances achieve +8.7% on BigBench Hard vs per-instance CoT."
+          "notes": "Cai et al. (2023) â€” Large Language Models as Tool Makers (LATM); LLM-generated tools reused across problem instances achieve +8.7% on BigBench Hard vs per-instance CoT."
         },
         {
           "class": "B",
           "source": "https://github.com/ctlllll/LLM-ToolMaker",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "LATM repo \u00e2\u20ac\u201d reproducible tool-maker/tool-user pipeline with evaluation on BigBench Hard tasks and tool reuse across problem batches."
+          "notes": "LATM repo â€” reproducible tool-maker/tool-user pipeline with evaluation on BigBench Hard tasks and tool reuse across problem batches."
         }
       ],
       "knownAgents": [],
@@ -4337,7 +4338,7 @@
       "id": "tool-select",
       "name": "Tool Select",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Chooses the most appropriate tool or API from a set of available options given a task description.",
       "prerequisites": [],
@@ -4366,7 +4367,7 @@
       "id": "tool-use",
       "name": "Tool Use",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "uncommon",
       "description": "Invokes external functions or APIs by generating well-formed call signatures, parsing results, and incorporating them into reasoning.",
       "prerequisites": [],
@@ -4383,14 +4384,14 @@
           "source": "https://arxiv.org/abs/2302.04761",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Toolformer (Schick et al., 2023) \u00e2\u20ac\u201d self-supervised method teaching LLMs to call APIs; zero-shot tool use surpasses GPT-3 175B on several benchmarks."
+          "notes": "Toolformer (Schick et al., 2023) â€” self-supervised method teaching LLMs to call APIs; zero-shot tool use surpasses GPT-3 175B on several benchmarks."
         },
         {
           "class": "B",
           "source": "https://github.com/OpenBMB/ToolBench",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "ToolBench \u00e2\u20ac\u201d open benchmark with 16,000+ real-world APIs; end-to-end tool-use training and evaluation harness."
+          "notes": "ToolBench â€” open benchmark with 16,000+ real-world APIs; end-to-end tool-use training and evaluation harness."
         }
       ],
       "knownAgents": [],
@@ -4403,7 +4404,7 @@
       "id": "translate",
       "name": "Translate",
       "type": "basic",
-      "level": "0\u2605",
+      "level": "0★",
       "rarity": "common",
       "description": "Converts text from one natural language to another while preserving meaning, tone, and formatting.",
       "prerequisites": [],
@@ -4417,7 +4418,7 @@
           "source": "https://arxiv.org/abs/2207.04672",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "NLLB (No Language Left Behind) \u00e2\u20ac\u201d Meta AI paper demonstrating 200-language translation at human-level quality on FLORES-200 benchmark."
+          "notes": "NLLB (No Language Left Behind) â€” Meta AI paper demonstrating 200-language translation at human-level quality on FLORES-200 benchmark."
         }
       ],
       "knownAgents": [],
@@ -4430,7 +4431,7 @@
       "id": "translation-pipeline",
       "name": "Translation Pipeline",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Translates content end-to-end while preserving sentiment and adapting tone and register for the target audience.",
       "prerequisites": [
@@ -4446,7 +4447,7 @@
           "source": "https://arxiv.org/abs/2308.11596",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SeamlessM4T (Meta AI) \u00e2\u20ac\u201d unified speech and text translation model with tone and register control; BLEU +3.3 over NLLB on FLORES-200."
+          "notes": "SeamlessM4T (Meta AI) â€” unified speech and text translation model with tone and register control; BLEU +3.3 over NLLB on FLORES-200."
         }
       ],
       "knownAgents": [],
@@ -4459,7 +4460,7 @@
       "id": "tree-of-thought",
       "name": "Tree of Thought",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Frames problem solving as a search over a tree of partial solutions, using LLM-generated evaluations to prune unpromising branches and backtrack, dramatically improving success on complex reasoning tasks.",
       "prerequisites": [
@@ -4476,14 +4477,14 @@
           "source": "https://arxiv.org/abs/2305.10601",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Yao et al. (2023) \u00e2\u20ac\u201d Tree of Thoughts: Deliberate Problem Solving with LLMs; +74% on Game of 24 and +4% on Creative Writing vs chain-of-thought baseline."
+          "notes": "Yao et al. (2023) â€” Tree of Thoughts: Deliberate Problem Solving with LLMs; +74% on Game of 24 and +4% on Creative Writing vs chain-of-thought baseline."
         },
         {
           "class": "B",
           "source": "https://github.com/princeton-nlp/tree-of-thought-llm",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Princeton-NLP ToT repo \u00e2\u20ac\u201d reproducible breadth-first and depth-first tree search implementations with evaluation scripts for Game of 24 and Mini Crosswords."
+          "notes": "Princeton-NLP ToT repo â€” reproducible breadth-first and depth-first tree search implementations with evaluation scripts for Game of 24 and Mini Crosswords."
         }
       ],
       "knownAgents": [],
@@ -4496,7 +4497,7 @@
       "id": "ubiquitous-language",
       "name": "Ubiquitous Language",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Establishes and maintains a consistent, domain-driven vocabulary between the agent and human, formalising terminology in a shared glossary (typically CONTEXT.md) to reduce ambiguity and token waste.",
       "prerequisites": [
@@ -4526,7 +4527,7 @@
       "id": "ux-audit",
       "name": "UX Audit",
       "type": "basic",
-      "level": "0\u2605",
+      "level": "0★",
       "rarity": "uncommon",
       "description": "Systematically evaluates a user interface against established usability heuristics or accessibility standards, producing a scored finding report with remediation recommendations.",
       "prerequisites": [],
@@ -4551,7 +4552,7 @@
       "id": "vertical-slice-planning",
       "name": "Vertical Slice Planning",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Decomposes a product plan into independently-demoable vertical slices that each cut through all integration layers end-to-end. Classifies each slice as HITL (human-in-the-loop) or AFK (autonomous), identifies dependency ordering, and publishes structured issues with acceptance criteria.",
       "prerequisites": [
@@ -4579,7 +4580,7 @@
       "id": "video-intelligence",
       "name": "Video Intelligence",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "rare",
       "description": "Processes video streams by extracting frames, transcribing audio, and applying multimodal reasoning to understand temporal and visual context.",
       "prerequisites": [
@@ -4609,7 +4610,7 @@
       "id": "vision-qa",
       "name": "Visual Question Answering",
       "type": "basic",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Answers natural-language questions grounded in a specific image or screenshot by combining visual perception with language reasoning, enabling visual debugging, UI analysis, and document-image Q&A.",
       "prerequisites": [],
@@ -4621,7 +4622,7 @@
           "source": "https://arxiv.org/abs/2604.17488",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "AutoVQA-G (ICASSP 2026) \u2014 self-improving agentic framework for automated VQA and grounding annotation; uses Chain-of-Thought verification + prompt optimization to generate high-quality VQA-G datasets."
+          "notes": "AutoVQA-G (ICASSP 2026) — self-improving agentic framework for automated VQA and grounding annotation; uses Chain-of-Thought verification + prompt optimization to generate high-quality VQA-G datasets."
         },
         {
           "class": "C",
@@ -4641,7 +4642,7 @@
       "id": "voice-agent",
       "name": "Voice Agent",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Handles spoken interactions end-to-end: transcribes audio input, produces language responses, and synthesizes speech output.",
       "prerequisites": [
@@ -4659,7 +4660,7 @@
           "source": "https://github.com/rasa/rasa",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Rasa Open Source \u00e2\u20ac\u201d production voice agent framework with ASR/TTS integrations; reproducible pipeline with test suite and documented benchmarks."
+          "notes": "Rasa Open Source â€” production voice agent framework with ASR/TTS integrations; reproducible pipeline with test suite and documented benchmarks."
         }
       ],
       "knownAgents": [],
@@ -4675,7 +4676,7 @@
       "id": "web-scrape",
       "name": "Web Scrape",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Retrieves and structures data from web pages into usable entities.",
       "prerequisites": [
@@ -4684,7 +4685,8 @@
         "extract-entities"
       ],
       "derivatives": [
-        "knowledge-harvest"
+        "knowledge-harvest",
+        "x-twitter-automation"
       ],
       "conditions": "Structured output mode required.",
       "evidence": [
@@ -4706,7 +4708,7 @@
       "id": "web-search",
       "name": "Web Search",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Queries external search engines or APIs and retrieves relevant result sets.",
       "prerequisites": [],
@@ -4736,7 +4738,7 @@
       "id": "wiki-search",
       "name": "Wiki Search",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "uncommon",
       "description": "Builds, maintains, and queries an interlinked markdown or wiki-style knowledge base so an agent can retrieve durable local context across research sessions.",
       "prerequisites": [
@@ -4767,7 +4769,7 @@
       "id": "workflow-automation",
       "name": "Workflow Automation",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "uncommon",
       "description": "Designs, configures, and runs trigger-based multi-step automation pipelines that connect external services, schedule jobs, and orchestrate tool sequences without continuous human supervision.",
       "prerequisites": [
@@ -4777,7 +4779,8 @@
       ],
       "derivatives": [
         "release-automation",
-        "deployment-automation"
+        "deployment-automation",
+        "x-twitter-automation"
       ],
       "conditions": "",
       "evidence": [
@@ -4813,7 +4816,7 @@
       "id": "write-report",
       "name": "Write Report",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Produces structured, multi-section written output with headings, citations, and coherent narrative.",
       "prerequisites": [],
@@ -4837,6 +4840,37 @@
       "status": "provisional",
       "createdAt": "2026-04-26",
       "updatedAt": "2026-05-06",
+      "version": "0.1.0"
+    },
+    {
+      "id": "x-twitter-automation",
+      "name": "X/Twitter Automation",
+      "type": "extra",
+      "level": "4★",
+      "rarity": "rare",
+      "description": "Coordinates platform-specific X/Twitter search, tweet and reply retrieval, user lookup, follower export, monitoring, and approval-gated write workflows for social-media agent tasks.",
+      "prerequisites": [
+        "browser-automation",
+        "web-scrape",
+        "workflow-automation"
+      ],
+      "derivatives": [],
+      "conditions": "Requires configured X/Twitter access, repeatable read paths, and explicit approval gates before posting tweets, replies, DMs, or other write actions.",
+      "evidence": [
+        {
+          "class": "B",
+          "source": "https://github.com/Xquik-dev/hermes-tweet",
+          "evaluator": "kriptoburak",
+          "date": "2026-05-15",
+          "notes": "Hermes Tweet provides an installable Hermes Agent X/Twitter skill and plugin for searching tweets, reading replies, looking up users, monitoring tweets, exporting followers, and gating post, reply, and DM actions."
+        }
+      ],
+      "knownAgents": [
+        "Xquik-dev/hermes-tweet"
+      ],
+      "status": "provisional",
+      "createdAt": "2026-05-15",
+      "updatedAt": "2026-05-15",
       "version": "0.1.0"
     }
   ],
@@ -4914,6 +4948,11 @@
     {
       "sourceSkillId": "browser-automation",
       "targetSkillId": "stealth-browser-interaction",
+      "edgeType": "prerequisite"
+    },
+    {
+      "sourceSkillId": "browser-automation",
+      "targetSkillId": "x-twitter-automation",
       "edgeType": "prerequisite"
     },
     {
@@ -5747,6 +5786,11 @@
       "edgeType": "prerequisite"
     },
     {
+      "sourceSkillId": "web-scrape",
+      "targetSkillId": "x-twitter-automation",
+      "edgeType": "prerequisite"
+    },
+    {
       "sourceSkillId": "web-search",
       "targetSkillId": "autonomous-web-research",
       "edgeType": "prerequisite"
@@ -5784,6 +5828,11 @@
     {
       "sourceSkillId": "workflow-automation",
       "targetSkillId": "release-automation",
+      "edgeType": "prerequisite"
+    },
+    {
+      "sourceSkillId": "workflow-automation",
+      "targetSkillId": "x-twitter-automation",
       "edgeType": "prerequisite"
     },
     {

--- a/docs/graph/gaia.svg
+++ b/docs/graph/gaia.svg
@@ -13,199 +13,202 @@
 <circle cx="640.0" cy="440.0" r="54"/>
 </g>
 <g class="edges" fill="none">
-<line x1="909.884" y1="531.585" x2="721.389" y2="290.749" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="717.589" y1="714.235" x2="721.389" y2="290.749" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="604.954" y1="273.652" x2="621.922" y2="270.964" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="804.038" y1="673.059" x2="621.922" y2="270.964" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="436.354" y1="639.383" x2="566.559" y2="593.318" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="694.168" y1="160.195" x2="566.559" y2="593.318" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="565.943" y1="715.21" x2="566.559" y2="593.318" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="389.442" y1="575.815" x2="738.012" y2="301.098" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="901.083" y1="554.283" x2="738.012" y2="301.098" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="917.555" y1="504.718" x2="738.012" y2="301.098" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="798.494" y1="378.521" x2="643.534" y2="386.116" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="909.884" y1="531.585" x2="720.223" y2="290.119" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="717.589" y1="714.235" x2="720.223" y2="290.119" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="589.344" y1="277.723" x2="622.203" y2="270.934" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="804.038" y1="673.059" x2="622.203" y2="270.934" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="436.354" y1="639.383" x2="575.266" y2="597.193" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="694.168" y1="160.195" x2="575.266" y2="597.193" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="565.943" y1="715.21" x2="575.266" y2="597.193" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="389.442" y1="575.815" x2="736.673" y2="300.164" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="901.083" y1="554.283" x2="736.673" y2="300.164" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="917.555" y1="504.718" x2="736.673" y2="300.164" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="797.313" y1="375.559" x2="643.534" y2="386.116" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
 <line x1="357.193" y1="475.287" x2="643.534" y2="386.116" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="712.312" y1="593.854" x2="643.534" y2="386.116" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="924.74" y1="427.837" x2="553.809" y2="586.53" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="901.083" y1="554.283" x2="553.809" y2="586.53" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="917.555" y1="504.718" x2="553.809" y2="586.53" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="712.312" y1="593.854" x2="606.315" y2="397.794" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="491.367" y1="522.511" x2="606.315" y2="397.794" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="526.085" y1="566.188" x2="606.315" y2="397.794" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="581.451" y1="599.6" x2="535.032" y2="573.723" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="588.983" y1="720.397" x2="535.032" y2="573.723" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="588.983" y1="720.397" x2="748.095" y2="308.793" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="455.389" y1="657.126" x2="748.095" y2="308.793" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="535.032" y1="573.723" x2="760.756" y2="320.343" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="830.3" y1="227.842" x2="760.756" y2="320.343" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="661.345" y1="155.8" x2="760.756" y2="320.343" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="924.74" y1="427.837" x2="772.954" y2="334.06" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="924.827" y1="449.928" x2="772.954" y2="334.06" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="909.884" y1="531.585" x2="772.954" y2="334.06" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="644.162" y1="155.03" x2="781.292" y2="345.467" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="783.054" y1="193.503" x2="781.292" y2="345.467" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="891.742" y1="573.607" x2="781.292" y2="345.467" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="764.873" y1="183.813" x2="791.472" y2="362.823" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="355.429" y1="455.634" x2="791.472" y2="362.823" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="742.471" y1="705.941" x2="791.472" y2="362.823" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="400.053" y1="593.787" x2="798.494" y2="378.521" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="436.354" y1="639.383" x2="798.494" y2="378.521" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="830.3" y1="227.842" x2="798.494" y2="378.521" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="604.954" y1="273.652" x2="640.717" y2="270.002" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="901.083" y1="554.283" x2="640.717" y2="270.002" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="924.74" y1="427.837" x2="802.857" y2="391.239" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="588.347" y1="159.72" x2="802.857" y2="391.239" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="909.884" y1="531.585" x2="807.418" y2="410.483" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="804.038" y1="673.059" x2="807.418" y2="410.483" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="748.095" y1="308.793" x2="809.554" y2="427.691" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="862.168" y1="618.511" x2="809.554" y2="427.691" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="844.998" y1="637.992" x2="809.96" y2="443.688" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="891.742" y1="573.607" x2="809.96" y2="443.688" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="830.3" y1="227.842" x2="809.96" y2="443.688" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="694.168" y1="160.195" x2="809.96" y2="443.688" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="828.198" y1="654.025" x2="808.618" y2="461.631" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="891.742" y1="573.607" x2="808.618" y2="461.631" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="694.168" y1="160.195" x2="808.618" y2="461.631" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="748.095" y1="308.793" x2="805.331" y2="479.57" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="738.012" y1="301.098" x2="805.331" y2="479.57" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="772.954" y1="334.06" x2="693.968" y2="441.868" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="738.012" y1="301.098" x2="693.968" y2="441.868" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="718.741" y1="590.664" x2="643.534" y2="386.116" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="924.74" y1="427.837" x2="562.356" y2="591.233" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="901.083" y1="554.283" x2="562.356" y2="591.233" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="917.555" y1="504.718" x2="562.356" y2="591.233" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="718.741" y1="590.664" x2="606.315" y2="397.794" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="497.106" y1="532.093" x2="606.315" y2="397.794" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="533.931" y1="572.851" x2="606.315" y2="397.794" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="590.245" y1="602.556" x2="543.168" y2="579.726" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="588.983" y1="720.397" x2="543.168" y2="579.726" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="588.983" y1="720.397" x2="746.676" y2="307.636" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="455.389" y1="657.126" x2="746.676" y2="307.636" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="543.168" y1="579.726" x2="759.27" y2="318.861" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="830.3" y1="227.842" x2="759.27" y2="318.861" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="661.345" y1="155.8" x2="759.27" y2="318.861" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="924.74" y1="427.837" x2="771.455" y2="332.205" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="924.827" y1="449.928" x2="771.455" y2="332.205" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="909.884" y1="531.585" x2="771.455" y2="332.205" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="644.162" y1="155.03" x2="779.826" y2="343.312" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="783.054" y1="193.503" x2="779.826" y2="343.312" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="891.742" y1="573.607" x2="779.826" y2="343.312" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="764.873" y1="183.813" x2="790.124" y2="360.232" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="355.429" y1="455.634" x2="790.124" y2="360.232" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="742.471" y1="705.941" x2="790.124" y2="360.232" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="400.053" y1="593.787" x2="797.313" y2="375.559" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="436.354" y1="639.383" x2="797.313" y2="375.559" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="830.3" y1="227.842" x2="797.313" y2="375.559" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="589.344" y1="277.723" x2="640.706" y2="270.001" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="901.083" y1="554.283" x2="640.706" y2="270.001" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="924.74" y1="427.837" x2="801.849" y2="387.992" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="588.347" y1="159.72" x2="801.849" y2="387.992" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="909.884" y1="531.585" x2="806.734" y2="406.838" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="804.038" y1="673.059" x2="806.734" y2="406.838" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="746.676" y1="307.636" x2="809.219" y2="423.725" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="862.168" y1="618.511" x2="809.219" y2="423.725" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="844.998" y1="637.992" x2="809.999" y2="439.458" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="891.742" y1="573.607" x2="809.999" y2="439.458" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="830.3" y1="227.842" x2="809.999" y2="439.458" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="694.168" y1="160.195" x2="809.999" y2="439.458" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="828.198" y1="654.025" x2="809.133" y2="457.15" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="891.742" y1="573.607" x2="809.133" y2="457.15" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="694.168" y1="160.195" x2="809.133" y2="457.15" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="746.676" y1="307.636" x2="806.381" y2="474.89" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="736.673" y1="300.164" x2="806.381" y2="474.89" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="771.455" y1="332.205" x2="693.968" y2="441.868" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="736.673" y1="300.164" x2="693.968" y2="441.868" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
 <line x1="367.721" y1="355.804" x2="693.968" y2="441.868" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="665.248" y1="723.879" x2="800.375" y2="496.391" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="539.661" y1="706.753" x2="800.375" y2="496.391" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="637.454" y1="724.989" x2="800.375" y2="496.391" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="760.447" y1="698.297" x2="657.208" y2="270.873" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="922.074" y1="399.267" x2="657.208" y2="270.873" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="909.884" y1="531.585" x2="657.208" y2="270.873" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="657.208" y1="270.873" x2="794.081" y2="511.826" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="488.149" y1="363.572" x2="794.081" y2="511.826" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="414.799" y1="614.67" x2="794.081" y2="511.826" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="618.297" y1="155.828" x2="674.224" y2="273.481" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="760.447" y1="698.297" x2="674.224" y2="273.481" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="712.312" y1="593.854" x2="526.085" y2="566.188" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="565.943" y1="715.21" x2="526.085" y2="566.188" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="902.028" y1="327.901" x2="526.085" y2="566.188" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="807.418" y1="410.483" x2="512.657" y2="552.623" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="690.107" y1="720.561" x2="512.657" y2="552.623" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="512.657" y1="552.623" x2="673.417" y2="482.418" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="574.996" y1="282.919" x2="673.417" y2="482.418" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="665.248" y1="723.879" x2="801.985" y2="491.584" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="539.661" y1="706.753" x2="801.985" y2="491.584" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="637.454" y1="724.989" x2="801.985" y2="491.584" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="760.447" y1="698.297" x2="656.94" y2="270.846" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="922.074" y1="399.267" x2="656.94" y2="270.846" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="909.884" y1="531.585" x2="656.94" y2="270.846" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="656.94" y1="270.846" x2="796.258" y2="506.959" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="482.468" y1="376.096" x2="796.258" y2="506.959" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="414.799" y1="614.67" x2="796.258" y2="506.959" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="618.297" y1="155.828" x2="673.697" y2="273.373" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="760.447" y1="698.297" x2="673.697" y2="273.373" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="718.741" y1="590.664" x2="533.931" y2="572.851" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="565.943" y1="715.21" x2="533.931" y2="572.851" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="902.028" y1="327.901" x2="533.931" y2="572.851" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="806.734" y1="406.838" x2="519.918" y2="560.334" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="690.107" y1="720.561" x2="519.918" y2="560.334" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="519.918" y1="560.334" x2="673.417" y2="482.418" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="560.833" y1="289.559" x2="673.417" y2="482.418" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
 <line x1="661.345" y1="155.8" x2="673.417" y2="482.418" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="760.447" y1="698.297" x2="786.21" y2="526.734" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="922.074" y1="399.267" x2="786.21" y2="526.734" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="909.884" y1="531.585" x2="786.21" y2="526.734" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="909.884" y1="531.585" x2="776.536" y2="541.282" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="644.162" y1="155.03" x2="776.536" y2="541.282" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="665.248" y1="723.879" x2="776.536" y2="541.282" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="661.345" y1="155.8" x2="500.436" y2="537.067" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="902.028" y1="327.901" x2="500.436" y2="537.067" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="694.168" y1="160.195" x2="500.436" y2="537.067" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="891.742" y1="573.607" x2="765.997" y2="554.126" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="877.732" y1="597.189" x2="765.997" y2="554.126" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="581.451" y1="599.6" x2="491.367" y2="522.511" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="891.742" y1="573.607" x2="491.367" y2="522.511" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="922.22" y1="479.711" x2="491.367" y2="522.511" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="712.312" y1="593.854" x2="486.045" y2="512.095" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="922.074" y1="399.267" x2="486.045" y2="512.095" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="830.3" y1="227.842" x2="486.045" y2="512.095" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="518.455" y1="182.218" x2="478.402" y2="492.784" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="367.721" y1="355.804" x2="478.402" y2="492.784" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="518.455" y1="182.218" x2="474.109" y2="477.152" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="544.268" y1="299.518" x2="474.109" y2="477.152" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="539.661" y1="706.753" x2="474.109" y2="477.152" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="798.494" y1="378.521" x2="471.072" y2="459.061" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="738.012" y1="301.098" x2="471.072" y2="459.061" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="924.74" y1="427.837" x2="471.072" y2="459.061" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="690.107" y1="720.561" x2="470.015" y2="442.277" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="909.884" y1="531.585" x2="470.015" y2="442.277" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="912.117" y1="355.281" x2="470.015" y2="442.277" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="472.798" y1="409.282" x2="638.474" y2="493.978" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="760.447" y1="698.297" x2="788.984" y2="521.876" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="922.074" y1="399.267" x2="788.984" y2="521.876" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="909.884" y1="531.585" x2="788.984" y2="521.876" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="909.884" y1="531.585" x2="779.95" y2="536.51" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="644.162" y1="155.03" x2="779.95" y2="536.51" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="665.248" y1="723.879" x2="779.95" y2="536.51" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="661.345" y1="155.8" x2="506.944" y2="545.812" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="902.028" y1="327.901" x2="506.944" y2="545.812" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="694.168" y1="160.195" x2="506.944" y2="545.812" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="891.742" y1="573.607" x2="770.028" y2="549.512" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="877.732" y1="597.189" x2="770.028" y2="549.512" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="590.245" y1="602.556" x2="497.106" y2="532.093" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="891.742" y1="573.607" x2="497.106" y2="532.093" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="922.22" y1="479.711" x2="497.106" y2="532.093" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="718.741" y1="590.664" x2="491.199" y2="522.209" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="922.074" y1="399.267" x2="491.199" y2="522.209" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="830.3" y1="227.842" x2="491.199" y2="522.209" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="518.455" y1="182.218" x2="482.407" y2="503.752" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="367.721" y1="355.804" x2="482.407" y2="503.752" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="518.455" y1="182.218" x2="477.123" y2="488.695" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="532.183" y1="308.564" x2="477.123" y2="488.695" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="539.661" y1="706.753" x2="477.123" y2="488.695" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="797.313" y1="375.559" x2="472.877" y2="471.143" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="736.673" y1="300.164" x2="472.877" y2="471.143" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="924.74" y1="427.837" x2="472.877" y2="471.143" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="690.107" y1="720.561" x2="470.64" y2="454.741" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="909.884" y1="531.585" x2="470.64" y2="454.741" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="912.117" y1="355.281" x2="470.64" y2="454.741" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="470.94" y1="422.145" x2="638.474" y2="493.978" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
 <line x1="742.471" y1="705.941" x2="638.474" y2="493.978" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
 <line x1="637.454" y1="724.989" x2="638.474" y2="493.978" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="369.274" y1="529.064" x2="754.096" y2="566.024" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="764.873" y1="183.813" x2="754.096" y2="566.024" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="877.732" y1="597.189" x2="754.096" y2="566.024" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="742.471" y1="705.941" x2="472.798" y2="409.282" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="804.038" y1="673.059" x2="472.798" y2="409.282" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="637.454" y1="724.989" x2="472.798" y2="409.282" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="565.943" y1="715.21" x2="470.303" y2="429.858" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="804.038" y1="673.059" x2="470.303" y2="429.858" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="798.494" y1="378.521" x2="476.035" y2="395.107" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="588.983" y1="720.397" x2="476.035" y2="395.107" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="560.132" y1="166.42" x2="476.035" y2="395.107" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="909.884" y1="531.585" x2="481.79" y2="377.795" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="739.835" y1="173.058" x2="481.79" y2="377.795" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="760.447" y1="698.297" x2="744.776" y2="573.873" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="916.93" y1="372.661" x2="744.776" y2="573.873" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="922.22" y1="479.711" x2="744.776" y2="573.873" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="717.589" y1="714.235" x2="744.776" y2="573.873" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="865.129" y1="265.238" x2="744.776" y2="573.873" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="789.474" y1="682.657" x2="744.776" y2="573.873" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="804.038" y1="673.059" x2="726.237" y2="586.503" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="613.08" y1="723.726" x2="726.237" y2="586.503" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="597.282" y1="604.545" x2="603.051" y2="479.38" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="369.274" y1="529.064" x2="758.752" y2="561.647" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="764.873" y1="183.813" x2="758.752" y2="561.647" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="877.732" y1="597.189" x2="758.752" y2="561.647" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="742.471" y1="705.941" x2="470.94" y2="422.145" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="804.038" y1="673.059" x2="470.94" y2="422.145" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="637.454" y1="724.989" x2="470.94" y2="422.145" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="565.943" y1="715.21" x2="470.019" y2="442.528" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="804.038" y1="673.059" x2="470.019" y2="442.528" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="797.313" y1="375.559" x2="473.041" y2="407.988" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="588.983" y1="720.397" x2="473.041" y2="407.988" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="560.132" y1="166.42" x2="473.041" y2="407.988" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="909.884" y1="531.585" x2="477.35" y2="390.553" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="739.835" y1="173.058" x2="477.35" y2="390.553" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="760.447" y1="698.297" x2="749.879" y2="569.718" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="916.93" y1="372.661" x2="749.879" y2="569.718" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="922.22" y1="479.711" x2="749.879" y2="569.718" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="717.589" y1="714.235" x2="749.879" y2="569.718" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="865.129" y1="265.238" x2="749.879" y2="569.718" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="789.474" y1="682.657" x2="749.879" y2="569.718" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="804.038" y1="673.059" x2="732.138" y2="582.866" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="613.08" y1="723.726" x2="732.138" y2="582.866" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="606.068" y1="606.579" x2="603.051" y2="479.38" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
 <line x1="355.429" y1="455.634" x2="603.051" y2="479.38" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="472.798" y1="409.282" x2="603.051" y2="479.38" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="553.809" y1="586.53" x2="586.19" y2="435.472" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="470.94" y1="422.145" x2="603.051" y2="479.38" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="562.356" y1="591.233" x2="586.19" y2="435.472" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
 <line x1="909.884" y1="531.585" x2="586.19" y2="435.472" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="472.798" y1="409.282" x2="586.19" y2="435.472" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="712.312" y1="593.854" x2="488.149" y2="363.572" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="924.74" y1="427.837" x2="488.149" y2="363.572" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="901.083" y1="554.283" x2="488.149" y2="363.572" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="604.954" y1="273.652" x2="687.569" y2="276.791" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="901.083" y1="554.283" x2="687.569" y2="276.791" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="739.835" y1="173.058" x2="687.569" y2="276.791" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="588.983" y1="720.397" x2="712.312" y2="593.854" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="830.3" y1="227.842" x2="712.312" y2="593.854" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="922.074" y1="399.267" x2="712.312" y2="593.854" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="470.94" y1="422.145" x2="586.19" y2="435.472" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="718.741" y1="590.664" x2="482.468" y2="376.096" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="924.74" y1="427.837" x2="482.468" y2="376.096" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="901.083" y1="554.283" x2="482.468" y2="376.096" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="589.344" y1="277.723" x2="686.845" y2="276.582" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="901.083" y1="554.283" x2="686.845" y2="276.582" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="739.835" y1="173.058" x2="686.845" y2="276.582" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="588.983" y1="720.397" x2="718.741" y2="590.664" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="830.3" y1="227.842" x2="718.741" y2="590.664" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="922.074" y1="399.267" x2="718.741" y2="590.664" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
 <line x1="377.27" y1="550.445" x2="674.585" y2="398.529" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="712.312" y1="593.854" x2="674.585" y2="398.529" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="718.741" y1="590.664" x2="674.585" y2="398.529" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
 <line x1="357.193" y1="475.287" x2="674.585" y2="398.529" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="565.943" y1="715.21" x2="696.263" y2="600.42" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="922.074" y1="399.267" x2="696.263" y2="600.42" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="419.86" y1="258.994" x2="696.263" y2="600.42" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="772.954" y1="334.06" x2="708.464" y2="284.396" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="909.884" y1="531.585" x2="708.464" y2="284.396" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="739.835" y1="173.058" x2="497.719" y2="346.961" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="665.248" y1="723.879" x2="497.719" y2="346.961" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="924.74" y1="427.837" x2="497.719" y2="346.961" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="721.389" y1="290.749" x2="507.713" y2="333.229" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="810.048" y1="211.289" x2="507.713" y2="333.229" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="560.132" y1="166.42" x2="507.713" y2="333.229" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="708.464" y1="284.396" x2="516.446" y2="323.234" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="539.837" y1="173.181" x2="516.446" y2="323.234" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="810.048" y1="211.289" x2="516.446" y2="323.234" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="748.095" y1="308.793" x2="530.952" y2="309.583" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="455.389" y1="657.126" x2="530.952" y2="309.583" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="400.053" y1="593.787" x2="683.588" y2="604.317" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="844.998" y1="637.992" x2="683.588" y2="604.317" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="694.168" y1="160.195" x2="683.588" y2="604.317" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="613.08" y1="723.726" x2="666.434" y2="607.932" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="637.454" y1="724.989" x2="666.434" y2="607.932" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="924.74" y1="427.837" x2="544.268" y2="299.518" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="613.08" y1="723.726" x2="544.268" y2="299.518" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="879.461" y1="285.457" x2="646.497" y2="609.876" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="783.054" y1="193.503" x2="646.497" y2="609.876" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="902.028" y1="327.901" x2="646.497" y2="609.876" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="912.117" y1="355.281" x2="557.64" y2="291.283" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="804.038" y1="673.059" x2="557.64" y2="291.283" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="891.742" y1="573.607" x2="574.996" y2="282.919" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="377.965" y1="327.918" x2="574.996" y2="282.919" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="804.038" y1="673.059" x2="629.105" y2="609.651" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="742.471" y1="705.941" x2="629.105" y2="609.651" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="754.096" y1="566.024" x2="613.807" y2="607.97" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="434.379" y1="242.655" x2="613.807" y2="607.97" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="434.379" y1="242.655" x2="597.282" y2="604.545" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="764.873" y1="183.813" x2="597.282" y2="604.545" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="452.166" y1="225.656" x2="597.282" y2="604.545" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="588.983" y1="720.397" x2="581.451" y2="599.6" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="862.168" y1="618.511" x2="581.451" y2="599.6" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="891.742" y1="573.607" x2="581.451" y2="599.6" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="760.447" y1="698.297" x2="590.731" y2="277.296" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="922.22" y1="479.711" x2="590.731" y2="277.296" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="830.3" y1="227.842" x2="590.731" y2="277.296" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="804.038" y1="673.059" x2="604.954" y2="273.652" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="613.08" y1="723.726" x2="604.954" y2="273.652" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="539.661" y1="706.753" x2="604.954" y2="273.652" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="565.943" y1="715.21" x2="703.236" y2="597.801" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="922.074" y1="399.267" x2="703.236" y2="597.801" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="419.86" y1="258.994" x2="703.236" y2="597.801" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="771.455" y1="332.205" x2="707.455" y2="283.955" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="909.884" y1="531.585" x2="707.455" y2="283.955" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="739.835" y1="173.058" x2="490.522" y2="359.029" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="665.248" y1="723.879" x2="490.522" y2="359.029" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="924.74" y1="427.837" x2="490.522" y2="359.029" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="720.223" y1="290.119" x2="499.198" y2="344.739" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="810.048" y1="211.289" x2="499.198" y2="344.739" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="560.132" y1="166.42" x2="499.198" y2="344.739" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="707.455" y1="283.955" x2="506.93" y2="334.206" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="539.837" y1="173.181" x2="506.93" y2="334.206" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="810.048" y1="211.289" x2="506.93" y2="334.206" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="746.676" y1="307.636" x2="519.997" y2="319.587" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="455.389" y1="657.126" x2="519.997" y2="319.587" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="400.053" y1="593.787" x2="690.941" y2="602.188" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="844.998" y1="637.992" x2="690.941" y2="602.188" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="694.168" y1="160.195" x2="690.941" y2="602.188" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="613.08" y1="723.726" x2="674.236" y2="606.517" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="637.454" y1="724.989" x2="674.236" y2="606.517" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="924.74" y1="427.837" x2="532.183" y2="308.564" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="613.08" y1="723.726" x2="532.183" y2="308.564" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="879.461" y1="285.457" x2="654.723" y2="609.361" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="783.054" y1="193.503" x2="654.723" y2="609.361" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="902.028" y1="327.901" x2="654.723" y2="609.361" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="912.117" y1="355.281" x2="544.569" y2="299.313" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="804.038" y1="673.059" x2="544.569" y2="299.313" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="891.742" y1="573.607" x2="560.833" y2="289.559" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="377.965" y1="327.918" x2="560.833" y2="289.559" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="804.038" y1="673.059" x2="637.613" y2="609.983" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="742.471" y1="705.941" x2="637.613" y2="609.983" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="758.752" y1="561.647" x2="622.489" y2="609.096" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="434.379" y1="242.655" x2="622.489" y2="609.096" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="434.379" y1="242.655" x2="606.068" y2="606.579" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="764.873" y1="183.813" x2="606.068" y2="606.579" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="452.166" y1="225.656" x2="606.068" y2="606.579" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="588.983" y1="720.397" x2="590.245" y2="602.556" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="862.168" y1="618.511" x2="590.245" y2="602.556" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="891.742" y1="573.607" x2="590.245" y2="602.556" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="760.447" y1="698.297" x2="575.743" y2="282.612" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="922.22" y1="479.711" x2="575.743" y2="282.612" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="830.3" y1="227.842" x2="575.743" y2="282.612" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="804.038" y1="673.059" x2="589.344" y2="277.723" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="613.08" y1="723.726" x2="589.344" y2="277.723" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="539.661" y1="706.753" x2="589.344" y2="277.723" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="746.676" y1="307.636" x2="605.741" y2="273.488" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="590.245" y1="602.556" x2="605.741" y2="273.488" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="589.344" y1="277.723" x2="605.741" y2="273.488" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
 </g>
 <g class="nodes" filter="url(#glow)">
 <circle cx="539.661" cy="706.753" r="6" fill="#38bdf8" stroke="#7dd3fc" stroke-width="1.6"><title>API Call</title></circle>
@@ -278,69 +281,70 @@
 <circle cx="588.347" cy="159.72" r="6" fill="#38bdf8" stroke="#7dd3fc" stroke-width="1.6"><title>Visual Question Answering</title></circle>
 <circle cx="588.983" cy="720.397" r="6" fill="#38bdf8" stroke="#7dd3fc" stroke-width="1.6"><title>Web Search</title></circle>
 <circle cx="565.943" cy="715.21" r="6" fill="#38bdf8" stroke="#7dd3fc" stroke-width="1.6"><title>Write Report</title></circle>
-<circle cx="721.389" cy="290.749" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Agent Evaluation</title></circle>
-<circle cx="621.922" cy="270.964" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Agentic Workflow Design</title></circle>
-<circle cx="566.559" cy="593.318" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Architecture Diagram</title></circle>
-<circle cx="738.012" cy="301.098" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Automated Testing</title></circle>
-<circle cx="553.809" cy="586.53" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Autonomous Debug</title></circle>
-<circle cx="535.032" cy="573.723" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Autonomous Web Research</title></circle>
-<circle cx="748.095" cy="308.793" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Browser Automation</title></circle>
-<circle cx="760.756" cy="320.343" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Career Operations</title></circle>
-<circle cx="772.954" cy="334.06" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Code Review Pipeline</title></circle>
-<circle cx="781.292" cy="345.467" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Content Moderation</title></circle>
-<circle cx="791.472" cy="362.823" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Conversational Agent</title></circle>
-<circle cx="798.494" cy="378.521" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Data Analysis</title></circle>
-<circle cx="640.717" cy="270.002" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Deployment Automation</title></circle>
-<circle cx="802.857" cy="391.239" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Design Generation</title></circle>
-<circle cx="807.418" cy="410.483" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Design Review</title></circle>
-<circle cx="809.554" cy="427.691" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Design System Extraction</title></circle>
-<circle cx="809.96" cy="443.688" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Document Analyst</title></circle>
-<circle cx="808.618" cy="461.631" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Document Digitization</title></circle>
-<circle cx="805.331" cy="479.57" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>End-to-End Testing</title></circle>
-<circle cx="800.375" cy="496.391" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Function Calling</title></circle>
-<circle cx="657.208" cy="270.873" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Gaia Audit</title></circle>
-<circle cx="794.081" cy="511.826" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Gaia Meta Audit</title></circle>
-<circle cx="674.224" cy="273.481" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Gaia Triage</title></circle>
-<circle cx="526.085" cy="566.188" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Ghostwrite</title></circle>
-<circle cx="512.657" cy="552.623" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Grill Me</title></circle>
-<circle cx="786.21" cy="526.734" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Grounding</title></circle>
-<circle cx="776.536" cy="541.282" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Guardrails</title></circle>
-<circle cx="500.436" cy="537.067" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Humanize Prose</title></circle>
-<circle cx="765.997" cy="554.126" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Knowledge Graph Construction</title></circle>
-<circle cx="491.367" cy="522.511" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Knowledge Harvest</title></circle>
-<circle cx="486.045" cy="512.095" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Literature Review</title></circle>
-<circle cx="478.402" cy="492.784" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>MCP Debugger Control</title></circle>
-<circle cx="474.109" cy="477.152" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>MCP Server Creation</title></circle>
-<circle cx="471.072" cy="459.061" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>ML Pipeline</title></circle>
-<circle cx="470.015" cy="442.277" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Multi-Agent Debate</title></circle>
-<circle cx="754.096" cy="566.024" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Multimodal Reasoning</title></circle>
-<circle cx="470.303" cy="429.858" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>PRD Generation</title></circle>
-<circle cx="472.798" cy="409.282" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Plan and Execute</title></circle>
-<circle cx="476.035" cy="395.107" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Prediction Market Analysis</title></circle>
-<circle cx="481.79" cy="377.795" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Prompt Optimization</title></circle>
-<circle cx="744.776" cy="573.873" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>RAG Pipeline</title></circle>
-<circle cx="726.237" cy="586.503" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>ReAct Reasoning</title></circle>
-<circle cx="488.149" cy="363.572" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Registry Curation</title></circle>
-<circle cx="687.569" cy="276.791" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Release Automation</title></circle>
-<circle cx="712.312" cy="593.854" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Research</title></circle>
-<circle cx="696.263" cy="600.42" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Scientific Writing</title></circle>
-<circle cx="708.464" cy="284.396" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Security Audit</title></circle>
-<circle cx="497.719" cy="346.961" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Skill Authoring</title></circle>
-<circle cx="507.713" cy="333.229" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Skill Performance Benchmarking</title></circle>
-<circle cx="516.446" cy="323.234" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Skill Security Analysis</title></circle>
-<circle cx="530.952" cy="309.583" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Stealth Browser Interaction</title></circle>
-<circle cx="683.588" cy="604.317" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Text-to-SQL Pipeline</title></circle>
-<circle cx="666.434" cy="607.932" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Tool Chaining</title></circle>
-<circle cx="544.268" cy="299.518" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Tool Creation</title></circle>
-<circle cx="646.497" cy="609.876" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Translation Pipeline</title></circle>
-<circle cx="557.64" cy="291.283" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Tree of Thought</title></circle>
-<circle cx="574.996" cy="282.919" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Ubiquitous Language</title></circle>
-<circle cx="629.105" cy="609.651" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Vertical Slice Planning</title></circle>
-<circle cx="613.807" cy="607.97" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Video Intelligence</title></circle>
-<circle cx="597.282" cy="604.545" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Voice Agent</title></circle>
-<circle cx="581.451" cy="599.6" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Web Scrape</title></circle>
-<circle cx="590.731" cy="277.296" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Wiki Search</title></circle>
-<circle cx="604.954" cy="273.652" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Workflow Automation</title></circle>
+<circle cx="720.223" cy="290.119" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Agent Evaluation</title></circle>
+<circle cx="622.203" cy="270.934" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Agentic Workflow Design</title></circle>
+<circle cx="575.266" cy="597.193" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Architecture Diagram</title></circle>
+<circle cx="736.673" cy="300.164" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Automated Testing</title></circle>
+<circle cx="562.356" cy="591.233" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Autonomous Debug</title></circle>
+<circle cx="543.168" cy="579.726" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Autonomous Web Research</title></circle>
+<circle cx="746.676" cy="307.636" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Browser Automation</title></circle>
+<circle cx="759.27" cy="318.861" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Career Operations</title></circle>
+<circle cx="771.455" cy="332.205" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Code Review Pipeline</title></circle>
+<circle cx="779.826" cy="343.312" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Content Moderation</title></circle>
+<circle cx="790.124" cy="360.232" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Conversational Agent</title></circle>
+<circle cx="797.313" cy="375.559" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Data Analysis</title></circle>
+<circle cx="640.706" cy="270.001" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Deployment Automation</title></circle>
+<circle cx="801.849" cy="387.992" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Design Generation</title></circle>
+<circle cx="806.734" cy="406.838" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Design Review</title></circle>
+<circle cx="809.219" cy="423.725" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Design System Extraction</title></circle>
+<circle cx="809.999" cy="439.458" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Document Analyst</title></circle>
+<circle cx="809.133" cy="457.15" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Document Digitization</title></circle>
+<circle cx="806.381" cy="474.89" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>End-to-End Testing</title></circle>
+<circle cx="801.985" cy="491.584" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Function Calling</title></circle>
+<circle cx="656.94" cy="270.846" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Gaia Audit</title></circle>
+<circle cx="796.258" cy="506.959" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Gaia Meta Audit</title></circle>
+<circle cx="673.697" cy="273.373" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Gaia Triage</title></circle>
+<circle cx="533.931" cy="572.851" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Ghostwrite</title></circle>
+<circle cx="519.918" cy="560.334" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Grill Me</title></circle>
+<circle cx="788.984" cy="521.876" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Grounding</title></circle>
+<circle cx="779.95" cy="536.51" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Guardrails</title></circle>
+<circle cx="506.944" cy="545.812" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Humanize Prose</title></circle>
+<circle cx="770.028" cy="549.512" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Knowledge Graph Construction</title></circle>
+<circle cx="497.106" cy="532.093" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Knowledge Harvest</title></circle>
+<circle cx="491.199" cy="522.209" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Literature Review</title></circle>
+<circle cx="482.407" cy="503.752" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>MCP Debugger Control</title></circle>
+<circle cx="477.123" cy="488.695" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>MCP Server Creation</title></circle>
+<circle cx="472.877" cy="471.143" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>ML Pipeline</title></circle>
+<circle cx="470.64" cy="454.741" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Multi-Agent Debate</title></circle>
+<circle cx="758.752" cy="561.647" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Multimodal Reasoning</title></circle>
+<circle cx="470.019" cy="442.528" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>PRD Generation</title></circle>
+<circle cx="470.94" cy="422.145" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Plan and Execute</title></circle>
+<circle cx="473.041" cy="407.988" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Prediction Market Analysis</title></circle>
+<circle cx="477.35" cy="390.553" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Prompt Optimization</title></circle>
+<circle cx="749.879" cy="569.718" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>RAG Pipeline</title></circle>
+<circle cx="732.138" cy="582.866" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>ReAct Reasoning</title></circle>
+<circle cx="482.468" cy="376.096" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Registry Curation</title></circle>
+<circle cx="686.845" cy="276.582" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Release Automation</title></circle>
+<circle cx="718.741" cy="590.664" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Research</title></circle>
+<circle cx="703.236" cy="597.801" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Scientific Writing</title></circle>
+<circle cx="707.455" cy="283.955" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Security Audit</title></circle>
+<circle cx="490.522" cy="359.029" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Skill Authoring</title></circle>
+<circle cx="499.198" cy="344.739" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Skill Performance Benchmarking</title></circle>
+<circle cx="506.93" cy="334.206" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Skill Security Analysis</title></circle>
+<circle cx="519.997" cy="319.587" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Stealth Browser Interaction</title></circle>
+<circle cx="690.941" cy="602.188" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Text-to-SQL Pipeline</title></circle>
+<circle cx="674.236" cy="606.517" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Tool Chaining</title></circle>
+<circle cx="532.183" cy="308.564" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Tool Creation</title></circle>
+<circle cx="654.723" cy="609.361" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Translation Pipeline</title></circle>
+<circle cx="544.569" cy="299.313" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Tree of Thought</title></circle>
+<circle cx="560.833" cy="289.559" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Ubiquitous Language</title></circle>
+<circle cx="637.613" cy="609.983" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Vertical Slice Planning</title></circle>
+<circle cx="622.489" cy="609.096" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Video Intelligence</title></circle>
+<circle cx="606.068" cy="606.579" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Voice Agent</title></circle>
+<circle cx="590.245" cy="602.556" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Web Scrape</title></circle>
+<circle cx="575.743" cy="282.612" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Wiki Search</title></circle>
+<circle cx="589.344" cy="277.723" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Workflow Automation</title></circle>
+<circle cx="605.741" cy="273.488" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>X/Twitter Automation</title></circle>
 <circle cx="651.074" cy="328.549" r="13" fill="#7c3aed" stroke="#a78bfa" stroke-width="1.6"><title>Feed Monitoring</title></circle>
 <circle cx="748.688" cy="412.964" r="13" fill="#7c3aed" stroke="#a78bfa" stroke-width="1.6"><title>Few-Shot Learning</title></circle>
 <circle cx="702.245" cy="533.11" r="13" fill="#7c3aed" stroke="#a78bfa" stroke-width="1.6"><title>Fine-Tune</title></circle>
@@ -372,69 +376,70 @@
 <text x="810.048" y="198.3" fill="#38bdf8" font-size="10" font-weight="600" opacity="0.92">Skill Discovery</text>
 <text x="613.08" y="710.7" fill="#38bdf8" font-size="10" font-weight="600" opacity="0.92">Tool Use</text>
 <text x="565.943" y="702.2" fill="#38bdf8" font-size="10" font-weight="600" opacity="0.92">Write Report</text>
-<text x="721.389" y="273.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Agent Evaluation</text>
-<text x="621.922" y="254.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Agentic Workflow Design</text>
-<text x="566.559" y="576.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Architecture Diagram</text>
-<text x="738.012" y="284.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Automated Testing</text>
-<text x="553.809" y="569.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Autonomous Debug</text>
-<text x="535.032" y="556.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Autonomous Web Research</text>
-<text x="748.095" y="291.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Browser Automation</text>
-<text x="760.756" y="303.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Career Operations</text>
-<text x="772.954" y="317.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Code Review Pipeline</text>
-<text x="781.292" y="328.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Content Moderation</text>
-<text x="791.472" y="345.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Conversational Agent</text>
-<text x="798.494" y="361.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Data Analysis</text>
-<text x="640.717" y="253.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Deployment Automation</text>
-<text x="802.857" y="374.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Design Generation</text>
-<text x="807.418" y="393.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Design Review</text>
-<text x="809.554" y="410.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Design System Extraction</text>
-<text x="809.96" y="426.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Document Analyst</text>
-<text x="808.618" y="444.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Document Digitization</text>
-<text x="805.331" y="462.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">End-to-End Testing</text>
-<text x="800.375" y="479.4" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Function Calling</text>
-<text x="657.208" y="253.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Gaia Audit</text>
-<text x="794.081" y="494.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Gaia Meta Audit</text>
-<text x="674.224" y="256.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Gaia Triage</text>
-<text x="526.085" y="549.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Ghostwrite</text>
-<text x="512.657" y="535.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Grill Me</text>
-<text x="786.21" y="509.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Grounding</text>
-<text x="776.536" y="524.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Guardrails</text>
-<text x="500.436" y="520.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Humanize Prose</text>
-<text x="765.997" y="537.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Knowledge Graph Construction</text>
-<text x="491.367" y="505.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Knowledge Harvest</text>
-<text x="486.045" y="495.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Literature Review</text>
-<text x="478.402" y="475.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">MCP Debugger Control</text>
-<text x="474.109" y="460.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">MCP Server Creation</text>
-<text x="471.072" y="442.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">ML Pipeline</text>
-<text x="470.015" y="425.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Multi-Agent Debate</text>
-<text x="754.096" y="549.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Multimodal Reasoning</text>
-<text x="470.303" y="412.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">PRD Generation</text>
-<text x="472.798" y="392.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Plan and Execute</text>
-<text x="476.035" y="378.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Prediction Market Analysis</text>
-<text x="481.79" y="360.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Prompt Optimization</text>
-<text x="744.776" y="556.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">RAG Pipeline</text>
-<text x="726.237" y="569.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">ReAct Reasoning</text>
-<text x="488.149" y="346.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Registry Curation</text>
-<text x="687.569" y="259.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Release Automation</text>
-<text x="712.312" y="576.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Research</text>
-<text x="696.263" y="583.4" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Scientific Writing</text>
-<text x="708.464" y="267.4" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Security Audit</text>
-<text x="497.719" y="330.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Skill Authoring</text>
-<text x="507.713" y="316.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Skill Performance Benchmarking</text>
-<text x="516.446" y="306.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Skill Security Analysis</text>
-<text x="530.952" y="292.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Stealth Browser Interaction</text>
-<text x="683.588" y="587.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Text-to-SQL Pipeline</text>
-<text x="666.434" y="590.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Tool Chaining</text>
-<text x="544.268" y="282.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Tool Creation</text>
-<text x="646.497" y="592.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Translation Pipeline</text>
-<text x="557.64" y="274.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Tree of Thought</text>
-<text x="574.996" y="265.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Ubiquitous Language</text>
-<text x="629.105" y="592.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Vertical Slice Planning</text>
-<text x="613.807" y="591.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Video Intelligence</text>
-<text x="597.282" y="587.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Voice Agent</text>
-<text x="581.451" y="582.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Web Scrape</text>
-<text x="590.731" y="260.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Wiki Search</text>
-<text x="604.954" y="256.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Workflow Automation</text>
+<text x="720.223" y="273.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Agent Evaluation</text>
+<text x="622.203" y="253.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Agentic Workflow Design</text>
+<text x="575.266" y="580.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Architecture Diagram</text>
+<text x="736.673" y="283.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Automated Testing</text>
+<text x="562.356" y="574.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Autonomous Debug</text>
+<text x="543.168" y="562.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Autonomous Web Research</text>
+<text x="746.676" y="290.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Browser Automation</text>
+<text x="759.27" y="301.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Career Operations</text>
+<text x="771.455" y="315.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Code Review Pipeline</text>
+<text x="779.826" y="326.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Content Moderation</text>
+<text x="790.124" y="343.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Conversational Agent</text>
+<text x="797.313" y="358.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Data Analysis</text>
+<text x="640.706" y="253.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Deployment Automation</text>
+<text x="801.849" y="371.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Design Generation</text>
+<text x="806.734" y="389.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Design Review</text>
+<text x="809.219" y="406.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Design System Extraction</text>
+<text x="809.999" y="422.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Document Analyst</text>
+<text x="809.133" y="440.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Document Digitization</text>
+<text x="806.381" y="457.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">End-to-End Testing</text>
+<text x="801.985" y="474.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Function Calling</text>
+<text x="656.94" y="253.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Gaia Audit</text>
+<text x="796.258" y="490.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Gaia Meta Audit</text>
+<text x="673.697" y="256.4" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Gaia Triage</text>
+<text x="533.931" y="555.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Ghostwrite</text>
+<text x="519.918" y="543.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Grill Me</text>
+<text x="788.984" y="504.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Grounding</text>
+<text x="779.95" y="519.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Guardrails</text>
+<text x="506.944" y="528.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Humanize Prose</text>
+<text x="770.028" y="532.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Knowledge Graph Construction</text>
+<text x="497.106" y="515.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Knowledge Harvest</text>
+<text x="491.199" y="505.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Literature Review</text>
+<text x="482.407" y="486.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">MCP Debugger Control</text>
+<text x="477.123" y="471.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">MCP Server Creation</text>
+<text x="472.877" y="454.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">ML Pipeline</text>
+<text x="470.64" y="437.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Multi-Agent Debate</text>
+<text x="758.752" y="544.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Multimodal Reasoning</text>
+<text x="470.019" y="425.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">PRD Generation</text>
+<text x="470.94" y="405.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Plan and Execute</text>
+<text x="473.041" y="391.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Prediction Market Analysis</text>
+<text x="477.35" y="373.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Prompt Optimization</text>
+<text x="749.879" y="552.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">RAG Pipeline</text>
+<text x="732.138" y="565.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">ReAct Reasoning</text>
+<text x="482.468" y="359.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Registry Curation</text>
+<text x="686.845" y="259.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Release Automation</text>
+<text x="718.741" y="573.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Research</text>
+<text x="703.236" y="580.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Scientific Writing</text>
+<text x="707.455" y="267.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Security Audit</text>
+<text x="490.522" y="342.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Skill Authoring</text>
+<text x="499.198" y="327.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Skill Performance Benchmarking</text>
+<text x="506.93" y="317.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Skill Security Analysis</text>
+<text x="519.997" y="302.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Stealth Browser Interaction</text>
+<text x="690.941" y="585.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Text-to-SQL Pipeline</text>
+<text x="674.236" y="589.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Tool Chaining</text>
+<text x="532.183" y="291.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Tool Creation</text>
+<text x="654.723" y="592.4" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Translation Pipeline</text>
+<text x="544.569" y="282.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Tree of Thought</text>
+<text x="560.833" y="272.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Ubiquitous Language</text>
+<text x="637.613" y="593.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Vertical Slice Planning</text>
+<text x="622.489" y="592.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Video Intelligence</text>
+<text x="606.068" y="589.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Voice Agent</text>
+<text x="590.245" y="585.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Web Scrape</text>
+<text x="575.743" y="265.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Wiki Search</text>
+<text x="589.344" y="260.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Workflow Automation</text>
+<text x="605.741" y="256.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">X/Twitter Automation</text>
 <text x="651.074" y="308.5" fill="#7c3aed" font-size="16" font-weight="600" opacity="0.92">Feed Monitoring</text>
 <text x="748.688" y="393.0" fill="#7c3aed" font-size="16" font-weight="600" opacity="0.92">Few-Shot Learning</text>
 <text x="702.245" y="513.1" fill="#7c3aed" font-size="16" font-weight="600" opacity="0.92">Fine-Tune</text>
@@ -454,7 +459,7 @@
 <circle cx="52" cy="765" r="6" fill="#38bdf8"/>
 <text x="68" y="770">Basic: 70</text>
 <circle cx="52" cy="793" r="6" fill="#a78bfa"/>
-<text x="68" y="798">Extra: 63</text>
+<text x="68" y="798">Extra: 64</text>
 <circle cx="52" cy="821" r="6" fill="#7c3aed"/>
 <text x="68" y="826">Unique: 5</text>
 <circle cx="52" cy="849" r="6" fill="#fbbf24"/>

--- a/docs/graph/named/index.json
+++ b/docs/graph/named/index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-14",
+  "generatedAt": "2026-05-15",
   "buckets": {
     "automated-testing": [
       {
@@ -1365,6 +1365,27 @@
         "user-journey",
         "visual-regression"
       ]
+    },
+    {
+      "id": "xquik-dev/hermes-tweet",
+      "name": "Hermes Tweet",
+      "contributor": "xquik-dev",
+      "origin": true,
+      "genericSkillRef": "x-twitter-automation",
+      "status": "awakened",
+      "level": "4★",
+      "description": "Installable Hermes Agent skill and plugin for X/Twitter search, reply reading, user lookup, monitoring, follower export, and approval-gated write actions.",
+      "tags": [
+        "x-twitter",
+        "twitter",
+        "social-automation",
+        "hermes-agent",
+        "monitoring"
+      ],
+      "links": {
+        "github": "https://github.com/Xquik-dev/hermes-tweet",
+        "docs": "https://docs.xquik.com/guides/hermes-tweet"
+      }
     }
   ],
   "byContributor": {
@@ -1481,6 +1502,9 @@
     ],
     "vercel": [
       "vercel/find-skills"
+    ],
+    "xquik-dev": [
+      "xquik-dev/hermes-tweet"
     ],
     "yonatangross": [
       "yonatangross/orchestkit-rag"

--- a/docs/index.html
+++ b/docs/index.html
@@ -573,5 +573,5 @@
 </html>
 
 <!-- gaia:stats-start -->
-<!-- skills=146; namedSkills=49; uniqueSkills=5; version=3.9.2 -->
+<!-- skills=147; namedSkills=49; uniqueSkills=5; version=3.9.2 -->
 <!-- gaia:stats-end -->

--- a/docs/tree.md
+++ b/docs/tree.md
@@ -1,7 +1,7 @@
 # Gaia Skill Tree
 
 ```
-GAIA SKILL TREE  v3.9.2  ·  generated 2026-05-14
+GAIA SKILL TREE  v3.9.2  ·  generated 2026-05-15
 ══════════════════════════════════════════════════════════════════════
 Upgrade paths — each legendary shows its full prerequisite chain.
 Shared prerequisites marked (↑ see above) on second occurrence.
@@ -134,4 +134,4 @@ Pure / Undeveloped — basic skills not yet wired into any upgrade path.
 
 ```
 
-*Generated from gaia.json on 2026-05-14. Do not edit directly.*
+*Generated from gaia.json on 2026-05-15. Do not edit directly.*

--- a/registry/combinations.md
+++ b/registry/combinations.md
@@ -73,3 +73,4 @@
 | ◇ Extra Skill: /web-scrape | Extra Skill | Web Search, Parse HTML, Extract Entities | 3★ | Structured output mode required. |
 | ◇ Extra Skill: /wiki-search | Extra Skill | Retrieve, Embed Text, Summarize | 4★ | Requires an accessible local wiki or markdown knowledge-base directory and a consistent linking or indexing convention. |
 | ◇ Extra Skill: /workflow-automation | Extra Skill | Plan and Decompose, Tool Use, API Call | 4★ |  |
+| ◇ Extra Skill: /x-twitter-automation | Extra Skill | Browser Automation, Web Scrape, Workflow Automation | 4★ | Requires configured X/Twitter access, repeatable read paths, and explicit approval gates before posting tweets, replies, DMs, or other write actions. |

--- a/registry/gaia.gexf
+++ b/registry/gaia.gexf
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <gexf xmlns="http://www.gexf.net/1.2draft" version="1.2">
-  <meta lastmodifieddate="2026-05-14">
+  <meta lastmodifieddate="2026-05-15">
     <creator>Gaia</creator>
     <description>Gaia Skill Registry Graph</description>
   </meta>
@@ -1180,6 +1180,14 @@
           <attvalue for="type" value="basic" />
         </attvalues>
       </node>
+      <node id="x-twitter-automation" label="X/Twitter Automation">
+        <attvalues>
+          <attvalue for="level" value="4★" />
+          <attvalue for="rarity" value="rare" />
+          <attvalue for="status" value="provisional" />
+          <attvalue for="type" value="extra" />
+        </attvalues>
+      </node>
     </nodes>
     <edges>
       <edge id="e0" source="evaluate-output" target="agent-eval" />
@@ -1375,6 +1383,9 @@
       <edge id="e190" source="plan-decompose" target="workflow-automation" />
       <edge id="e191" source="tool-use" target="workflow-automation" />
       <edge id="e192" source="api-call" target="workflow-automation" />
+      <edge id="e193" source="browser-automation" target="x-twitter-automation" />
+      <edge id="e194" source="web-scrape" target="x-twitter-automation" />
+      <edge id="e195" source="workflow-automation" target="x-twitter-automation" />
     </edges>
   </graph>
 </gexf>

--- a/registry/gaia.json
+++ b/registry/gaia.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/skill.schema.json",
   "version": "3.9.2",
-  "generatedAt": "2026-05-14T20:36:31.357434Z",
+  "generatedAt": "2026-05-15T09:39:30.366045Z",
   "meta": {
     "typeLabels": {
       "basic": "Basic Skill",
@@ -10,49 +10,49 @@
       "ultimate": "Ultimate Skill"
     },
     "levelLabels": {
-      "0\u2605": "Basic",
-      "1\u2605": "Awakened",
-      "2\u2605": "Named",
-      "3\u2605": "Evolved",
-      "4\u2605": "Hardened",
-      "5\u2605": "Transcendent",
-      "6\u2605": "Transcendent \u2605"
+      "0★": "Basic",
+      "1★": "Awakened",
+      "2★": "Named",
+      "3★": "Evolved",
+      "4★": "Hardened",
+      "5★": "Transcendent",
+      "6★": "Transcendent ★"
     },
     "rarityLabels": {
       "legendary": "Divine"
     },
     "levelColors": {
-      "0\u2605": {
+      "0★": {
         "hex": "#94a3b8",
         "bg": "rgba(148,163,184,.12)",
         "border": "rgba(148,163,184,.4)"
       },
-      "1\u2605": {
+      "1★": {
         "hex": "#38bdf8",
         "bg": "rgba(56,189,248,.12)",
         "border": "rgba(56,189,248,.4)"
       },
-      "2\u2605": {
+      "2★": {
         "hex": "#63cab7",
         "bg": "rgba(99,202,183,.15)",
         "border": "rgba(99,202,183,.4)"
       },
-      "3\u2605": {
+      "3★": {
         "hex": "#a78bfa",
         "bg": "rgba(167,139,250,.15)",
         "border": "rgba(167,139,250,.4)"
       },
-      "4\u2605": {
+      "4★": {
         "hex": "#e879f9",
         "bg": "rgba(232,121,249,.15)",
         "border": "rgba(232,121,249,.4)"
       },
-      "5\u2605": {
+      "5★": {
         "hex": "#fbbf24",
         "bg": "rgba(251,191,36,.15)",
         "border": "rgba(251,191,36,.4)"
       },
-      "6\u2605": {
+      "6★": {
         "hex": "#fbbf24",
         "bg": "rgba(251,191,36,.22)",
         "border": "rgba(251,191,36,.55)"
@@ -77,10 +77,10 @@
       }
     },
     "typeSymbols": {
-      "basic": "\u25cb",
-      "extra": "\u25c7",
-      "unique": "\u25c9",
-      "ultimate": "\u25c6"
+      "basic": "○",
+      "extra": "◇",
+      "unique": "◉",
+      "ultimate": "◆"
     },
     "demeritLabels": {
       "niche-integration": "Niche integrations",
@@ -93,7 +93,7 @@
       "id": "agent-eval",
       "name": "Agent Evaluation",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Holistically evaluates an AI agent's performance on multi-step tasks by running standardised benchmarks, scoring full interaction trajectories, and producing reproducible capability reports.",
       "prerequisites": [
@@ -137,7 +137,7 @@
       "id": "agentic-workflow-design",
       "name": "Agentic Workflow Design",
       "type": "extra",
-      "level": "5\u2605",
+      "level": "5★",
       "rarity": "rare",
       "description": "Autonomously designs, authors, and iterates on complex multi-step workflows by translating high-level goals into executable DAGs or playbooks, managing task dependencies and distributed execution environments.",
       "prerequisites": [
@@ -172,7 +172,7 @@
       "id": "api-call",
       "name": "API Call",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "common",
       "description": "Constructs, executes, and handles responses from HTTP APIs by interpreting documentation and selecting appropriate endpoints and parameters.",
       "prerequisites": [],
@@ -188,7 +188,7 @@
           "source": "https://arxiv.org/abs/2305.15334",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Gorilla (Patil et al.) \u00e2\u20ac\u201d LLM that generates accurate API calls across TorchHub, TensorFlow Hub, and HuggingFace; 20.43% AST accuracy improvement over GPT-4."
+          "notes": "Gorilla (Patil et al.) â€” LLM that generates accurate API calls across TorchHub, TensorFlow Hub, and HuggingFace; 20.43% AST accuracy improvement over GPT-4."
         }
       ],
       "knownAgents": [],
@@ -201,7 +201,7 @@
       "id": "architecture-diagram",
       "name": "Architecture Diagram",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "uncommon",
       "description": "Generates technical architecture, infrastructure, or cloud diagrams as structured visual artifacts from natural-language system descriptions.",
       "prerequisites": [
@@ -232,7 +232,7 @@
       "id": "audience-model",
       "name": "Audience Model",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Adapts tone, complexity, and framing of output to match a target audience profile.",
       "prerequisites": [],
@@ -261,7 +261,7 @@
       "id": "automated-testing",
       "name": "Automated Testing",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Generates test suites, executes them in a sandbox, interprets failures, and iterates until the target pass rate is reached.",
       "prerequisites": [
@@ -281,7 +281,7 @@
           "source": "https://github.com/princeton-nlp/SWE-bench",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SWE-bench Verified \u00e2\u20ac\u201d open-source evaluation harness where agents fix GitHub issues by generating and passing test suites; full execution logs archived."
+          "notes": "SWE-bench Verified â€” open-source evaluation harness where agents fix GitHub issues by generating and passing test suites; full execution logs archived."
         }
       ],
       "knownAgents": [],
@@ -294,7 +294,7 @@
       "id": "autonomous-data-scientist",
       "name": "Autonomous Data Scientist",
       "type": "ultimate",
-      "level": "5\u2605",
+      "level": "5★",
       "rarity": "legendary",
       "description": "Conducts end-to-end data science workflows autonomously: hypothesis generation, data analysis, statistical modeling, and insight reporting.",
       "prerequisites": [
@@ -310,21 +310,21 @@
           "source": "https://arxiv.org/abs/2210.12641",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "DS-1000 \u00e2\u20ac\u201d benchmark of 1000 data science problems across NumPy/Pandas/Scikit-learn; GPT-4 achieves 43.3% pass@1, establishing reproducible DS evaluation."
+          "notes": "DS-1000 â€” benchmark of 1000 data science problems across NumPy/Pandas/Scikit-learn; GPT-4 achieves 43.3% pass@1, establishing reproducible DS evaluation."
         },
         {
           "class": "A",
           "source": "https://arxiv.org/abs/2208.01756",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "AutoML Survey (He et al., ACM CSUR) \u00e2\u20ac\u201d systematic review of autonomous ML pipeline search; demonstrates automated feature engineering, model selection, and HPO."
+          "notes": "AutoML Survey (He et al., ACM CSUR) â€” systematic review of autonomous ML pipeline search; demonstrates automated feature engineering, model selection, and HPO."
         },
         {
           "class": "B",
           "source": "https://github.com/microsoft/autogen",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "AutoGen (Microsoft) \u00e2\u20ac\u201d multi-agent framework with reproducible data science notebooks; science agent achieves 44.3% on DS-1000 with full execution logs."
+          "notes": "AutoGen (Microsoft) â€” multi-agent framework with reproducible data science notebooks; science agent achieves 44.3% on DS-1000 with full execution logs."
         }
       ],
       "knownAgents": [],
@@ -338,7 +338,7 @@
       "id": "autonomous-debug",
       "name": "Autonomous Debug",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Independently identifies, diagnoses, and fixes software bugs through code generation and execution.",
       "prerequisites": [
@@ -367,7 +367,7 @@
       "id": "autonomous-research-agent",
       "name": "Autonomous Research Agent",
       "type": "ultimate",
-      "level": "6\u2605",
+      "level": "6★",
       "rarity": "legendary",
       "description": "Independently conducts end-to-end research cycles including hypothesis generation, evidence gathering, synthesis, and reporting.",
       "prerequisites": [
@@ -383,7 +383,7 @@
           "source": "https://github.com/gaia-registry/gaia/blob/main/docs/evidence/seed.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Seed evidence \u00e2\u20ac\u201d apex tier structural validation placeholder."
+          "notes": "Seed evidence â€” apex tier structural validation placeholder."
         },
         {
           "class": "B",
@@ -404,7 +404,7 @@
       "id": "autonomous-web-research",
       "name": "Autonomous Web Research",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Independently surveys, maps, and extracts structured information from the web by autonomously deciding which domains to crawl and synthesizing data into comprehensive research reports.",
       "prerequisites": [
@@ -436,7 +436,7 @@
       "id": "browser-automation",
       "name": "Browser Automation",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Navigates web pages, fills forms, clicks elements, and extracts information by combining web search with screenshot-based GUI control to complete multi-step web tasks.",
       "prerequisites": [
@@ -445,7 +445,8 @@
       ],
       "derivatives": [
         "autonomous-research-agent",
-        "e2e-testing"
+        "e2e-testing",
+        "x-twitter-automation"
       ],
       "conditions": "",
       "evidence": [
@@ -454,14 +455,14 @@
           "source": "https://arxiv.org/abs/2401.13919",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "WebVoyager (He et al., 2024) \u00e2\u20ac\u201d end-to-end web agent with GPT-4V; 59.1% task success on real-world web tasks across 15 popular websites."
+          "notes": "WebVoyager (He et al., 2024) â€” end-to-end web agent with GPT-4V; 59.1% task success on real-world web tasks across 15 popular websites."
         },
         {
           "class": "B",
           "source": "https://github.com/web-arena-x/webarena",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "WebArena \u00e2\u20ac\u201d self-hosted web environment with 812 realistic tasks; reproducible benchmark with ground-truth evaluation scripts."
+          "notes": "WebArena â€” self-hosted web environment with 812 realistic tasks; reproducible benchmark with ground-truth evaluation scripts."
         }
       ],
       "knownAgents": [],
@@ -474,7 +475,7 @@
       "id": "browser-control",
       "name": "Browser Control",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
       "description": "Directly controls a web browser via low-level protocols (like CDP) to manipulate DOM, manage cookies, and intercept network traffic.",
       "prerequisites": [],
@@ -501,7 +502,7 @@
       "id": "career-operations",
       "name": "Career Operations",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "legendary",
       "description": "Orchestrates an end-to-end job application pipeline, including automated search, fit evaluation, and tailored CV/cover letter generation.",
       "prerequisites": [
@@ -530,7 +531,7 @@
       "id": "chain-of-thought",
       "name": "Chain-of-Thought Reasoning",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "uncommon",
       "description": "Produces explicit intermediate reasoning steps before arriving at a final answer, dramatically improving accuracy on multi-step problems.",
       "prerequisites": [],
@@ -547,14 +548,14 @@
           "source": "https://arxiv.org/abs/2201.11903",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Wei et al. (2022) \u00e2\u20ac\u201d Chain-of-Thought Prompting; +18% on GSM8K and +14% on MATH with PaLM 540B vs standard prompting."
+          "notes": "Wei et al. (2022) â€” Chain-of-Thought Prompting; +18% on GSM8K and +14% on MATH with PaLM 540B vs standard prompting."
         },
         {
           "class": "B",
           "source": "https://github.com/princeton-nlp/chain-of-thought-hub",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Chain-of-Thought Hub \u00e2\u20ac\u201d reproducible evaluation suite covering 10+ reasoning benchmarks with CoT prompts and baselines."
+          "notes": "Chain-of-Thought Hub â€” reproducible evaluation suite covering 10+ reasoning benchmarks with CoT prompts and baselines."
         }
       ],
       "knownAgents": [],
@@ -567,7 +568,7 @@
       "id": "chunk-document",
       "name": "Chunk Document",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Splits a document into semantically meaningful segments optimized for embedding and retrieval.",
       "prerequisites": [],
@@ -594,7 +595,7 @@
       "id": "cite-sources",
       "name": "Cite Sources",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Attributes claims to specific sources with proper references, URLs, or bibliographic entries.",
       "prerequisites": [],
@@ -625,7 +626,7 @@
       "id": "classify",
       "name": "Classify",
       "type": "basic",
-      "level": "0\u2605",
+      "level": "0★",
       "rarity": "common",
       "description": "Assigns one or more categorical labels to an input based on learned or rule-based criteria.",
       "prerequisites": [],
@@ -653,7 +654,7 @@
       "id": "code-execution",
       "name": "Code Execution",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "common",
       "description": "Writes and executes code in a sandboxed environment, uses the runtime output to verify correctness, and iterates until the result is correct.",
       "prerequisites": [],
@@ -669,14 +670,14 @@
           "source": "https://arxiv.org/abs/2211.10435",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "PAL (Gao et al., 2023) \u00e2\u20ac\u201d Program-Aided Language Models; delegates computation to Python interpreter, achieving +7% on GSM8K over direct CoT."
+          "notes": "PAL (Gao et al., 2023) â€” Program-Aided Language Models; delegates computation to Python interpreter, achieving +7% on GSM8K over direct CoT."
         },
         {
           "class": "B",
           "source": "https://github.com/reasoning-machines/pal",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "PAL repo \u00e2\u20ac\u201d reproducible harness across 13 reasoning benchmarks; evaluation scripts and baseline comparisons included."
+          "notes": "PAL repo â€” reproducible harness across 13 reasoning benchmarks; evaluation scripts and baseline comparisons included."
         }
       ],
       "knownAgents": [],
@@ -689,7 +690,7 @@
       "id": "code-explain",
       "name": "Code Explain",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "common",
       "description": "Generates accurate natural-language explanations of source code, describing intent, logic flow, and key decisions at function or module level.",
       "prerequisites": [],
@@ -724,7 +725,7 @@
       "id": "code-generation",
       "name": "Code Generation",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Produces syntactically correct and functionally appropriate source code from specifications or prompts.",
       "prerequisites": [],
@@ -756,7 +757,7 @@
       "id": "code-review-pipeline",
       "name": "Code Review Pipeline",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Performs automated code review by generating, diffing, and evaluating code changes for correctness, style, security, and maintainability.",
       "prerequisites": [
@@ -775,7 +776,7 @@
           "source": "https://arxiv.org/abs/2203.09095",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "CodeReviewer (Microsoft) \u00e2\u20ac\u201d pre-trained model for code review tasks; 28.7% BLEU improvement on comment generation and change quality prediction."
+          "notes": "CodeReviewer (Microsoft) â€” pre-trained model for code review tasks; 28.7% BLEU improvement on comment generation and change quality prediction."
         }
       ],
       "knownAgents": [],
@@ -788,7 +789,7 @@
       "id": "computer-use",
       "name": "Computer Use",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "rare",
       "description": "Controls desktop GUIs and web browsers by interpreting screenshots, issuing mouse/keyboard actions, and verifying visual state to complete open-ended computer tasks.",
       "prerequisites": [],
@@ -802,14 +803,14 @@
           "source": "https://arxiv.org/abs/2307.13854",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "WebArena (Zhou et al., 2023) \u00e2\u20ac\u201d realistic 812-task benchmark for autonomous web agents; establishes controlled eval for GUI-based computer use."
+          "notes": "WebArena (Zhou et al., 2023) â€” realistic 812-task benchmark for autonomous web agents; establishes controlled eval for GUI-based computer use."
         },
         {
           "class": "B",
           "source": "https://github.com/xlang-ai/OSWorld",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "OSWorld \u00e2\u20ac\u201d 369 computer tasks across real OS environments (Windows, macOS, Ubuntu); reproducible VM-based evaluation harness."
+          "notes": "OSWorld â€” 369 computer tasks across real OS environments (Windows, macOS, Ubuntu); reproducible VM-based evaluation harness."
         }
       ],
       "knownAgents": [],
@@ -822,7 +823,7 @@
       "id": "content-moderation",
       "name": "Content Moderation",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Detects policy-violating content by combining intent classification, sentiment scoring, and entity extraction across text, images, and mixed media.",
       "prerequisites": [
@@ -838,7 +839,7 @@
           "source": "https://platform.openai.com/docs/guides/moderation",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "OpenAI Moderation API \u00e2\u20ac\u201d publicly documented multi-category content classifier with reproducible API calls, category scores, and evaluation methodology."
+          "notes": "OpenAI Moderation API â€” publicly documented multi-category content classifier with reproducible API calls, category scores, and evaluation methodology."
         }
       ],
       "knownAgents": [],
@@ -851,7 +852,7 @@
       "id": "context-compression",
       "name": "Context Compression",
       "type": "basic",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "common",
       "description": "Reduces the length of prompts or retrieved context to fit token limits while preserving semantic content, using techniques such as selective token removal, summarization, or token-classification-based pruning (e.g. LLMLingua).",
       "prerequisites": [],
@@ -863,14 +864,14 @@
           "source": "https://arxiv.org/abs/2403.12968",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "LLMLingua-2 (ACL 2024 Findings) \u2014 data-distillation for efficient task-agnostic prompt compression; 3x-6x speed-up, BERT-base token classifier; demonstrates measurable perplexity-based faithfulness."
+          "notes": "LLMLingua-2 (ACL 2024 Findings) — data-distillation for efficient task-agnostic prompt compression; 3x-6x speed-up, BERT-base token classifier; demonstrates measurable perplexity-based faithfulness."
         },
         {
           "class": "B",
           "source": "https://github.com/microsoft/LLMLingua",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "Microsoft LLMLingua \u2014 reproducible open-source implementation of LLMLingua-1/2/LongLLMLingua; CI, README, Apache-2.0 license."
+          "notes": "Microsoft LLMLingua — reproducible open-source implementation of LLMLingua-1/2/LongLLMLingua; CI, README, Apache-2.0 license."
         },
         {
           "class": "C",
@@ -890,7 +891,7 @@
       "id": "conversational-agent",
       "name": "Conversational Agent",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Manages coherent multi-turn dialogue by routing intent, maintaining memory across turns, and generating contextually appropriate responses.",
       "prerequisites": [
@@ -906,7 +907,7 @@
           "source": "https://github.com/langchain-ai/langchain/tree/master/libs/langchain/langchain/chains/conversation",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "LangChain ConversationChain \u00e2\u20ac\u201d reproducible open-source multi-turn conversational agent with buffer and summary memory backends."
+          "notes": "LangChain ConversationChain â€” reproducible open-source multi-turn conversational agent with buffer and summary memory backends."
         }
       ],
       "knownAgents": [],
@@ -919,7 +920,7 @@
       "id": "data-analysis",
       "name": "Data Analysis",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Conducts end-to-end quantitative analysis: queries data via SQL, computes statistics, generates visualizations, and summarizes findings.",
       "prerequisites": [
@@ -939,7 +940,7 @@
           "source": "https://github.com/Sinaptik-AI/pandas-ai",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "pandas-ai \u00e2\u20ac\u201d open-source agent for natural-language data analysis over pandas DataFrames; reproducible demos with logging and output artifacts."
+          "notes": "pandas-ai â€” open-source agent for natural-language data analysis over pandas DataFrames; reproducible demos with logging and output artifacts."
         }
       ],
       "knownAgents": [],
@@ -952,7 +953,7 @@
       "id": "data-visualize",
       "name": "Data Visualize",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "common",
       "description": "Generates charts, graphs, and visual summaries from datasets by selecting appropriate visualization types and mapping data dimensions.",
       "prerequisites": [],
@@ -967,7 +968,7 @@
           "source": "https://github.com/microsoft/lida",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "LIDA (Microsoft) \u00e2\u20ac\u201d open-source LLM-based data visualization tool with reproducible generation pipeline; evaluated on diverse real-world datasets."
+          "notes": "LIDA (Microsoft) â€” open-source LLM-based data visualization tool with reproducible generation pipeline; evaluated on diverse real-world datasets."
         }
       ],
       "knownAgents": [],
@@ -980,9 +981,9 @@
       "id": "deployment-automation",
       "name": "Deployment Automation",
       "type": "extra",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
-      "description": "Automate CI/CD pipeline execution and deployment to target environments \u2014 build, test, artifact publishing, environment promotion, and rollback strategies.",
+      "description": "Automate CI/CD pipeline execution and deployment to target environments — build, test, artifact publishing, environment promotion, and rollback strategies.",
       "prerequisites": [
         "workflow-automation",
         "execute-bash"
@@ -995,7 +996,7 @@
           "source": "https://github.com/intelligentcode-ai/skills/blob/main/skills/devops-engineer/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "intelligentcode-ai/skills devops-engineer \u2014 CI/CD pipeline design and deployment automation with build systems and release management."
+          "notes": "intelligentcode-ai/skills devops-engineer — CI/CD pipeline design and deployment automation with build systems and release management."
         }
       ],
       "knownAgents": [],
@@ -1011,7 +1012,7 @@
       "id": "design-generation",
       "name": "Design Generation",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "rare",
       "description": "Generates high-fidelity visual assets, prototypes, and UI components from design intent or discovery forms, adhering to brand and UX standards.",
       "prerequisites": [
@@ -1041,9 +1042,9 @@
       "id": "design-review",
       "name": "Design Review",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "rare",
-      "description": "Stress-tests a plan or design through relentless targeted questioning, walking the decision tree branch-by-branch, resolving concept dependencies, surfacing contradictions against the existing codebase, and crystallising ubiquitous language \u2014 optionally persisting resolved decisions to CONTEXT.md and ADRs.",
+      "description": "Stress-tests a plan or design through relentless targeted questioning, walking the decision tree branch-by-branch, resolving concept dependencies, surfacing contradictions against the existing codebase, and crystallising ubiquitous language — optionally persisting resolved decisions to CONTEXT.md and ADRs.",
       "prerequisites": [
         "evaluate-output",
         "plan-decompose"
@@ -1076,7 +1077,7 @@
       "id": "design-system-extraction",
       "name": "Design System Extraction",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "rare",
       "description": "Automates the discovery and extraction of design tokens, component architectures, and CSS configurations from live web applications or URLs.",
       "prerequisites": [
@@ -1106,7 +1107,7 @@
       "id": "detect-anomaly",
       "name": "Detect Anomaly",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
       "description": "Identifies statistical outliers, novel patterns, or deviations from expected behavior in structured or unstructured data.",
       "prerequisites": [],
@@ -1120,7 +1121,7 @@
           "source": "https://arxiv.org/abs/2007.02500",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Deep Learning for Anomaly Detection survey (Pang et al., ACM CSUR) \u00e2\u20ac\u201d comprehensive benchmark of 30+ methods across fraud, intrusion, and medical anomaly detection."
+          "notes": "Deep Learning for Anomaly Detection survey (Pang et al., ACM CSUR) â€” comprehensive benchmark of 30+ methods across fraud, intrusion, and medical anomaly detection."
         }
       ],
       "knownAgents": [],
@@ -1133,7 +1134,7 @@
       "id": "diff-content",
       "name": "Diff Content",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Compares two versions of content and produces a structured delta highlighting additions, deletions, and modifications.",
       "prerequisites": [],
@@ -1160,7 +1161,7 @@
       "id": "document-analyst",
       "name": "Document Analyst",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Parses, extracts entities from, summarizes, and formats structured documents.",
       "prerequisites": [
@@ -1190,7 +1191,7 @@
       "id": "document-digitization",
       "name": "Document Digitization",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Converts scanned or PDF documents into structured, machine-readable output by parsing layout, extracting entities, and formatting results.",
       "prerequisites": [
@@ -1206,7 +1207,7 @@
           "source": "https://github.com/VikParuchuri/marker",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Marker \u00e2\u20ac\u201d open-source PDF-to-markdown pipeline with reproducible benchmarks; outperforms Nougat on edit distance across 1000+ arXiv PDFs."
+          "notes": "Marker â€” open-source PDF-to-markdown pipeline with reproducible benchmarks; outperforms Nougat on edit distance across 1000+ arXiv PDFs."
         }
       ],
       "knownAgents": [],
@@ -1219,7 +1220,7 @@
       "id": "document-editing",
       "name": "Document Editing",
       "type": "basic",
-      "level": "0\u2605",
+      "level": "0★",
       "rarity": "common",
       "description": "Reads, edits, repacks, and applies styling or design principles to structured binary document formats such as PPTX, DOCX, and XLSX.",
       "prerequisites": [],
@@ -1246,7 +1247,7 @@
       "id": "e2e-testing",
       "name": "End-to-End Testing",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Execute full end-to-end user journey tests using browser automation frameworks (Playwright/Puppeteer), validating complete workflows from UI to backend across real environments.",
       "prerequisites": [
@@ -1261,14 +1262,14 @@
           "source": "https://github.com/zachblume/autospec",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "autospec \u2014 AI agent that takes a web app URL and autonomously QAs it, saving passing specs as E2E test code (59 stars, active)."
+          "notes": "autospec — AI agent that takes a web app URL and autonomously QAs it, saving passing specs as E2E test code (59 stars, active)."
         },
         {
           "class": "C",
           "source": "https://github.com/intelligentcode-ai/skills/blob/main/skills/user-tester/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "intelligentcode-ai/skills user-tester \u2014 E2E testing specialist with Puppeteer/Playwright automation and cross-browser user journey validation."
+          "notes": "intelligentcode-ai/skills user-tester — E2E testing specialist with Puppeteer/Playwright automation and cross-browser user journey validation."
         }
       ],
       "knownAgents": [],
@@ -1281,7 +1282,7 @@
       "id": "embed-text",
       "name": "Embed Text",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Converts text into dense vector representations suitable for similarity search and clustering.",
       "prerequisites": [],
@@ -1310,7 +1311,7 @@
       "id": "error-interpretation",
       "name": "Error Interpretation",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Diagnoses error messages, stack traces, and failure modes to identify root causes and suggest fixes.",
       "prerequisites": [],
@@ -1338,7 +1339,7 @@
       "id": "evaluate-output",
       "name": "Evaluate Output",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Assesses the quality, correctness, or safety of generated output against defined criteria.",
       "prerequisites": [],
@@ -1373,7 +1374,7 @@
       "id": "execute-bash",
       "name": "Execute Bash",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Runs shell commands in a sandboxed environment, captures stdout/stderr, and handles exit codes.",
       "prerequisites": [],
@@ -1404,7 +1405,7 @@
       "id": "extract-entities",
       "name": "Extract Entities",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Identifies and extracts named entities such as people, organizations, dates, and locations from text.",
       "prerequisites": [],
@@ -1436,7 +1437,7 @@
       "id": "feed-monitoring",
       "name": "Feed Monitoring",
       "type": "unique",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "common",
       "description": "Monitors RSS, Atom, blog, or other recurring content feeds, discovers updates, tracks read state, and surfaces new signals for downstream agent workflows.",
       "prerequisites": [],
@@ -1463,7 +1464,7 @@
       "id": "few-shot-learning",
       "name": "Few-Shot Learning",
       "type": "unique",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "common",
       "description": "Conditions a language model on a small number of input-output demonstrations within the prompt, enabling task adaptation without weight updates.",
       "prerequisites": [],
@@ -1478,7 +1479,7 @@
           "source": "https://arxiv.org/abs/2005.14165",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Brown et al. (2020) \u00e2\u20ac\u201d Language Models are Few-Shot Learners (GPT-3); in-context learning from 1-100 examples achieves near-SOTA on SuperGLUE, translation, and QA benchmarks."
+          "notes": "Brown et al. (2020) â€” Language Models are Few-Shot Learners (GPT-3); in-context learning from 1-100 examples achieves near-SOTA on SuperGLUE, translation, and QA benchmarks."
         }
       ],
       "knownAgents": [],
@@ -1491,7 +1492,7 @@
       "id": "fine-tune",
       "name": "Fine-Tune",
       "type": "unique",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "uncommon",
       "description": "Adapts a pre-trained model to a new task or domain by updating model weights using parameter-efficient methods such as LoRA, QLoRA, or full supervised fine-tuning, without retraining from scratch.",
       "prerequisites": [],
@@ -1530,7 +1531,7 @@
       "id": "format-output",
       "name": "Format Output",
       "type": "basic",
-      "level": "0\u2605",
+      "level": "0★",
       "rarity": "common",
       "description": "Structures raw output into a specified format such as markdown, JSON, CSV, or HTML.",
       "prerequisites": [],
@@ -1561,7 +1562,7 @@
       "id": "framework-upgrade",
       "name": "Framework Upgrade",
       "type": "basic",
-      "level": "0\u2605",
+      "level": "0★",
       "rarity": "common",
       "description": "Guides an agent through upgrading a project from one major framework version to another, including breaking-change detection, migration steps, and post-upgrade validation.",
       "prerequisites": [],
@@ -1586,7 +1587,7 @@
       "id": "full-stack-developer",
       "name": "Full-Stack Developer",
       "type": "ultimate",
-      "level": "5\u2605",
+      "level": "5★",
       "rarity": "legendary",
       "description": "Autonomously implements, reviews, tests, and refactors complete software features across the full development lifecycle from specification to merged PR.",
       "prerequisites": [
@@ -1602,21 +1603,21 @@
           "source": "https://arxiv.org/abs/2310.06770",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SWE-bench \u00e2\u20ac\u201d 2294 real GitHub issues; Claude 3.5 Sonnet (Cognition) resolves 49% on Verified, demonstrating full-cycle autonomous development."
+          "notes": "SWE-bench â€” 2294 real GitHub issues; Claude 3.5 Sonnet (Cognition) resolves 49% on Verified, demonstrating full-cycle autonomous development."
         },
         {
           "class": "B",
           "source": "https://github.com/princeton-nlp/SWE-agent",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SWE-agent \u00e2\u20ac\u201d open-source agent with AgentComputer Interface; reproducible harness achieving 12.5% on SWE-bench full with logs and eval scripts."
+          "notes": "SWE-agent â€” open-source agent with AgentComputer Interface; reproducible harness achieving 12.5% on SWE-bench full with logs and eval scripts."
         },
         {
           "class": "A",
           "source": "https://arxiv.org/abs/2402.01030",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "CodeAct \u00e2\u20ac\u201d executable code action space for LLM agents; +20% task completion vs JSON/text-based actions across 17 programming benchmarks."
+          "notes": "CodeAct â€” executable code action space for LLM agents; +20% task completion vs JSON/text-based actions across 17 programming benchmarks."
         }
       ],
       "knownAgents": [],
@@ -1630,7 +1631,7 @@
       "id": "function-calling",
       "name": "Function Calling",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Selects an external callable, emits schema-valid arguments, invokes the function or API, and integrates the returned result into the agent loop.",
       "prerequisites": [
@@ -1666,7 +1667,7 @@
       "id": "gaia-audit",
       "name": "Gaia Audit",
       "type": "extra",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
       "description": "Reviews one Gaia skill, named skill, or real-skill catalog item against current evidence, source URLs, taxonomy mapping, promotion status, and demotion criteria, then proposes the smallest source-of-truth correction.",
       "prerequisites": [
@@ -1697,7 +1698,7 @@
       "id": "gaia-meta-audit",
       "name": "Gaia Meta Audit",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "rare",
       "description": "Scans Gaia registry and real-skill catalog entries for review candidates whose evidence may be outdated, superseded, overpromoted, unmapped, stale, or insufficient for their current level or named-skill claim.",
       "prerequisites": [
@@ -1726,7 +1727,7 @@
       "id": "gaia-triage",
       "name": "Gaia Triage",
       "type": "extra",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
       "description": "Triage and audit GitHub issues for the Gaia Skill Tree project. Helps identify stale issues, gather evidence from the codebase, and manage issue lifecycle via GitHub CLI.",
       "prerequisites": [
@@ -1754,7 +1755,7 @@
       "id": "generate-sql",
       "name": "Generate SQL",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "common",
       "description": "Translates natural-language data questions into syntactically correct, executable SQL queries against a given schema.",
       "prerequisites": [],
@@ -1769,7 +1770,7 @@
           "source": "https://arxiv.org/abs/1809.08887",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Spider benchmark \u00e2\u20ac\u201d cross-domain text-to-SQL dataset; LLM baselines reach >85% exact match, establishing reproducible evaluation methodology."
+          "notes": "Spider benchmark â€” cross-domain text-to-SQL dataset; LLM baselines reach >85% exact match, establishing reproducible evaluation methodology."
         }
       ],
       "knownAgents": [],
@@ -1782,7 +1783,7 @@
       "id": "generate-test",
       "name": "Generate Test",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "common",
       "description": "Produces unit tests, integration tests, and edge-case test cases from source code or natural-language specifications.",
       "prerequisites": [],
@@ -1796,7 +1797,7 @@
           "source": "https://arxiv.org/abs/2107.03374",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Codex/HumanEval (Chen et al.) \u00e2\u20ac\u201d evaluates LLMs on writing Python functions that pass hand-crafted unit tests; pass@1 72.0% for GPT-4."
+          "notes": "Codex/HumanEval (Chen et al.) â€” evaluates LLMs on writing Python functions that pass hand-crafted unit tests; pass@1 72.0% for GPT-4."
         }
       ],
       "knownAgents": [],
@@ -1809,7 +1810,7 @@
       "id": "generate-text",
       "name": "Generate Text",
       "type": "basic",
-      "level": "0\u2605",
+      "level": "0★",
       "rarity": "common",
       "description": "Produces coherent natural language output given a prompt, instruction, or context window.",
       "prerequisites": [],
@@ -1838,7 +1839,7 @@
       "id": "ghostwrite",
       "name": "Ghostwrite",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Produces audience-tailored, research-backed long-form written content.",
       "prerequisites": [
@@ -1867,7 +1868,7 @@
       "id": "grill-me",
       "name": "Grill Me",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Conducts a relentless, one-question-at-a-time Socratic interview to stress-test designs and force the resolution of hidden assumptions before code is written.",
       "prerequisites": [
@@ -1897,7 +1898,7 @@
       "id": "grill-with-docs",
       "name": "Grill With Docs",
       "type": "ultimate",
-      "level": "5\u2605",
+      "level": "5★",
       "rarity": "legendary",
       "description": "The apex of agentic design alignment. Fuses relentless Socratic questioning with deep domain awareness, ensuring every decision is cross-referenced against a persistent ubiquitous language and documented via real-time ADR generation.",
       "prerequisites": [
@@ -1934,7 +1935,7 @@
       "id": "grounding",
       "name": "Grounding",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Verifies generated claims against retrieved evidence, identifies unsupported or contradicted assertions, and anchors outputs in traceable, cited sources.",
       "prerequisites": [
@@ -1970,7 +1971,7 @@
       "id": "guardrails",
       "name": "Guardrails",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Wraps LLM outputs with programmatic safety rules, content filters, and topical constraints that detect policy violations and enforce compliant, on-policy responses before they reach the user.",
       "prerequisites": [
@@ -2006,7 +2007,7 @@
       "id": "humanize-prose",
       "name": "Humanize Prose",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "uncommon",
       "description": "Audits and rewrites prose to remove generic AI-writing patterns, preserve author intent, and adapt tone toward a more natural human voice.",
       "prerequisites": [
@@ -2037,7 +2038,7 @@
       "id": "hypothesis-generate",
       "name": "Hypothesis Generation",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "rare",
       "description": "Formulates novel, testable scientific hypotheses by synthesising existing literature, identifying knowledge gaps, and proposing mechanistic explanations.",
       "prerequisites": [],
@@ -2051,21 +2052,21 @@
           "source": "https://arxiv.org/abs/2304.05376",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "ChemCrow (Bran et al., 2023) \u00e2\u20ac\u201d LLM augmented with 18 chemistry tools autonomously proposes and validates synthesis routes; GPT-4 outperforms on Chem. benchmark."
+          "notes": "ChemCrow (Bran et al., 2023) â€” LLM augmented with 18 chemistry tools autonomously proposes and validates synthesis routes; GPT-4 outperforms on Chem. benchmark."
         },
         {
           "class": "A",
           "source": "https://arxiv.org/abs/2304.05332",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Coscientist (Boiko et al., 2023) \u00e2\u20ac\u201d autonomous LLM system designs and executes chemistry experiments; independently re-derived Suzuki coupling conditions."
+          "notes": "Coscientist (Boiko et al., 2023) â€” autonomous LLM system designs and executes chemistry experiments; independently re-derived Suzuki coupling conditions."
         },
         {
           "class": "B",
           "source": "https://github.com/SakanaAI/AI-Scientist",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "The AI Scientist (Sakana AI) \u00e2\u20ac\u201d end-to-end pipeline generating ideas, running experiments, and writing ML papers; 50+ auto-generated manuscripts reviewed."
+          "notes": "The AI Scientist (Sakana AI) â€” end-to-end pipeline generating ideas, running experiments, and writing ML papers; 50+ auto-generated manuscripts reviewed."
         }
       ],
       "knownAgents": [],
@@ -2078,7 +2079,7 @@
       "id": "image-caption",
       "name": "Image Caption",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
       "description": "Generates accurate natural-language descriptions of images, capturing objects, actions, and spatial relationships.",
       "prerequisites": [],
@@ -2092,7 +2093,7 @@
           "source": "https://arxiv.org/abs/2301.12597",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "BLIP-2 \u00e2\u20ac\u201d bootstrapped language-image pre-training achieving SOTA on COCO Captions (CIDEr 145.8) and NoCaps benchmarks."
+          "notes": "BLIP-2 â€” bootstrapped language-image pre-training achieving SOTA on COCO Captions (CIDEr 145.8) and NoCaps benchmarks."
         }
       ],
       "knownAgents": [],
@@ -2105,7 +2106,7 @@
       "id": "image-generate",
       "name": "Image Generate",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
       "description": "Creates photorealistic or stylized images from text prompts using diffusion-based or autoregressive generative models.",
       "prerequisites": [],
@@ -2117,7 +2118,7 @@
           "source": "https://arxiv.org/abs/2112.10752",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Latent Diffusion Models (Rombach et al.) \u00e2\u20ac\u201d foundational paper for Stable Diffusion; achieves FID 5.11 on LSUN-Beds at 200\u00c3\u2014 less compute than pixel-space diffusion."
+          "notes": "Latent Diffusion Models (Rombach et al.) â€” foundational paper for Stable Diffusion; achieves FID 5.11 on LSUN-Beds at 200Ã— less compute than pixel-space diffusion."
         }
       ],
       "knownAgents": [],
@@ -2130,7 +2131,7 @@
       "id": "issue-triage",
       "name": "Issue Triage",
       "type": "basic",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "uncommon",
       "description": "Classifies incoming issue reports through a structured state machine, assigns triage roles (bug/enhancement, needs-info/ready-for-agent/wontfix), reproduces bugs, requests missing detail, and produces structured resolution briefs for agent or human handoff.",
       "prerequisites": [],
@@ -2169,7 +2170,7 @@
       "id": "knowledge-graph-build",
       "name": "Knowledge Graph Construction",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Extracts entities and relations from unstructured text, resolves co-references, and assembles them into a queryable graph structure with typed edges.",
       "prerequisites": [
@@ -2187,14 +2188,14 @@
           "source": "https://arxiv.org/abs/2306.08302",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Pan et al. (2024) \u00e2\u20ac\u201d Unifying Large Language Models and Knowledge Graphs: A Roadmap; comprehensive survey showing LLM-KG synergy improves downstream tasks by 5-15%."
+          "notes": "Pan et al. (2024) â€” Unifying Large Language Models and Knowledge Graphs: A Roadmap; comprehensive survey showing LLM-KG synergy improves downstream tasks by 5-15%."
         },
         {
           "class": "B",
           "source": "https://github.com/microsoft/graphrag",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Microsoft GraphRAG \u00e2\u20ac\u201d production KG construction pipeline; extracts community summaries and entity graphs from corpora, enabling global sensemaking queries."
+          "notes": "Microsoft GraphRAG â€” production KG construction pipeline; extracts community summaries and entity graphs from corpora, enabling global sensemaking queries."
         }
       ],
       "knownAgents": [],
@@ -2207,7 +2208,7 @@
       "id": "knowledge-harvest",
       "name": "Knowledge Harvest",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Extracts, structures, and embeds knowledge from web sources into a searchable corpus.",
       "prerequisites": [
@@ -2236,7 +2237,7 @@
       "id": "literature-review",
       "name": "Literature Review",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "uncommon",
       "description": "Conducts systematic multi-database academic literature searches following PRISMA/SWARM protocols, screens and synthesises findings, verifies all citations, and generates a structured review report.",
       "prerequisites": [
@@ -2252,14 +2253,14 @@
           "source": "https://arxiv.org/abs/2501.05468",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "Rouzrokh et al. (2025) \u2014 LatteReview: multi-agent framework for systematic review automation; modular agents for title/abstract screening, relevance scoring, and structured data extraction with RAG and multimodal support."
+          "notes": "Rouzrokh et al. (2025) — LatteReview: multi-agent framework for systematic review automation; modular agents for title/abstract screening, relevance scoring, and structured data extraction with RAG and multimodal support."
         },
         {
           "class": "B",
           "source": "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/scientific-skills/literature-review/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "K-Dense-AI scientific-agent-skills \u2014 reproducible literature-review skill: seven-phase workflow from research-question planning through multi-database search, screening, extraction, synthesis, citation verification to final PDF output."
+          "notes": "K-Dense-AI scientific-agent-skills — reproducible literature-review skill: seven-phase workflow from research-question planning through multi-database search, screening, extraction, synthesis, citation verification to final PDF output."
         }
       ],
       "knownAgents": [],
@@ -2272,7 +2273,7 @@
       "id": "logical-inference",
       "name": "Logical Inference",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "uncommon",
       "description": "Applies deductive, inductive, or abductive reasoning to derive valid conclusions from premises and structured knowledge.",
       "prerequisites": [],
@@ -2287,7 +2288,7 @@
           "source": "https://arxiv.org/abs/2201.11903",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Chain-of-Thought prompting (Wei et al.) \u00e2\u20ac\u201d few-shot CoT elicits multi-step reasoning; +18% on GSM8K and +15% on SVAMP over standard prompting."
+          "notes": "Chain-of-Thought prompting (Wei et al.) â€” few-shot CoT elicits multi-step reasoning; +18% on GSM8K and +15% on SVAMP over standard prompting."
         }
       ],
       "knownAgents": [],
@@ -2300,7 +2301,7 @@
       "id": "math-reason",
       "name": "Math Reason",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
       "description": "Solves multi-step mathematical problems including arithmetic, algebra, calculus, and competition mathematics through symbolic and numeric reasoning.",
       "prerequisites": [],
@@ -2315,7 +2316,7 @@
           "source": "https://arxiv.org/abs/2206.14858",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Minerva (Google) \u00e2\u20ac\u201d 50.3% on MATH and 78.5% on MMLU-STEM benchmarks using chain-of-thought over scientific literature."
+          "notes": "Minerva (Google) â€” 50.3% on MATH and 78.5% on MMLU-STEM benchmarks using chain-of-thought over scientific literature."
         }
       ],
       "knownAgents": [],
@@ -2328,7 +2329,7 @@
       "id": "mcp-debugger-control",
       "name": "MCP Debugger Control",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Exposes low-level debugger capabilities (breakpoints, stepping, stack inspection, variable evaluation) to AI agents via the Model Context Protocol, enabling real-time runtime diagnosis and autonomous bug fixing.",
       "prerequisites": [
@@ -2363,9 +2364,9 @@
       "id": "mcp-integration",
       "name": "MCP Integration",
       "type": "basic",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
-      "description": "Connect to and invoke tools exposed by Model Context Protocol (MCP) servers \u2014 enumerate available tools, execute calls, and handle responses across any MCP-compatible backend.",
+      "description": "Connect to and invoke tools exposed by Model Context Protocol (MCP) servers — enumerate available tools, execute calls, and handle responses across any MCP-compatible backend.",
       "prerequisites": [],
       "derivatives": [
         "mcp-server-creation"
@@ -2391,7 +2392,7 @@
           "source": "https://github.com/intelligentcode-ai/skills/blob/main/skills/mcp-client/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "intelligentcode-ai/skills mcp-client \u2014 portable CLI MCP client with server enumeration, tool display, and on-demand execution."
+          "notes": "intelligentcode-ai/skills mcp-client — portable CLI MCP client with server enumeration, tool display, and on-demand execution."
         }
       ],
       "knownAgents": [],
@@ -2407,7 +2408,7 @@
       "id": "mcp-server-creation",
       "name": "MCP Server Creation",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Designs and implements Model Context Protocol servers that expose external APIs, files, or services as well-typed tools with clear schemas, authentication, and testable agent workflows.",
       "prerequisites": [
@@ -2449,7 +2450,7 @@
       "id": "memory-manage",
       "name": "Memory Manage",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
       "description": "Maintains, indexes, and retrieves conversational and long-term memory across sessions, managing context window constraints.",
       "prerequisites": [],
@@ -2464,7 +2465,7 @@
           "source": "https://arxiv.org/abs/2310.08560",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "MemGPT \u00e2\u20ac\u201d virtual context management system enabling LLMs to handle unbounded memory; benchmarked on multi-session dialogue and document QA."
+          "notes": "MemGPT â€” virtual context management system enabling LLMs to handle unbounded memory; benchmarked on multi-session dialogue and document QA."
         }
       ],
       "knownAgents": [],
@@ -2477,7 +2478,7 @@
       "id": "ml-pipeline",
       "name": "ML Pipeline",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Designs and implements production ML pipelines with experiment tracking (MLflow, W&B), feature stores (Feast), orchestration (Kubeflow, Airflow), and automated retraining workflows including model evaluation gates and A/B deployment.",
       "prerequisites": [
@@ -2493,14 +2494,14 @@
           "source": "https://arxiv.org/abs/2502.18530",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "Xue et al. (2025) \u2014 IMPROVE: Iterative Model Pipeline Refinement and Optimization Leveraging LLM Experts; iterative component-level refinement consistently outperforms single-step zero-shot LLM-based ML pipeline optimization with theoretical convergence guarantees."
+          "notes": "Xue et al. (2025) — IMPROVE: Iterative Model Pipeline Refinement and Optimization Leveraging LLM Experts; iterative component-level refinement consistently outperforms single-step zero-shot LLM-based ML pipeline optimization with theoretical convergence guarantees."
         },
         {
           "class": "B",
           "source": "https://github.com/Jeffallan/claude-skills/blob/main/skills/ml-pipeline/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "Jeffallan/claude-skills \u2014 reproducible ml-pipeline skill: full lifecycle from data validation and feature engineering through distributed training, experiment tracking, model evaluation gates, A/B testing, and automated retraining with DVC/Feast/MLflow/Kubeflow."
+          "notes": "Jeffallan/claude-skills — reproducible ml-pipeline skill: full lifecycle from data validation and feature engineering through distributed training, experiment tracking, model evaluation gates, A/B testing, and automated retraining with DVC/Feast/MLflow/Kubeflow."
         }
       ],
       "knownAgents": [],
@@ -2513,7 +2514,7 @@
       "id": "multi-agent-debate",
       "name": "Multi-Agent Debate",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Runs multiple LLM agents that propose, critique, and iteratively refine answers across structured debate rounds, converging on more accurate and well-reasoned responses than any single agent achieves.",
       "prerequisites": [
@@ -2549,7 +2550,7 @@
       "id": "multi-agent-orchestration-v",
       "name": "Multi-Agent Orchestration",
       "type": "ultimate",
-      "level": "5\u2605",
+      "level": "5★",
       "rarity": "legendary",
       "description": "Coordinates multiple specialized agents across complex workflows with dynamic task allocation and conflict resolution.",
       "prerequisites": [
@@ -2565,7 +2566,7 @@
           "source": "https://github.com/gaia-registry/gaia/blob/main/docs/evidence/seed.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Seed evidence \u00e2\u20ac\u201d structural validation placeholder."
+          "notes": "Seed evidence â€” structural validation placeholder."
         }
       ],
       "knownAgents": [],
@@ -2579,7 +2580,7 @@
       "id": "multimodal-reasoning",
       "name": "Multimodal Reasoning",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "rare",
       "description": "Integrates information from images and text to answer questions requiring visual grounding and logical inference across modalities.",
       "prerequisites": [
@@ -2595,7 +2596,7 @@
           "source": "https://arxiv.org/abs/2304.08485",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "LLaVA \u00e2\u20ac\u201d large language and vision assistant; 85.1% on ScienceQA and 64.3% on TextVQA, establishing reproducible multimodal reasoning benchmark."
+          "notes": "LLaVA â€” large language and vision assistant; 85.1% on ScienceQA and 64.3% on TextVQA, establishing reproducible multimodal reasoning benchmark."
         }
       ],
       "knownAgents": [],
@@ -2611,7 +2612,7 @@
       "id": "object-detection",
       "name": "Object Detection",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
       "description": "Locates and classifies multiple objects within images by producing bounding boxes, confidence scores, and category labels in a single forward pass.",
       "prerequisites": [],
@@ -2646,7 +2647,7 @@
       "id": "ocr",
       "name": "OCR",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
       "description": "Extracts machine-readable text from raster images, scanned pages, and photo documents using optical character recognition, preserving layout and handling skew, noise, and varied fonts.",
       "prerequisites": [],
@@ -2680,7 +2681,7 @@
       "id": "parallel-execution",
       "name": "Parallel Execution",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
       "description": "Decompose a task into independent sub-tasks and execute them concurrently, merging results with configurable concurrency limits and queue-based state tracking.",
       "prerequisites": [],
@@ -2692,7 +2693,7 @@
           "source": "https://github.com/intelligentcode-ai/skills/blob/main/skills/parallel-execution/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "intelligentcode-ai/skills parallel-execution \u2014 concurrent work item execution with independence verification and configurable concurrency (default 5)."
+          "notes": "intelligentcode-ai/skills parallel-execution — concurrent work item execution with independence verification and configurable concurrency (default 5)."
         }
       ],
       "knownAgents": [],
@@ -2705,7 +2706,7 @@
       "id": "parse-html",
       "name": "Parse HTML",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Extracts structured content from raw HTML, navigating DOM trees and handling malformed markup.",
       "prerequisites": [],
@@ -2732,7 +2733,7 @@
       "id": "parse-json",
       "name": "Parse JSON",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Extracts structured data from JSON-formatted input, handling nested objects and arrays.",
       "prerequisites": [],
@@ -2760,7 +2761,7 @@
       "id": "parse-pdf",
       "name": "Parse PDF",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Extracts text, tables, equations, and structure from PDF documents, preserving layout and reading order.",
       "prerequisites": [],
@@ -2774,7 +2775,7 @@
           "source": "https://arxiv.org/abs/2308.13418",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Nougat (Meta AI) \u00e2\u20ac\u201d visual transformer for scientific PDF parsing; 7.6% edit distance on arXiv papers, handling LaTeX, tables, and equations."
+          "notes": "Nougat (Meta AI) â€” visual transformer for scientific PDF parsing; 7.6% edit distance on arXiv papers, handling LaTeX, tables, and equations."
         }
       ],
       "knownAgents": [],
@@ -2787,7 +2788,7 @@
       "id": "plan-and-execute",
       "name": "Plan and Execute",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Decomposes complex objectives into sub-tasks, selects tools, and orchestrates execution.",
       "prerequisites": [
@@ -2818,7 +2819,7 @@
       "id": "plan-decompose",
       "name": "Plan and Decompose",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Breaks a complex objective into an ordered sequence of executable sub-tasks.",
       "prerequisites": [],
@@ -2851,7 +2852,7 @@
       "id": "prd-generation",
       "name": "PRD Generation",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "uncommon",
       "description": "Synthesizes conversation context and codebase knowledge into a structured Product Requirements Document containing a problem statement, extensive user stories, implementation decisions, module boundaries, testing decisions, and out-of-scope items.",
       "prerequisites": [
@@ -2886,7 +2887,7 @@
       "id": "prediction-market-analysis",
       "name": "Prediction Market Analysis",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Queries prediction-market data, compares market probabilities and price history, and summarizes probabilistic signals for forecasting or decision-support workflows.",
       "prerequisites": [
@@ -2917,7 +2918,7 @@
       "id": "prompt-injection-defense",
       "name": "Prompt Injection Defense",
       "type": "basic",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Detects and neutralizes adversarial instructions injected into agent context from untrusted external sources (indirect prompt injection), using techniques such as context isolation, hierarchical intent verification, or semantic consistency checks.",
       "prerequisites": [],
@@ -2931,21 +2932,21 @@
           "source": "https://arxiv.org/abs/2604.10134",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "PlanGuard (2026) \u2014 training-free indirect prompt injection defense; planning-based consistency verification reduces InjecAgent attack success rate from 72.8% to 0%."
+          "notes": "PlanGuard (2026) — training-free indirect prompt injection defense; planning-based consistency verification reduces InjecAgent attack success rate from 72.8% to 0%."
         },
         {
           "class": "B",
           "source": "https://github.com/tldrsec/prompt-injection-defenses",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "tldrsec/prompt-injection-defenses (682 stars) \u2014 curated, reproducible catalog of defense techniques with implementation references; actively maintained."
+          "notes": "tldrsec/prompt-injection-defenses (682 stars) — curated, reproducible catalog of defense techniques with implementation references; actively maintained."
         },
         {
           "class": "C",
           "source": "https://skillsmp.com/api/v1/skills/search?q=prompt-injection-defense",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "SkillsMP top hit: openclaw/prompt-injection-defense (4,419 stars) \u2014 'Harden agent sessions against prompt injection from untrusted content'; references CaMeL benchmark."
+          "notes": "SkillsMP top hit: openclaw/prompt-injection-defense (4,419 stars) — 'Harden agent sessions against prompt injection from untrusted content'; references CaMeL benchmark."
         }
       ],
       "knownAgents": [],
@@ -2958,7 +2959,7 @@
       "id": "prompt-optimization",
       "name": "Prompt Optimization",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "uncommon",
       "description": "Automatically improves prompt instructions through iterative compilation, treating prompts as programs that can be optimized against a metric using LLM-driven feedback loops.",
       "prerequisites": [
@@ -2975,14 +2976,14 @@
           "source": "https://arxiv.org/abs/2310.03714",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Khattab et al. (2023) \u00e2\u20ac\u201d DSPy: Compiling Declarative Language Model Calls into Self-Improving Pipelines; automated prompt tuning matches or exceeds hand-crafted prompts on GSM8K, HotPotQA, and FEVER."
+          "notes": "Khattab et al. (2023) â€” DSPy: Compiling Declarative Language Model Calls into Self-Improving Pipelines; automated prompt tuning matches or exceeds hand-crafted prompts on GSM8K, HotPotQA, and FEVER."
         },
         {
           "class": "B",
           "source": "https://github.com/stanfordnlp/dspy",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "DSPy \u00e2\u20ac\u201d Stanford NLP library for programmable LM pipelines; 18k+ GitHub stars, supports multiple optimizers (BootstrapFewShot, MIPRO, COPRO) across any LM."
+          "notes": "DSPy â€” Stanford NLP library for programmable LM pipelines; 18k+ GitHub stars, supports multiple optimizers (BootstrapFewShot, MIPRO, COPRO) across any LM."
         }
       ],
       "knownAgents": [],
@@ -2995,7 +2996,7 @@
       "id": "question-answer",
       "name": "Question Answer",
       "type": "basic",
-      "level": "0\u2605",
+      "level": "0★",
       "rarity": "common",
       "description": "Produces accurate, context-grounded answers to natural-language questions, handling unanswerable cases.",
       "prerequisites": [],
@@ -3011,7 +3012,7 @@
           "source": "https://arxiv.org/abs/1806.03822",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SQuAD 2.0 \u00e2\u20ac\u201d reading comprehension benchmark with 150K questions; modern LLMs exceed human F1 (90.9), providing rigorous reproducible evaluation."
+          "notes": "SQuAD 2.0 â€” reading comprehension benchmark with 150K questions; modern LLMs exceed human F1 (90.9), providing rigorous reproducible evaluation."
         }
       ],
       "knownAgents": [],
@@ -3024,7 +3025,7 @@
       "id": "rag-pipeline",
       "name": "RAG Pipeline",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "End-to-end retrieval-augmented generation combining document chunking, embedding, retrieval, and relevance scoring.",
       "prerequisites": [
@@ -3063,7 +3064,7 @@
       "id": "rank",
       "name": "Rank",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Orders a set of candidate items by relevance, quality, or fitness for a given objective.",
       "prerequisites": [],
@@ -3090,7 +3091,7 @@
       "id": "re-act-reasoning",
       "name": "ReAct Reasoning",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Interleaves free-form reasoning traces with discrete tool actions in a single loop, enabling agents to plan, act, observe, and update beliefs step-by-step.",
       "prerequisites": [
@@ -3108,14 +3109,14 @@
           "source": "https://arxiv.org/abs/2210.03629",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "ReAct (Yao et al., 2023) \u00e2\u20ac\u201d reasoning+acting paradigm; +34% on HotpotQA and +10% on ALFWorld vs chain-of-thought-only baselines."
+          "notes": "ReAct (Yao et al., 2023) â€” reasoning+acting paradigm; +34% on HotpotQA and +10% on ALFWorld vs chain-of-thought-only baselines."
         },
         {
           "class": "B",
           "source": "https://github.com/ysymyth/ReAct",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "ReAct repo \u00e2\u20ac\u201d reproducible prompts and evaluation harness for HotpotQA, FEVER, ALFWorld, and WebShop benchmarks."
+          "notes": "ReAct repo â€” reproducible prompts and evaluation harness for HotpotQA, FEVER, ALFWorld, and WebShop benchmarks."
         }
       ],
       "knownAgents": [],
@@ -3128,7 +3129,7 @@
       "id": "real-time-voice-assistant",
       "name": "Real-Time Voice Assistant",
       "type": "ultimate",
-      "level": "5\u2605",
+      "level": "5★",
       "rarity": "legendary",
       "description": "Provides low-latency spoken interactions combining real-time speech I/O, persistent memory, and goal-directed task execution across multi-session conversations.",
       "prerequisites": [
@@ -3144,21 +3145,21 @@
           "source": "https://arxiv.org/abs/2312.11805",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "AudioPaLM (Google) \u00e2\u20ac\u201d unified audio language model supporting real-time spoken dialogue; SOTA on ASR and speech translation, demonstrating end-to-end voice assistant capability."
+          "notes": "AudioPaLM (Google) â€” unified audio language model supporting real-time spoken dialogue; SOTA on ASR and speech translation, demonstrating end-to-end voice assistant capability."
         },
         {
           "class": "A",
           "source": "https://arxiv.org/abs/2305.11206",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "VoiceBox (Meta AI) \u00e2\u20ac\u201d generative speech model with zero-shot TTS; enables real-time voice assistants with <100ms synthesis latency benchmarked on VCTK."
+          "notes": "VoiceBox (Meta AI) â€” generative speech model with zero-shot TTS; enables real-time voice assistants with <100ms synthesis latency benchmarked on VCTK."
         },
         {
           "class": "B",
           "source": "https://github.com/openai/whisper",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Whisper + LLM integration demos \u00e2\u20ac\u201d open-source real-time voice assistant pipelines combining Whisper STT, LLM reasoning, and TTS with documented latency benchmarks."
+          "notes": "Whisper + LLM integration demos â€” open-source real-time voice assistant pipelines combining Whisper STT, LLM reasoning, and TTS with documented latency benchmarks."
         }
       ],
       "knownAgents": [],
@@ -3172,7 +3173,7 @@
       "id": "recursive-self-improvement",
       "name": "Recursive Self-Improvement",
       "type": "ultimate",
-      "level": "5\u2605",
+      "level": "5★",
       "rarity": "legendary",
       "description": "Agent iteratively refines its own prompts, tools, or strategies based on performance feedback loops.",
       "prerequisites": [
@@ -3188,7 +3189,7 @@
           "source": "https://github.com/gaia-registry/gaia/blob/main/docs/evidence/seed.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Seed evidence \u00e2\u20ac\u201d structural validation placeholder."
+          "notes": "Seed evidence â€” structural validation placeholder."
         }
       ],
       "knownAgents": [],
@@ -3202,7 +3203,7 @@
       "id": "refactor-code",
       "name": "Refactor Code",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
       "description": "Restructures existing source code to improve readability, maintainability, or performance without changing observable behavior.",
       "prerequisites": [],
@@ -3216,7 +3217,7 @@
           "source": "https://arxiv.org/abs/2310.06770",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SWE-bench \u00e2\u20ac\u201d 2294 real GitHub issues benchmark; agents that resolve issues must safely refactor code while passing existing test suites."
+          "notes": "SWE-bench â€” 2294 real GitHub issues benchmark; agents that resolve issues must safely refactor code while passing existing test suites."
         }
       ],
       "knownAgents": [],
@@ -3229,7 +3230,7 @@
       "id": "registry-curation",
       "name": "Registry Curation",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Systematically discovers, evaluates, and ingests new skill definitions into a structured skill registry: researching capabilities, sourcing reproducible evidence, scripting graph updates, validating schema and DAG integrity, and publishing via pull request.",
       "prerequisites": [
@@ -3247,7 +3248,7 @@
           "source": "https://github.com/mbtiongson1/gaia-skill-tree/pull/2",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Reproducible demonstration: Claude Code agent researched 30 popular AI skills, sourced 22 peer-reviewed papers, generated gaia.json via script, passed all 6 validator checks, and submitted PR \u00e2\u20ac\u201d full inputs/outputs archived in the PR diff."
+          "notes": "Reproducible demonstration: Claude Code agent researched 30 popular AI skills, sourced 22 peer-reviewed papers, generated gaia.json via script, passed all 6 validator checks, and submitted PR â€” full inputs/outputs archived in the PR diff."
         },
         {
           "class": "B",
@@ -3261,7 +3262,7 @@
           "source": "https://github.com/mbtiongson1/gaia-skill-tree",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Batch 3 curation: 5 skills added (2 atomic, 3 composite) \u00e2\u20ac\u201d self-consistency, few-shot-learning, tree-of-thought, prompt-optimization, tool-creation."
+          "notes": "Batch 3 curation: 5 skills added (2 atomic, 3 composite) â€” self-consistency, few-shot-learning, tree-of-thought, prompt-optimization, tool-creation."
         },
         {
           "class": "B",
@@ -3288,7 +3289,7 @@
       "id": "release-automation",
       "name": "Release Automation",
       "type": "extra",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
       "description": "Automate the full software release cycle: determine semantic version bump, update CHANGELOG, commit, create a git tag, and publish a GitHub release with release notes.",
       "prerequisites": [
@@ -3304,7 +3305,7 @@
           "source": "https://github.com/intelligentcode-ai/skills/blob/main/skills/release/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "intelligentcode-ai/skills release \u2014 automates semantic versioning, CHANGELOG updates, PR merging, git tagging, and GitHub release creation with verification gates."
+          "notes": "intelligentcode-ai/skills release — automates semantic versioning, CHANGELOG updates, PR merging, git tagging, and GitHub release creation with verification gates."
         }
       ],
       "knownAgents": [],
@@ -3317,9 +3318,9 @@
       "id": "requirements-analysis",
       "name": "Requirements Analysis",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "common",
-      "description": "Elicit and structure requirements from stakeholder inputs into formal specifications \u2014 user stories, acceptance criteria, and traceability matrices.",
+      "description": "Elicit and structure requirements from stakeholder inputs into formal specifications — user stories, acceptance criteria, and traceability matrices.",
       "prerequisites": [],
       "derivatives": [],
       "conditions": "",
@@ -3329,7 +3330,7 @@
           "source": "https://github.com/intelligentcode-ai/skills/blob/main/skills/requirements-engineer/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "intelligentcode-ai/skills requirements-engineer \u2014 business analysis specialist bridging stakeholders and technical teams for full requirements lifecycle."
+          "notes": "intelligentcode-ai/skills requirements-engineer — business analysis specialist bridging stakeholders and technical teams for full requirements lifecycle."
         }
       ],
       "knownAgents": [],
@@ -3342,7 +3343,7 @@
       "id": "research",
       "name": "Research",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Conducts multi-source information gathering, synthesis, and citation for a given topic.",
       "prerequisites": [
@@ -3377,7 +3378,7 @@
       "id": "retrieve",
       "name": "Retrieve",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Fetches relevant documents or passages from an indexed corpus given a query.",
       "prerequisites": [],
@@ -3407,7 +3408,7 @@
       "id": "reward-modeling",
       "name": "Reward Modeling",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "rare",
       "description": "Learns a scalar reward signal from human preference comparisons between model outputs, enabling reinforcement learning from human feedback (RLHF) to align model behavior with human values.",
       "prerequisites": [],
@@ -3442,7 +3443,7 @@
       "id": "route-intent",
       "name": "Route Intent",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Classifies user intent and directs execution to the appropriate handler, tool, or sub-agent.",
       "prerequisites": [],
@@ -3471,9 +3472,9 @@
       "id": "schema-design",
       "name": "Schema Design",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "common",
-      "description": "Design database schemas across relational, NoSQL, graph, and time-series stores \u2014 entity modelling, normalization, indexing strategies, and migration planning.",
+      "description": "Design database schemas across relational, NoSQL, graph, and time-series stores — entity modelling, normalization, indexing strategies, and migration planning.",
       "prerequisites": [],
       "derivatives": [],
       "conditions": "",
@@ -3483,7 +3484,7 @@
           "source": "https://github.com/intelligentcode-ai/skills/blob/main/skills/database-engineer/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "intelligentcode-ai/skills database-engineer \u2014 schema design and query optimization expert across relational, NoSQL, graph, time-series, and data warehouses."
+          "notes": "intelligentcode-ai/skills database-engineer — schema design and query optimization expert across relational, NoSQL, graph, time-series, and data warehouses."
         }
       ],
       "knownAgents": [],
@@ -3496,9 +3497,9 @@
       "id": "scientific-discovery",
       "name": "Autonomous Scientific Discovery",
       "type": "ultimate",
-      "level": "5\u2605",
+      "level": "5★",
       "rarity": "legendary",
-      "description": "Autonomously generates novel scientific hypotheses, designs and executes experiments, analyses results, and produces a written report \u00e2\u20ac\u201d completing a full research cycle without human intervention.",
+      "description": "Autonomously generates novel scientific hypotheses, designs and executes experiments, analyses results, and produces a written report â€” completing a full research cycle without human intervention.",
       "prerequisites": [
         "hypothesis-generate",
         "research",
@@ -3512,21 +3513,21 @@
           "source": "https://arxiv.org/abs/2304.05376",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "ChemCrow (Bran et al., 2023) \u00e2\u20ac\u201d autonomous chemistry agent completes synthesis planning and molecular design tasks rated expert-level by human chemists."
+          "notes": "ChemCrow (Bran et al., 2023) â€” autonomous chemistry agent completes synthesis planning and molecular design tasks rated expert-level by human chemists."
         },
         {
           "class": "A",
           "source": "https://arxiv.org/abs/2304.05332",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Coscientist (Boiko et al., 2023) \u00e2\u20ac\u201d autonomously planned and executed real wet-lab chemistry experiments, confirmed by GC-MS analysis."
+          "notes": "Coscientist (Boiko et al., 2023) â€” autonomously planned and executed real wet-lab chemistry experiments, confirmed by GC-MS analysis."
         },
         {
           "class": "B",
           "source": "https://github.com/SakanaAI/AI-Scientist",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "AI Scientist (Lu et al., 2024) \u00e2\u20ac\u201d generates idea, writes code, runs experiments, and produces a full NeurIPS-style paper; 50+ manuscripts auto-generated."
+          "notes": "AI Scientist (Lu et al., 2024) â€” generates idea, writes code, runs experiments, and produces a full NeurIPS-style paper; 50+ manuscripts auto-generated."
         }
       ],
       "knownAgents": [],
@@ -3540,7 +3541,7 @@
       "id": "scientific-visualization",
       "name": "Scientific Visualization",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
       "description": "Creates publication-ready scientific figures with multi-panel layouts, statistical annotations, colorblind-safe palettes, and journal-specific formatting (Nature, Science, Cell) using matplotlib, seaborn, and plotly.",
       "prerequisites": [],
@@ -3554,7 +3555,7 @@
           "source": "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/scientific-skills/scientific-visualization/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "K-Dense-AI scientific-agent-skills \u2014 reproducible scientific-visualization skill orchestrating matplotlib, seaborn, and plotly for journal-quality multi-panel figures with PDF/EPS/TIFF/PNG export and accessibility annotations."
+          "notes": "K-Dense-AI scientific-agent-skills — reproducible scientific-visualization skill orchestrating matplotlib, seaborn, and plotly for journal-quality multi-panel figures with PDF/EPS/TIFF/PNG export and accessibility annotations."
         }
       ],
       "knownAgents": [],
@@ -3567,7 +3568,7 @@
       "id": "scientific-writing",
       "name": "Scientific Writing",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Composes research manuscripts in IMRAD structure with reporting-guideline compliance (CONSORT, STROBE, PRISMA), citation management, publication-quality figures, and LaTeX/PDF formatting.",
       "prerequisites": [
@@ -3583,14 +3584,14 @@
           "source": "https://arxiv.org/abs/2405.20477",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "Chamoun et al. (ACL 2024 Findings) \u2014 SWIFT: automated focused feedback for scientific writing; multi-component LLM system (planner, investigator, reviewer, controller) rated more specific and helpful than human reviewers on 300 peer-reviewed manuscripts."
+          "notes": "Chamoun et al. (ACL 2024 Findings) — SWIFT: automated focused feedback for scientific writing; multi-component LLM system (planner, investigator, reviewer, controller) rated more specific and helpful than human reviewers on 300 peer-reviewed manuscripts."
         },
         {
           "class": "B",
           "source": "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/scientific-skills/scientific-writing/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "K-Dense-AI scientific-agent-skills \u2014 reproducible scientific-writing skill: two-stage outline-to-prose pipeline with IMRAD structure, multi-style citation management, and reporting-guideline validation (CONSORT, STROBE, PRISMA, STARD, TRIPOD)."
+          "notes": "K-Dense-AI scientific-agent-skills — reproducible scientific-writing skill: two-stage outline-to-prose pipeline with IMRAD structure, multi-style citation management, and reporting-guideline validation (CONSORT, STROBE, PRISMA, STARD, TRIPOD)."
         }
       ],
       "knownAgents": [],
@@ -3603,7 +3604,7 @@
       "id": "score-relevance",
       "name": "Score Relevance",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Assigns a numerical relevance score to candidate items relative to a query or objective.",
       "prerequisites": [],
@@ -3631,7 +3632,7 @@
       "id": "security-audit",
       "name": "Security Audit",
       "type": "extra",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "rare",
       "description": "Systematically identify security vulnerabilities, assess attack surface, and produce actionable remediation guidance across code, dependencies, and infrastructure.",
       "prerequisites": [
@@ -3648,14 +3649,14 @@
           "source": "https://github.com/intelligentcode-ai/skills/blob/main/skills/security-engineer/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "intelligentcode-ai/skills security-engineer \u2014 vulnerability assessment and security architecture with zero-trust principles and compliance management."
+          "notes": "intelligentcode-ai/skills security-engineer — vulnerability assessment and security architecture with zero-trust principles and compliance management."
         },
         {
           "class": "C",
           "source": "https://github.com/microsoft/PromptKit",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "microsoft/PromptKit (42 stars) \u2014 composable prompt components for security audits, code review, and bug investigation with any LLM."
+          "notes": "microsoft/PromptKit (42 stars) — composable prompt components for security audits, code review, and bug investigation with any LLM."
         }
       ],
       "knownAgents": [],
@@ -3668,7 +3669,7 @@
       "id": "self-consistency",
       "name": "Self-Consistency",
       "type": "unique",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Samples multiple independent reasoning paths for the same problem and selects the answer by majority vote, improving robustness without any additional training.",
       "prerequisites": [],
@@ -3683,7 +3684,7 @@
           "source": "https://arxiv.org/abs/2203.11171",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Wang et al. (2022) \u00e2\u20ac\u201d Self-Consistency Improves Chain of Thought Reasoning in Language Models; +17.9% on GSM8K and +11.0% on MATH over greedy CoT decoding."
+          "notes": "Wang et al. (2022) â€” Self-Consistency Improves Chain of Thought Reasoning in Language Models; +17.9% on GSM8K and +11.0% on MATH over greedy CoT decoding."
         }
       ],
       "knownAgents": [],
@@ -3696,7 +3697,7 @@
       "id": "self-critique",
       "name": "Self-Critique",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "uncommon",
       "description": "Iteratively evaluates and refines its own outputs using self-generated feedback, improving quality without external supervision.",
       "prerequisites": [],
@@ -3711,14 +3712,14 @@
           "source": "https://arxiv.org/abs/2303.17651",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Self-Refine (Madaan et al., 2023) \u00e2\u20ac\u201d iterative self-feedback loop; +20% on code generation and +13% on math reasoning vs single-pass generation."
+          "notes": "Self-Refine (Madaan et al., 2023) â€” iterative self-feedback loop; +20% on code generation and +13% on math reasoning vs single-pass generation."
         },
         {
           "class": "B",
           "source": "https://github.com/madaan/self-refine",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Self-Refine repo \u00e2\u20ac\u201d reproducible demos across 7 tasks (code, math, dialogue, sentiment reversal) with evaluation scripts."
+          "notes": "Self-Refine repo â€” reproducible demos across 7 tasks (code, math, dialogue, sentiment reversal) with evaluation scripts."
         }
       ],
       "knownAgents": [],
@@ -3731,7 +3732,7 @@
       "id": "semantic-cache",
       "name": "Semantic Cache",
       "type": "unique",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Stores LLM responses keyed by embedding similarity so that semantically equivalent queries are served from cache, reducing inference latency and token cost without sacrificing answer quality.",
       "prerequisites": [],
@@ -3770,7 +3771,7 @@
       "id": "sentiment-analysis",
       "name": "Sentiment Analysis",
       "type": "basic",
-      "level": "0\u2605",
+      "level": "0★",
       "rarity": "common",
       "description": "Determines the emotional valence (positive, negative, neutral) and intensity of text input.",
       "prerequisites": [],
@@ -3785,7 +3786,7 @@
           "source": "https://arxiv.org/abs/1810.04805",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "BERT paper \u00e2\u20ac\u201d achieves SOTA on SST-2 sentiment benchmark (93.5% accuracy), foundational evidence for LLM-based sentiment analysis."
+          "notes": "BERT paper â€” achieves SOTA on SST-2 sentiment benchmark (93.5% accuracy), foundational evidence for LLM-based sentiment analysis."
         }
       ],
       "knownAgents": [],
@@ -3798,7 +3799,7 @@
       "id": "skill-authoring",
       "name": "Skill Authoring",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Designs, writes, packages, and iteratively improves reusable agent skill directories with metadata, progressive instructions, supporting assets, and measurable trigger criteria.",
       "prerequisites": [
@@ -3839,7 +3840,7 @@
       "id": "skill-discovery",
       "name": "Skill Discovery",
       "type": "basic",
-      "level": "0\u2605",
+      "level": "0★",
       "rarity": "common",
       "description": "Searches a skill or tool registry, ranks results by relevance and install count, and surfaces candidates for the agent to adopt or invoke.",
       "prerequisites": [],
@@ -3867,7 +3868,7 @@
       "id": "skill-performance-benchmarking",
       "name": "Skill Performance Benchmarking",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Builds and runs task suites that measure whether agents select, invoke, and complete installed skills correctly across artifact-rich workflows and repeated trials.",
       "prerequisites": [
@@ -3915,7 +3916,7 @@
       "id": "skill-security-analysis",
       "name": "Skill Security Analysis",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Assesses third-party agent skills for malicious behavior, unsafe permissions, prompt-injection exposure, repository-context mismatch, and supply-chain risk before installation or invocation.",
       "prerequisites": [
@@ -3961,7 +3962,7 @@
       "id": "speech-to-text",
       "name": "Speech to Text",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "common",
       "description": "Transcribes spoken audio into accurate text, handling diverse accents, noise conditions, and multiple languages.",
       "prerequisites": [],
@@ -3975,7 +3976,7 @@
           "source": "https://arxiv.org/abs/2212.04356",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Whisper (OpenAI) \u00e2\u20ac\u201d large-scale weak supervision across 680K hours of audio achieves near-human WER on LibriSpeech and multilingual benchmarks."
+          "notes": "Whisper (OpenAI) â€” large-scale weak supervision across 680K hours of audio achieves near-human WER on LibriSpeech and multilingual benchmarks."
         }
       ],
       "knownAgents": [],
@@ -3988,7 +3989,7 @@
       "id": "statistical-analysis",
       "name": "Statistical Analysis",
       "type": "basic",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Performs hypothesis testing, regression analysis, and Bayesian modelling with effect size calculation and APA-formatted statistical reporting using scipy, statsmodels, and PyMC.",
       "prerequisites": [],
@@ -4003,14 +4004,14 @@
           "source": "https://arxiv.org/abs/2511.06701",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "Sargsyan (2025) \u2014 Structural Enforcement of Statistical Rigor in AI-Driven Discovery; monadic architecture achieves 1.1% false discovery rate vs 41% for naive LLM approaches across automated hypothesis-testing pipelines."
+          "notes": "Sargsyan (2025) — Structural Enforcement of Statistical Rigor in AI-Driven Discovery; monadic architecture achieves 1.1% false discovery rate vs 41% for naive LLM approaches across automated hypothesis-testing pipelines."
         },
         {
           "class": "B",
           "source": "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/scientific-skills/statistical-analysis/SKILL.md",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "K-Dense-AI scientific-agent-skills \u2014 reproducible statistical-analysis skill covering parametric, non-parametric, and Bayesian workflows with scipy/statsmodels/pingouin/PyMC and APA-formatted output."
+          "notes": "K-Dense-AI scientific-agent-skills — reproducible statistical-analysis skill covering parametric, non-parametric, and Bayesian workflows with scipy/statsmodels/pingouin/PyMC and APA-formatted output."
         }
       ],
       "knownAgents": [],
@@ -4023,7 +4024,7 @@
       "id": "stealth-browser-interaction",
       "name": "Stealth Browser Interaction",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "uncommon",
       "description": "Operates web browsers through an advanced stealth layer that handles bot-detection, fingerprinting, session rotation, and human-like interaction patterns to maintain resilient access to protected domains.",
       "prerequisites": [
@@ -4059,7 +4060,7 @@
       "id": "structured-output",
       "name": "Structured Output Generation",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Generates output guaranteed to conform to a given schema (JSON, YAML, Pydantic model, etc.) using constrained decoding or grammar-guided generation.",
       "prerequisites": [],
@@ -4077,14 +4078,14 @@
           "source": "https://arxiv.org/abs/2307.09702",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Willard & Louf (2023) \u00e2\u20ac\u201d Efficient Guided Generation for LLMs; finite-state machine approach guarantees schema-valid output with <1% throughput overhead."
+          "notes": "Willard & Louf (2023) â€” Efficient Guided Generation for LLMs; finite-state machine approach guarantees schema-valid output with <1% throughput overhead."
         },
         {
           "class": "B",
           "source": "https://github.com/outlines-dev/outlines",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Outlines library \u00e2\u20ac\u201d production-grade constrained decoding supporting JSON Schema, regex, and CFG grammars; 2k+ GitHub stars."
+          "notes": "Outlines library â€” production-grade constrained decoding supporting JSON Schema, regex, and CFG grammars; 2k+ GitHub stars."
         }
       ],
       "knownAgents": [],
@@ -4097,7 +4098,7 @@
       "id": "summarize",
       "name": "Summarize",
       "type": "basic",
-      "level": "0\u2605",
+      "level": "0★",
       "rarity": "common",
       "description": "Condenses longer input into a shorter representation that preserves key information and intent.",
       "prerequisites": [],
@@ -4128,7 +4129,7 @@
       "id": "test-driven-development",
       "name": "Test-Driven Development",
       "type": "basic",
-      "level": "0\u2605",
+      "level": "0★",
       "rarity": "uncommon",
       "description": "Enforces a strict red-green-refactor TDD loop: writes failing tests before implementation, blocks code generation that skips the test step, and validates coverage thresholds before marking tasks complete.",
       "prerequisites": [],
@@ -4153,7 +4154,7 @@
       "id": "text-to-speech",
       "name": "Text to Speech",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "common",
       "description": "Synthesizes natural-sounding speech audio from text input, supporting voice cloning and prosody control.",
       "prerequisites": [],
@@ -4167,7 +4168,7 @@
           "source": "https://arxiv.org/abs/2301.02111",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "VALL-E (Microsoft) \u00e2\u20ac\u201d neural codec language model achieving SOTA speech synthesis with 3-second voice cloning on LibriSpeech."
+          "notes": "VALL-E (Microsoft) â€” neural codec language model achieving SOTA speech synthesis with 3-second voice cloning on LibriSpeech."
         }
       ],
       "knownAgents": [],
@@ -4180,7 +4181,7 @@
       "id": "text-to-sql-pipeline",
       "name": "Text-to-SQL Pipeline",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Converts natural-language queries into validated, executable SQL against a target schema and returns formatted result sets.",
       "prerequisites": [
@@ -4196,7 +4197,7 @@
           "source": "https://arxiv.org/abs/2304.11015",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "DIN-SQL \u00e2\u20ac\u201d decomposed in-context learning for text-to-SQL; 82.8% execution accuracy on Spider dev, demonstrating end-to-end pipeline."
+          "notes": "DIN-SQL â€” decomposed in-context learning for text-to-SQL; 82.8% execution accuracy on Spider dev, demonstrating end-to-end pipeline."
         }
       ],
       "knownAgents": [],
@@ -4209,7 +4210,7 @@
       "id": "token-observability",
       "name": "Token Observability",
       "type": "basic",
-      "level": "2\u2605",
+      "level": "2★",
       "rarity": "uncommon",
       "description": "Tracks and analyzes token usage and cost across multiple AI models and agents, providing session-level and project-level spending metrics.",
       "prerequisites": [],
@@ -4236,7 +4237,7 @@
       "id": "tokenize",
       "name": "Tokenize",
       "type": "basic",
-      "level": "0\u2605",
+      "level": "0★",
       "rarity": "common",
       "description": "Splits input text into discrete tokens suitable for downstream processing by language models. MODIFIED FOR TESTING.",
       "prerequisites": [],
@@ -4263,7 +4264,7 @@
       "id": "tool-chaining",
       "name": "Tool Chaining",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Sequences multiple tool invocations into a dependency graph where the output of each tool feeds as structured input to the next, handling state propagation, intermediate result validation, and error recovery across multi-step execution pipelines.",
       "prerequisites": [
@@ -4278,7 +4279,7 @@
           "source": "https://arxiv.org/abs/2604.07223",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "TraceSafe (2026) \u2014 first benchmark with 1,000+ instances explicitly evaluating sequential multi-step tool-calling trajectories across 12 risk categories; establishes tool-chaining as a distinct, measurable capability surface."
+          "notes": "TraceSafe (2026) — first benchmark with 1,000+ instances explicitly evaluating sequential multi-step tool-calling trajectories across 12 risk categories; establishes tool-chaining as a distinct, measurable capability surface."
         },
         {
           "class": "C",
@@ -4298,7 +4299,7 @@
       "id": "tool-creation",
       "name": "Tool Creation",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Dynamically generates reusable tool functions (code) at runtime to solve novel sub-tasks, then invokes those tools to complete the overall objective without human-written APIs.",
       "prerequisites": [
@@ -4317,14 +4318,14 @@
           "source": "https://arxiv.org/abs/2305.17126",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Cai et al. (2023) \u00e2\u20ac\u201d Large Language Models as Tool Makers (LATM); LLM-generated tools reused across problem instances achieve +8.7% on BigBench Hard vs per-instance CoT."
+          "notes": "Cai et al. (2023) â€” Large Language Models as Tool Makers (LATM); LLM-generated tools reused across problem instances achieve +8.7% on BigBench Hard vs per-instance CoT."
         },
         {
           "class": "B",
           "source": "https://github.com/ctlllll/LLM-ToolMaker",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "LATM repo \u00e2\u20ac\u201d reproducible tool-maker/tool-user pipeline with evaluation on BigBench Hard tasks and tool reuse across problem batches."
+          "notes": "LATM repo â€” reproducible tool-maker/tool-user pipeline with evaluation on BigBench Hard tasks and tool reuse across problem batches."
         }
       ],
       "knownAgents": [],
@@ -4337,7 +4338,7 @@
       "id": "tool-select",
       "name": "Tool Select",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Chooses the most appropriate tool or API from a set of available options given a task description.",
       "prerequisites": [],
@@ -4366,7 +4367,7 @@
       "id": "tool-use",
       "name": "Tool Use",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "uncommon",
       "description": "Invokes external functions or APIs by generating well-formed call signatures, parsing results, and incorporating them into reasoning.",
       "prerequisites": [],
@@ -4383,14 +4384,14 @@
           "source": "https://arxiv.org/abs/2302.04761",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Toolformer (Schick et al., 2023) \u00e2\u20ac\u201d self-supervised method teaching LLMs to call APIs; zero-shot tool use surpasses GPT-3 175B on several benchmarks."
+          "notes": "Toolformer (Schick et al., 2023) â€” self-supervised method teaching LLMs to call APIs; zero-shot tool use surpasses GPT-3 175B on several benchmarks."
         },
         {
           "class": "B",
           "source": "https://github.com/OpenBMB/ToolBench",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "ToolBench \u00e2\u20ac\u201d open benchmark with 16,000+ real-world APIs; end-to-end tool-use training and evaluation harness."
+          "notes": "ToolBench â€” open benchmark with 16,000+ real-world APIs; end-to-end tool-use training and evaluation harness."
         }
       ],
       "knownAgents": [],
@@ -4403,7 +4404,7 @@
       "id": "translate",
       "name": "Translate",
       "type": "basic",
-      "level": "0\u2605",
+      "level": "0★",
       "rarity": "common",
       "description": "Converts text from one natural language to another while preserving meaning, tone, and formatting.",
       "prerequisites": [],
@@ -4417,7 +4418,7 @@
           "source": "https://arxiv.org/abs/2207.04672",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "NLLB (No Language Left Behind) \u00e2\u20ac\u201d Meta AI paper demonstrating 200-language translation at human-level quality on FLORES-200 benchmark."
+          "notes": "NLLB (No Language Left Behind) â€” Meta AI paper demonstrating 200-language translation at human-level quality on FLORES-200 benchmark."
         }
       ],
       "knownAgents": [],
@@ -4430,7 +4431,7 @@
       "id": "translation-pipeline",
       "name": "Translation Pipeline",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Translates content end-to-end while preserving sentiment and adapting tone and register for the target audience.",
       "prerequisites": [
@@ -4446,7 +4447,7 @@
           "source": "https://arxiv.org/abs/2308.11596",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "SeamlessM4T (Meta AI) \u00e2\u20ac\u201d unified speech and text translation model with tone and register control; BLEU +3.3 over NLLB on FLORES-200."
+          "notes": "SeamlessM4T (Meta AI) â€” unified speech and text translation model with tone and register control; BLEU +3.3 over NLLB on FLORES-200."
         }
       ],
       "knownAgents": [],
@@ -4459,7 +4460,7 @@
       "id": "tree-of-thought",
       "name": "Tree of Thought",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Frames problem solving as a search over a tree of partial solutions, using LLM-generated evaluations to prune unpromising branches and backtrack, dramatically improving success on complex reasoning tasks.",
       "prerequisites": [
@@ -4476,14 +4477,14 @@
           "source": "https://arxiv.org/abs/2305.10601",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Yao et al. (2023) \u00e2\u20ac\u201d Tree of Thoughts: Deliberate Problem Solving with LLMs; +74% on Game of 24 and +4% on Creative Writing vs chain-of-thought baseline."
+          "notes": "Yao et al. (2023) â€” Tree of Thoughts: Deliberate Problem Solving with LLMs; +74% on Game of 24 and +4% on Creative Writing vs chain-of-thought baseline."
         },
         {
           "class": "B",
           "source": "https://github.com/princeton-nlp/tree-of-thought-llm",
           "evaluator": "mbtiongson1",
           "date": "2026-04-29",
-          "notes": "Princeton-NLP ToT repo \u00e2\u20ac\u201d reproducible breadth-first and depth-first tree search implementations with evaluation scripts for Game of 24 and Mini Crosswords."
+          "notes": "Princeton-NLP ToT repo â€” reproducible breadth-first and depth-first tree search implementations with evaluation scripts for Game of 24 and Mini Crosswords."
         }
       ],
       "knownAgents": [],
@@ -4496,7 +4497,7 @@
       "id": "ubiquitous-language",
       "name": "Ubiquitous Language",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "rare",
       "description": "Establishes and maintains a consistent, domain-driven vocabulary between the agent and human, formalising terminology in a shared glossary (typically CONTEXT.md) to reduce ambiguity and token waste.",
       "prerequisites": [
@@ -4526,7 +4527,7 @@
       "id": "ux-audit",
       "name": "UX Audit",
       "type": "basic",
-      "level": "0\u2605",
+      "level": "0★",
       "rarity": "uncommon",
       "description": "Systematically evaluates a user interface against established usability heuristics or accessibility standards, producing a scored finding report with remediation recommendations.",
       "prerequisites": [],
@@ -4551,7 +4552,7 @@
       "id": "vertical-slice-planning",
       "name": "Vertical Slice Planning",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Decomposes a product plan into independently-demoable vertical slices that each cut through all integration layers end-to-end. Classifies each slice as HITL (human-in-the-loop) or AFK (autonomous), identifies dependency ordering, and publishes structured issues with acceptance criteria.",
       "prerequisites": [
@@ -4579,7 +4580,7 @@
       "id": "video-intelligence",
       "name": "Video Intelligence",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "rare",
       "description": "Processes video streams by extracting frames, transcribing audio, and applying multimodal reasoning to understand temporal and visual context.",
       "prerequisites": [
@@ -4609,7 +4610,7 @@
       "id": "vision-qa",
       "name": "Visual Question Answering",
       "type": "basic",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Answers natural-language questions grounded in a specific image or screenshot by combining visual perception with language reasoning, enabling visual debugging, UI analysis, and document-image Q&A.",
       "prerequisites": [],
@@ -4621,7 +4622,7 @@
           "source": "https://arxiv.org/abs/2604.17488",
           "evaluator": "mbtiongson1",
           "date": "2026-04-30",
-          "notes": "AutoVQA-G (ICASSP 2026) \u2014 self-improving agentic framework for automated VQA and grounding annotation; uses Chain-of-Thought verification + prompt optimization to generate high-quality VQA-G datasets."
+          "notes": "AutoVQA-G (ICASSP 2026) — self-improving agentic framework for automated VQA and grounding annotation; uses Chain-of-Thought verification + prompt optimization to generate high-quality VQA-G datasets."
         },
         {
           "class": "C",
@@ -4641,7 +4642,7 @@
       "id": "voice-agent",
       "name": "Voice Agent",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Handles spoken interactions end-to-end: transcribes audio input, produces language responses, and synthesizes speech output.",
       "prerequisites": [
@@ -4659,7 +4660,7 @@
           "source": "https://github.com/rasa/rasa",
           "evaluator": "mbtiongson1",
           "date": "2026-04-28",
-          "notes": "Rasa Open Source \u00e2\u20ac\u201d production voice agent framework with ASR/TTS integrations; reproducible pipeline with test suite and documented benchmarks."
+          "notes": "Rasa Open Source â€” production voice agent framework with ASR/TTS integrations; reproducible pipeline with test suite and documented benchmarks."
         }
       ],
       "knownAgents": [],
@@ -4675,7 +4676,7 @@
       "id": "web-scrape",
       "name": "Web Scrape",
       "type": "extra",
-      "level": "3\u2605",
+      "level": "3★",
       "rarity": "uncommon",
       "description": "Retrieves and structures data from web pages into usable entities.",
       "prerequisites": [
@@ -4684,7 +4685,8 @@
         "extract-entities"
       ],
       "derivatives": [
-        "knowledge-harvest"
+        "knowledge-harvest",
+        "x-twitter-automation"
       ],
       "conditions": "Structured output mode required.",
       "evidence": [
@@ -4706,7 +4708,7 @@
       "id": "web-search",
       "name": "Web Search",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Queries external search engines or APIs and retrieves relevant result sets.",
       "prerequisites": [],
@@ -4736,7 +4738,7 @@
       "id": "wiki-search",
       "name": "Wiki Search",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "uncommon",
       "description": "Builds, maintains, and queries an interlinked markdown or wiki-style knowledge base so an agent can retrieve durable local context across research sessions.",
       "prerequisites": [
@@ -4767,7 +4769,7 @@
       "id": "workflow-automation",
       "name": "Workflow Automation",
       "type": "extra",
-      "level": "4\u2605",
+      "level": "4★",
       "rarity": "uncommon",
       "description": "Designs, configures, and runs trigger-based multi-step automation pipelines that connect external services, schedule jobs, and orchestrate tool sequences without continuous human supervision.",
       "prerequisites": [
@@ -4777,7 +4779,8 @@
       ],
       "derivatives": [
         "release-automation",
-        "deployment-automation"
+        "deployment-automation",
+        "x-twitter-automation"
       ],
       "conditions": "",
       "evidence": [
@@ -4813,7 +4816,7 @@
       "id": "write-report",
       "name": "Write Report",
       "type": "basic",
-      "level": "1\u2605",
+      "level": "1★",
       "rarity": "common",
       "description": "Produces structured, multi-section written output with headings, citations, and coherent narrative.",
       "prerequisites": [],
@@ -4837,6 +4840,37 @@
       "status": "provisional",
       "createdAt": "2026-04-26",
       "updatedAt": "2026-05-06",
+      "version": "0.1.0"
+    },
+    {
+      "id": "x-twitter-automation",
+      "name": "X/Twitter Automation",
+      "type": "extra",
+      "level": "4★",
+      "rarity": "rare",
+      "description": "Coordinates platform-specific X/Twitter search, tweet and reply retrieval, user lookup, follower export, monitoring, and approval-gated write workflows for social-media agent tasks.",
+      "prerequisites": [
+        "browser-automation",
+        "web-scrape",
+        "workflow-automation"
+      ],
+      "derivatives": [],
+      "conditions": "Requires configured X/Twitter access, repeatable read paths, and explicit approval gates before posting tweets, replies, DMs, or other write actions.",
+      "evidence": [
+        {
+          "class": "B",
+          "source": "https://github.com/Xquik-dev/hermes-tweet",
+          "evaluator": "kriptoburak",
+          "date": "2026-05-15",
+          "notes": "Hermes Tweet provides an installable Hermes Agent X/Twitter skill and plugin for searching tweets, reading replies, looking up users, monitoring tweets, exporting followers, and gating post, reply, and DM actions."
+        }
+      ],
+      "knownAgents": [
+        "Xquik-dev/hermes-tweet"
+      ],
+      "status": "provisional",
+      "createdAt": "2026-05-15",
+      "updatedAt": "2026-05-15",
       "version": "0.1.0"
     }
   ],
@@ -4914,6 +4948,11 @@
     {
       "sourceSkillId": "browser-automation",
       "targetSkillId": "stealth-browser-interaction",
+      "edgeType": "prerequisite"
+    },
+    {
+      "sourceSkillId": "browser-automation",
+      "targetSkillId": "x-twitter-automation",
       "edgeType": "prerequisite"
     },
     {
@@ -5747,6 +5786,11 @@
       "edgeType": "prerequisite"
     },
     {
+      "sourceSkillId": "web-scrape",
+      "targetSkillId": "x-twitter-automation",
+      "edgeType": "prerequisite"
+    },
+    {
       "sourceSkillId": "web-search",
       "targetSkillId": "autonomous-web-research",
       "edgeType": "prerequisite"
@@ -5784,6 +5828,11 @@
     {
       "sourceSkillId": "workflow-automation",
       "targetSkillId": "release-automation",
+      "edgeType": "prerequisite"
+    },
+    {
+      "sourceSkillId": "workflow-automation",
+      "targetSkillId": "x-twitter-automation",
       "edgeType": "prerequisite"
     },
     {

--- a/registry/gaia.svg
+++ b/registry/gaia.svg
@@ -13,199 +13,202 @@
 <circle cx="640.0" cy="440.0" r="54"/>
 </g>
 <g class="edges" fill="none">
-<line x1="909.884" y1="531.585" x2="721.389" y2="290.749" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="717.589" y1="714.235" x2="721.389" y2="290.749" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="604.954" y1="273.652" x2="621.922" y2="270.964" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="804.038" y1="673.059" x2="621.922" y2="270.964" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="436.354" y1="639.383" x2="566.559" y2="593.318" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="694.168" y1="160.195" x2="566.559" y2="593.318" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="565.943" y1="715.21" x2="566.559" y2="593.318" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="389.442" y1="575.815" x2="738.012" y2="301.098" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="901.083" y1="554.283" x2="738.012" y2="301.098" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="917.555" y1="504.718" x2="738.012" y2="301.098" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="798.494" y1="378.521" x2="643.534" y2="386.116" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="909.884" y1="531.585" x2="720.223" y2="290.119" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="717.589" y1="714.235" x2="720.223" y2="290.119" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="589.344" y1="277.723" x2="622.203" y2="270.934" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="804.038" y1="673.059" x2="622.203" y2="270.934" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="436.354" y1="639.383" x2="575.266" y2="597.193" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="694.168" y1="160.195" x2="575.266" y2="597.193" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="565.943" y1="715.21" x2="575.266" y2="597.193" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="389.442" y1="575.815" x2="736.673" y2="300.164" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="901.083" y1="554.283" x2="736.673" y2="300.164" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="917.555" y1="504.718" x2="736.673" y2="300.164" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="797.313" y1="375.559" x2="643.534" y2="386.116" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
 <line x1="357.193" y1="475.287" x2="643.534" y2="386.116" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="712.312" y1="593.854" x2="643.534" y2="386.116" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="924.74" y1="427.837" x2="553.809" y2="586.53" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="901.083" y1="554.283" x2="553.809" y2="586.53" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="917.555" y1="504.718" x2="553.809" y2="586.53" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="712.312" y1="593.854" x2="606.315" y2="397.794" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="491.367" y1="522.511" x2="606.315" y2="397.794" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="526.085" y1="566.188" x2="606.315" y2="397.794" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="581.451" y1="599.6" x2="535.032" y2="573.723" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="588.983" y1="720.397" x2="535.032" y2="573.723" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="588.983" y1="720.397" x2="748.095" y2="308.793" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="455.389" y1="657.126" x2="748.095" y2="308.793" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="535.032" y1="573.723" x2="760.756" y2="320.343" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="830.3" y1="227.842" x2="760.756" y2="320.343" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="661.345" y1="155.8" x2="760.756" y2="320.343" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="924.74" y1="427.837" x2="772.954" y2="334.06" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="924.827" y1="449.928" x2="772.954" y2="334.06" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="909.884" y1="531.585" x2="772.954" y2="334.06" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="644.162" y1="155.03" x2="781.292" y2="345.467" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="783.054" y1="193.503" x2="781.292" y2="345.467" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="891.742" y1="573.607" x2="781.292" y2="345.467" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="764.873" y1="183.813" x2="791.472" y2="362.823" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="355.429" y1="455.634" x2="791.472" y2="362.823" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="742.471" y1="705.941" x2="791.472" y2="362.823" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="400.053" y1="593.787" x2="798.494" y2="378.521" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="436.354" y1="639.383" x2="798.494" y2="378.521" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="830.3" y1="227.842" x2="798.494" y2="378.521" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="604.954" y1="273.652" x2="640.717" y2="270.002" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="901.083" y1="554.283" x2="640.717" y2="270.002" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="924.74" y1="427.837" x2="802.857" y2="391.239" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="588.347" y1="159.72" x2="802.857" y2="391.239" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="909.884" y1="531.585" x2="807.418" y2="410.483" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="804.038" y1="673.059" x2="807.418" y2="410.483" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="748.095" y1="308.793" x2="809.554" y2="427.691" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="862.168" y1="618.511" x2="809.554" y2="427.691" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="844.998" y1="637.992" x2="809.96" y2="443.688" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="891.742" y1="573.607" x2="809.96" y2="443.688" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="830.3" y1="227.842" x2="809.96" y2="443.688" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="694.168" y1="160.195" x2="809.96" y2="443.688" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="828.198" y1="654.025" x2="808.618" y2="461.631" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="891.742" y1="573.607" x2="808.618" y2="461.631" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="694.168" y1="160.195" x2="808.618" y2="461.631" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="748.095" y1="308.793" x2="805.331" y2="479.57" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="738.012" y1="301.098" x2="805.331" y2="479.57" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="772.954" y1="334.06" x2="693.968" y2="441.868" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="738.012" y1="301.098" x2="693.968" y2="441.868" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="718.741" y1="590.664" x2="643.534" y2="386.116" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="924.74" y1="427.837" x2="562.356" y2="591.233" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="901.083" y1="554.283" x2="562.356" y2="591.233" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="917.555" y1="504.718" x2="562.356" y2="591.233" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="718.741" y1="590.664" x2="606.315" y2="397.794" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="497.106" y1="532.093" x2="606.315" y2="397.794" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="533.931" y1="572.851" x2="606.315" y2="397.794" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="590.245" y1="602.556" x2="543.168" y2="579.726" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="588.983" y1="720.397" x2="543.168" y2="579.726" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="588.983" y1="720.397" x2="746.676" y2="307.636" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="455.389" y1="657.126" x2="746.676" y2="307.636" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="543.168" y1="579.726" x2="759.27" y2="318.861" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="830.3" y1="227.842" x2="759.27" y2="318.861" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="661.345" y1="155.8" x2="759.27" y2="318.861" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="924.74" y1="427.837" x2="771.455" y2="332.205" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="924.827" y1="449.928" x2="771.455" y2="332.205" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="909.884" y1="531.585" x2="771.455" y2="332.205" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="644.162" y1="155.03" x2="779.826" y2="343.312" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="783.054" y1="193.503" x2="779.826" y2="343.312" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="891.742" y1="573.607" x2="779.826" y2="343.312" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="764.873" y1="183.813" x2="790.124" y2="360.232" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="355.429" y1="455.634" x2="790.124" y2="360.232" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="742.471" y1="705.941" x2="790.124" y2="360.232" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="400.053" y1="593.787" x2="797.313" y2="375.559" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="436.354" y1="639.383" x2="797.313" y2="375.559" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="830.3" y1="227.842" x2="797.313" y2="375.559" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="589.344" y1="277.723" x2="640.706" y2="270.001" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="901.083" y1="554.283" x2="640.706" y2="270.001" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="924.74" y1="427.837" x2="801.849" y2="387.992" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="588.347" y1="159.72" x2="801.849" y2="387.992" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="909.884" y1="531.585" x2="806.734" y2="406.838" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="804.038" y1="673.059" x2="806.734" y2="406.838" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="746.676" y1="307.636" x2="809.219" y2="423.725" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="862.168" y1="618.511" x2="809.219" y2="423.725" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="844.998" y1="637.992" x2="809.999" y2="439.458" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="891.742" y1="573.607" x2="809.999" y2="439.458" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="830.3" y1="227.842" x2="809.999" y2="439.458" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="694.168" y1="160.195" x2="809.999" y2="439.458" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="828.198" y1="654.025" x2="809.133" y2="457.15" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="891.742" y1="573.607" x2="809.133" y2="457.15" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="694.168" y1="160.195" x2="809.133" y2="457.15" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="746.676" y1="307.636" x2="806.381" y2="474.89" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="736.673" y1="300.164" x2="806.381" y2="474.89" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="771.455" y1="332.205" x2="693.968" y2="441.868" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="736.673" y1="300.164" x2="693.968" y2="441.868" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
 <line x1="367.721" y1="355.804" x2="693.968" y2="441.868" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="665.248" y1="723.879" x2="800.375" y2="496.391" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="539.661" y1="706.753" x2="800.375" y2="496.391" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="637.454" y1="724.989" x2="800.375" y2="496.391" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="760.447" y1="698.297" x2="657.208" y2="270.873" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="922.074" y1="399.267" x2="657.208" y2="270.873" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="909.884" y1="531.585" x2="657.208" y2="270.873" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="657.208" y1="270.873" x2="794.081" y2="511.826" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="488.149" y1="363.572" x2="794.081" y2="511.826" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="414.799" y1="614.67" x2="794.081" y2="511.826" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="618.297" y1="155.828" x2="674.224" y2="273.481" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="760.447" y1="698.297" x2="674.224" y2="273.481" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="712.312" y1="593.854" x2="526.085" y2="566.188" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="565.943" y1="715.21" x2="526.085" y2="566.188" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="902.028" y1="327.901" x2="526.085" y2="566.188" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="807.418" y1="410.483" x2="512.657" y2="552.623" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="690.107" y1="720.561" x2="512.657" y2="552.623" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="512.657" y1="552.623" x2="673.417" y2="482.418" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="574.996" y1="282.919" x2="673.417" y2="482.418" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="665.248" y1="723.879" x2="801.985" y2="491.584" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="539.661" y1="706.753" x2="801.985" y2="491.584" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="637.454" y1="724.989" x2="801.985" y2="491.584" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="760.447" y1="698.297" x2="656.94" y2="270.846" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="922.074" y1="399.267" x2="656.94" y2="270.846" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="909.884" y1="531.585" x2="656.94" y2="270.846" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="656.94" y1="270.846" x2="796.258" y2="506.959" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="482.468" y1="376.096" x2="796.258" y2="506.959" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="414.799" y1="614.67" x2="796.258" y2="506.959" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="618.297" y1="155.828" x2="673.697" y2="273.373" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="760.447" y1="698.297" x2="673.697" y2="273.373" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="718.741" y1="590.664" x2="533.931" y2="572.851" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="565.943" y1="715.21" x2="533.931" y2="572.851" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="902.028" y1="327.901" x2="533.931" y2="572.851" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="806.734" y1="406.838" x2="519.918" y2="560.334" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="690.107" y1="720.561" x2="519.918" y2="560.334" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="519.918" y1="560.334" x2="673.417" y2="482.418" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="560.833" y1="289.559" x2="673.417" y2="482.418" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
 <line x1="661.345" y1="155.8" x2="673.417" y2="482.418" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="760.447" y1="698.297" x2="786.21" y2="526.734" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="922.074" y1="399.267" x2="786.21" y2="526.734" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="909.884" y1="531.585" x2="786.21" y2="526.734" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="909.884" y1="531.585" x2="776.536" y2="541.282" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="644.162" y1="155.03" x2="776.536" y2="541.282" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="665.248" y1="723.879" x2="776.536" y2="541.282" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="661.345" y1="155.8" x2="500.436" y2="537.067" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="902.028" y1="327.901" x2="500.436" y2="537.067" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="694.168" y1="160.195" x2="500.436" y2="537.067" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="891.742" y1="573.607" x2="765.997" y2="554.126" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="877.732" y1="597.189" x2="765.997" y2="554.126" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="581.451" y1="599.6" x2="491.367" y2="522.511" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="891.742" y1="573.607" x2="491.367" y2="522.511" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="922.22" y1="479.711" x2="491.367" y2="522.511" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="712.312" y1="593.854" x2="486.045" y2="512.095" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="922.074" y1="399.267" x2="486.045" y2="512.095" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="830.3" y1="227.842" x2="486.045" y2="512.095" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="518.455" y1="182.218" x2="478.402" y2="492.784" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="367.721" y1="355.804" x2="478.402" y2="492.784" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="518.455" y1="182.218" x2="474.109" y2="477.152" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="544.268" y1="299.518" x2="474.109" y2="477.152" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="539.661" y1="706.753" x2="474.109" y2="477.152" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="798.494" y1="378.521" x2="471.072" y2="459.061" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="738.012" y1="301.098" x2="471.072" y2="459.061" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="924.74" y1="427.837" x2="471.072" y2="459.061" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="690.107" y1="720.561" x2="470.015" y2="442.277" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="909.884" y1="531.585" x2="470.015" y2="442.277" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="912.117" y1="355.281" x2="470.015" y2="442.277" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="472.798" y1="409.282" x2="638.474" y2="493.978" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="760.447" y1="698.297" x2="788.984" y2="521.876" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="922.074" y1="399.267" x2="788.984" y2="521.876" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="909.884" y1="531.585" x2="788.984" y2="521.876" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="909.884" y1="531.585" x2="779.95" y2="536.51" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="644.162" y1="155.03" x2="779.95" y2="536.51" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="665.248" y1="723.879" x2="779.95" y2="536.51" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="661.345" y1="155.8" x2="506.944" y2="545.812" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="902.028" y1="327.901" x2="506.944" y2="545.812" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="694.168" y1="160.195" x2="506.944" y2="545.812" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="891.742" y1="573.607" x2="770.028" y2="549.512" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="877.732" y1="597.189" x2="770.028" y2="549.512" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="590.245" y1="602.556" x2="497.106" y2="532.093" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="891.742" y1="573.607" x2="497.106" y2="532.093" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="922.22" y1="479.711" x2="497.106" y2="532.093" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="718.741" y1="590.664" x2="491.199" y2="522.209" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="922.074" y1="399.267" x2="491.199" y2="522.209" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="830.3" y1="227.842" x2="491.199" y2="522.209" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="518.455" y1="182.218" x2="482.407" y2="503.752" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="367.721" y1="355.804" x2="482.407" y2="503.752" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="518.455" y1="182.218" x2="477.123" y2="488.695" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="532.183" y1="308.564" x2="477.123" y2="488.695" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="539.661" y1="706.753" x2="477.123" y2="488.695" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="797.313" y1="375.559" x2="472.877" y2="471.143" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="736.673" y1="300.164" x2="472.877" y2="471.143" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="924.74" y1="427.837" x2="472.877" y2="471.143" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="690.107" y1="720.561" x2="470.64" y2="454.741" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="909.884" y1="531.585" x2="470.64" y2="454.741" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="912.117" y1="355.281" x2="470.64" y2="454.741" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="470.94" y1="422.145" x2="638.474" y2="493.978" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
 <line x1="742.471" y1="705.941" x2="638.474" y2="493.978" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
 <line x1="637.454" y1="724.989" x2="638.474" y2="493.978" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="369.274" y1="529.064" x2="754.096" y2="566.024" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="764.873" y1="183.813" x2="754.096" y2="566.024" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="877.732" y1="597.189" x2="754.096" y2="566.024" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="742.471" y1="705.941" x2="472.798" y2="409.282" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="804.038" y1="673.059" x2="472.798" y2="409.282" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="637.454" y1="724.989" x2="472.798" y2="409.282" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="565.943" y1="715.21" x2="470.303" y2="429.858" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="804.038" y1="673.059" x2="470.303" y2="429.858" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="798.494" y1="378.521" x2="476.035" y2="395.107" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="588.983" y1="720.397" x2="476.035" y2="395.107" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="560.132" y1="166.42" x2="476.035" y2="395.107" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="909.884" y1="531.585" x2="481.79" y2="377.795" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="739.835" y1="173.058" x2="481.79" y2="377.795" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="760.447" y1="698.297" x2="744.776" y2="573.873" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="916.93" y1="372.661" x2="744.776" y2="573.873" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="922.22" y1="479.711" x2="744.776" y2="573.873" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="717.589" y1="714.235" x2="744.776" y2="573.873" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="865.129" y1="265.238" x2="744.776" y2="573.873" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="789.474" y1="682.657" x2="744.776" y2="573.873" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="804.038" y1="673.059" x2="726.237" y2="586.503" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="613.08" y1="723.726" x2="726.237" y2="586.503" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="597.282" y1="604.545" x2="603.051" y2="479.38" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="369.274" y1="529.064" x2="758.752" y2="561.647" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="764.873" y1="183.813" x2="758.752" y2="561.647" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="877.732" y1="597.189" x2="758.752" y2="561.647" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="742.471" y1="705.941" x2="470.94" y2="422.145" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="804.038" y1="673.059" x2="470.94" y2="422.145" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="637.454" y1="724.989" x2="470.94" y2="422.145" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="565.943" y1="715.21" x2="470.019" y2="442.528" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="804.038" y1="673.059" x2="470.019" y2="442.528" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="797.313" y1="375.559" x2="473.041" y2="407.988" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="588.983" y1="720.397" x2="473.041" y2="407.988" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="560.132" y1="166.42" x2="473.041" y2="407.988" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="909.884" y1="531.585" x2="477.35" y2="390.553" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="739.835" y1="173.058" x2="477.35" y2="390.553" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="760.447" y1="698.297" x2="749.879" y2="569.718" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="916.93" y1="372.661" x2="749.879" y2="569.718" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="922.22" y1="479.711" x2="749.879" y2="569.718" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="717.589" y1="714.235" x2="749.879" y2="569.718" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="865.129" y1="265.238" x2="749.879" y2="569.718" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="789.474" y1="682.657" x2="749.879" y2="569.718" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="804.038" y1="673.059" x2="732.138" y2="582.866" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="613.08" y1="723.726" x2="732.138" y2="582.866" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="606.068" y1="606.579" x2="603.051" y2="479.38" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
 <line x1="355.429" y1="455.634" x2="603.051" y2="479.38" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="472.798" y1="409.282" x2="603.051" y2="479.38" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="553.809" y1="586.53" x2="586.19" y2="435.472" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="470.94" y1="422.145" x2="603.051" y2="479.38" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="562.356" y1="591.233" x2="586.19" y2="435.472" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
 <line x1="909.884" y1="531.585" x2="586.19" y2="435.472" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="472.798" y1="409.282" x2="586.19" y2="435.472" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="712.312" y1="593.854" x2="488.149" y2="363.572" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="924.74" y1="427.837" x2="488.149" y2="363.572" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="901.083" y1="554.283" x2="488.149" y2="363.572" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="604.954" y1="273.652" x2="687.569" y2="276.791" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="901.083" y1="554.283" x2="687.569" y2="276.791" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="739.835" y1="173.058" x2="687.569" y2="276.791" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="588.983" y1="720.397" x2="712.312" y2="593.854" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="830.3" y1="227.842" x2="712.312" y2="593.854" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="922.074" y1="399.267" x2="712.312" y2="593.854" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="470.94" y1="422.145" x2="586.19" y2="435.472" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="718.741" y1="590.664" x2="482.468" y2="376.096" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="924.74" y1="427.837" x2="482.468" y2="376.096" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="901.083" y1="554.283" x2="482.468" y2="376.096" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="589.344" y1="277.723" x2="686.845" y2="276.582" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="901.083" y1="554.283" x2="686.845" y2="276.582" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="739.835" y1="173.058" x2="686.845" y2="276.582" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="588.983" y1="720.397" x2="718.741" y2="590.664" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="830.3" y1="227.842" x2="718.741" y2="590.664" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="922.074" y1="399.267" x2="718.741" y2="590.664" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
 <line x1="377.27" y1="550.445" x2="674.585" y2="398.529" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="712.312" y1="593.854" x2="674.585" y2="398.529" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="718.741" y1="590.664" x2="674.585" y2="398.529" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
 <line x1="357.193" y1="475.287" x2="674.585" y2="398.529" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="565.943" y1="715.21" x2="696.263" y2="600.42" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="922.074" y1="399.267" x2="696.263" y2="600.42" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="419.86" y1="258.994" x2="696.263" y2="600.42" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="772.954" y1="334.06" x2="708.464" y2="284.396" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="909.884" y1="531.585" x2="708.464" y2="284.396" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="739.835" y1="173.058" x2="497.719" y2="346.961" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="665.248" y1="723.879" x2="497.719" y2="346.961" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="924.74" y1="427.837" x2="497.719" y2="346.961" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="721.389" y1="290.749" x2="507.713" y2="333.229" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="810.048" y1="211.289" x2="507.713" y2="333.229" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="560.132" y1="166.42" x2="507.713" y2="333.229" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="708.464" y1="284.396" x2="516.446" y2="323.234" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="539.837" y1="173.181" x2="516.446" y2="323.234" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="810.048" y1="211.289" x2="516.446" y2="323.234" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="748.095" y1="308.793" x2="530.952" y2="309.583" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="455.389" y1="657.126" x2="530.952" y2="309.583" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="400.053" y1="593.787" x2="683.588" y2="604.317" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="844.998" y1="637.992" x2="683.588" y2="604.317" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="694.168" y1="160.195" x2="683.588" y2="604.317" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="613.08" y1="723.726" x2="666.434" y2="607.932" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="637.454" y1="724.989" x2="666.434" y2="607.932" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="924.74" y1="427.837" x2="544.268" y2="299.518" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="613.08" y1="723.726" x2="544.268" y2="299.518" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="879.461" y1="285.457" x2="646.497" y2="609.876" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="783.054" y1="193.503" x2="646.497" y2="609.876" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="902.028" y1="327.901" x2="646.497" y2="609.876" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="912.117" y1="355.281" x2="557.64" y2="291.283" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="804.038" y1="673.059" x2="557.64" y2="291.283" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="891.742" y1="573.607" x2="574.996" y2="282.919" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="377.965" y1="327.918" x2="574.996" y2="282.919" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="804.038" y1="673.059" x2="629.105" y2="609.651" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="742.471" y1="705.941" x2="629.105" y2="609.651" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="754.096" y1="566.024" x2="613.807" y2="607.97" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="434.379" y1="242.655" x2="613.807" y2="607.97" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="434.379" y1="242.655" x2="597.282" y2="604.545" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="764.873" y1="183.813" x2="597.282" y2="604.545" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="452.166" y1="225.656" x2="597.282" y2="604.545" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="588.983" y1="720.397" x2="581.451" y2="599.6" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="862.168" y1="618.511" x2="581.451" y2="599.6" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="891.742" y1="573.607" x2="581.451" y2="599.6" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="760.447" y1="698.297" x2="590.731" y2="277.296" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="922.22" y1="479.711" x2="590.731" y2="277.296" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="830.3" y1="227.842" x2="590.731" y2="277.296" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="804.038" y1="673.059" x2="604.954" y2="273.652" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="613.08" y1="723.726" x2="604.954" y2="273.652" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="539.661" y1="706.753" x2="604.954" y2="273.652" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="565.943" y1="715.21" x2="703.236" y2="597.801" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="922.074" y1="399.267" x2="703.236" y2="597.801" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="419.86" y1="258.994" x2="703.236" y2="597.801" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="771.455" y1="332.205" x2="707.455" y2="283.955" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="909.884" y1="531.585" x2="707.455" y2="283.955" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="739.835" y1="173.058" x2="490.522" y2="359.029" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="665.248" y1="723.879" x2="490.522" y2="359.029" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="924.74" y1="427.837" x2="490.522" y2="359.029" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="720.223" y1="290.119" x2="499.198" y2="344.739" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="810.048" y1="211.289" x2="499.198" y2="344.739" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="560.132" y1="166.42" x2="499.198" y2="344.739" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="707.455" y1="283.955" x2="506.93" y2="334.206" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="539.837" y1="173.181" x2="506.93" y2="334.206" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="810.048" y1="211.289" x2="506.93" y2="334.206" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="746.676" y1="307.636" x2="519.997" y2="319.587" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="455.389" y1="657.126" x2="519.997" y2="319.587" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="400.053" y1="593.787" x2="690.941" y2="602.188" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="844.998" y1="637.992" x2="690.941" y2="602.188" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="694.168" y1="160.195" x2="690.941" y2="602.188" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="613.08" y1="723.726" x2="674.236" y2="606.517" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="637.454" y1="724.989" x2="674.236" y2="606.517" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="924.74" y1="427.837" x2="532.183" y2="308.564" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="613.08" y1="723.726" x2="532.183" y2="308.564" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="879.461" y1="285.457" x2="654.723" y2="609.361" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="783.054" y1="193.503" x2="654.723" y2="609.361" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="902.028" y1="327.901" x2="654.723" y2="609.361" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="912.117" y1="355.281" x2="544.569" y2="299.313" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="804.038" y1="673.059" x2="544.569" y2="299.313" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="891.742" y1="573.607" x2="560.833" y2="289.559" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="377.965" y1="327.918" x2="560.833" y2="289.559" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="804.038" y1="673.059" x2="637.613" y2="609.983" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="742.471" y1="705.941" x2="637.613" y2="609.983" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="758.752" y1="561.647" x2="622.489" y2="609.096" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="434.379" y1="242.655" x2="622.489" y2="609.096" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="434.379" y1="242.655" x2="606.068" y2="606.579" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="764.873" y1="183.813" x2="606.068" y2="606.579" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="452.166" y1="225.656" x2="606.068" y2="606.579" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="588.983" y1="720.397" x2="590.245" y2="602.556" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="862.168" y1="618.511" x2="590.245" y2="602.556" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="891.742" y1="573.607" x2="590.245" y2="602.556" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="760.447" y1="698.297" x2="575.743" y2="282.612" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="922.22" y1="479.711" x2="575.743" y2="282.612" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="830.3" y1="227.842" x2="575.743" y2="282.612" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="804.038" y1="673.059" x2="589.344" y2="277.723" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="613.08" y1="723.726" x2="589.344" y2="277.723" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="539.661" y1="706.753" x2="589.344" y2="277.723" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="746.676" y1="307.636" x2="605.741" y2="273.488" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="590.245" y1="602.556" x2="605.741" y2="273.488" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="589.344" y1="277.723" x2="605.741" y2="273.488" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
 </g>
 <g class="nodes" filter="url(#glow)">
 <circle cx="539.661" cy="706.753" r="6" fill="#38bdf8" stroke="#7dd3fc" stroke-width="1.6"><title>API Call</title></circle>
@@ -278,69 +281,70 @@
 <circle cx="588.347" cy="159.72" r="6" fill="#38bdf8" stroke="#7dd3fc" stroke-width="1.6"><title>Visual Question Answering</title></circle>
 <circle cx="588.983" cy="720.397" r="6" fill="#38bdf8" stroke="#7dd3fc" stroke-width="1.6"><title>Web Search</title></circle>
 <circle cx="565.943" cy="715.21" r="6" fill="#38bdf8" stroke="#7dd3fc" stroke-width="1.6"><title>Write Report</title></circle>
-<circle cx="721.389" cy="290.749" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Agent Evaluation</title></circle>
-<circle cx="621.922" cy="270.964" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Agentic Workflow Design</title></circle>
-<circle cx="566.559" cy="593.318" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Architecture Diagram</title></circle>
-<circle cx="738.012" cy="301.098" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Automated Testing</title></circle>
-<circle cx="553.809" cy="586.53" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Autonomous Debug</title></circle>
-<circle cx="535.032" cy="573.723" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Autonomous Web Research</title></circle>
-<circle cx="748.095" cy="308.793" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Browser Automation</title></circle>
-<circle cx="760.756" cy="320.343" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Career Operations</title></circle>
-<circle cx="772.954" cy="334.06" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Code Review Pipeline</title></circle>
-<circle cx="781.292" cy="345.467" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Content Moderation</title></circle>
-<circle cx="791.472" cy="362.823" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Conversational Agent</title></circle>
-<circle cx="798.494" cy="378.521" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Data Analysis</title></circle>
-<circle cx="640.717" cy="270.002" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Deployment Automation</title></circle>
-<circle cx="802.857" cy="391.239" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Design Generation</title></circle>
-<circle cx="807.418" cy="410.483" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Design Review</title></circle>
-<circle cx="809.554" cy="427.691" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Design System Extraction</title></circle>
-<circle cx="809.96" cy="443.688" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Document Analyst</title></circle>
-<circle cx="808.618" cy="461.631" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Document Digitization</title></circle>
-<circle cx="805.331" cy="479.57" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>End-to-End Testing</title></circle>
-<circle cx="800.375" cy="496.391" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Function Calling</title></circle>
-<circle cx="657.208" cy="270.873" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Gaia Audit</title></circle>
-<circle cx="794.081" cy="511.826" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Gaia Meta Audit</title></circle>
-<circle cx="674.224" cy="273.481" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Gaia Triage</title></circle>
-<circle cx="526.085" cy="566.188" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Ghostwrite</title></circle>
-<circle cx="512.657" cy="552.623" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Grill Me</title></circle>
-<circle cx="786.21" cy="526.734" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Grounding</title></circle>
-<circle cx="776.536" cy="541.282" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Guardrails</title></circle>
-<circle cx="500.436" cy="537.067" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Humanize Prose</title></circle>
-<circle cx="765.997" cy="554.126" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Knowledge Graph Construction</title></circle>
-<circle cx="491.367" cy="522.511" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Knowledge Harvest</title></circle>
-<circle cx="486.045" cy="512.095" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Literature Review</title></circle>
-<circle cx="478.402" cy="492.784" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>MCP Debugger Control</title></circle>
-<circle cx="474.109" cy="477.152" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>MCP Server Creation</title></circle>
-<circle cx="471.072" cy="459.061" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>ML Pipeline</title></circle>
-<circle cx="470.015" cy="442.277" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Multi-Agent Debate</title></circle>
-<circle cx="754.096" cy="566.024" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Multimodal Reasoning</title></circle>
-<circle cx="470.303" cy="429.858" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>PRD Generation</title></circle>
-<circle cx="472.798" cy="409.282" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Plan and Execute</title></circle>
-<circle cx="476.035" cy="395.107" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Prediction Market Analysis</title></circle>
-<circle cx="481.79" cy="377.795" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Prompt Optimization</title></circle>
-<circle cx="744.776" cy="573.873" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>RAG Pipeline</title></circle>
-<circle cx="726.237" cy="586.503" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>ReAct Reasoning</title></circle>
-<circle cx="488.149" cy="363.572" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Registry Curation</title></circle>
-<circle cx="687.569" cy="276.791" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Release Automation</title></circle>
-<circle cx="712.312" cy="593.854" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Research</title></circle>
-<circle cx="696.263" cy="600.42" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Scientific Writing</title></circle>
-<circle cx="708.464" cy="284.396" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Security Audit</title></circle>
-<circle cx="497.719" cy="346.961" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Skill Authoring</title></circle>
-<circle cx="507.713" cy="333.229" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Skill Performance Benchmarking</title></circle>
-<circle cx="516.446" cy="323.234" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Skill Security Analysis</title></circle>
-<circle cx="530.952" cy="309.583" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Stealth Browser Interaction</title></circle>
-<circle cx="683.588" cy="604.317" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Text-to-SQL Pipeline</title></circle>
-<circle cx="666.434" cy="607.932" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Tool Chaining</title></circle>
-<circle cx="544.268" cy="299.518" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Tool Creation</title></circle>
-<circle cx="646.497" cy="609.876" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Translation Pipeline</title></circle>
-<circle cx="557.64" cy="291.283" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Tree of Thought</title></circle>
-<circle cx="574.996" cy="282.919" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Ubiquitous Language</title></circle>
-<circle cx="629.105" cy="609.651" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Vertical Slice Planning</title></circle>
-<circle cx="613.807" cy="607.97" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Video Intelligence</title></circle>
-<circle cx="597.282" cy="604.545" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Voice Agent</title></circle>
-<circle cx="581.451" cy="599.6" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Web Scrape</title></circle>
-<circle cx="590.731" cy="277.296" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Wiki Search</title></circle>
-<circle cx="604.954" cy="273.652" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Workflow Automation</title></circle>
+<circle cx="720.223" cy="290.119" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Agent Evaluation</title></circle>
+<circle cx="622.203" cy="270.934" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Agentic Workflow Design</title></circle>
+<circle cx="575.266" cy="597.193" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Architecture Diagram</title></circle>
+<circle cx="736.673" cy="300.164" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Automated Testing</title></circle>
+<circle cx="562.356" cy="591.233" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Autonomous Debug</title></circle>
+<circle cx="543.168" cy="579.726" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Autonomous Web Research</title></circle>
+<circle cx="746.676" cy="307.636" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Browser Automation</title></circle>
+<circle cx="759.27" cy="318.861" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Career Operations</title></circle>
+<circle cx="771.455" cy="332.205" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Code Review Pipeline</title></circle>
+<circle cx="779.826" cy="343.312" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Content Moderation</title></circle>
+<circle cx="790.124" cy="360.232" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Conversational Agent</title></circle>
+<circle cx="797.313" cy="375.559" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Data Analysis</title></circle>
+<circle cx="640.706" cy="270.001" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Deployment Automation</title></circle>
+<circle cx="801.849" cy="387.992" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Design Generation</title></circle>
+<circle cx="806.734" cy="406.838" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Design Review</title></circle>
+<circle cx="809.219" cy="423.725" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Design System Extraction</title></circle>
+<circle cx="809.999" cy="439.458" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Document Analyst</title></circle>
+<circle cx="809.133" cy="457.15" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Document Digitization</title></circle>
+<circle cx="806.381" cy="474.89" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>End-to-End Testing</title></circle>
+<circle cx="801.985" cy="491.584" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Function Calling</title></circle>
+<circle cx="656.94" cy="270.846" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Gaia Audit</title></circle>
+<circle cx="796.258" cy="506.959" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Gaia Meta Audit</title></circle>
+<circle cx="673.697" cy="273.373" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Gaia Triage</title></circle>
+<circle cx="533.931" cy="572.851" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Ghostwrite</title></circle>
+<circle cx="519.918" cy="560.334" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Grill Me</title></circle>
+<circle cx="788.984" cy="521.876" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Grounding</title></circle>
+<circle cx="779.95" cy="536.51" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Guardrails</title></circle>
+<circle cx="506.944" cy="545.812" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Humanize Prose</title></circle>
+<circle cx="770.028" cy="549.512" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Knowledge Graph Construction</title></circle>
+<circle cx="497.106" cy="532.093" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Knowledge Harvest</title></circle>
+<circle cx="491.199" cy="522.209" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Literature Review</title></circle>
+<circle cx="482.407" cy="503.752" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>MCP Debugger Control</title></circle>
+<circle cx="477.123" cy="488.695" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>MCP Server Creation</title></circle>
+<circle cx="472.877" cy="471.143" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>ML Pipeline</title></circle>
+<circle cx="470.64" cy="454.741" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Multi-Agent Debate</title></circle>
+<circle cx="758.752" cy="561.647" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Multimodal Reasoning</title></circle>
+<circle cx="470.019" cy="442.528" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>PRD Generation</title></circle>
+<circle cx="470.94" cy="422.145" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Plan and Execute</title></circle>
+<circle cx="473.041" cy="407.988" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Prediction Market Analysis</title></circle>
+<circle cx="477.35" cy="390.553" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Prompt Optimization</title></circle>
+<circle cx="749.879" cy="569.718" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>RAG Pipeline</title></circle>
+<circle cx="732.138" cy="582.866" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>ReAct Reasoning</title></circle>
+<circle cx="482.468" cy="376.096" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Registry Curation</title></circle>
+<circle cx="686.845" cy="276.582" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Release Automation</title></circle>
+<circle cx="718.741" cy="590.664" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Research</title></circle>
+<circle cx="703.236" cy="597.801" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Scientific Writing</title></circle>
+<circle cx="707.455" cy="283.955" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Security Audit</title></circle>
+<circle cx="490.522" cy="359.029" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Skill Authoring</title></circle>
+<circle cx="499.198" cy="344.739" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Skill Performance Benchmarking</title></circle>
+<circle cx="506.93" cy="334.206" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Skill Security Analysis</title></circle>
+<circle cx="519.997" cy="319.587" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Stealth Browser Interaction</title></circle>
+<circle cx="690.941" cy="602.188" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Text-to-SQL Pipeline</title></circle>
+<circle cx="674.236" cy="606.517" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Tool Chaining</title></circle>
+<circle cx="532.183" cy="308.564" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Tool Creation</title></circle>
+<circle cx="654.723" cy="609.361" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Translation Pipeline</title></circle>
+<circle cx="544.569" cy="299.313" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Tree of Thought</title></circle>
+<circle cx="560.833" cy="289.559" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Ubiquitous Language</title></circle>
+<circle cx="637.613" cy="609.983" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Vertical Slice Planning</title></circle>
+<circle cx="622.489" cy="609.096" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Video Intelligence</title></circle>
+<circle cx="606.068" cy="606.579" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Voice Agent</title></circle>
+<circle cx="590.245" cy="602.556" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Web Scrape</title></circle>
+<circle cx="575.743" cy="282.612" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Wiki Search</title></circle>
+<circle cx="589.344" cy="277.723" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Workflow Automation</title></circle>
+<circle cx="605.741" cy="273.488" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>X/Twitter Automation</title></circle>
 <circle cx="651.074" cy="328.549" r="13" fill="#7c3aed" stroke="#a78bfa" stroke-width="1.6"><title>Feed Monitoring</title></circle>
 <circle cx="748.688" cy="412.964" r="13" fill="#7c3aed" stroke="#a78bfa" stroke-width="1.6"><title>Few-Shot Learning</title></circle>
 <circle cx="702.245" cy="533.11" r="13" fill="#7c3aed" stroke="#a78bfa" stroke-width="1.6"><title>Fine-Tune</title></circle>
@@ -372,69 +376,70 @@
 <text x="810.048" y="198.3" fill="#38bdf8" font-size="10" font-weight="600" opacity="0.92">Skill Discovery</text>
 <text x="613.08" y="710.7" fill="#38bdf8" font-size="10" font-weight="600" opacity="0.92">Tool Use</text>
 <text x="565.943" y="702.2" fill="#38bdf8" font-size="10" font-weight="600" opacity="0.92">Write Report</text>
-<text x="721.389" y="273.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Agent Evaluation</text>
-<text x="621.922" y="254.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Agentic Workflow Design</text>
-<text x="566.559" y="576.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Architecture Diagram</text>
-<text x="738.012" y="284.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Automated Testing</text>
-<text x="553.809" y="569.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Autonomous Debug</text>
-<text x="535.032" y="556.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Autonomous Web Research</text>
-<text x="748.095" y="291.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Browser Automation</text>
-<text x="760.756" y="303.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Career Operations</text>
-<text x="772.954" y="317.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Code Review Pipeline</text>
-<text x="781.292" y="328.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Content Moderation</text>
-<text x="791.472" y="345.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Conversational Agent</text>
-<text x="798.494" y="361.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Data Analysis</text>
-<text x="640.717" y="253.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Deployment Automation</text>
-<text x="802.857" y="374.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Design Generation</text>
-<text x="807.418" y="393.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Design Review</text>
-<text x="809.554" y="410.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Design System Extraction</text>
-<text x="809.96" y="426.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Document Analyst</text>
-<text x="808.618" y="444.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Document Digitization</text>
-<text x="805.331" y="462.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">End-to-End Testing</text>
-<text x="800.375" y="479.4" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Function Calling</text>
-<text x="657.208" y="253.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Gaia Audit</text>
-<text x="794.081" y="494.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Gaia Meta Audit</text>
-<text x="674.224" y="256.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Gaia Triage</text>
-<text x="526.085" y="549.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Ghostwrite</text>
-<text x="512.657" y="535.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Grill Me</text>
-<text x="786.21" y="509.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Grounding</text>
-<text x="776.536" y="524.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Guardrails</text>
-<text x="500.436" y="520.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Humanize Prose</text>
-<text x="765.997" y="537.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Knowledge Graph Construction</text>
-<text x="491.367" y="505.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Knowledge Harvest</text>
-<text x="486.045" y="495.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Literature Review</text>
-<text x="478.402" y="475.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">MCP Debugger Control</text>
-<text x="474.109" y="460.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">MCP Server Creation</text>
-<text x="471.072" y="442.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">ML Pipeline</text>
-<text x="470.015" y="425.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Multi-Agent Debate</text>
-<text x="754.096" y="549.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Multimodal Reasoning</text>
-<text x="470.303" y="412.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">PRD Generation</text>
-<text x="472.798" y="392.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Plan and Execute</text>
-<text x="476.035" y="378.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Prediction Market Analysis</text>
-<text x="481.79" y="360.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Prompt Optimization</text>
-<text x="744.776" y="556.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">RAG Pipeline</text>
-<text x="726.237" y="569.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">ReAct Reasoning</text>
-<text x="488.149" y="346.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Registry Curation</text>
-<text x="687.569" y="259.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Release Automation</text>
-<text x="712.312" y="576.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Research</text>
-<text x="696.263" y="583.4" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Scientific Writing</text>
-<text x="708.464" y="267.4" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Security Audit</text>
-<text x="497.719" y="330.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Skill Authoring</text>
-<text x="507.713" y="316.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Skill Performance Benchmarking</text>
-<text x="516.446" y="306.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Skill Security Analysis</text>
-<text x="530.952" y="292.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Stealth Browser Interaction</text>
-<text x="683.588" y="587.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Text-to-SQL Pipeline</text>
-<text x="666.434" y="590.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Tool Chaining</text>
-<text x="544.268" y="282.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Tool Creation</text>
-<text x="646.497" y="592.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Translation Pipeline</text>
-<text x="557.64" y="274.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Tree of Thought</text>
-<text x="574.996" y="265.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Ubiquitous Language</text>
-<text x="629.105" y="592.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Vertical Slice Planning</text>
-<text x="613.807" y="591.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Video Intelligence</text>
-<text x="597.282" y="587.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Voice Agent</text>
-<text x="581.451" y="582.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Web Scrape</text>
-<text x="590.731" y="260.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Wiki Search</text>
-<text x="604.954" y="256.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Workflow Automation</text>
+<text x="720.223" y="273.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Agent Evaluation</text>
+<text x="622.203" y="253.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Agentic Workflow Design</text>
+<text x="575.266" y="580.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Architecture Diagram</text>
+<text x="736.673" y="283.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Automated Testing</text>
+<text x="562.356" y="574.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Autonomous Debug</text>
+<text x="543.168" y="562.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Autonomous Web Research</text>
+<text x="746.676" y="290.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Browser Automation</text>
+<text x="759.27" y="301.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Career Operations</text>
+<text x="771.455" y="315.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Code Review Pipeline</text>
+<text x="779.826" y="326.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Content Moderation</text>
+<text x="790.124" y="343.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Conversational Agent</text>
+<text x="797.313" y="358.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Data Analysis</text>
+<text x="640.706" y="253.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Deployment Automation</text>
+<text x="801.849" y="371.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Design Generation</text>
+<text x="806.734" y="389.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Design Review</text>
+<text x="809.219" y="406.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Design System Extraction</text>
+<text x="809.999" y="422.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Document Analyst</text>
+<text x="809.133" y="440.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Document Digitization</text>
+<text x="806.381" y="457.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">End-to-End Testing</text>
+<text x="801.985" y="474.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Function Calling</text>
+<text x="656.94" y="253.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Gaia Audit</text>
+<text x="796.258" y="490.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Gaia Meta Audit</text>
+<text x="673.697" y="256.4" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Gaia Triage</text>
+<text x="533.931" y="555.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Ghostwrite</text>
+<text x="519.918" y="543.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Grill Me</text>
+<text x="788.984" y="504.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Grounding</text>
+<text x="779.95" y="519.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Guardrails</text>
+<text x="506.944" y="528.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Humanize Prose</text>
+<text x="770.028" y="532.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Knowledge Graph Construction</text>
+<text x="497.106" y="515.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Knowledge Harvest</text>
+<text x="491.199" y="505.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Literature Review</text>
+<text x="482.407" y="486.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">MCP Debugger Control</text>
+<text x="477.123" y="471.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">MCP Server Creation</text>
+<text x="472.877" y="454.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">ML Pipeline</text>
+<text x="470.64" y="437.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Multi-Agent Debate</text>
+<text x="758.752" y="544.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Multimodal Reasoning</text>
+<text x="470.019" y="425.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">PRD Generation</text>
+<text x="470.94" y="405.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Plan and Execute</text>
+<text x="473.041" y="391.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Prediction Market Analysis</text>
+<text x="477.35" y="373.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Prompt Optimization</text>
+<text x="749.879" y="552.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">RAG Pipeline</text>
+<text x="732.138" y="565.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">ReAct Reasoning</text>
+<text x="482.468" y="359.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Registry Curation</text>
+<text x="686.845" y="259.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Release Automation</text>
+<text x="718.741" y="573.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Research</text>
+<text x="703.236" y="580.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Scientific Writing</text>
+<text x="707.455" y="267.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Security Audit</text>
+<text x="490.522" y="342.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Skill Authoring</text>
+<text x="499.198" y="327.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Skill Performance Benchmarking</text>
+<text x="506.93" y="317.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Skill Security Analysis</text>
+<text x="519.997" y="302.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Stealth Browser Interaction</text>
+<text x="690.941" y="585.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Text-to-SQL Pipeline</text>
+<text x="674.236" y="589.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Tool Chaining</text>
+<text x="532.183" y="291.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Tool Creation</text>
+<text x="654.723" y="592.4" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Translation Pipeline</text>
+<text x="544.569" y="282.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Tree of Thought</text>
+<text x="560.833" y="272.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Ubiquitous Language</text>
+<text x="637.613" y="593.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Vertical Slice Planning</text>
+<text x="622.489" y="592.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Video Intelligence</text>
+<text x="606.068" y="589.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Voice Agent</text>
+<text x="590.245" y="585.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Web Scrape</text>
+<text x="575.743" y="265.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Wiki Search</text>
+<text x="589.344" y="260.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Workflow Automation</text>
+<text x="605.741" y="256.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">X/Twitter Automation</text>
 <text x="651.074" y="308.5" fill="#7c3aed" font-size="16" font-weight="600" opacity="0.92">Feed Monitoring</text>
 <text x="748.688" y="393.0" fill="#7c3aed" font-size="16" font-weight="600" opacity="0.92">Few-Shot Learning</text>
 <text x="702.245" y="513.1" fill="#7c3aed" font-size="16" font-weight="600" opacity="0.92">Fine-Tune</text>
@@ -454,7 +459,7 @@
 <circle cx="52" cy="765" r="6" fill="#38bdf8"/>
 <text x="68" y="770">Basic: 70</text>
 <circle cx="52" cy="793" r="6" fill="#a78bfa"/>
-<text x="68" y="798">Extra: 63</text>
+<text x="68" y="798">Extra: 64</text>
 <circle cx="52" cy="821" r="6" fill="#7c3aed"/>
 <text x="68" y="826">Unique: 5</text>
 <circle cx="52" cy="849" r="6" fill="#fbbf24"/>

--- a/registry/named-skills.json
+++ b/registry/named-skills.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-14",
+  "generatedAt": "2026-05-15",
   "buckets": {
     "automated-testing": [
       {
@@ -1365,6 +1365,27 @@
         "user-journey",
         "visual-regression"
       ]
+    },
+    {
+      "id": "xquik-dev/hermes-tweet",
+      "name": "Hermes Tweet",
+      "contributor": "xquik-dev",
+      "origin": true,
+      "genericSkillRef": "x-twitter-automation",
+      "status": "awakened",
+      "level": "4★",
+      "description": "Installable Hermes Agent skill and plugin for X/Twitter search, reply reading, user lookup, monitoring, follower export, and approval-gated write actions.",
+      "tags": [
+        "x-twitter",
+        "twitter",
+        "social-automation",
+        "hermes-agent",
+        "monitoring"
+      ],
+      "links": {
+        "github": "https://github.com/Xquik-dev/hermes-tweet",
+        "docs": "https://docs.xquik.com/guides/hermes-tweet"
+      }
     }
   ],
   "byContributor": {
@@ -1481,6 +1502,9 @@
     ],
     "vercel": [
       "vercel/find-skills"
+    ],
+    "xquik-dev": [
+      "xquik-dev/hermes-tweet"
     ],
     "yonatangross": [
       "yonatangross/orchestkit-rag"

--- a/registry/named/xquik-dev/hermes-tweet.md
+++ b/registry/named/xquik-dev/hermes-tweet.md
@@ -1,0 +1,25 @@
+---
+id: xquik-dev/hermes-tweet
+name: Hermes Tweet
+contributor: xquik-dev
+origin: true
+genericSkillRef: x-twitter-automation
+status: awakened
+level: "4★"
+description: Installable Hermes Agent skill and plugin for X/Twitter search, reply reading, user lookup, monitoring, follower export, and approval-gated write actions.
+links:
+  github: https://github.com/Xquik-dev/hermes-tweet
+  docs: https://docs.xquik.com/guides/hermes-tweet
+tags:
+  - x-twitter
+  - twitter
+  - social-automation
+  - hermes-agent
+  - monitoring
+createdAt: "2026-05-15"
+updatedAt: "2026-05-15"
+---
+
+## Overview
+
+Hermes Tweet gives Hermes Agent workflows a reusable X/Twitter automation route for searching tweets, reading replies, looking up users, monitoring tweets, exporting followers, and gating post, reply, or DM actions behind explicit approval.

--- a/registry/nodes/extra/browser-automation.json
+++ b/registry/nodes/extra/browser-automation.json
@@ -11,7 +11,8 @@
   ],
   "derivatives": [
     "autonomous-research-agent",
-    "e2e-testing"
+    "e2e-testing",
+    "x-twitter-automation"
   ],
   "conditions": "",
   "evidence": [

--- a/registry/nodes/extra/web-scrape.json
+++ b/registry/nodes/extra/web-scrape.json
@@ -11,7 +11,8 @@
     "extract-entities"
   ],
   "derivatives": [
-    "knowledge-harvest"
+    "knowledge-harvest",
+    "x-twitter-automation"
   ],
   "conditions": "Structured output mode required.",
   "evidence": [

--- a/registry/nodes/extra/workflow-automation.json
+++ b/registry/nodes/extra/workflow-automation.json
@@ -12,7 +12,8 @@
   ],
   "derivatives": [
     "release-automation",
-    "deployment-automation"
+    "deployment-automation",
+    "x-twitter-automation"
   ],
   "conditions": "",
   "evidence": [

--- a/registry/nodes/extra/x-twitter-automation.json
+++ b/registry/nodes/extra/x-twitter-automation.json
@@ -1,0 +1,31 @@
+{
+  "id": "x-twitter-automation",
+  "name": "X/Twitter Automation",
+  "type": "extra",
+  "level": "4★",
+  "rarity": "rare",
+  "description": "Coordinates platform-specific X/Twitter search, tweet and reply retrieval, user lookup, follower export, monitoring, and approval-gated write workflows for social-media agent tasks.",
+  "prerequisites": [
+    "browser-automation",
+    "web-scrape",
+    "workflow-automation"
+  ],
+  "derivatives": [],
+  "conditions": "Requires configured X/Twitter access, repeatable read paths, and explicit approval gates before posting tweets, replies, DMs, or other write actions.",
+  "evidence": [
+    {
+      "class": "B",
+      "source": "https://github.com/Xquik-dev/hermes-tweet",
+      "evaluator": "kriptoburak",
+      "date": "2026-05-15",
+      "notes": "Hermes Tweet provides an installable Hermes Agent X/Twitter skill and plugin for searching tweets, reading replies, looking up users, monitoring tweets, exporting followers, and gating post, reply, and DM actions."
+    }
+  ],
+  "knownAgents": [
+    "Xquik-dev/hermes-tweet"
+  ],
+  "status": "provisional",
+  "createdAt": "2026-05-15",
+  "updatedAt": "2026-05-15",
+  "version": "0.1.0"
+}

--- a/registry/registry.md
+++ b/registry/registry.md
@@ -134,6 +134,7 @@
 | ◇ Extra Skill: /wiki-search | Extra Skill | 4★ | Hardened | `/wiki-search` |
 | ◇ Extra Skill: /workflow-automation | Extra Skill | 4★ | Hardened | `/workflow-automation` |
 | ○ glincker/readme-generator | Basic Skill | 1★ | Awakened | `/write-report` |
+| ◇ Extra Skill: /x-twitter-automation | Extra Skill | 4★ | Hardened | `/x-twitter-automation` |
 
 ## Unique Skills
 

--- a/registry/skills/extra/browser-automation.md
+++ b/registry/skills/extra/browser-automation.md
@@ -17,6 +17,7 @@ Navigates web pages, fills forms, clicks elements, and extracts information by c
 ## Unlocks
 - [Autonomous Research Agent](../ultimate/autonomous-research-agent.md)
 - [End-to-End Testing](../extra/e2e-testing.md)
+- [X/Twitter Automation](../extra/x-twitter-automation.md)
 
 ## Fusion Condition
 _None specified._

--- a/registry/skills/extra/web-scrape.md
+++ b/registry/skills/extra/web-scrape.md
@@ -17,6 +17,7 @@ Retrieves and structures data from web pages into usable entities.
 
 ## Unlocks
 - [Knowledge Harvest](../extra/knowledge-harvest.md)
+- [X/Twitter Automation](../extra/x-twitter-automation.md)
 
 ## Fusion Condition
 Structured output mode required.

--- a/registry/skills/extra/workflow-automation.md
+++ b/registry/skills/extra/workflow-automation.md
@@ -18,6 +18,7 @@ Designs, configures, and runs trigger-based multi-step automation pipelines that
 ## Unlocks
 - [Release Automation](../extra/release-automation.md)
 - [Deployment Automation](../extra/deployment-automation.md)
+- [X/Twitter Automation](../extra/x-twitter-automation.md)
 
 ## Fusion Condition
 _None specified._

--- a/registry/skills/extra/x-twitter-automation.md
+++ b/registry/skills/extra/x-twitter-automation.md
@@ -1,0 +1,32 @@
+# Extra Skill: /x-twitter-automation  [4★ · Hardened]
+**ID:** x-twitter-automation  
+**Type:** Extra Skill  
+**Level:** 4★  
+**Tier:** Hardened  
+**Skill Call:** `/x-twitter-automation`
+
+---
+
+## Description
+Coordinates platform-specific X/Twitter search, tweet and reply retrieval, user lookup, follower export, monitoring, and approval-gated write workflows for social-media agent tasks.
+
+## Prerequisites
+- [Browser Automation](../extra/browser-automation.md)
+- [Web Scrape](../extra/web-scrape.md)
+- [Workflow Automation](../extra/workflow-automation.md)
+
+## Unlocks
+_None._
+
+## Fusion Condition
+Requires configured X/Twitter access, repeatable read paths, and explicit approval gates before posting tweets, replies, DMs, or other write actions.
+
+## Evidence
+| Class | Source | Evaluator | Date |
+|---|---|---|---|
+| B | https://github.com/Xquik-dev/hermes-tweet | kriptoburak | 2026-05-15 |
+
+## Known Agents
+- Xquik-dev/hermes-tweet
+
+---


### PR DESCRIPTION
## Summary
- Add canonical `x-twitter-automation` as a 4★ extra skill with Hermes Tweet evidence.
- Wire it to `browser-automation`, `web-scrape`, and `workflow-automation`.
- Add `xquik-dev/hermes-tweet` as an awakened named implementation and regenerate projections.

## Evidence
- References the accepted proposal in #66.
- Uses https://github.com/Xquik-dev/hermes-tweet as the public reproducible implementation.
- Includes docs link for the named implementation: https://docs.xquik.com/guides/hermes-tweet.

## Validation
- `python scripts/validate.py`
- `python scripts/validate_intake.py`
- `python scripts/validate.py --check-meta-sync`
- `python scripts/build_docs.py --check`
- `pytest tests/test_validate.py tests/test_named_skills.py tests/test_registry_layout.py tests/test_docs_site.py tests/test_docs_skill_explorer.py`
- Link checks for the Hermes Tweet repo, Hermes Tweet docs, and issue #66

## Local Note
- `pytest tests/` reached 381 passed, 1 local packaging smoke failure while `venv.EnvBuilder(with_pip=True)` tried to run `ensurepip` from the uv-managed Python dylib path on macOS. The failure is unrelated to the registry change and should not reproduce in CI with `actions/setup-python`.
