### PR TITLE
infra: Add GitHub Actions workflow for PR preview deployments

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,26 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    paths:
+      - '**/index.html'
+
+jobs:
+  preview:
+    name: Deploy PR preview
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: docs/
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: auto


### PR DESCRIPTION
## Summary
Adds a new GitHub Actions workflow to automatically deploy preview builds for pull requests that modify HTML documentation files.

## Changes
- **New workflow file**: `.github/workflows/pr-preview.yml`
  - Triggers on pull request events (`opened`, `synchronize`, `reopened`, `closed`) when `**/index.html` files are modified
  - Uses `rossjrw/pr-preview-action@v1` to deploy previews from the `docs/` directory
  - Publishes previews to the `gh-pages` branch under an `pr-preview` umbrella directory
  - Configured with `auto` action mode to handle preview creation and cleanup automatically
  - Requires `contents: write` and `pull-requests: write` permissions

## Implementation Details
- The workflow is scoped to HTML file changes to avoid unnecessary deployments
- Preview artifacts are organized under `pr-preview/` on the `gh-pages` branch for easy management
- The `auto` action mode will automatically clean up previews when PRs are closed

https://claude.ai/code/session_017ZKXixvJCiEJi5xgth78uf