### PR TITLE
fix(mobile): wrap flowchart basics row + match tree curve tension

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -5839,6 +5839,7 @@ h4.se-install-sub-h { font-size: .85rem; }
   gap: 28px;
   justify-content: center;
   flex-wrap: wrap;
+  max-width: 100%;
 }
 
 .se-flowchart-row-label {

--- a/docs/js/named-skills.js
+++ b/docs/js/named-skills.js
@@ -360,7 +360,7 @@
 
         var dx = tx - fx;
         var dy = ty - fy;
-        var ctrl = Math.abs(dy) * 0.55 + Math.abs(dx) * 0.12;
+        var ctrl = Math.abs(dy) * 0.25 + Math.abs(dx) * 0.05;
         var d = 'M' + fx.toFixed(1) + ',' + fy.toFixed(1) +
                 ' C' + fx.toFixed(1) + ',' + (fy + ctrl).toFixed(1) +
                 ' ' + tx.toFixed(1) + ',' + (ty - ctrl).toFixed(1) +


### PR DESCRIPTION
## Summary

- **Mobile wrap fix**: Added `max-width: 100%` to `.se-flowchart-row` in `styles.css`. Without it, the column flex parent (`align-items: center`) gives each row unbounded cross-axis width, so `flex-wrap: wrap` never fires — the basic nodes just overflow off-screen horizontally on mobile.
- **Tree curve tension**: Lowered the Bézier control-point distance in `named-skills.js` from `dy×0.55 / dx×0.12` → `dy×0.25 / dx×0.05`, matching the exact formula used by the skill flowchart (`skill-explorer.js:904`). This eliminates the tall vertical spikes and gives the tree view the same smooth S-curve appearance.

## Files changed

| File | Change |
|---|---|
| `docs/css/styles.css` | `max-width: 100%` on `.se-flowchart-row` |
| `docs/js/named-skills.js` | Control distance multipliers `0.55/0.12` → `0.25/0.05` |

## Test plan

- [ ] Open Named Skills Explorer → Tree view on mobile (~390px): verify bottom basic nodes wrap into multiple lines instead of overflowing
- [ ] Confirm tree-view curves are shallow S-curves, not tall spikes
- [ ] Open a skill detail panel → Upgrade Path flowchart: verify S-curves are unchanged
- [ ] Check desktop layout is unaffected (max-width: 100% is a no-op when content is narrower than the container)

https://claude.ai/code/session_01HUM64JSoQKdsqXP5nbEf1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUM64JSoQKdsqXP5nbEf1L)_