### PR TITLE
docs: perform meta-audit and establish new evidence criteria

### DIFF
--- a/docs/audits/2026-05-17-meta-audit.md
+++ b/docs/audits/2026-05-17-meta-audit.md
@@ -1,0 +1,27 @@
+# Gaia Meta Audit: 2026-05-17
+
+**Date:** 2026-05-17
+**Auditors:** META Agent
+**Scope:** Scan Gaia registry and real-skill catalog entries for candidates that may need review because they are outdated, superseded, overpromoted, weakly sourced, stale, duplicate, or incorrectly mapped.
+
+## Summary of Findings
+
+During the meta-audit scan, multiple red flags were identified:
+
+1.  **Seed Evidence Drift on 4★+ Skills:** Several high-level skills (Extra and Ultimate) are still using old `gaia-registry/gaia` placeholder URLs that no longer exist, rather than concrete community usage evidence.
+2.  **Repo-Root Catalog Entries:** Multiple high-profile entries in `real-skills.json` (such as `karpathy-autoresearch`, `devin-ai-autonomous-swe`) map to generic repository roots instead of specific `SKILL.md` or playbook files.
+3.  **Heavyweight Dependencies:** Several skills (`agentic-workflow-design`, `deployment-automation`, `stealth-browser-interaction`, `voice-agent`) have known heavyweight dependencies that act as demerits, but this was verified as structurally sound in the schema.
+
+## Prioritized Audit Queue
+
+| Priority | Target | Why review | Suggested audit action | Source files |
+|---|---|---|---|---|
+| P0 | `autonomous-research-agent` (6★ Ultimate) | Uses `gaia-registry/gaia` seed evidence (`docs/evidence/seed.md`) which resolves as missing. | Require live, composable evidence before retaining 6★ apex confidence. Replace seed evidence with current primary evidence. | `registry/nodes/ultimate/autonomous-research-agent.json` |
+| P0 | `recursive-self-improvement` (5★ Ultimate) | Uses `gaia-registry/gaia` seed evidence (`docs/evidence/seed.md`) which resolves as missing. | Require live, composable evidence before retaining 5★. | `registry/nodes/ultimate/recursive-self-improvement.json` |
+| P0 | `multi-agent-orchestration-v` (5★ Ultimate) | Uses `gaia-registry/gaia` seed evidence (`docs/evidence/seed.md`) which resolves as missing. | Require live, composable evidence before retaining 5★. | `registry/nodes/ultimate/multi-agent-orchestration-v.json` |
+| P1 | `autonomous-debug` (4★ Extra) | Uses `gaia-registry/gaia` seed evidence (`docs/evidence/autonomousDebug.md`) which resolves as missing. | Replace with live evidence or demote below Hardened. | `registry/nodes/extra/autonomous-debug.json` |
+| P1 | `ghostwrite` (4★ Extra) | Uses `gaia-registry/gaia` seed evidence (`docs/evidence/ghostwrite.md`) which resolves as missing. | Replace with live evidence or demote below Hardened. | `registry/nodes/extra/ghostwrite.json` |
+| P1 | `knowledge-harvest` (4★ Extra) | Uses `gaia-registry/gaia` seed evidence (`docs/evidence/knowledgeHarvest.md`) which resolves as missing. | Replace with live evidence or demote below Hardened. | `registry/nodes/extra/knowledge-harvest.json` |
+| P1 | `plan-and-execute` (4★ Extra) | Uses `gaia-registry/gaia` seed evidence (`docs/evidence/planAndExecute.md`) which resolves as missing. | Replace with live evidence or demote below Hardened. | `registry/nodes/extra/plan-and-execute.json` |
+| P2 | `karpathy-autoresearch` (Real Skill) | Source URL is a repository root (`https://github.com/karpathy/autoresearch`) instead of a specific `SKILL.md` or playbook. | Update to specific documentation file, or downgrade status. | `registry/real-skills.json` |
+| P2 | `devin-ai-autonomous-swe` (Real Skill) | Source URL is a repository root (`https://github.com/cognition-labs/devin`) instead of a specific `SKILL.md` or playbook. | Update to specific documentation file, or downgrade status. | `registry/real-skills.json` |

--- a/docs/meta-audit-criteria.md
+++ b/docs/meta-audit-criteria.md
@@ -1,0 +1,15 @@
+# Meta-Audit Criteria and Policy Updates
+
+As of the May 2026 Meta-Audit, the following criteria updates are active for Gaia registry curation:
+
+## 1. Stricter Evidence for 4★+ Skills
+Any skill claiming a level of **4★ (Hardened)** or higher must rely on live, verifiable, and composable usage evidence.
+*   **Seed Evidence Ban:** The use of placeholder `gaia-registry/gaia` seed evidence (e.g., `docs/evidence/seed.md`, `docs/evidence/autonomousDebug.md`) is no longer sufficient to maintain a 4★+ ranking.
+*   Skills currently relying on such seed evidence will be flagged in the meta-audit queue and are subject to demotion if live evidence is not provided.
+
+## 2. Prohibition of Repo-Root Links for Named Claims
+When adding entries to `registry/real-skills.json` or claiming a named skill, the source URL must point to a specific skill implementation.
+*   **No Generic Repositories:** URLs resolving to generic repository roots (e.g., `https://github.com/karpathy/autoresearch`, `https://github.com/cognition-labs/devin`) or homepages are no longer accepted.
+*   **Explicit Files Required:** Source links must point directly to a concrete `SKILL.md` file, an agent playbook, or an explicit source code implementation (e.g., `.md`, `.py`, `.ts`, `.json`).
+
+Contributors are encouraged to review the queue in `docs/audits/` and update their evidence accordingly before the next major registry curation pass.


### PR DESCRIPTION
This PR represents the output of the `/gaia-meta-audit` process. It establishes a prioritized queue of capabilities requiring focused `/gaia-audit` correction—most notably 4★, 5★, and 6★ level capabilities that rely on missing seed evidence, as well as catalog issues with generic repository roots.

It also introduces `docs/meta-audit-criteria.md`, proposing stricter requirements for evidence validation.

---
*PR created automatically by Jules for task [339671305880012081](https://jules.google.com/task/339671305880012081) started by @mbtiongson1*