### PR TITLE
docs: update README with TUI, fix tier taxonomy per CONTEXT.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 <div align="center">
-  <img src="docs/assets/marks/diamond-seal.svg" alt="The Diamond Seal" width="120" />
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/marks/diamond-seal-favicon.svg">
+    <img src="docs/assets/marks/diamond-seal.svg" alt="The Diamond Seal" width="120" />
+  </picture>
 </div>
 
 # Gaia - AI Agent Skill Registry
@@ -7,8 +10,8 @@
 > The open, evidence-backed skill graph for AI agents: collect, evolve, and fuse capabilities into something legendary.
 
 [![Validate](https://github.com/mbtiongson1/gaia-skill-tree/actions/workflows/validate.yml/badge.svg)](https://github.com/mbtiongson1/gaia-skill-tree/actions/workflows/validate.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Tutorial](https://img.shields.io/badge/Tutorial-gaia.tiongson.co-38bdf8)](https://gaia.tiongson.co/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-fbbf24.svg)](LICENSE)
+[![Website](https://img.shields.io/badge/Website-gaia.tiongson.co-ef4444)](https://gaia.tiongson.co/)
 
 ---
 
@@ -43,9 +46,20 @@ Uniques — graph-isolated Basic Skills that ranked up through depth alone
   ◉ openai/few-shot-learning  [4★ · Hardened]
   ◉ huggingface/semantic-cache  [4★ · Hardened]
 
-Full registry: docs/tree.md
-Your tree renders: generated-output/tree.{md,html}
+(166 skills total — see docs/tree.md)
 ```
+
+### How skills fuse
+
+When two or more Basic skills combine, they can form an Extra. This is what `gaia scan` and `gaia fuse` render in your terminal:
+
+```text
+  mattpocock/grill-me  ─┐
+                        ├──▶  mattpocock/grill-with-docs  ◇
+  mattpocock/ubiquitous-language  ─┘
+```
+
+Basics fuse into Extras; Extras can fuse into Ultimates. Evidence powers each ascent.
 
 > [!TIP]
 > **New here?** The interactive tutorial at **[gaia.tiongson.co](https://gaia.tiongson.co/)** covers everything visually: skill tiers, the stars axis, The Initiate's Rite, and copy-paste commands.
@@ -65,7 +79,9 @@ Skills rank up through **evidence**, not declaration. Basics fuse into Extras or
 
 ---
 
-## Install
+## Quickstart
+
+**1. Install the CLI**
 
 <!-- gaia:version-start -->
 Current Gaia CLI version: `3.16.1`.
@@ -83,69 +99,81 @@ npm install -g @gaia-registry/cli
 ```
 <!-- gaia:version-end -->
 
-For registry development, clone and install editable:
+<details>
+<summary>npm / pipx / Windows alternatives</summary>
+
+**npm wrapper:**
 ```bash
-git clone https://github.com/mbtiongson1/gaia-skill-tree.git
-cd gaia-skill-tree
-pip install -e ".[embeddings]"
+npm install -g @gaia-registry/cli
 ```
 
-<details>
-<summary>Troubleshooting</summary>
-
-If pip fails, try pipx:
+**pipx (if pip fails):**
 ```bash
 brew install pipx        # macOS
 pipx install gaia-cli
 ```
 
-Windows — if `gaia` isn't recognized after install:
+**Windows PATH fix** (if `gaia` isn't found after install):
 ```powershell
 $env:PATH += ";" + (python -c "import sysconfig; print(sysconfig.get_path('scripts', 'nt_user'))")
 ```
+
+**Registry development** (editable install):
+```bash
+git clone https://github.com/mbtiongson1/gaia-skill-tree.git
+cd gaia-skill-tree
+pip install -e ".[embeddings]"
+```
 </details>
 
-## Terminal UI (TUI)
-
-Running `gaia` with no arguments launches an interactive terminal interface when connected to a terminal:
-
-```bash
-gaia
-```
-
-The TUI provides an intuitive, keyboard-navigable interface for browsing skills, viewing your tree, and managing promotions—without needing to memorize CLI commands.
-
-## Updating Gaia
-
-To instantly pull the latest registry data and update the core CLI, use:
-
-```bash
-gaia update
-```
-
-> **Note:** Semantic search users must manually update embeddings by running `pip install gaia-cli[embeddings] --upgrade` if required. `gaia update` alone handles the core tools in seconds.
-
-## The Initiate's Rite
-
-Begin your journey through the registry with these ceremonial steps:
+**2. Initialise & scan**
 
 ```bash
 gaia init --user your-username
-gaia update          # pull latest registry + CLI
-gaia scan            # detect skills in your repository, render tree
-gaia appraise        # inspect a skill card with status and actions
-gaia promote web-search   # rank up scan-approved candidates
-gaia push --dry-run  # preview intake submission
-gaia push            # submit for maintainer review
+gaia scan
 ```
 
-Alternatively, launch the interactive TUI to navigate these steps visually:
+Detects skills your agent demonstrates.
+
+**3. Push for review**
+
+```bash
+gaia push
+```
+
+A GitHub PR opens automatically. Maintainers review; your name attaches at 2★.
+
+**4. Bond your agent (optional)**
+
+```bash
+claude mcp add gaia -- npx @gaia-registry/mcp-server
+```
+
+Any MCP-compatible client. See [packages/mcp/](packages/mcp/) for config examples.
+
+---
+
+**Or explore interactively** with the [Terminal UI](#terminal-ui-experimental) (after step 1 → `gaia` with no args).
+
+> **Keep up to date:** Run `gaia update` anytime to pull latest registry + CLI.
+
+## Terminal UI (experimental)
+
+> **New.** Agent-first interface designed for Claude Code, Codex, and other AI agents.
+
+After step 1, launch with no arguments:
 
 ```bash
 gaia
 ```
 
-`gaia scan` writes `generated-output/promotion-candidates.json`, renders your tree to `generated-output/tree.{html,md}`, and prints detected skills with fusion diagrams.
+Navigate your skills:
+- **Fuzzy search** by name, description, or intent
+- **View tree** (`^T`) and **run scan** (`^G`) without leaving the TUI
+- **Install skills** with one keystroke
+- Keyboard-native: `↑↓` navigate · `Enter` install · `q` quit
+
+Requires `textual` (included with `pip install gaia-cli`).
 
 ---
 
@@ -191,8 +219,7 @@ options:
   --version, -v         Print the Gaia CLI version and exit.
   --canon               Show canonical registry data instead of local-first view.
 
-Quick usage (run `gaia` with no args for the TUI):
-  gaia                                            Launch interactive TUI
+Quick usage:
   gaia init [--user <name>] [--scan <path>] [--yes]
   gaia scan [--quiet] [--auto-promote]
   gaia pull
@@ -253,16 +280,6 @@ tests/                    Python test suite
 <!-- gaia:layout-end -->
 
 ---
-
-## Maintainer Hooks
-
-Contributors who edit the canonical graph can install the repo-local hook once:
-
-```bash
-bash scripts/install-git-hooks.sh
-```
-
-The pre-commit hook checks version lockstep, applies a semantic bump from the commit message, regenerates registry artifacts, runs `gaia docs build`, and stages generated outputs.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -51,11 +51,12 @@ Personal renders: generated-output/tree.md and generated-output/tree.html
 
 | Symbol | Tier | Levels | Evidence floor |
 |--------|------|--------|---------------|
-| ○ Basic | Primitive, indivisible capability | 0★ (F) Unawakened → 1★ (D) Awakened | None |
-| ◇ Extra | Emerges from combining 2+ basic skills | 2★ (C) Named → 3★ (B) Evolved → 4★ (A) Hardened | C → B → B/A |
-| ◆ Ultimate | High-complexity emergent capability | 5★ (S) Transcendent → 6★ (SS) Transcendent ★ | A → A + peer review |
+| ○ Basic | Primitive, indivisible capability | 0★ Unawakened → 1★ Awakened | None |
+| ◉ Unique | Graph-isolated Basic Skill that ranked up without fusing | 1★ Awakened → 6★ Transcendent ★ | None (depth alone) |
+| ◇ Extra | Emerges from combining 2+ Basic Skills or fusing Extras | 2★ Named → 3★ Evolved → 4★ Hardened → 5★ Transcendent | Class C+ evidence |
+| ◆ Ultimate | High-complexity emergent capability (fewer than 1% of agents) | 5★ Transcendent → 6★ Transcendent ★ | Class A (peer-reviewed) |
 
-Skills rank up through evidence, not declaration. Each demerit demotes the skill by one star (floored at 1★, valid for 2★+ only).
+Skills rank up through **evidence**, not declaration. Basics fuse into Extras or Ultimates; Extras can fuse with other Extras. Each demerit demotes a skill by one star (floored at 1★, valid for 2★+ only).
 
 ---
 
@@ -99,6 +100,16 @@ $env:PATH += ";" + (python -c "import sysconfig; print(sysconfig.get_path('scrip
 ```
 </details>
 
+## Terminal UI (TUI)
+
+Running `gaia` with no arguments launches an interactive terminal interface when connected to a terminal:
+
+```bash
+gaia
+```
+
+The TUI provides an intuitive, keyboard-navigable interface for browsing skills, viewing your tree, and managing promotions—without needing to memorize CLI commands.
+
 ## Updating Gaia
 
 To instantly pull the latest registry data and update the core CLI, use:
@@ -111,14 +122,22 @@ gaia update
 
 ## The Initiate's Rite
 
+Begin your journey through the registry with these ceremonial steps:
+
 ```bash
 gaia init --user your-username
 gaia update          # pull latest registry + CLI
-gaia scan            # detect skills, render tree
-gaia appraise        # inspect a skill plaque
-gaia promote web-search   # promote scan-approved candidates
+gaia scan            # detect skills in your repository, render tree
+gaia appraise        # inspect a skill card with status and actions
+gaia promote web-search   # rank up scan-approved candidates
 gaia push --dry-run  # preview intake submission
 gaia push            # submit for maintainer review
+```
+
+Alternatively, launch the interactive TUI to navigate these steps visually:
+
+```bash
+gaia
 ```
 
 `gaia scan` writes `generated-output/promotion-candidates.json`, renders your tree to `generated-output/tree.{html,md}`, and prints detected skills with fusion diagrams.
@@ -167,7 +186,8 @@ options:
   --version, -v         Print the Gaia CLI version and exit.
   --canon               Show canonical registry data instead of local-first view.
 
-Quick usage:
+Quick usage (run `gaia` with no args for the TUI):
+  gaia                                            Launch interactive TUI
   gaia init [--user <name>] [--scan <path>] [--yes]
   gaia scan [--quiet] [--auto-promote]
   gaia pull

--- a/README.md
+++ b/README.md
@@ -17,26 +17,31 @@
 Every AI agent capability exists somewhere on this graph. Skills start at the foundation tier, awaken through evidence, evolve through use, and fuse into things greater than the sum of their parts.
 
 ```text
-GAIA SKILL TREE
-=======================================================
+◆ garrytan/gstack  [5★]
+  ├─ ○ garrytan/office-hours  [0★]
+  ├─ ◇ garrytan/plan-eng-review  [3★]
+  │  ├─ ○ garrytan/design-html  [1★]
+  │  ├─ ○ /diff-content  [1★]
+  │  └─ ○ garrytan/benchmark  [1★]
+  ├─ ◇ mattpocock/to-issues  [3★]
+  │  ├─ ○ /plan-decompose  [1★]
+  │  └─ ○ /route-intent  [1★]
+  └─ ◇ firecrawl/firecrawl  [3★]
+     ├─ ○ /web-search  [1★]
+     ├─ ○ /parse-html  [1★]
+     └─ ○ /extract-entities  [1★]
 
-◆ karpathy/autoresearch  [6★]
-  ├─ ◇ /research  [3★]
-  │  ├─ ○ /web-search  [1★]
-  │  ├─ ○ /summarize  [0★]
-  │  └─ ○ /cite-sources  [1★]
-  ├─ ◇ /knowledge-harvest  [4★]
-  │  ├─ ◇ firecrawl/firecrawl  [3★] ...
-  │  └─ ○ /embed-text  [1★]
-  └─ ◇ /ghostwrite  [4★] ...
+◆ obra/superpowers  [5★]
+  ├─ ○ obra/brainstorming  [1★]
+  ├─ ○ obra/executing-plans  [2★]
+  ├─ ◇ obra/finishing-a-development-branch  [2★]
+  │  └─ ◇ garrytan/plan-eng-review  [3★]
+  └─ ○ obra/writing-plans  [2★]
 
-◆ /recursive-self-improvement  [5★]
-  ├─ ◇ devin-ai/autonomous-swe  [4★]
-  │  ├─ ○ /code-generation  [1★]
-  │  ├─ ○ /execute-bash  [1★]
-  │  └─ ○ /error-interpretation  [1★]
-  ├─ ◉ nousresearch/feed-monitoring  [4★]
-  └─ ◇ /plan-and-execute  [4★] ...
+Uniques — graph-isolated Basic Skills that ranked up through depth alone
+  ◉ nousresearch/feed-monitoring  [4★ · Hardened]
+  ◉ openai/few-shot-learning  [4★ · Hardened]
+  ◉ huggingface/semantic-cache  [4★ · Hardened]
 
 Full registry: docs/tree.md
 Your tree renders: generated-output/tree.{md,html}

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ GAIA SKILL TREE
   │  ├─ ○ /code-generation  [1★]
   │  ├─ ○ /execute-bash  [1★]
   │  └─ ○ /error-interpretation  [1★]
-  ├─ ◉ /feed-monitoring  [4★]
+  ├─ ◉ nousresearch/feed-monitoring  [4★]
   └─ ◇ /plan-and-execute  [4★] ...
 
 Full registry: docs/tree.md

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ GAIA SKILL TREE
   │  ├─ ○ /code-generation  [1★]
   │  ├─ ○ /execute-bash  [1★]
   │  └─ ○ /error-interpretation  [1★]
-  ├─ ○ /evaluate-output  [1★]
+  ├─ ◉ /feed-monitoring  [4★]
   └─ ◇ /plan-and-execute  [4★] ...
 
-Full graph: docs/tree.md
-Personal renders: generated-output/tree.md and generated-output/tree.html
+Full registry: docs/tree.md
+Your tree renders: generated-output/tree.{md,html}
 ```
 
 > [!TIP]

--- a/docs/index.html
+++ b/docs/index.html
@@ -198,6 +198,24 @@
               <div class="qs-tip mt-sm"><span class="qs-tip-icon">💡</span><span>Any MCP-compatible agent: use <code>npx @gaia-registry/mcp-server</code>. See <a href="https://github.com/mbtiongson1/gaia-skill-tree/tree/main/packages/mcp" target="_blank" class="text-tier-basic">packages/mcp</a> for config-file examples.</span></div>
             </div>
           </li>
+          <li class="rite-step">
+            <span class="rite-numeral" aria-hidden="true">V.</span>
+            <div class="rite-body">
+              <strong>Explore interactively (optional)</strong>
+              <p>Launch the agent-first Terminal UI with no arguments.</p>
+              <div class="os-tabs" role="tablist" aria-label="Operating System selection">
+                <button type="button" class="os-tab active" data-os="unix" onclick="switchOsTab(this)" role="tab" aria-selected="true">macOS · Linux</button>
+                <button type="button" class="os-tab" data-os="win" onclick="switchOsTab(this)" role="tab" aria-selected="false">Windows</button>
+              </div>
+              <div class="os-panel active" data-os="unix" role="tabpanel">
+                <pre><span class="cmd">gaia</span></pre>
+              </div>
+              <div class="os-panel" data-os="win" role="tabpanel">
+                <pre><span class="cmd">py -m gaia_cli</span></pre>
+              </div>
+              <div class="qs-tip mt-sm"><span class="qs-tip-icon">💡</span><span>The Terminal UI is new and experimental — designed for AI agents like Claude Code and Codex. Keyboard-native, fuzzy searchable, no CLI memorization required.</span></div>
+            </div>
+          </li>
         </ol>
       </div>
 


### PR DESCRIPTION
- Add Terminal UI section explaining 'gaia' with no args launches TUI
- Update Skill Tiers to include Unique tier per CONTEXT.md taxonomy
- Clarify tier progression and fusion rules
- Update The Initiate's Rite with TUI launching instructions
- Align terminology and evidence requirements with CONTEXT.md
- Update quick usage example to highlight TUI entry point

https://claude.ai/code/session_01Bm2U3yNZg4BvAaMXZpAuoj