### PR TITLE
infra: automate PyPI publishing on standard release tags v*

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -3,7 +3,7 @@ name: Publish gaia-cli to PyPI
 on:
   push:
     tags:
-      - 'gaia-cli-v*'
+      - 'v*'
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
Changes the tag trigger pattern in publish-pypi.yml from gaia-cli-v* to v* so that standard releases automatically deploy to PyPI.