### PR TITLE
🎨 Palette: add aria-label attributes to search input and copy buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-17 - Add aria-labels to icon-only buttons
+**Learning:** Adding a `title` attribute to icon-only buttons is often insufficient for comprehensive screen reader support. It's crucial to also include explicitly defined `aria-label` attributes to ensure they are consistently read by screen readers. Similarly, inputs without explicitly linked labels require an `aria-label`.
+**Action:** When implementing new icon-only buttons or forms in the future, check if `aria-label` attributes are included to guarantee accessibility across all assistive technologies. This applies to both dynamically generated JS elements and static HTML.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,0 @@
-## 2024-05-17 - Add aria-labels to icon-only buttons
-**Learning:** Adding a `title` attribute to icon-only buttons is often insufficient for comprehensive screen reader support. It's crucial to also include explicitly defined `aria-label` attributes to ensure they are consistently read by screen readers. Similarly, inputs without explicitly linked labels require an `aria-label`.
-**Action:** When implementing new icon-only buttons or forms in the future, check if `aria-label` attributes are included to guarantee accessibility across all assistive technologies. This applies to both dynamically generated JS elements and static HTML.

--- a/docs/index.html
+++ b/docs/index.html
@@ -386,7 +386,7 @@
       capability.</p>
 
     <div class="ns-controls">
-      <input type="search" id="nsSearch" class="ns-search" placeholder="Search skills, tags, contributors…"
+      <input type="search" id="nsSearch" class="ns-search" aria-label="Search skills, tags, contributors" placeholder="Search skills, tags, contributors…"
         autocomplete="off">
       <div class="ns-filter-row">
         <div class="ns-type-tabs" id="nsTypeTabs">
@@ -549,7 +549,7 @@
       <div class="usp-row">
         <span class="usp-prompt">$</span>
         <span id="uspCmd" class="usp-cmd">gaia propose /web-search</span>
-        <button class="usp-copy" id="uspCopyBtn" title="Copy command">
+        <button class="usp-copy" id="uspCopyBtn" title="Copy command" aria-label="Copy command">
           <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8"
             stroke-linecap="round" stroke-linejoin="round">
             <rect x="5" y="5" width="9" height="9" rx="1.5" />

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -36,6 +36,7 @@ window.switchOsTab = function(btn) {
       btn.className = 'copy-btn';
       btn.innerHTML = CLIP;
       btn.title = 'Copy';
+      btn.setAttribute('aria-label', 'Copy to clipboard');
       btn.addEventListener('click', function(){
         var text = pre.innerText;
         navigator.clipboard.writeText(text).then(function(){


### PR DESCRIPTION
* 💡 What: Added aria-label to search input and copy icon-only buttons.
* 🎯 Why: Without explicit aria-labels, screen readers may fail to announce the purpose of these UI elements (title attribute is insufficient).
* ♿ Accessibility: Improved screen reader accessibility.

---
*PR created automatically by Jules for task [3277718546237059352](https://jules.google.com/task/3277718546237059352) started by @mbtiongson1*