### PR TITLE
docs: mark stale plan as superseded after registry reorg

### DIFF
--- a/docs/superpowers/plans/2026-05-09-skill-demerit-criteria.md
+++ b/docs/superpowers/plans/2026-05-09-skill-demerit-criteria.md
@@ -1,5 +1,10 @@
 # Skill Demerit Criteria Implementation Plan
 
+> **Superseded (May 2026):** The `registry/skills/basic/`, `registry/skills/extra/`, and
+> `registry/skills/ultimate/` paths referenced in this document were removed in the May 2026
+> registry reorganization. Canonical skill data now lives under `registry/nodes/`. This document
+> is preserved for historical reference only.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add canonical skill demerit criteria that lower a 2★+ skill's progression ceiling by one level per demerit, while preserving the existing evidence-backed `level` field as the source-of-truth claim.


### PR DESCRIPTION
## Summary

Marks the May 2026 skill-demerit plan doc as superseded now that the `registry/skills/` subdirectories it references were deleted in the May 2026 registry reorganization. Preserves the file for historical reference.

### Files Changed

- `docs/superpowers/plans/2026-05-09-skill-demerit-criteria.md` — prepends a superseded notice pointing to `registry/nodes/` as the current location of canonical skill data

### Notes

- No `gaia docs build` run — this is a targeted MD-only update
- Wiki pages (`Home.md`, `CLI-Reference.md`, `Initiates-Rite.md`) were synced separately via direct push to `master`

https://claude.ai/code/session_01JAfMFNhtCTmWjfbab1wcmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAfMFNhtCTmWjfbab1wcmM)_