### PR TITLE
fix(ci): reduce auto-merge workflow spam

### DIFF
--- a/.github/workflows/auto-merge-small-prs.yml
+++ b/.github/workflows/auto-merge-small-prs.yml
@@ -2,7 +2,13 @@ name: Auto-merge small PRs
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened, labeled]
+
+# Cancel any in-progress run for the same PR when a new one starts.
+# This prevents a queue of stale runs from piling up and spamming notifications.
+concurrency:
+  group: auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 permissions:
   pull-requests: write
@@ -32,8 +38,6 @@ jobs:
           # 3. Doesn't modify critical files (.github, pyproject.toml, package.json)
 
           if [ "$CHANGED_FILES" -lt 20 ]; then
-            # We allow .jules/ changes but still block critical files in .github/
-            # and package manifest files.
             CRITICAL_FILES=$(git diff --name-only origin/main...HEAD | grep -E '(^\.github/|^pyproject\.toml|package\.json|package-lock\.json)' || true)
             if [ -z "$CRITICAL_FILES" ]; then
               echo "eligible=true" >> $GITHUB_OUTPUT
@@ -45,17 +49,6 @@ jobs:
             echo "eligible=false" >> $GITHUB_OUTPUT
             echo "Skipping auto-merge: PR changes $CHANGED_FILES files (limit: 20)"
           fi
-
-      - name: Wait for checks to pass
-        if: steps.check.outputs.eligible == 'true'
-        uses: octocat/request-action@v1.3.1
-        id: wait-checks
-        with:
-          route: GET /repos/{owner}/{repo}/commits/{ref}/check-runs
-          owner: ${{ github.repository_owner }}
-          repo: ${{ github.event.repository.name }}
-          ref: ${{ github.event.pull_request.head.sha }}
-        continue-on-error: true
 
       - name: Wait for checks and update body
         if: steps.check.outputs.eligible == 'true'

--- a/.github/workflows/auto-merge-small-prs.yml
+++ b/.github/workflows/auto-merge-small-prs.yml
@@ -66,10 +66,8 @@ jobs:
           # Update PR body with [skip-gen] marker
           BODY=$(gh pr view ${{ github.event.pull_request.number }} --json body -q .body)
           if ! echo "$BODY" | grep -q "\[skip-gen\]"; then
-            gh pr edit ${{ github.event.pull_request.number }} \
-              --body "$BODY
-
-[skip-gen]"
+            NEW_BODY="$(printf '%s\n\n[skip-gen]' "$BODY")"
+            gh pr edit ${{ github.event.pull_request.number }} --body "$NEW_BODY"
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Drop 'synchronize' trigger — firing on every push to every PR was the
  primary source of inbox noise; only 'opened', 'reopened', and 'labeled'
  are needed to evaluate eligibility
- Add concurrency group so stale runs are cancelled when a newer run
  starts for the same PR, preventing queued notification floods
- Remove non-existent 'octocat/request-action@v1.3.1' step which was
  causing workflow failures (and failure-notification emails) on every run;
  the shell polling loop below it already handles waiting for checks

https://claude.ai/code/session_018GZqta1NXBAhZyihz2F77K