### PR TITLE
Fix ultimates counter color in hero section

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -94,7 +94,7 @@
         </span>
         <span class="ls-sep">/</span>
         <span class="ls-stat">
-          <span class="ls-num ls-num-ults" id="ledgerUlts">—</span>
+          <span class="ls-num ls-num-apex" id="ledgerUlts">—</span>
           <span class="ls-label">ultimates</span>
         </span>
         <span class="ls-sep">/</span>


### PR DESCRIPTION
Fix ultimates counter color in hero section
  
  The "4 ultimates" counter in the hero section was using a non-existent `ls-num-ults` CSS class. Updated it to use `ls-num-apex` to ensure the correct apex color is applied.

---
*PR created automatically by Jules for task [3262163903482857506](https://jules.google.com/task/3262163903482857506) started by @mbtiongson1*