### PR TITLE
feat(skill): add /feature-pipeline multi-agent exploration-to-ship skill

### DIFF
--- a/.agents/skills/feature-pipeline/scripts/state.sh
+++ b/.agents/skills/feature-pipeline/scripts/state.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# State management for the feature-pipeline suite.
+#
+# Usage:
+#   state.sh init "<feature>"      — create fresh .fp-state.json
+#   state.sh show                  — pretty-print current state
+#   state.sh get  <key>            — print single value (raw)
+#   state.sh set  <key> <value>    — update one field
+#   state.sh push <key> <value>    — append value to a JSON array field
+#
+# Env:  FP_STATE_FILE  (default: .fp-state.json)
+
+set -euo pipefail
+STATE="${FP_STATE_FILE:-.fp-state.json}"
+cmd="${1:-show}"; shift || true
+
+_ts() { date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ; }
+_require_state() { [[ -f "$STATE" ]] || { echo "No state file found. Run: state.sh init \"<feature>\"" >&2; exit 1; }; }
+_require_jq()    { command -v jq &>/dev/null || { echo "jq is required but not installed." >&2; exit 1; }; }
+
+_require_jq
+
+case "$cmd" in
+  init)
+    feature="${1:?Usage: state.sh init \"<feature>\"}"
+    cat > "$STATE" <<JSON
+{
+  "feature":          "$feature",
+  "phase":            1,
+  "branch":           null,
+  "prNumber":         null,
+  "prUrl":            null,
+  "issueNumbers":     [],
+  "planApproved":     false,
+  "reviewCommentUrl": null,
+  "ciRound":          0,
+  "ciStatus":         "pending",
+  "lastUpdated":      "$(_ts)"
+}
+JSON
+    echo "✓ State initialised → $STATE"
+    jq '.' "$STATE"
+    ;;
+
+  show)
+    _require_state
+    jq '.' "$STATE"
+    ;;
+
+  get)
+    _require_state
+    key="${1:?Usage: state.sh get <key>}"
+    jq -r ".$key // empty" "$STATE"
+    ;;
+
+  set)
+    _require_state
+    key="${1:?Usage: state.sh set <key> <value>}"
+    val="${2?Usage: state.sh set <key> <value>}"  # allow empty string
+    ts="$(_ts)"
+    # Preserve JSON types: booleans, integers, null
+    if [[ "$val" == "true" || "$val" == "false" || "$val" == "null" ]]; then
+      jq ".$key = $val | .lastUpdated = \"$ts\"" "$STATE" > "$STATE.tmp"
+    elif [[ "$val" =~ ^-?[0-9]+$ ]]; then
+      jq ".$key = ($val) | .lastUpdated = \"$ts\"" "$STATE" > "$STATE.tmp"
+    else
+      jq ".$key = \"$val\" | .lastUpdated = \"$ts\"" "$STATE" > "$STATE.tmp"
+    fi
+    mv "$STATE.tmp" "$STATE"
+    echo "✓ $key = $val"
+    ;;
+
+  push)
+    _require_state
+    key="${1:?Usage: state.sh push <key> <value>}"
+    val="${2:?Usage: state.sh push <key> <value>}"
+    ts="$(_ts)"
+    if [[ "$val" =~ ^-?[0-9]+$ ]]; then
+      jq ".$key += [$val] | .lastUpdated = \"$ts\"" "$STATE" > "$STATE.tmp"
+    else
+      jq ".$key += [\"$val\"] | .lastUpdated = \"$ts\"" "$STATE" > "$STATE.tmp"
+    fi
+    mv "$STATE.tmp" "$STATE"
+    echo "✓ pushed $val → $key"
+    ;;
+
+  *)
+    echo "Unknown command: $cmd" >&2
+    echo "Commands: init show get set push" >&2
+    exit 1
+    ;;
+esac

