### PR TITLE
fix(mcp): report package version from server metadata

### DIFF
--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gaia-registry/mcp-server",
-  "version": "3.0.1",
+  "version": "3.11.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gaia-registry/mcp-server",
-      "version": "3.0.1",
+      "version": "3.11.15",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,5 +1,6 @@
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { createRequire } from "module";
 import { z } from "zod";
 import { lookupSkill } from "./tools/lookup.js";
 import { getMyTree } from "./tools/myTree.js";
@@ -8,10 +9,25 @@ import { scanContext } from "./tools/scanContext.js";
 import { propose } from "./tools/propose.js";
 import { getRegistryResource, getUserTreeResource } from "./resources/registry.js";
 
+const require = createRequire(import.meta.url);
+
+function readPackageVersion(): string {
+  for (const packagePath of ["../package.json", "../../package.json"]) {
+    try {
+      return (require(packagePath) as { version: string }).version;
+    } catch {
+      // Try the next relative path. Source runs from src/, compiled code runs from dist/src/.
+    }
+  }
+  throw new Error("Unable to read package version for MCP server");
+}
+
+const version = readPackageVersion();
+
 export function createServer(): McpServer {
   const server = new McpServer({
     name: "gaia-skill-registry",
-    version: "0.1.0",
+    version,
   });
 
   server.tool(

--- a/packages/mcp/tests/mcp-protocol.test.ts
+++ b/packages/mcp/tests/mcp-protocol.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createServer } from "../src/index.js";
+import mcpPackage from "../package.json";
 
 describe("MCP protocol layer", () => {
   let client: Client;
@@ -20,9 +21,10 @@ describe("MCP protocol layer", () => {
 
   // ── Server identity ──────────────────────────────────────────────────────
 
-  it("reports server name after initialize", () => {
+  it("reports server name and package version after initialize", () => {
     const info = client.getServerVersion();
     expect(info?.name).toBe("gaia-skill-registry");
+    expect(info?.version).toBe(mcpPackage.version);
   });
 
   // ── tools/list ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Reads the MCP server version from `packages/mcp/package.json` instead of hardcoding `0.1.0`
- Handles both source (`src/`) and compiled (`dist/src/`) runtime paths
- Adds a protocol test asserting initialize metadata matches the package version
- Updates the MCP package lock root version to match `package.json`

## Validation
- `cd packages/mcp && npm run build`
- `cd packages/mcp && npm test`
- `node -e "import('./dist/src/index.js').then(m=>{m.createServer(); console.log('compiled import ok')})"`

Closes #214