### PR TITLE
fix(cli): normalize slash-prefixed uninstall skill ids

### DIFF
--- a/src/gaia_cli/install.py
+++ b/src/gaia_cli/install.py
@@ -288,6 +288,7 @@ def sync_skills(registry_path):
 
 
 def uninstall_skill(skill_id):
+    skill_id = skill_id.lstrip("/")
     parts = skill_id.split("/", 1)
     if len(parts) != 2:
         print("Error: Invalid skill ID format. Expected 'contributor/skill-name'.", file=sys.stderr)

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -1127,7 +1127,7 @@ def skills_command(args):
             sys.exit(1)
         return
     if verb == "uninstall":
-        success = uninstall_skill(args.skill_id)
+        success = uninstall_skill(args.skill_id.lstrip("/"))
         if not success:
             sys.exit(1)
         return

--- a/tests/test_dx.py
+++ b/tests/test_dx.py
@@ -148,6 +148,27 @@ def test_bare_skills_command_prints_skills_help(monkeypatch, capsys):
     assert "gaia skills info <skill_id>" in output
 
 
+def test_skills_info_accepts_leading_slash_named_skill_id(tmp_path, monkeypatch, capsys):
+    named_dir = tmp_path / "registry" / "named" / "testuser"
+    named_dir.mkdir(parents=True)
+    (named_dir / "my-skill.md").write_text(
+        "---\n"
+        "id: testuser/my-skill\n"
+        "name: My Skill\n"
+        "level: 2★\n"
+        "description: Test skill.\n"
+        "---\n"
+        "Content here.",
+        encoding="utf-8",
+    )
+
+    run_cli(monkeypatch, ["--registry", str(tmp_path), "skills", "info", "/testuser/my-skill"])
+
+    output = capsys.readouterr().out
+    assert "testuser/my-skill" in output
+    assert "Test skill." in output
+
+
 def test_promote_label_override_is_not_available(monkeypatch):
     with pytest.raises(SystemExit) as exc:
         run_cli(monkeypatch, ["promote", "web-search", "--label", "3★"])

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -273,6 +273,25 @@ class TestInstallFlow:
         result = uninstall_skill("ghost/skill")
         assert result is True
 
+    def test_uninstall_accepts_leading_slash_named_skill_id(self, tmp_path, monkeypatch):
+        """uninstall_skill normalizes slash-prefixed named skill IDs."""
+        monkeypatch.chdir(tmp_path)
+
+        skill_dir = tmp_path / "registry" / "named" / "testuser"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "my-skill.md").write_text(
+            "---\nid: testuser/my-skill\n---\nContent here."
+        )
+
+        assert install_skill("testuser/my-skill", str(tmp_path)) is True
+        repo_file = tmp_path / ".gaia" / "named-skills" / "testuser" / "my-skill.md"
+        assert repo_file.exists()
+
+        result = uninstall_skill("/testuser/my-skill")
+        assert result is True
+        assert not repo_file.exists()
+        assert load_manifest()["installed"] == []
+
     def test_uninstall_removes_repo_file(self, tmp_path, monkeypatch):
         """uninstall_skill removes the local repo copy of the skill."""
         monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
## Summary
- Normalize slash-prefixed named skill IDs in `uninstall_skill`
- Normalize `gaia skills uninstall /contributor/skill` at the CLI call site
- Add regression coverage for slash-prefixed uninstall and info paths

## Validation
- `PYTHONPATH=src python3 -m pytest tests/test_install.py tests/test_dx.py`
- `PYTHONPATH=src python3 scripts/validate.py`

Closes #281
