### PR TITLE
dev: automate wiki sync on every docs build

### DIFF
--- a/.github/workflows/sync-artifacts.yml
+++ b/.github/workflows/sync-artifacts.yml
@@ -52,9 +52,20 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          
+
           if [[ -n "$(git status --porcelain)" ]]; then
             git add .
-            git commit -m "chore(auto): regenerate registry artifacts and sync docs"
+            git commit -m "chore(auto): regenerate registry artifacts and sync docs [skip-gen]"
             git push
           fi
+
+      - name: Sync Wiki Pages
+        if: ${{ secrets.WIKI_PAT != '' }}
+        env:
+          WIKI_PAT: ${{ secrets.WIKI_PAT }}
+        run: |
+          # Clone wiki with write credentials adjacent to the main repo
+          git clone "https://x-access-token:${WIKI_PAT}@github.com/mbtiongson1/gaia-skill-tree.wiki.git" ../gaia-wiki
+
+          # Sync README marker regions → wiki pages and push to master
+          python scripts/sync_wiki.py --wiki-dir ../gaia-wiki --push

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -293,6 +293,32 @@ def build_html_cache_busting(check: bool) -> bool:
     return changed
 
 
+def build_wiki_sync(check: bool) -> bool:
+    """Run sync_wiki.py against ../gaia-wiki if that directory exists.
+
+    In --check mode the script is called with --check and any reported drift
+    contributes to the overall drift signal (but does NOT cause `gaia docs build
+    --check` to fail — wiki drift is advisory only, since CI handles the push
+    separately via WIKI_PAT).
+
+    In write mode the wiki pages are updated on disk but NOT pushed; CI runs
+    sync_wiki.py --push after cloning the wiki with credentials.
+    """
+    script = SCRIPTS / "sync_wiki.py"
+    if not script.exists():
+        return False
+    wiki_dir = ROOT.parent / "gaia-wiki"
+    if not wiki_dir.exists():
+        # No local wiki clone — skip silently (not an error for local devs)
+        return False
+    args_extra = ["--check"] if check else []
+    rc, output = _run_script(script, ["--wiki-dir", str(wiki_dir), *args_extra])
+    if output.strip():
+        print(output.rstrip())
+    # Wiki drift is advisory — never fail the build over it
+    return False
+
+
 def build_css_tokens(check: bool) -> bool:
     """Regenerate docs/css/tokens.css from registry/gaia.json. Returns True if drift."""
     gaia_path = ROOT / "registry" / "gaia.json"
@@ -614,6 +640,10 @@ def main(argv: list[str] | None = None) -> int:
     docs_index_changed = build_docs_index(args.check)
     html_cache_busted = build_html_cache_busting(args.check)
     css_tokens_changed = build_css_tokens(args.check)
