### PR TITLE
design(favicon): add diamond seal SVG as browser tab icon

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -14,6 +14,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+  <link rel="icon" type="image/svg+xml" href="assets/marks/diamond-seal.svg">
   <link rel="stylesheet" href="css/styles.css?v=3.21.3">
   <link rel="stylesheet" href="css/plaque.css?v=3.21.3">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->


### PR DESCRIPTION
## Summary
- Adds `<link rel="icon">` pointing to `assets/marks/diamond-seal.svg` in `docs/index.html`
- Replaces the generic browser tab icon with the Gaia diamond seal
- Uses `currentColor` so it adapts to light/dark browser themes

## Test plan
- [x] Open `docs/index.html` in browser and verify the diamond seal appears in the tab