--- a/.agents/skills/fp-drift/SKILL.md
+++ b/.agents/skills/fp-drift/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: fp-drift
+description: >-
+  Phase 5 of the feature-pipeline suite. Runs gaia dev diff against main to
+  check for unexpected skill drift on the PR branch, then delivers the final
+  pipeline summary. Use after /fp-iterate has confirmed CI is green and printed
+  the M4 stop hook. Also useful standalone to check skill drift on any branch.
+version: 3.0.0
+---
+
+# fp-drift  (Phase 5 — Drift Check & Summary)
+
+Fetch main, check for skill drift, deliver the final summary. Lightweight —
+runs directly without spawning a sub-agent.
+
+## Setup
+
+```bash
+STATE=".agents/skills/feature-pipeline/scripts/state.sh"
+feature=$($STATE get feature)
+branch=$($STATE get branch)
+pr=$($STATE get prNumber)
+prUrl=$($STATE get prUrl)
+issues=$($STATE get issueNumbers)
+```
+
+If state is missing or `ciStatus != "green"`, print a warning and exit:
+`⚠ CI is not confirmed green. Run /fp-iterate first.`
+
+## Drift check
+
+```bash
+git fetch origin main
+gaia dev diff 2>/dev/null || gaia validate
+```
+
+**If unexpected drift is detected** (skills changed that are unrelated to the
+PR's stated purpose):
+
+Print a warning table:
+
+```
+⚠ Skill drift detected:
+
+| Skill ID | Field | Value on main | Value on branch |
+|----------|-------|---------------|-----------------|
+| …        | …     | …             | …               |
+```
+
+Do NOT auto-fix. End your turn — let the user decide whether the drift is
+intentional.
+
+**If no unexpected drift:**
+
+Collect the commit list:
+
+```bash
+git log origin/main..HEAD --oneline
+```
+
+Print the final summary:
+
+```
+✅ Feature Pipeline Complete
+════════════════════════════════════════════════════════
+
+Feature explored : {{feature}}
+Issues filed     : <count>  (links: <#N> <#M> …)
+PR               : <prUrl>
+CI               : All checks green ✅
+Skill drift      : None detected ✅
+
+Commits
+───────
+<sha7> <message>
+…
+
+What was fixed
+──────────────
+• <issue title>
+…
+```
+
+End the pipeline:
+
+```bash
+$STATE set phase 7
+$STATE set ciStatus "done"
+```
+
+Print:
+```
+── Pipeline complete ──────────────────────────────────────────────────────────
+```

--- a/.agents/skills/fp-explore/SKILL.md
+++ b/.agents/skills/fp-explore/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: fp-explore
+description: >-
+  Phase 1 of the feature-pipeline suite. Use this to explore a CLI or feature
+  as a developer stress-testing it for the first time, then file GitHub issues
+  for every distinct finding. Reads the target feature from .fp-state.json (or
+  the argument if provided). Bounded: completes in one agent turn. Use after
+  /feature-pipeline init, or invoke standalone with /fp-explore <feature>.
+version: 3.0.0
+argument-hint: "[<feature>]"
+---
+
+# fp-explore  (Phase 1 — Feature Exploration)
+
+Explore `{{feature}}`, file GitHub issues, write issue numbers into state,
+print the M1 stop hook. Done in a single bounded turn.
+
+## Setup
+
+Read the target feature:
+
+```bash
+# If no argument given, read from state:
+feature=$(.agents/skills/feature-pipeline/scripts/state.sh get feature)
+# If state missing, ask the user which feature to explore.
+```
+
+If `.fp-state.json` doesn't exist yet:
+
+```bash
+.agents/skills/feature-pipeline/scripts/state.sh init "<feature>"
+```
+
+## Exploration steps
+
+1. **Orient** — read `--help` output, README sections, and any `CONTEXT.md`
+   entries for `{{feature}}`. Note the expected behaviour.
+
+2. **Explore** — invoke `{{feature}}` in **five or more** distinct ways:
+   - Happy path (normal use)
+   - Edge case (empty input, missing file, zero results)
+   - Invalid input (bad flag, wrong type)
+   - Flag combination (two or more flags together)
+   - Piped or composed output (`| jq`, `| head`, etc.)
+
+3. **Scratchpad** — for each issue found, capture:
+   - One-line title
+   - Exact reproduction commands
+   - Expected vs actual behaviour
+   - Severity: `low` | `medium` | `high`
+
+4. **Cap at 8 findings** — if you find more, pick the highest-severity ones.
+   Quality over quantity.
+
+## Filing issues
+
+For each finding, run:
+
+```bash
+gh issue create \
+  --title "[{{feature}}] <short description>" \
+  --label "exploration,needs-triage" \
+  --body "## Steps to reproduce
+<commands>
+
+## Expected
+<what should happen>
+
+## Actual
+<what happens>
+
+## Severity
+<low | medium | high>"
+```
+
+After each issue is created, append its number to state:
+
+```bash
+.agents/skills/feature-pipeline/scripts/state.sh push issueNumbers <N>
+```
+
+## Phase completion
+
+Print the severity table:
+
+```
+| Issue # | Title | Severity |
+|---------|-------|----------|
+| #N      | …     | high     |
+```
+
+Advance state to Phase 2:
+
+```bash
+.agents/skills/feature-pipeline/scripts/state.sh set phase 2
+```
+
+Then print the M1 stop hook and end your turn:
+
+```
+╔══ STOP HOOK M1 ══════════════════════════════════════════════════════════════╗
+║  Phase 1 complete — <N> issues filed for {{feature}}                         ║
+║  Review above, then run /fp-plan to continue.                                ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+## Constraints
+
+- File issues via `gh` — do not use GitHub MCP tools here (script is faster).
+- Cap at 8 issues. Do not keep exploring after the cap.
+- Push issueNumbers to state after **each** issue (not in batch at the end).
+- End the turn after the stop hook. Do not start Phase 2 yourself.

--- a/.agents/skills/fp-implement/SKILL.md
+++ b/.agents/skills/fp-implement/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: fp-implement
+description: >-
+  Phase 2d of the feature-pipeline suite. Reads the approved implementation
+  plan from state and commits it step by step. Only runs when planApproved is
+  true. Use after /fp-plan has received user approval and printed the M2-plan
+  stop hook. Each commit is atomic; pushes after every step.
+version: 3.0.0
+---
+
+# fp-implement  (Phase 2d — Implementation)
+
+Commit the approved plan one step at a time. Bounded: finishes or hits an
+obstacle, updates state, ends the turn.
+
+## Setup
+
+```bash
+STATE=".agents/skills/feature-pipeline/scripts/state.sh"
+```
+
+Verify preconditions before touching any code:
+
+```bash
+approved=$($STATE get planApproved)   # must be "true"
+branch=$($STATE get branch)
+pr=$($STATE get prNumber)
+```
+
+If `planApproved != true`, print:
+```
+⚠ Plan not yet approved. Run /fp-plan first.
+```
+and end the turn.
+
+Checkout the branch:
+
+```bash
+git checkout "$branch"
+```
+
+## Implementation loop
+
+Read the plan from the PR body (`gh pr view "$pr" --json body`), or ask the
+user to paste it.
+
+For each numbered plan step:
+
+1. Implement the change in the relevant file(s).
+2. Commit atomically:
+   ```bash
+   git add -p   # stage only the relevant hunk
+   git commit -m "<type>(<scope>): <description>"
+   git push
+   ```
+3. Print one line: `  ✓ Step N committed: <commit hash short>`
+
+If a step raises an unexpected obstacle (import error, schema conflict, etc.):
+- Leave a `TODO` comment at the exact location.
+- Commit the partial work: `wip(<scope>): partial step N — <obstacle summary>`.
+- Update state:
+  ```bash
+  $STATE set ciStatus "blocked"
+  ```
+- Print what the obstacle is and end your turn. Do not attempt the next step.
+
+## Phase completion (all steps done)
+
+```bash
+$STATE set phase 4   # jump to review-ready
+```
+
+Update PR labels via `mcp__github__update_pull_request`:
+- Remove `needs-plan`
+- Add `in-progress`
+
+Print M2 stop hook and end your turn:
+
+```
+╔══ STOP HOOK M2 ══════════════════════════════════════════════════════════════╗
+║  Implementation complete — <N> commits pushed to <branch>                    ║
+║  Run /fp-review to start sandbox review.                                     ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+## Constraints
+
+- One commit per plan step — no squashing.
+- Never commit secrets, generated registry artifacts, or unrelated files.
+- `gaia add`/`gaia merge`/`gaia split` for any registry mutations —
+  never hand-edit `registry/nodes/`.
+- No force-pushes.

--- a/.agents/skills/fp-iterate/SKILL.md
+++ b/.agents/skills/fp-iterate/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: fp-iterate
+description: >-
+  Phase 4 of the feature-pipeline suite. Addresses outstanding review items
+  from the Phase 3 comment, then runs a bounded CI poll (max 10 rounds,
+  30s apart). If CI is still pending after the poll, exits cleanly — re-invoke
+  to retry. If CI fails, prints the failing check and exits. Use after /fp-review
+  has posted the sandbox review comment and printed the M3 stop hook.
+version: 3.0.0
+---
+
+# fp-iterate  (Phase 4 — Address Review & Watch CI)
+
+Address `[ ] issues` from the review comment, push fixes, poll CI. Bounded:
+always exits — either green, still-pending (retry), or failed (diagnose).
+
+## Setup
+
+```bash
+STATE=".agents/skills/feature-pipeline/scripts/state.sh"
+branch=$($STATE get branch)
+pr=$($STATE get prNumber)
+reviewUrl=$($STATE get reviewCommentUrl)
+ciRound=$($STATE get ciRound)
+```
+
+Checkout the branch:
+
+```bash
+git checkout "$branch"
+```
+
+## Step 1 — Address review items
+
+Read the review comment:
+
+```bash
+gh api "$reviewUrl" --jq '.body'
+```
+
+For each `- [ ] <description>` item in "Issues found":
+1. Fix the issue.
+2. Commit: `fix(<scope>): <description> (per review)`
+3. Push.
+4. Print: `  ✓ Fixed: <description>`
+
+If a review item is ambiguous or requires architectural input, leave it as
+`[ ]` and add a note. Do not guess — surface it in the stop hook message.
+
+## Step 2 — Bounded CI poll
+
+```bash
+.agents/skills/fp-iterate/scripts/ci-poll.sh "$pr" --max 10 --interval 30
+poll_exit=$?
+```
+
+Update round counter:
+
+```bash
+$STATE set ciRound $(( ciRound + 1 ))
+```
+
+**Exit code 0 — CI green:**
+
+```bash
+$STATE set ciStatus "green"
+$STATE set phase 6
+```
+
+Remove `in-progress` label, add `ready-for-review` via
+`mcp__github__update_pull_request`. Remove draft status.
+
+Print M4 stop hook and end your turn:
+
+```
+╔══ STOP HOOK M4 ══════════════════════════════════════════════════════════════╗
+║  CI green ✅  PR #<N> ready for review                                       ║
+║  Run /fp-drift for the final drift check and summary.                        ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+**Exit code 1 — still pending after 10 rounds:**
+
+```bash
+$STATE set ciStatus "pending"
+```
+
+Print and end your turn (do NOT loop):
+
+```
+⏱ CI still pending after round <ciRound>. Re-run /fp-iterate to check again.
+```
+
+**Exit code 2 — CI failed:**
+
+```bash
+$STATE set ciStatus "failed"
+```
+
+Read the failing check name from ci-poll output, fetch its logs:
+
+```bash
+gh run view --log-failed 2>/dev/null | head -60
+```
+
+Print the diagnosis (root cause, file, line if identifiable) and end your turn.
+Do not push a blind fix — wait for the user to confirm the approach.
+
+## Constraints
+
+- `ci-poll.sh` is the only CI mechanism. Do not write a manual sleep loop.
+- Re-invoking `/fp-iterate` is the intended retry path for exit code 1.
+- If the same check fails 3× across consecutive `/fp-iterate` runs
+  (`ciRound >= 3` and `ciStatus == "failed"`), escalate to the user with
+  the full log excerpt before attempting any fix.
+- No force-pushes.

--- a/.agents/skills/fp-iterate/scripts/ci-poll.sh
+++ b/.agents/skills/fp-iterate/scripts/ci-poll.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Bounded CI poll for a PR — exits cleanly, never loops forever.
+#
+# Usage:
+#   ci-poll.sh <pr-number> [--max N] [--interval S]
+#
+# Exit codes:
+#   0  — all required checks green
+#   1  — still pending after max rounds (re-invoke to retry)
+#   2  — one or more checks failed (read output for which ones)
+#   3  — usage / dependency error
+
+set -euo pipefail
+command -v gh &>/dev/null || { echo "gh CLI required." >&2; exit 3; }
+command -v jq &>/dev/null || { echo "jq required." >&2; exit 3; }
+
+PR="${1:?Usage: ci-poll.sh <pr-number> [--max N] [--interval S]}"
+shift
+
+MAX=10
+INTERVAL=30
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --max)      MAX="$2";      shift 2 ;;
+    --interval) INTERVAL="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 3 ;;
+  esac
+done
+
+echo "▶ ci-poll PR #$PR  max=${MAX} rounds  interval=${INTERVAL}s"
+round=0
+while [[ $round -lt $MAX ]]; do
+  round=$((round + 1))
+  echo -n "  [${round}/${MAX}] checking... "
+
+  result=$(gh pr checks "$PR" --json name,state,conclusion 2>/dev/null) || {
+    echo "gh pr checks failed, retrying." >&2
+    sleep "$INTERVAL"; continue
+  }
+
+  pending=$(echo "$result" | jq '[.[] | select(.state == "PENDING" or .state == "IN_PROGRESS")] | length')
+  failed=$(echo  "$result" | jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR" or .conclusion == "TIMED_OUT")] | length')
+
+  if [[ "$failed" -gt 0 ]]; then
+    echo "❌ $failed failed"
+    echo "$result" | jq -r '.[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR" or .conclusion == "TIMED_OUT") | "    FAIL: \(.name)"'
+    exit 2
+  fi
+
+  if [[ "$pending" -eq 0 ]]; then
+    echo "✅ all green"
+    exit 0
+  fi
+
+  echo "$pending pending — waiting ${INTERVAL}s"
+  sleep "$INTERVAL"
+done
+
+echo "⏱ max rounds (${MAX}) reached — still pending"
+exit 1

--- a/.agents/skills/fp-plan/SKILL.md
+++ b/.agents/skills/fp-plan/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: fp-plan
+description: >-
+  Phase 2 of the feature-pipeline suite. Reads issues from state, creates a
+  feature branch and draft PR, spawns HEAVIER to produce a numbered
+  implementation plan, presents the plan for user approval, then writes the
+  approved plan to state. Does NOT implement — that is /fp-implement. Use after
+  /fp-explore has filed at least one issue and printed the M1 stop hook.
+version: 3.0.0
+---
+
+# fp-plan  (Phase 2 — Plan & Draft PR)
+
+Read issues, create branch + draft PR, get a HEAVIER plan, wait for approval.
+One bounded turn. Implementation is a separate skill (/fp-implement).
+
+## Setup
+
+```bash
+STATE=".agents/skills/feature-pipeline/scripts/state.sh"
+feature=$($STATE get feature)
+issues=$($STATE get issueNumbers)   # JSON array e.g. [12,13,14]
+```
+
+Verify `phase == 2` and `issueNumbers` is non-empty before proceeding.
+
+## Step 1 — Problem Statement
+
+Read each issue body via:
+
+```bash
+gh issue view <N> --json title,body
+```
+
+Write a single paragraph Problem Statement: what is broken, why it matters,
+what a correct fix should achieve.
+
+## Step 2 — Create branch and draft PR
+
+```bash
+# Slugify the feature name
+slug=$(echo "$feature" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | cut -c1-40)
+branch="fix/${slug}-findings"
+
+git checkout -b "$branch"
+git push -u origin "$branch"
+
+$STATE set branch "$branch"
+```
+
+Open draft PR using GitHub MCP (`mcp__github__create_pull_request`):
+- **title**: `fix({{feature}}): address exploration findings`
+- **labels**: `draft`, `needs-plan`
+- **draft**: true
+- **body**:
+
+```markdown
+## Problem Statement
+<from Step 1>
+
+## Related issues
+- Closes #N
+- Closes #M
+
+## Plan
+_To be filled after approval._
+```
+
+Write PR info to state:
+
+```bash
+$STATE set prNumber <N>
+$STATE set prUrl    "<url>"
+```
+
+## Step 3 — HEAVIER plan
+
+Spawn HEAVIER with:
+- The issue titles and bodies
+- The PR URL
+- Excerpts from the source files relevant to `{{feature}}`
+
+HEAVIER brief:
+
+> Produce a numbered implementation plan for the issues listed.
+> Format each step as:
+> `N. <file/area>  —  <change>  —  <rationale>  [⚠ breaking | ⚠ test-only | ⚠ schema]`
+> Keep the plan to 3–8 steps. Be specific about file paths and function names.
+
+**Present the plan to the user verbatim. Do not proceed until the user
+explicitly types 'approve', 'continue', or provides edits.**
+
+Accept corrections inline. After approval:
+
+1. Update the PR body `## Plan` section with the final plan text.
+2. Write the approved plan to state:
+   ```bash
+   $STATE set planApproved true
+   $STATE set phase 3
+   ```
+   (Phase advances to 3 to indicate "ready for implement", but /fp-implement
+   reads `planApproved == true` and `phase == 3`.)
+
+Then print M2-plan stop hook and end your turn:
+
+```
+╔══ STOP HOOK M2-plan ═════════════════════════════════════════════════════════╗
+║  Plan approved — branch: <branch>  PR: #<N>                                 ║
+║  Run /fp-implement to commit the plan.                                       ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+## Constraints
+
+- Do not implement any code. /fp-implement does that.
+- Do not advance past plan approval without explicit user sign-off.
+- If HEAVIER spawning fails: write a Handover to `.fp-handover.md` with the
+  issue bodies and source excerpts; end your turn. Do not plan yourself.

--- a/.agents/skills/fp-review/SKILL.md
+++ b/.agents/skills/fp-review/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: fp-review
+description: >-
+  Phase 3 of the feature-pipeline suite. Spawns HEAVIER in a worktree sandbox
+  to run RED/GREEN tests on the PR diff and post a structured review comment.
+  Reads branch and PR number from state. Use after /fp-implement has pushed all
+  commits and printed the M2 stop hook.
+version: 3.0.0
+---
+
+# fp-review  (Phase 3 — Sandbox Review)
+
+Spawn HEAVIER in an isolated worktree, run tests, post a review comment.
+One bounded turn.
+
+## Setup
+
+```bash
+STATE=".agents/skills/feature-pipeline/scripts/state.sh"
+branch=$($STATE get branch)
+pr=$($STATE get prNumber)
+```
+
+Verify `phase == 4` (set by /fp-implement).
+
+## HEAVIER brief
+
+Spawn HEAVIER in `isolation: worktree` on `$branch`.
+
+> You are reviewing PR #$pr on branch $branch.
+>
+> 1. Read the full diff: `git diff origin/main...HEAD`
+> 2. For each changed public surface (function, CLI flag, schema field):
+>    a. Write a RED test — it must FAIL before the fix. Verify by temporarily
+>       reverting that change, running the test, then re-applying.
+>    b. Write a GREEN test — it must PASS with the fix in place.
+> 3. For schema-touching commits: run `gaia validate`
+> 4. For doc-touching commits: run `gaia docs build --check`
+> 5. Post this exact comment structure to the PR via `gh pr comment`:
+>
+> ```markdown
+> ## Sandbox Review
+>
+> ### RED tests
+> | Description | Result | Notes |
+> |-------------|--------|-------|
+>
+> ### GREEN tests
+> | Description | Result | Notes |
+> |-------------|--------|-------|
+>
+> ### Issues found
+> - [ ] <description> — `<file>:<line>`
+>
+> ### Verdict: APPROVE / REQUEST CHANGES
+> ```
+
+After HEAVIER posts the comment, read the comment URL from its output.
+
+## Phase completion
+
+```bash
+$STATE set reviewCommentUrl "<url>"
+$STATE set phase 5
+```
+
+Print M3 stop hook and end your turn:
+
+```
+╔══ STOP HOOK M3 ══════════════════════════════════════════════════════════════╗
+║  Sandbox review posted — PR #<N>                                             ║
+║  Review the comment, then run /fp-iterate to address findings + watch CI.   ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+## Constraints
+
+- If HEAVIER spawning fails: write `.fp-handover.md` with diff URL and branch
+  name; end your turn. Do not review the PR yourself.
+- Do not push any commits. This phase is read + comment only.

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,13 @@
 # Gaia Skill Registry — .gitignore
 
+# feature-pipeline runtime state (local, per-machine)
+.fp-state.json
+.fp-handover.md
+feature-pipeline-workspace/
+
+# Externally installed agent skills (managed by `gaia skills install`)
+.agents/skills/skill-creator
+
 # Python
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
Adds a new five-phase orchestration skill that takes a raw feature or CLI
name and drives it through a complete explore-to-PR-to-green-CI pipeline
using tiered model assignment:

  Phase 1 (Haiku)   — sandbox-tests the feature, files GitHub issues
  Phase 2 (Sonnet+Opus) — drafts PR, Opus plans approach, user approves,
                           Sonnet commits implementation
  Phase 3 (Opus)    — worktree sandbox, RED/GREEN tests, posts PR comment
  Phase 4 (Sonnet)  — iterates on review findings, watches CI until green
  Phase 5 (Haiku)   — gaia dev diff drift check, sends user summary

Files added:
  .agents/skills/feature-pipeline/SKILL.md
  registry/nodes/extra/feature-pipeline.json
  registry/skills/extra/feature-pipeline.md

Registry: extra skill, 1★ Awakened, prerequisites:
  dispatching-parallel-agents, code-review-pipeline

Docs regenerated. gaia validate passes. [skip-gen]

https://claude.ai/code/session_01XaF3hbMapywgBeKxA8ojcu