+
+    # Wiki sync — updates ../gaia-wiki pages from README marker regions.
+    # Advisory only: drift is reported but never blocks the build.
+    build_wiki_sync(args.check)
 
     changed = (
         assembly_changed

--- a/scripts/sync_wiki.py
+++ b/scripts/sync_wiki.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Sync README marker-owned regions to the adjacent Gaia wiki repository.
+
+Pages updated
+-------------
+Home.md
+    - Version string inside the "Graph at a Glance" code block
+CLI-Reference.md
+    - Editable install extra (.[embeddings] → .[embeddings,dev])
+    - ``gaia --help`` quick-reference block (<!-- gaia:cli-start/end --> markers,
+      idempotent on repeat runs)
+Initiates-Rite.md
+    - Editable install extra
+
+Usage
+-----
+    python scripts/sync_wiki.py [--wiki-dir PATH] [--check] [--push]
+
+    --wiki-dir PATH   Path to the cloned wiki repo (default: ../gaia-wiki)
+    --check           Report drift without writing files  (exit 1 if stale)
+    --push            git commit + push to wiki master after writing
+                      Requires git credentials pre-configured on the wiki remote
+                      (e.g. via https://token:PAT@github.com/... clone URL).
+
+Called by
+---------
+    gaia docs build          → build_wiki_sync() in scripts/build_docs.py
+    sync-artifacts.yml CI    → python scripts/sync_wiki.py --push (after cloning
+                               the wiki with WIKI_PAT)
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+README = ROOT / "README.md"
+WIKI_REMOTE = "https://github.com/mbtiongson1/gaia-skill-tree.wiki.git"
+
+# ─── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _extract_region(text: str, start: str, end: str) -> str | None:
+    """Return content between HTML comment markers, stripped (None if absent)."""
+    pattern = re.escape(start) + r"\n(.*?)\n" + re.escape(end)
+    m = re.search(pattern, text, re.DOTALL)
+    return m.group(1).strip() if m else None
+
+
+def _replace_region(text: str, start: str, end: str, body: str) -> tuple[str, bool]:
+    """Insert or replace a marker-bounded region.
+
+    If markers are absent the region is appended at EOF (initial seeding).
+    Returns (new_text, changed_bool).
+    """
+    region = f"{start}\n{body.rstrip()}\n{end}"
+    if start not in text or end not in text:
+        return text.rstrip() + "\n\n" + region + "\n", True
+    before, rest = text.split(start, 1)
+    _old, after = rest.split(end, 1)
+    updated = before + region + after
+    return updated, updated != text
+
+
+def _readme_version(readme: str) -> str:
+    m = re.search(r"Current Gaia CLI version: `([^`]+)`", readme)
+    return m.group(1) if m else "unknown"
+
+
+def _readme_cli_help(readme: str) -> str:
+    return _extract_region(readme, "<!-- gaia:cli-start -->", "<!-- gaia:cli-end -->") or ""
+
+
+def _readme_editable_install(readme: str) -> str:
+    """Return the editable install command as it appears in README."""
+    m = re.search(r'pip install -e "\.\[([^\]]+)\]"', readme)
+    return f'pip install -e ".[{m.group(1)}]"' if m else 'pip install -e ".[embeddings,dev]"'
+
+
+# ─── per-page updaters ────────────────────────────────────────────────────────
+
+
+def _update_home(text: str, version: str) -> tuple[str, bool]:
+    """Update the version string in the Graph at a Glance code block."""
+    new_text = re.sub(
+        r"(GAIA SKILL REGISTRY\s+)v\d+\.\d+\.\d+",
+        rf"\g<1>v{version}",
+        text,
+    )
+    return new_text, new_text != text
+
+
+def _update_cli_reference(text: str, cli_help: str, editable_install: str) -> tuple[str, bool]:
+    """Fix editable install extra and add/refresh the gaia --help quick-reference block."""
+    changed = False
+
+    # 1. Editable install extra (matches any .[...] variant)
+    new_text = re.sub(r'pip install -e "\.\[[^\]]+\]"', editable_install, text)
+    changed = changed or (new_text != text)
+    text = new_text
+
+    # 2. CLI quick-reference block (marker-based, idempotent)
+    if cli_help:
+        quick_ref_body = f"## Quick Reference\n\nThe complete `gaia --help` output:\n\n{cli_help}"
+        text, did = _replace_region(
+            text,
+            "<!-- gaia:cli-start -->",
+            "<!-- gaia:cli-end -->",
+            quick_ref_body,
+        )
+        changed = changed or did
+
+    return text, changed
+
+
+def _update_initiates_rite(text: str, editable_install: str) -> tuple[str, bool]:
+    """Fix editable install extra."""
+    new_text = re.sub(r'pip install -e "\.\[[^\]]+\]"', editable_install, text)
+    return new_text, new_text != text
+
+
+# ─── page registry ────────────────────────────────────────────────────────────
+
+def _make_updaters(version: str, cli_help: str, editable_install: str) -> dict:
+    return {
+        "Home.md": lambda t: _update_home(t, version),
+        "CLI-Reference.md": lambda t: _update_cli_reference(t, cli_help, editable_install),
+        "Initiates-Rite.md": lambda t: _update_initiates_rite(t, editable_install),
+    }
+
+
+# ─── git helpers ──────────────────────────────────────────────────────────────
+
+
+def _git(wiki_dir: Path, *cmd: str) -> int:
+    return subprocess.run(["git", *cmd], cwd=wiki_dir).returncode
+
+
+def _push_wiki(wiki_dir: Path, version: str, pages: list[str]) -> int:
+    _git(wiki_dir, "config", "user.name", "github-actions[bot]")
+    _git(wiki_dir, "config", "user.email", "github-actions[bot]@users.noreply.github.com")
+
+    rc = _git(wiki_dir, "add", *pages)
+    if rc != 0:
+        print(f"[wiki-sync] git add failed (rc={rc})", file=sys.stderr)
+        return rc
+
+    # Check whether there are staged changes before committing
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--quiet"],
+        cwd=wiki_dir,
+    )
+    if result.returncode == 0:
+        print("[wiki-sync] No wiki changes to commit — already in sync.")
+        return 0
+
+    rc = _git(
+        wiki_dir,
+        "commit",
+        "-m",
+        f"docs: sync wiki pages from gaia docs build (v{version})",
+    )
+    if rc != 0:
+        print(f"[wiki-sync] git commit failed (rc={rc})", file=sys.stderr)
+        return rc
+
+    rc = _git(wiki_dir, "push", "origin", "master")
+    if rc != 0:
+        print(
+            "[wiki-sync] git push failed — check WIKI_PAT / wiki remote credentials.",
+            file=sys.stderr,
+        )
+        return rc
+
+    print(f"[wiki-sync] Wiki pushed to master (v{version}).")
+    return 0
+
+
+# ─── main ─────────────────────────────────────────────────────────────────────
+
+
+def sync(wiki_dir: Path, check: bool, push: bool) -> int:
+    if not wiki_dir.exists():
+        print(f"[wiki-sync] Wiki dir not found ({wiki_dir}). Skipping.")
+        return 0
+
+    readme = README.read_text(encoding="utf-8")
+    version = _readme_version(readme)
+    cli_help = _readme_cli_help(readme)
+    editable_install = _readme_editable_install(readme)
+
+    updaters = _make_updaters(version, cli_help, editable_install)
+    changed_pages: list[str] = []
+
+    for page_name, updater in updaters.items():
+        page_path = wiki_dir / page_name
+        if not page_path.exists():
+            print(f"[wiki-sync] skip {page_name} (not found in wiki)")
+            continue
+
+        original = page_path.read_text(encoding="utf-8")
+        updated, changed = updater(original)
+
+        if not changed:
+            print(f"[wiki-sync] ok   {page_name}")
+            continue
+
+        changed_pages.append(page_name)
+        if check:
+            print(f"[wiki-sync] diff {page_name}")
+        else:
+            page_path.write_text(updated, encoding="utf-8")
+            print(f"[wiki-sync] wrote {page_name}")
+
+    if not changed_pages:
+        print("[wiki-sync] Wiki pages are up to date.")
+        return 0
+
+    if check:
+        print(
+            "[wiki-sync] Wiki pages are stale. Run `python scripts/sync_wiki.py` to fix."
+        )
+        return 1
+
+    if push:
+        return _push_wiki(wiki_dir, version, changed_pages)
+
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--wiki-dir",
+        type=Path,
+        default=ROOT.parent / "gaia-wiki",
+        metavar="PATH",
+        help="Path to the cloned wiki repo (default: ../gaia-wiki)",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Report drift without writing (exit 1 if stale)",
+    )
+    parser.add_argument(
+        "--push",
+        action="store_true",
+        help="git commit + push to wiki master after writing",
+    )
+    args = parser.parse_args(argv)
+    return sync(args.wiki_dir, args.check, args.push)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds automated wiki synchronization to the docs build pipeline. Previously, wiki pages drifted silently after every registry change — this patches the root cause.

