### PR TITLE
fix(mcp): address exploration findings for packages/mcp

### DIFF
--- a/packages/mcp/TODO.md
+++ b/packages/mcp/TODO.md
@@ -1,0 +1,9 @@
+# MCP Findings Fix Plan
+
+This file tracks the implementation of fixes for the MCP exploration findings.
+
+- [ ] [packages/mcp] Missing gaia CLI integration (#402)
+- [ ] [packages/mcp] Hardcoded Registry URL (#403)
+- [ ] [packages/mcp] Verbose Zod Validation Errors (#404)
+- [ ] [packages/mcp] Hidden Dependency on ~/.gaia/cache (#405)
+- [ ] [packages/mcp] gaia_propose PR state handling (#406)

--- a/packages/mcp/src/config/cache.ts
+++ b/packages/mcp/src/config/cache.ts
@@ -8,7 +8,8 @@ interface CacheEntry {
   filePath: string;
 }
 
-const CACHE_DIR = join(homedir(), ".gaia", "cache");
+const GAIA_HOME = process.env.GAIA_HOME || join(homedir(), ".gaia");
+const CACHE_DIR = join(GAIA_HOME, "cache");
 const CACHE_META = join(CACHE_DIR, "meta.json");
 const TTL_MS = 5 * 60 * 1000;
 

--- a/packages/mcp/src/config/identity.ts
+++ b/packages/mcp/src/config/identity.ts
@@ -3,37 +3,101 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 import type { GaiaConfig } from "../graph/types.js";
 
+function parseGaiaConfig(raw: string): Partial<GaiaConfig> {
+  const config: Partial<GaiaConfig> = {};
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#") || !trimmed.includes("=")) continue;
+    const [key, ...rest] = trimmed.split("=");
+    const value = rest.join("=").trim().replace(/^"(.*)"$/, "$1");
+
+    const k = key.trim();
+    if (k === "username" || k === "gaiaUser") config.gaiaUser = value;
+    if (k === "gaiaRegistryRef") config.gaiaRegistryRef = value;
+    if (k === "localRegistryPath") config.localRegistryPath = value;
+  }
+  return config;
+}
+
+function readLocalConfig(): Partial<GaiaConfig> | null {
+  const tomlPath = join(process.cwd(), ".gaia", "config.toml");
+  if (existsSync(tomlPath)) {
+    try {
+      return parseGaiaConfig(readFileSync(tomlPath, "utf-8"));
+    } catch {}
+  }
+  const jsonPath = join(process.cwd(), ".gaia", "config.json");
+  if (existsSync(jsonPath)) {
+    try {
+      return JSON.parse(readFileSync(jsonPath, "utf-8"));
+    } catch {}
+  }
+  return null;
+}
+
+function readGlobalConfig(): Partial<GaiaConfig> | null {
+  const gaiaHome = process.env.GAIA_HOME || join(homedir(), ".gaia");
+  const jsonPath = join(gaiaHome, "config.json");
+  if (existsSync(jsonPath)) {
+    try {
+      return JSON.parse(readFileSync(jsonPath, "utf-8"));
+    } catch {}
+  }
+  return null;
+}
+
 export function resolveIdentity(): string | null {
   if (process.env.GAIA_USER) {
     return process.env.GAIA_USER;
   }
 
-  const localConfig = join(process.cwd(), ".gaia", "config.json");
-  if (existsSync(localConfig)) {
-    try {
-      const config: GaiaConfig = JSON.parse(readFileSync(localConfig, "utf-8"));
-      if (config.gaiaUser) return config.gaiaUser;
-    } catch {}
-  }
+  const local = readLocalConfig();
+  if (local?.gaiaUser) return local.gaiaUser;
 
-  const globalConfig = join(homedir(), ".gaia", "config.json");
-  if (existsSync(globalConfig)) {
-    try {
-      const config: GaiaConfig = JSON.parse(readFileSync(globalConfig, "utf-8"));
-      if (config.gaiaUser) return config.gaiaUser;
-    } catch {}
-  }
+  const global = readGlobalConfig();
+  if (global?.gaiaUser) return global.gaiaUser;
 
   return null;
 }
 
 export function resolveRegistryUrl(): string | null {
-  const localConfig = join(process.cwd(), ".gaia", "config.json");
-  if (existsSync(localConfig)) {
-    try {
-      const config: GaiaConfig = JSON.parse(readFileSync(localConfig, "utf-8"));
-      if (config.gaiaRegistryRef) return config.gaiaRegistryRef;
-    } catch {}
+  if (process.env.GAIA_REGISTRY_URL) {
+    return process.env.GAIA_REGISTRY_URL;
   }
+
+  const local = readLocalConfig();
+  if (local?.gaiaRegistryRef) return local.gaiaRegistryRef;
+
+  const global = readGlobalConfig();
+  // Python CLI saves global registry path in 'defaultRegistry', not URL
+  // but if it's a URL-like string we can use it.
+  const defaultReg = (global as any)?.defaultRegistry;
+  if (defaultReg && (defaultReg.startsWith("http://") || defaultReg.startsWith("https://"))) {
+    return defaultReg;
+  }
+
+  return null;
+}
+
+export function resolveRegistryPath(): string | null {
+  if (process.env.GAIA_REGISTRY_PATH) {
+    return process.env.GAIA_REGISTRY_PATH;
+  }
+
+  const local = readLocalConfig();
+  if (local?.localRegistryPath) return local.localRegistryPath;
+
+  const global = readGlobalConfig();
+  const defaultReg = (global as any)?.defaultRegistry;
+  if (defaultReg && !defaultReg.startsWith("http://") && !defaultReg.startsWith("https://")) {
+    return defaultReg;
+  }
+
+  // Check if CWD is a registry
+  const cwd = process.cwd();
+  if (existsSync(join(cwd, "registry", "gaia.json"))) {
+    return cwd;
+  }
+
   return null;
 }

--- a/packages/mcp/src/graph/loader.ts
+++ b/packages/mcp/src/graph/loader.ts
@@ -1,5 +1,8 @@
 import { getCached, getEtag, putCache } from "../config/cache.js";
+import { resolveRegistryPath, resolveRegistryUrl } from "../config/identity.js";
 import type { GaiaGraph } from "./types.js";
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
 
 const REGISTRY_URL =
   "https://raw.githubusercontent.com/mbtiongson1/gaia-skill-tree/main/registry/gaia.json";
@@ -9,9 +12,33 @@ const USERNAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9-]{0,37}[a-zA-Z0-9]$|^[a-zA-Z0-9]$/;
 let cachedGraph: GaiaGraph | null = null;
 
 export async function loadGraph(registryUrl?: string): Promise<GaiaGraph> {
-  const url = registryUrl ?? REGISTRY_URL;
-  const cacheKey = "gaia_graph";
+  // Priority: argument > local registry path > local config URL > default URL
+  let url = registryUrl;
+  if (!url) {
+    const localPath = resolveRegistryPath();
+    if (localPath) {
+      const graphPath = join(localPath, "registry", "gaia.json");
+      if (existsSync(graphPath)) {
+        url = graphPath;
+      }
+    }
+  }
+  if (!url) {
+    url = resolveRegistryUrl() ?? REGISTRY_URL;
+  }
 
+  // Handle local file path
+  if (existsSync(url)) {
+    try {
+      const data = readFileSync(url, "utf-8");
+      cachedGraph = JSON.parse(data);
+      return cachedGraph!;
+    } catch (err) {
+      console.error(`Failed to read local registry at ${url}:`, err);
+    }
+  }
+
+  const cacheKey = "gaia_graph";
   const cached = getCached(cacheKey);
   if (cached && !cached.stale) {
     if (!cachedGraph) {
@@ -64,7 +91,23 @@ export async function loadUserTree(
   registryUrl?: string
 ): Promise<Record<string, unknown> | null> {
   if (!USERNAME_RE.test(username)) return null;
-  const baseUrl = registryUrl ?? REGISTRY_URL.replace("/registry/gaia.json", "");
+
+  const localPath = resolveRegistryPath();
+  if (!registryUrl && localPath) {
+    const treePath = join(localPath, "skill-trees", username, "skill-tree.json");
+    if (existsSync(treePath)) {
+      try {
+        return JSON.parse(readFileSync(treePath, "utf-8")) as Record<string, unknown>;
+      } catch {
+        return null;
+      }
+    }
+  }
+
+  const baseUrl =
+    registryUrl ??
+    resolveRegistryUrl()?.replace("/registry/gaia.json", "") ??
+    REGISTRY_URL.replace("/registry/gaia.json", "");
   const url = `${baseUrl}/skill-trees/${encodeURIComponent(username)}/skill-tree.json`;
 
   try {

--- a/packages/mcp/src/graph/types.ts
+++ b/packages/mcp/src/graph/types.ts
@@ -83,6 +83,7 @@ export interface UserSkillTree {
 export interface GaiaConfig {
   gaiaUser: string;
   gaiaRegistryRef: string;
+  localRegistryPath?: string;
   scanPaths: string[];
   autoPromptCombinations: boolean;
   lastScan?: string;

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -8,6 +8,7 @@ import { suggest } from "./tools/suggest.js";
 import { scanContext } from "./tools/scanContext.js";
 import { propose } from "./tools/propose.js";
 import { getRegistryResource, getUserTreeResource } from "./resources/registry.js";
+import { withErrorHandling } from "./utils/errors.js";
 
 const require = createRequire(import.meta.url);
 
@@ -34,20 +35,18 @@ export function createServer(): McpServer {
     "gaia_lookup",
     "Look up a skill in the Gaia registry by ID or fuzzy name. Returns full metadata, prerequisites, derivatives, evidence, and graph context.",
     { query: z.string().describe("Skill ID (e.g. 'web-scrape') or fuzzy name (e.g. 'web scraping')") },
-    async ({ query }) => {
-      const result = await lookupSkill(query);
-      return { content: [{ type: "text", text: result }] };
-    }
+    withErrorHandling(async ({ query }) => {
+      return await lookupSkill(query);
+    })
   );
 
   server.tool(
     "gaia_my_tree",
     "Show the current user's Gaia skill tree — unlocked skills, pending fusions, and progression stats.",
     { username: z.string().regex(/^[a-zA-Z0-9][a-zA-Z0-9-]*$/, "Invalid GitHub username").max(39).optional().describe("GitHub username (defaults to configured GAIA_USER)") },
-    async ({ username }) => {
-      const result = await getMyTree(username);
-      return { content: [{ type: "text", text: result }] };
-    }
+    withErrorHandling(async ({ username }) => {
+      return await getMyTree(username);
+    })
   );
 
   server.tool(
@@ -57,10 +56,9 @@ export function createServer(): McpServer {
       context: z.array(z.string()).optional().describe("Project signals — descriptions of what you're building, package names, file patterns"),
       tools: z.array(z.string()).optional().describe("Names of MCP tools currently connected (e.g. 'web_search', 'bash', 'fetch')"),
     },
-    async ({ context, tools }) => {
-      const result = await suggest(context, tools);
-      return { content: [{ type: "text", text: result }] };
-    }
+    withErrorHandling(async ({ context, tools }) => {
+      return await suggest(context, tools);
+    })
   );
 
   server.tool(
@@ -70,10 +68,9 @@ export function createServer(): McpServer {
       connectedTools: z.array(z.string()).optional().describe("MCP tool names currently available (e.g. 'web_search', 'read_file', 'bash')"),
       projectSignals: z.array(z.string()).optional().describe("Descriptions of project capabilities (e.g. 'cheerio in package.json', 'building a web scraper')"),
     },
-    async ({ connectedTools, projectSignals }) => {
-      const result = await scanContext(connectedTools, projectSignals);
-      return { content: [{ type: "text", text: result }] };
-    }
+    withErrorHandling(async ({ connectedTools, projectSignals }) => {
+      return await scanContext(connectedTools, projectSignals);
+    })
   );
 
   server.tool(
@@ -86,10 +83,9 @@ export function createServer(): McpServer {
       type: z.enum(["basic", "extra", "unique", "ultimate"]).optional().describe("Skill type"),
       prerequisites: z.array(z.string()).optional().describe("Prerequisite skill IDs for extra/ultimate proposals"),
     },
-    async (input) => {
-      const result = await propose(input);
-      return { content: [{ type: "text", text: result }] };
-    }
+    withErrorHandling(async (input) => {
+      return await propose(input);
+    })
   );
 
   server.resource(

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -67,9 +67,10 @@ export function createServer(): McpServer {
     {
       connectedTools: z.array(z.string()).optional().describe("MCP tool names currently available (e.g. 'web_search', 'read_file', 'bash')"),
       projectSignals: z.array(z.string()).optional().describe("Descriptions of project capabilities (e.g. 'cheerio in package.json', 'building a web scraper')"),
+      deepScan: z.boolean().optional().describe("If true, invokes the local 'gaia' CLI to perform a deep source code scan for skill tokens."),
     },
-    withErrorHandling(async ({ connectedTools, projectSignals }) => {
-      return await scanContext(connectedTools, projectSignals);
+    withErrorHandling(async ({ connectedTools, projectSignals, deepScan }) => {
+      return await scanContext(connectedTools, projectSignals, deepScan);
     })
   );
 

--- a/packages/mcp/src/tools/propose.ts
+++ b/packages/mcp/src/tools/propose.ts
@@ -89,7 +89,8 @@ async function claimFusion(
     ],
   });
 
-  return `Fusion claimed! PR opened: ${prUrl}\n\n**${skill.name}** (${skill.type}, ${skill.level}, ${skill.rarity}) added to your tree.`;
+  const prVerb = prUrl.startsWith("http") ? "PR" : "Status";
+  return `Fusion claimed! ${prVerb}: ${prUrl}\n\n**${skill.name}** (${skill.type}, ${skill.level}, ${skill.rarity}) added to your tree.`;
 }
 
 async function proposeNovel(
@@ -150,5 +151,6 @@ async function proposeNovel(
     ],
   });
 
-  return `Novel skill proposed! PR opened: ${prUrl}\n\n**${input.name}** — pending review by maintainers.`;
+  const prVerb = prUrl.startsWith("http") ? "PR" : "Status";
+  return `Novel skill proposed! ${prVerb}: ${prUrl}\n\n**${input.name}** — pending review by maintainers.`;
 }

--- a/packages/mcp/src/tools/scanContext.ts
+++ b/packages/mcp/src/tools/scanContext.ts
@@ -3,18 +3,36 @@ import { resolveIdentity } from "../config/identity.js";
 import { detectCombinations } from "../advisor/fusionEngine.js";
 import { detectSkillsFromTools, detectSkillsFromSignals } from "../advisor/detector.js";
 import { scoreNovelty } from "../advisor/noveltyScorer.js";
+import { runGaia } from "../utils/gaia.js";
 import type { UserSkillTree, GaiaGraph } from "../graph/types.js";
 
 export async function scanContext(
   connectedTools?: string[],
-  projectSignals?: string[]
+  projectSignals?: string[],
+  deepScan?: boolean
 ): Promise<string> {
   const graph = await loadGraph();
   const user = resolveIdentity();
 
   const detectedFromTools = connectedTools ? detectSkillsFromTools(connectedTools) : [];
   const detectedFromSignals = projectSignals ? detectSkillsFromSignals(projectSignals) : [];
-  const allDetected = [...new Set([...detectedFromTools, ...detectedFromSignals])];
+  let allDetected = [...new Set([...detectedFromTools, ...detectedFromSignals])];
+
+  if (deepScan) {
+    try {
+      const deepOutput = await runGaia(["scan", "--json"]);
+      const parsed = JSON.parse(deepOutput);
+      if (parsed.matched && Array.isArray(parsed.matched)) {
+        for (const skill of parsed.matched) {
+          allDetected.push(skill);
+        }
+      }
+    } catch (err) {
+      console.warn("Deep scan failed, falling back to heuristic scan:", err);
+    }
+  }
+
+  allDetected = [...new Set(allDetected)];
 
   let ownedSkillIds: string[] = [];
   if (user) {

--- a/packages/mcp/src/utils/errors.ts
+++ b/packages/mcp/src/utils/errors.ts
@@ -1,0 +1,53 @@
+import { ZodError } from "zod";
+
+/**
+ * Enhances Zod error messages to be more human-readable for AI agents.
+ */
+export function formatZodError(error: ZodError): string {
+  const issues = error.issues.map((issue) => {
+    const path = issue.path.join(".");
+    let message = issue.message;
+
+    if (issue.code === "invalid_type") {
+      message = `Expected ${issue.expected}, but received ${issue.received}`;
+    }
+
+    return `* ${path ? `\`${path}\`: ` : ""}${message}`;
+  });
+
+  return `Invalid tool input:\n${issues.join("\n")}`;
+}
+
+/**
+ * Wraps a tool handler to provide better error messages and consistent formatting.
+ */
+export function withErrorHandling<T>(handler: (args: T) => Promise<string>) {
+  return async (args: T) => {
+    try {
+      const result = await handler(args);
+      return { content: [{ type: "text" as const, text: result }] };
+    } catch (err) {
+      if (err instanceof ZodError) {
+        return {
+          content: [{ type: "text" as const, text: formatZodError(err) }],
+          isError: true,
+        };
+      }
+
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      
+      // Check for specific error types to provide better advice
+      let helpfulMessage = `Error: ${errorMessage}`;
+      if (errorMessage.includes("GITHUB_TOKEN")) {
+        helpfulMessage += "\n\nTip: Ensure the GITHUB_TOKEN environment variable is set and has 'repo' permissions.";
+      } else if (errorMessage.includes("ENOENT")) {
+        helpfulMessage += "\n\nTip: A required file or directory was not found. Check your local registry path.";
+      }
+
+      return {
+        content: [{ type: "text" as const, text: helpfulMessage }],
+        isError: true,
+      };
+    }
+  };
+}

--- a/packages/mcp/src/utils/gaia.ts
+++ b/packages/mcp/src/utils/gaia.ts
@@ -1,0 +1,50 @@
+import { spawn } from "node:child_process";
+import { resolveRegistryPath } from "../config/identity.js";
+
+/**
+ * Standardized way to invoke the Gaia Python CLI from the MCP server.
+ * Honours local registry context by passing GAIA_REGISTRY_PATH.
+ */
+export async function runGaia(args: string[]): Promise<string> {
+  const registryPath = resolveRegistryPath();
+  const env = {
+    ...process.env,
+    // Ensure the subprocess uses the same registry context
+    ...(registryPath ? { GAIA_REGISTRY_PATH: registryPath } : {}),
+    // Force no-color for machine consumption
+    NO_COLOR: "1",
+    TERM: "dumb",
+  };
+
+  return new Promise((resolve, reject) => {
+    // We use shell: true to handle environment path resolution better across platforms
+    const proc = spawn("gaia", args, {
+      env,
+      shell: true,
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    proc.stdout.on("data", (data) => {
+      stdout += data.toString();
+    });
+
+    proc.stderr.on("data", (data) => {
+      stderr += data.toString();
+    });
+
+    proc.on("close", (code) => {
+      if (code === 0) {
+        resolve(stdout.trim());
+      } else {
+        const errorMsg = stderr.trim() || stdout.trim() || `Exit code ${code}`;
+        reject(new Error(`gaia ${args.join(" ")} failed: ${errorMsg}`));
+      }
+    });
+
+    proc.on("error", (err) => {
+      reject(new Error(`Failed to start gaia CLI: ${err.message}. Ensure gaia is installed and in your PATH.`));
+    });
+  });
+}

--- a/packages/mcp/src/utils/github.ts
+++ b/packages/mcp/src/utils/github.ts
@@ -67,6 +67,13 @@ export async function createPullRequest(
   if (!prRes.ok) {
     const errText = await prRes.text();
     if (errText.includes("A pull request already exists")) {
+      const listRes = await fetch(`${baseUrl}/pulls?head=${owner}:${branch}&state=open`, {
+        headers,
+      });
+      if (listRes.ok) {
+        const pulls = (await listRes.json()) as Array<{ html_url: string }>;
+        if (pulls.length > 0) return pulls[0].html_url;
+      }
       return `PR already exists for branch ${branch}`;
     }
     throw new Error(`Failed to create PR: ${prRes.status} ${errText}`);

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -310,7 +310,9 @@ def scan_command(args):
         print("Gaia not initialized. Run `gaia init` first.")
         return
     quiet = getattr(args, 'quiet', False)
-    if not quiet:
+    use_json = getattr(args, 'json', False)
+    
+    if not quiet and not use_json:
         print("Scanning repository...")
     scan_result = scan_repo_detailed()
     raw_tokens = {t.lstrip('/') for t in scan_result["tokens"]}
@@ -322,6 +324,15 @@ def scan_command(args):
     
     # Unified local context for display
     ctx = LocalContext.load(args.registry, username or "", include_scan=False)
+
+    if use_json:
+        out = {
+            "scanned": scan_result["files_scanned"],
+            "candidates": scan_result["candidate_count"],
+            "matched": sorted(list(resolved)),
+        }
+        print(json.dumps(out, indent=2))
+        return
 
     if not quiet:
         print(
@@ -1425,6 +1436,7 @@ def get_parser():
     scan_parser = subparsers.add_parser('scan', help="Scan configured paths for skill evidence")
     scan_parser.add_argument('--quiet', action='store_true', help="Suppress scan output; only show notifications")
     scan_parser.add_argument('--auto-promote', action='store_true', help="Promote every scan-recommended candidate after scanning")
+    scan_parser.add_argument('--json', action='store_true', help="Output scan results as JSON")
     subparsers.add_parser('pull', help="Refresh registry data from origin")
     subparsers.add_parser('update', help="Update all installed remote skills")
     

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -1349,7 +1349,15 @@ def mcp_command(args):
         print(f"MCP server build not found: {script}", file=sys.stderr)
         print("Run `npm run build` in packages/mcp first.", file=sys.stderr)
         sys.exit(1)
-    raise SystemExit(subprocess.call(["node", str(script)]))
+    
+    env = os.environ.copy()
+    env["GAIA_REGISTRY_PATH"] = str(args.registry)
+    
+    config = load_config()
+    if config and config.get("gaiaUser"):
+        env["GAIA_USER"] = config["gaiaUser"]
+        
+    raise SystemExit(subprocess.call(["node", str(script)], env=env))
 
 
 def docs_command(args):


### PR DESCRIPTION
## Problem Statement
The Gaia MCP server (`packages/mcp`) currently lacks deep integration with the core `gaia` CLI and ecosystem conventions. Key issues include a brittle 'gaia mcp' entry point that breaks in packaged environments, hardcoded remote registry URLs that prevent local testing, inconsistent configuration (ignoring `GAIA_HOME`), and technical error reporting that hinders agent usability. Addressing these findings will ensure the MCP server is a robust, "agent-native" extension of the Gaia toolkit that respects local context and provides a seamless setup experience.

Closes #402, #403, #404, #405, #406

## Plan
1. `packages/mcp/src/config/cache.ts` — Use GAIA_HOME environment variable
2. `packages/mcp/src/graph/loader.ts` — Respect GAIA_REGISTRY_PATH and local config
3. `packages/mcp/src/index.ts` — Implement human-readable Zod error formatting
4. `packages/mcp/src/utils/github.ts` — Return existing PR URL on conflict
5. `packages/mcp/src/utils/gaia.ts` (New) — Add runGaia(args: string[]) utility
6. `src/gaia_cli/main.py` — Update mcp_command to pass environmental context
7. `packages/mcp/src/tools/scanContext.ts` — Delegate complex scanning to Python
8. `packages/mcp/src/tools/propose.ts` — Improve PR state reporting

## Sandbox Review
(See previous PR for results)