### PR TITLE
fix(cli): normalize leading slash skill IDs

### DIFF
--- a/src/gaia_cli/install.py
+++ b/src/gaia_cli/install.py
@@ -81,6 +81,7 @@ def resolve_named_skill_reference(skill_ref, registry_path):
     - exact catalogRef frontmatter slug
     - unique bare skill-name slug
     """
+    skill_ref = skill_ref.lstrip("/")
     source = find_named_skill_source(skill_ref, registry_path)
     if source:
         return skill_ref, source

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -1156,7 +1156,7 @@ def skills_command(args):
         ctx = None
 
     if verb == "info":
-        q = args.skill_id
+        q = args.skill_id.lstrip("/")
         match = next((item for item in items if item.get("id") == q), None)
         if not match:
             print(f"Skill '/{q}' not found.", file=sys.stderr)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -12,6 +12,7 @@ from gaia_cli.install import (
     find_named_skill_source,
     install_skill,
     load_manifest,
+    resolve_named_skill_reference,
     save_manifest,
     uninstall_skill,
     list_installed,
@@ -127,6 +128,25 @@ class TestInstallFlow:
         assert entry["id"] == "testuser/my-skill"
         assert len(entry["sha256"]) == 64
         assert "testuser/my-skill.md" in entry["sourceRef"]
+
+    def test_install_accepts_leading_slash_named_skill_id(self, tmp_path, monkeypatch):
+        """install_skill normalizes slash-prefixed named skill IDs."""
+        monkeypatch.chdir(tmp_path)
+
+        skill_dir = tmp_path / "registry" / "named" / "testuser"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "my-skill.md").write_text(
+            "---\nid: testuser/my-skill\n---\nContent here."
+        )
+
+        resolved = resolve_named_skill_reference("/testuser/my-skill", str(tmp_path))
+        assert resolved is not None
+        assert resolved[0] == "testuser/my-skill"
+
+        result = install_skill("/testuser/my-skill", str(tmp_path))
+        assert result is True
+        manifest = load_manifest()
+        assert manifest["installed"][0]["id"] == "testuser/my-skill"
 
     def test_install_missing_skill_returns_false(self, tmp_path, monkeypatch):
         """install_skill returns False when the skill is not in the registry."""


### PR DESCRIPTION
## Summary
- Normalizes slash-prefixed named skill IDs in `gaia skills info`
- Normalizes install references before resolving named skill files, catalog refs, or bare slugs
- Adds coverage for installing `/contributor/skill` as the canonical `contributor/skill` ID

## Validation
- `PYTHONPATH=src python3 -m py_compile src/gaia_cli/install.py src/gaia_cli/main.py tests/test_install.py`
- `PYTHONPATH=src python3 -m gaia_cli.main --registry . skills info /huggingface/hf-cli`
- `GAIA_HOME=... PYTHONPATH=... python3 -m gaia_cli.main --registry ... skills install /huggingface/hf-cli`

Note: `pytest` is not installed in this Termux environment, so I verified syntax plus the affected CLI flows directly.

Closes #180