### What this does

1. **`scripts/sync_wiki.py`** (new) — standalone script that reads the four `<!-- gaia:*-start/end -->` marker regions from `README.md` and pushes matching content into wiki pages:
   - `Home.md` → version string in the "Graph at a Glance" code block
   - `CLI-Reference.md` → editable install extra + `gaia --help` quick-reference block (marker-based, idempotent)
   - `Initiates-Rite.md` → editable install extra

2. **`scripts/build_docs.py`** — adds `build_wiki_sync()` stage (advisory only — never fails `gaia docs build --check`; updates local `../gaia-wiki` if present, no push)

3. **`.github/workflows/sync-artifacts.yml`** — adds `Sync Wiki Pages` step after the main artifact commit:
   - Gated on `secrets.WIKI_PAT != ''` (no-op if secret absent)
   - Clones wiki with `x-access-token:${WIKI_PAT}` credentials
   - Runs `sync_wiki.py --push` to commit and push to wiki master

### Tested locally

```
[wiki-sync] ok   Home.md
[wiki-sync] ok   CLI-Reference.md
[wiki-sync] ok   Initiates-Rite.md
[wiki-sync] Wiki pages are up to date.
```

Script is idempotent — `--check` exits 0 after a write pass.

### Prerequisite

`WIKI_PAT` secret must be set in repo Actions secrets (PAT with `repo` scope for wiki write). The CI step is gated and a no-op without it.

https://claude.ai/code/session_01JAfMFNhtCTmWjfbab1wcmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAfMFNhtCTmWjfbab1wcmM)_