### PR TITLE
🎨 Palette: Add keyboard focus states to core buttons and tabs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-24 - Accessible icon-only copy buttons
 **Learning:** Icon-only copy buttons (like the `ns-install-copy` button) were relying solely on the `title` attribute for screen readers. While `title` gives hover tooltips, `aria-label` provides a much more robust and universally supported experience for assistive technologies on icon-only actions.
 **Action:** Always complement or replace visual `title` attributes with explicit `aria-label`s on icon-only buttons (`.ico` wrappers) to guarantee correct semantic parsing by screen readers.
+
+## 2024-06-25 - App-Wide Focus Ring Convention
+**Learning:** Found that multiple interactive elements (.btn, .mr-tab, .ns-tab, .os-tab, .se-tab-btn, .se-flow-btn) were missing keyboard focus indicators. The codebase has an established focus ring pattern for some components using `outline: 2px solid var(--tier-extra); outline-offset: 2px;`, which should be explicitly extended to generic buttons and tabs.
+**Action:** Always check for missing `:focus-visible` styles on interactive components and apply the `var(--tier-extra)` focus ring to maintain a consistent keyboard navigation experience across the app.

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -857,6 +857,17 @@ h1 em {
   border: none;
 }
 
+.btn:focus-visible,
+.btn-ghost:focus-visible,
+.mr-tab:focus-visible,
+.ns-tab:focus-visible,
+.os-tab:focus-visible,
+.se-tab-btn:focus-visible,
+.se-flow-btn:focus-visible {
+  outline: 2px solid var(--tier-extra);
+  outline-offset: 2px;
+}
+
 .btn-primary {
   background: var(--apex-gold);
   color: var(--bg);


### PR DESCRIPTION
### 💡 What
Added missing `:focus-visible` styles to multiple interactive elements (buttons and tabs) to improve keyboard accessibility.

### 🎯 Why
Keyboard users rely on visual focus indicators to understand which element is currently active. Several core components like `.btn`, `.btn-ghost`, and various tabs (`.ns-tab`, `.os-tab`, `.mr-tab`, `.se-tab-btn`, `.se-flow-btn`) were missing explicit `:focus-visible` states, making navigation difficult and inaccessible. 

### ♿ Accessibility
This enhancement aligns with WCAG 2.1 Success Criterion 2.4.7 (Focus Visible) by consistently applying the app's established focus ring pattern (`outline: 2px solid var(--tier-extra); outline-offset: 2px;`) to all primary interactive elements that previously lacked it. A critical learning was also logged in the `.jules/palette.md` journal.

---
*PR created automatically by Jules for task [14023232492207169866](https://jules.google.com/task/14023232492207169866) started by @mbtiongson1*