### PR TITLE
feat(skills): add regen and pr agent skills for manual workflows

### DIFF
--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: pr
+description: Push committed changes and create a draft PR on GitHub. Use when you have staged changes ready to push and want to open a draft PR for early feedback or documentation.
+---
+
+# PR
+
+Quickly push changes and open a draft pull request on GitHub.
+
+## When to Use
+
+- You have staged changes ready to push and want to create a draft PR
+- Early feedback needed on work-in-progress
+- Want to document and track changes before final review
+- Need to open a PR for discussion or CI validation
+
+## Instructions
+
+### Step 1: Verify Staged Changes
+
+Check what will be committed:
+```bash
+git status
+```
+
+Ensure all changes you want are staged with:
+```bash
+git add <files>
+```
+
+Or add everything:
+```bash
+git add .
+```
+
+### Step 2: Create Commit Message
+
+Write a clear, conventional commit message. Use the format:
+```
+<type>(<scope>): <description>
+
+<optional body with details>
+```
+
+Types: `feat`, `fix`, `chore`, `refactor`, `docs`, `test`, etc.
+
+Examples:
+- `feat(registry): add new skill category`
+- `fix(cli): resolve version mismatch`
+- `chore: regenerate artifacts`
+
+### Step 3: Commit Changes
+
+```bash
+git commit -m "your commit message here"
+```
+
+### Step 4: Push to Remote
+
+```bash
+git push -u origin <branch-name>
+```
+
+If you're on `main` or pushing to an existing branch:
+```bash
+git push
+```
+
+### Step 4: Create Draft PR
+
+```bash
+gh pr create --draft
+```
+
+This will prompt you for:
+- **Title** — auto-filled from commit, edit as needed
+- **Body** — add context, description, or leave blank
+- **Assignees** — optional
+- **Labels** — optional
+
+Or specify details inline:
+```bash
+gh pr create --draft --title "Your PR Title" --body "Description here"
+```
+
+## Tips
+
+- **Draft PRs** show as "Draft" and won't trigger auto-merge workflows
+- **Rebase before final PR** — `git rebase -i origin/main` to clean up commits
+- **Ready to review?** — Use `gh pr ready` to convert from draft to ready-for-review
+- **Add more commits** — Just push again with `git push`, the PR updates automatically
+
+## Troubleshooting
+
+**"fatal: The current branch has no upstream branch"**
+- Use `git push -u origin <branch-name>` on first push
+
+**"Permission denied" when pushing**
+- Check your git credentials: `gh auth status`
+- Re-authenticate if needed: `gh auth login`
+
+**PR creation fails**
+- Ensure you're in a git repository: `git rev-parse --show-toplevel`
+- Check GitHub CLI is installed: `gh version`

--- a/.agents/skills/regen/SKILL.md
+++ b/.agents/skills/regen/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: regen
+description: Manually trigger artifact regeneration, versioning, and chore commit. Use when you need fine-grained control over when registry artifacts sync (outside the automated sync-artifacts.yml workflow).
+---
+
+# Regen
+
+Manually regenerate registry artifacts, apply version bumps, and commit changes with full control over timing and bump classification.
+
+## When to Use
+
+- Registry changes need immediate artifact sync (not waiting for automated workflow)
+- You want to batch multiple registry/script changes into one controlled sync
+- Testing registry changes locally before pushing
+- Explicit version bump when automated classification might be incorrect
+- Emergency registry fixes that need immediate artifact regeneration
+
+## Instructions
+
+### Step 1: Verify Registry Changes Exist
+
+Ensure you have uncommitted or staged changes to:
+- `registry/nodes/`
+- `registry/named/`
+- `registry/schema/`
+- `registry/suites/`
+- `scripts/` (if regeneration scripts changed)
+
+Check with: `git status`
+
+### Step 2: Determine Bump Type
+
+Classify the changes as one of:
+
+- **patch**: Bug fixes, small registry updates, evidence additions, non-breaking corrections
+- **minor**: New skills added, new fields added (non-breaking), schema enhancements
+- **major**: Breaking schema changes, deprecated field removals, BREAKING CHANGE in commit message
+
+Default to **patch** if uncertain.
+
+### Step 3: Run the Sync
+
+Execute the sync with your chosen bump type. Replace `BUMP` with `patch`, `minor`, or `major`:
+
+```bash
+cd <project-root>
+gaia release BUMP
+gaia docs build
+```
+
+### Step 4: Verify Generated Changes
+
+Check what was generated:
+```bash
+git status
+git diff --stat
+```
+
+Review the version changes in:
+- `pyproject.toml`
+- `packages/cli-npm/package.json`
+- `packages/mcp/package.json`
+- `registry/gaia.json`
+
+### Step 5: Commit and Push
+
+If changes look correct:
+
+```bash
+git config user.name "$(git config user.name)"
+git config user.email "$(git config user.email)"
+git add .
+git commit -m "chore(manual): regenerate registry artifacts and sync docs (bump: BUMP)"
+git push
+```
+
+Or if you want to keep the standard message:
+
+```bash
+git add .
+git commit -m "chore(auto): regenerate registry artifacts and sync docs"
+git push
+```
+
+## Skipping Auto-Sync on Push
+
+If the automated `sync-artifacts.yml` workflow would conflict with your manual sync, add `[skip-gen]` to your commit message:
+
+```bash
+git commit -m "chore(manual): regenerate registry artifacts [skip-gen]"
+```
+
+This prevents the automated workflow from re-running on push.
+
+## Notes
+
+- This skill is for **manual, intentional syncs** — the default automated workflow (`.github/workflows/sync-artifacts.yml`) handles routine cases
+- Always review generated artifacts before pushing
+- Version bumps are locked across all packages (pyproject.toml, npm packages, gaia.json)
+- If you make mistakes, use `git reset --hard HEAD~1` to undo the last commit


### PR DESCRIPTION
Add two new agent skills to .agents/skills:

- **regen**: Manually trigger artifact regeneration, versioning, and chore commit for fine-grained control over registry artifact syncs (outside the automated sync-artifacts.yml workflow)
- **pr**: Quick workflow to push committed changes and create a draft PR on GitHub

These skills provide scripted control over common developer workflows.