### PR TITLE
feat(cli): add --suite-ref and --installation-file to gaia dev update-named (fixes #395)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,8 @@ gaia dev link target-id prereq-id-1,prereq-id-2 [--reset]
 
 # Update named skill frontmatter
 gaia dev update-named author/skill --status awakened --suite-components c1,c2
+gaia dev update-named author/skill --suite-ref capstone/suite
+gaia dev update-named capstone/suite --installation-file path/to/setup.md
 
 # Remove a skill
 gaia dev rm skill-id
@@ -296,20 +298,35 @@ If a tab's markdown contains a table with columns `Agent` (or `Host`) and `Flag`
 
 ### Editing and Submitting a PR
 
-1. **Modify the files:**
-   Make edits to the named skill markdown files under `registry/named/` and suite manifests under `registry/suites/`.
+Use `gaia dev` commands — do not edit files manually or invoke build scripts directly (see §1.B).
 
-2. **Extract and Rebuild:**
-   Run the index generator and documentation build scripts to extract the new frontmatter and regenerate the site:
+1. **Set suiteComponents on the capstone skill:**
    ```bash
-   python3 scripts/validate.py
-   python3 scripts/build_docs.py
+   gaia dev update-named garrytan/gstack \
+     --suite-components "garrytan/browse,garrytan/cso,garrytan/design-review,garrytan/garrytan,garrytan/office-hours"
    ```
 
-3. **Submit the PR:**
-   - Create a `dev/` branch for your changes (e.g. `dev/gstack-custom-setup`).
-   - Add and commit both the source named skill markdown files and the generated index files (`registry/named-skills.json`, `docs/graph/named/index.json`, `docs/css/styles.css`, `docs/js/skill-explorer.js`).
-   - Open your PR on GitHub for maintainer review.
+2. **Link each constituent skill back to the capstone:**
+   ```bash
+   gaia dev update-named garrytan/browse --suite-ref garrytan/gstack
+   gaia dev update-named garrytan/cso    --suite-ref garrytan/gstack
+   # …repeat for each component
+   ```
+
+3. **Replace the `## Installation` section from a markdown file:**
+   ```bash
+   gaia dev update-named garrytan/gstack --installation-file path/to/setup-guide.md
+   ```
+   The CLI automatically rebuilds docs after each command. Use `--no-build` on intermediate
+   steps and run `gaia dev build` once at the end when batching multiple changes.
+
+4. **Validate and open the PR:**
+   ```bash
+   gaia validate
+   ```
+   Create a `cli/` or `dev/` branch. If your branch also touches `CONTRIBUTING.md` or other
+   files outside the `cli/` scope, add the **`skip-scope-check`** label to the PR so CI scope
+   enforcement is bypassed.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -302,23 +302,22 @@ Use `gaia dev` commands — do not edit files manually or invoke build scripts d
 
 1. **Set suiteComponents on the capstone skill:**
    ```bash
-   gaia dev update-named garrytan/gstack \
+   gaia dev update-named garrytan/gstack --no-build \
      --suite-components "garrytan/browse,garrytan/cso,garrytan/design-review,garrytan/garrytan,garrytan/office-hours"
    ```
 
 2. **Link each constituent skill back to the capstone:**
    ```bash
-   gaia dev update-named garrytan/browse --suite-ref garrytan/gstack
-   gaia dev update-named garrytan/cso    --suite-ref garrytan/gstack
+   gaia dev update-named garrytan/browse --suite-ref garrytan/gstack --no-build
+   gaia dev update-named garrytan/cso    --suite-ref garrytan/gstack --no-build
    # …repeat for each component
    ```
 
 3. **Replace the `## Installation` section from a markdown file:**
    ```bash
-   gaia dev update-named garrytan/gstack --installation-file path/to/setup-guide.md
+   gaia dev update-named garrytan/gstack --installation-file path/to/setup-guide.md --no-build
+   gaia dev build   # single rebuild after all edits are complete
    ```
-   The CLI automatically rebuilds docs after each command. Use `--no-build` on intermediate
-   steps and run `gaia dev build` once at the end when batching multiple changes.
 
 4. **Validate and open the PR:**
    ```bash

--- a/src/gaia_cli/commands/dev.py
+++ b/src/gaia_cli/commands/dev.py
@@ -130,6 +130,16 @@ def _replace_section(body: str, section_heading: str, new_content: str) -> str:
     Matches ``## {section_heading}`` through the next ``##``-level heading
     or end-of-string, then substitutes new_content.  If the section is not
     found it is appended.
+
+    .. warning::
+        The lookahead ``(?=\\n##\\s|\\Z)`` is not fenced-code-block-aware.
+        A ``## Heading`` line *inside* a fenced code block (e.g. a HEREDOC
+        example) will be treated as a real section boundary, causing the
+        replacement to truncate too early.  This is acceptable for the
+        current named-skill corpus (no production file has bare ``## ``
+        lines inside Installation fences), but callers should avoid
+        embedding bare ``## `` lines inside fenced blocks in the
+        ``new_content`` they pass in.
     """
     import re
     pattern = rf"(##\s+{re.escape(section_heading)}\s*\n)(.*?)(?=\n##\s|\Z)"
@@ -957,6 +967,17 @@ def meta_update_named_command(args):
         meta["updatedAt"] = datetime.date.today().isoformat()
         _write_md(target_file, meta, body)
         print(f"Updated named skill frontmatter: {target_file}")
+
+        # Record timeline events for mutations that affect suite topology or content.
+        registry_path = args.registry
+        contributor = _get_contributor()
+        if getattr(args, "suite_ref", None):
+            append_skill_event(skill_id, "suite_ref_set", contributor,
+                               f"Set suiteRef to {args.suite_ref}", registry_path=registry_path)
+        if getattr(args, "installation_file", None):
+            append_skill_event(skill_id, "installation_updated", contributor,
+                               f"Replaced ## Installation section from {args.installation_file}",
+                               registry_path=registry_path)
         
         if not getattr(args, "no_build", False):
             print("Regenerating registry and documentation...")

--- a/src/gaia_cli/commands/dev.py
+++ b/src/gaia_cli/commands/dev.py
@@ -124,6 +124,21 @@ def _find_named_file(named_dir, skill_id):
             return p
     return None
 
+def _replace_section(body: str, section_heading: str, new_content: str) -> str:
+    """Replace (or append) a top-level markdown section in the body text.
+
+    Matches ``## {section_heading}`` through the next ``##``-level heading
+    or end-of-string, then substitutes new_content.  If the section is not
+    found it is appended.
+    """
+    import re
+    pattern = rf"(##\s+{re.escape(section_heading)}\s*\n)(.*?)(?=\n##\s|\Z)"
+    replacement = rf"\g<1>{new_content}\n"
+    result, n = re.subn(pattern, replacement, body, flags=re.DOTALL)
+    if n == 0:
+        result = body.rstrip("\n") + f"\n\n## {section_heading}\n\n{new_content}\n"
+    return result
+
 def _update_named_skill_ref(md_path: Path, old_ref: str, new_ref: str):
     """Update genericSkillRef in a named skill markdown file."""
     meta, body = _parse_md(md_path)
@@ -924,7 +939,20 @@ def meta_update_named_command(args):
     if getattr(args, "suite_components", None):
         meta["suiteComponents"] = [s.strip() for s in args.suite_components.split(",")]
         changed = True
-        
+
+    if getattr(args, "suite_ref", None):
+        meta["suiteRef"] = args.suite_ref
+        changed = True
+
+    if getattr(args, "installation_file", None):
+        install_path = Path(args.installation_file)
+        if not install_path.exists():
+            print(f"Error: Installation file '{install_path}' not found.")
+            sys.exit(1)
+        new_content = install_path.read_text(encoding="utf-8").strip()
+        body = _replace_section(body, "Installation", new_content)
+        changed = True
+
     if changed:
         meta["updatedAt"] = datetime.date.today().isoformat()
         _write_md(target_file, meta, body)

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -1534,6 +1534,8 @@ def get_parser():
     dev_update_named.add_argument('--status', help="New status (e.g. awakened, named)")
     dev_update_named.add_argument('--generic-ref', help="New generic skill reference")
     dev_update_named.add_argument('--suite-components', help="Comma-separated list of suite components")
+    dev_update_named.add_argument('--suite-ref', help="Suite capstone ID this skill belongs to (e.g. garrytan/gstack). Sets suiteRef in frontmatter.")
+    dev_update_named.add_argument('--installation-file', metavar='PATH', help="Path to a markdown file whose content replaces the '## Installation' section in the capstone skill.")
     dev_update_named.add_argument('--no-build', action='store_true', help="Skip rebuilding docs and graph assets after updating")
 
     dev_evidence = dev_sub.add_parser('evidence', help="Add evidence to a skill")

--- a/tests/test_meta_ops.py
+++ b/tests/test_meta_ops.py
@@ -151,3 +151,130 @@ def test_meta_add_extra_fields_non_dict_warns(tmp_path, monkeypatch, capsys):
     main()
     captured = capsys.readouterr()
     assert "Warning" in captured.out or "Warning" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# update-named tests
+# ---------------------------------------------------------------------------
+
+def write_named_skill(named_dir: Path, skill_id: str, extra_body: str = "") -> Path:
+    """Write a minimal named skill .md file and return its path."""
+    contributor, slug = skill_id.split("/", 1)
+    skill_dir = named_dir / contributor
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    path = skill_dir / f"{slug}.md"
+    path.write_text(
+        f"---\nid: {skill_id}\nname: Test Skill\ncontributor: {contributor}\n"
+        f"origin: true\ngenericSkillRef: skill-a\nstatus: named\nlevel: 2★\n"
+        f"description: A test skill for unit tests.\n---\n{extra_body}",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_update_named_suite_ref(tmp_path, monkeypatch):
+    """--suite-ref writes suiteRef to frontmatter."""
+    write_fixture_registry(tmp_path)
+    write_named_skill(tmp_path / "registry" / "named", "alice/named-a")
+    monkeypatch.setattr(sys, "argv", [
+        "gaia", "--registry", str(tmp_path),
+        "dev", "update-named", "alice/named-a",
+        "--suite-ref", "alice/capstone-suite",
+        "--no-build",
+    ])
+    main()
+
+    import yaml
+    content = (tmp_path / "registry" / "named" / "alice" / "named-a.md").read_text(encoding="utf-8")
+    _, frontmatter, _ = content.split("---", 2)
+    meta = yaml.safe_load(frontmatter)
+    assert meta.get("suiteRef") == "alice/capstone-suite"
+
+
+def test_update_named_installation_file_append(tmp_path, monkeypatch):
+    """--installation-file appends ## Installation when not present."""
+    write_fixture_registry(tmp_path)
+    write_named_skill(tmp_path / "registry" / "named", "alice/named-a")
+
+    install_md = tmp_path / "setup.md"
+    install_md.write_text("Run `pip install gaia` to get started.", encoding="utf-8")
+
+    monkeypatch.setattr(sys, "argv", [
+        "gaia", "--registry", str(tmp_path),
+        "dev", "update-named", "alice/named-a",
+        "--installation-file", str(install_md),
+        "--no-build",
+    ])
+    main()
+
+    content = (tmp_path / "registry" / "named" / "alice" / "named-a.md").read_text(encoding="utf-8")
+    assert "## Installation" in content
+    assert "pip install gaia" in content
+
+
+def test_update_named_installation_file_replace(tmp_path, monkeypatch):
+    """--installation-file replaces an existing ## Installation section."""
+    write_fixture_registry(tmp_path)
+    write_named_skill(
+        tmp_path / "registry" / "named", "alice/named-a",
+        extra_body="\n## Installation\n\nOld content here.\n\n## Usage\n\nSome usage.\n",
+    )
+
+    install_md = tmp_path / "setup.md"
+    install_md.write_text("New installation instructions.", encoding="utf-8")
+
+    monkeypatch.setattr(sys, "argv", [
+        "gaia", "--registry", str(tmp_path),
+        "dev", "update-named", "alice/named-a",
+        "--installation-file", str(install_md),
+        "--no-build",
+    ])
+    main()
+
+    content = (tmp_path / "registry" / "named" / "alice" / "named-a.md").read_text(encoding="utf-8")
+    assert "New installation instructions." in content
+    assert "Old content here." not in content
+    # Sibling section must be preserved
+    assert "## Usage" in content
+
+
+def test_update_named_installation_file_missing(tmp_path, monkeypatch):
+    """--installation-file with a non-existent path exits with code 1."""
+    write_fixture_registry(tmp_path)
+    write_named_skill(tmp_path / "registry" / "named", "alice/named-a")
+
+    monkeypatch.setattr(sys, "argv", [
+        "gaia", "--registry", str(tmp_path),
+        "dev", "update-named", "alice/named-a",
+        "--installation-file", str(tmp_path / "does-not-exist.md"),
+        "--no-build",
+    ])
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code != 0
+
+
+def test_replace_section_unit():
+    """_replace_section unit tests covering replace and append paths."""
+    from gaia_cli.commands.dev import _replace_section
+
+    # Replace existing section; sibling heading preserved
+    body = "\n## Installation\n\nOld text.\n\n## Usage\n\nHello.\n"
+    result = _replace_section(body, "Installation", "New text.")
+    assert "New text." in result
+    assert "Old text." not in result
+    assert "## Usage" in result
+
+    # Append when section is absent
+    body_no_section = "\n## Usage\n\nHello.\n"
+    result2 = _replace_section(body_no_section, "Installation", "Appended.")
+    assert "## Installation" in result2
+    assert "Appended." in result2
+    # Original content intact
+    assert "## Usage" in result2
+
+    # Code comment constraint: bare ## inside content is NOT fence-aware
+    # (this test documents the known limitation rather than asserting correct behaviour)
+    body_with_fence = "\n## Installation\n\n```bash\necho hi\n```\n\n## Next\n\nText.\n"
+    result3 = _replace_section(body_with_fence, "Installation", "Replacement.")
+    assert "Replacement." in result3


### PR DESCRIPTION
- Add --suite-ref flag to set suiteRef frontmatter on constituent named skills
- Add --installation-file flag to replace ## Installation section from a local .md file
- Add _replace_section() helper in dev.py for markdown body section swapping
- Rewrite CONTRIBUTING.md §10 'Editing and Submitting a PR' to use CLI commands
- Extend §1.B command table with new --suite-ref and --installation-file examples

The skip-scope-check label is required on the PR because CONTRIBUTING.md is outside
the cli/ branch scope.

https://claude.ai/code/session_01DReJF4aEiC3gy3a8Wpcjan