### PR TITLE
fix(ci): push version tag after auto-sync so release.yml fires

### DIFF
--- a/.github/workflows/sync-artifacts.yml
+++ b/.github/workflows/sync-artifacts.yml
@@ -64,6 +64,28 @@ jobs:
             git push
           fi
 
+          # Push a version tag so release.yml fires and creates a GitHub Release.
+          # Extract version from pyproject.toml (source of truth after gaia release).
+          VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          TAG="v${VERSION}"
+
+          # Only tag on the default branch to avoid duplicate releases from other branches.
+          DEFAULT_BRANCH=$(git remote show origin | awk '/HEAD branch/ {print $NF}')
+          CURRENT_BRANCH="${GITHUB_REF_NAME}"
+
+          if [[ "${CURRENT_BRANCH}" == "${DEFAULT_BRANCH}" ]]; then
+            # Skip if this tag already exists remotely (idempotent).
+            if git ls-remote --tags origin "${TAG}" | grep -q "${TAG}"; then
+              echo "Tag ${TAG} already exists on remote — skipping."
+            else
+              git tag "${TAG}"
+              git push origin "${TAG}"
+              echo "Pushed tag ${TAG} → release.yml will create the GitHub Release."
+            fi
+          else
+            echo "Not on default branch (${CURRENT_BRANCH}) — skipping tag push."
+          fi
+
       - name: Sync Wiki Pages
         if: github.event_name != 'pull_request' && github.repository == 'mbtiongson1/gaia-skill-tree'
         env:


### PR DESCRIPTION
sync-artifacts.yml was bumping all four version manifests via
'gaia release $BUMP --sync' but never creating or pushing a git tag.
release.yml only triggers on 'push: tags: v*', so no GitHub Release
was created despite the version reaching v3.23.9 (last release: v3.18.3).

Fix: after the commit-and-push step, extract the new version from
pyproject.toml, check the tag doesn't already exist on the remote,
and push it — but only when running on the default branch (main) to
avoid duplicate releases from feature branches.

https://claude.ai/code/session_01TbHaPqtQoLAoGRpZ47wFXp