### PR TITLE
docs(readme): update stale contributors table

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,30 +343,42 @@ Full policy/reviewer guidance: <https://github.com/mbtiongson1/gaia-skill-tree/w
 
 Thank you to everyone who has expanded the Gaia registry.
 
-| Contributor | Contribution |
+### Core Team
+
+| Contributor | Role |
 |---|---|
 | [@mbtiongson1](https://github.com/mbtiongson1) | Creator and maintainer: graph design, CLI, MCP server, curation pipeline |
-| [@rico-tiongson](https://github.com/rico-tiongson) | Coding cowork buddy and collaborator: early feature contributions and ongoing pair programming |
+| [@rico-tiongson](https://github.com/rico-tiongson) | Collaborator: early feature contributions and ongoing pair programming |
 | [@Juno](https://github.com/Juno) | Key contributor: graph browser expansion, function-calling skill, RAG pipeline evidence, and CLI DX improvements |
-| [@garrytan](https://github.com/garrytan) | Named skills: 47 skills across the gstack ecosystem — browse, benchmark, qa, ship, review, learn, canary, and 40 others |
-| [@google-deepmind](https://github.com/google-deepmind) | Named skills: 37 bioinformatics and AI research skills — alphafold, alphagenome, ensembl, clinvar, foldseek, and 32 others |
-| [@mattpocock](https://github.com/mattpocock) | Named skills: 20 skills — diagnose, tdd, to-prd, triage, zoom-out, grill-me, ubiquitous-language, and 13 others |
-| [@ruvnet](https://github.com/ruvnet) | Named skills: 48 skills — agentdb, flow-nexus, hive-mind-coordination, dual-collect, and 44 others |
-| [@obra](https://github.com/obra) | Named skills: 12 skills from the superpowers ecosystem — systematic-debugging, dispatching-parallel-agents, subagent-driven-development, and 9 others |
-| [@intelligentcode-ai](https://github.com/intelligentcode-ai) | Named skills: 8 skills — database-engineer, devops-engineer, mcp-client, security-engineer, requirements-engineer, and 3 others |
-| [@huggingface](https://github.com/huggingface) | Named skills: 7 skills — hf-cli, huggingface-llm-trainer, huggingface-datasets, transformers-js, and 3 others |
-| [@karpathy](https://github.com/karpathy) | Origin named skill: `karpathy/autoresearch` |
-| [@devin-ai](https://github.com/devin-ai) | Named skill: `devin-ai/autonomous-swe` |
-| [@addy-osmani](https://github.com/addy-osmani) | Named skill: `addy-osmani/test-driven-development` |
-| [@anthropic](https://github.com/anthropic) | Named skills: `anthropic/pptx`, `anthropic/skill-creator` |
-| [@openai](https://github.com/openai) | Named skills: `openai/few-shot-learning`, `openai/self-consistency` |
-| [@jules](https://github.com/jules) | Named skills: `jules/gaia-triage`, `jules/repo-docs-before-pr` |
-| [@glincker](https://github.com/GLINCKER) | Named skill: `glincker/readme-generator` |
-| [@spring-ai-alibaba](https://github.com/spring-ai-alibaba) | Named skill: `spring-ai/readme-generate` |
-| [@pexp13](https://github.com/pexp13) | Named skill: `pexp13/sentiment-analysis` |
-| [@kriptoburak](https://github.com/kriptoburak) | Evidence evaluator: `x-twitter-automation` evidence review |
+
+### Named Skill Contributors
+
+| Contributor | Skills |
+|---|---|
+| [@ruvnet](https://github.com/ruvnet) | 48 — agentdb, flow-nexus, hive-mind-coordination, browser, and 44 others |
+| [@garrytan](https://github.com/garrytan) | 47 — gstack ecosystem: browse, qa, ship, review, benchmark, learn, and 41 others |
+| [@google-deepmind](https://github.com/google-deepmind) | 37 — alphafold, alphagenome, ensembl, clinvar, foldseek, and 32 others |
+| [@mattpocock](https://github.com/mattpocock) | 20 — to-prd, triage, diagnose, tdd, zoom-out, grill-me, and 14 others |
+| [@obra](https://github.com/obra) | 12 — superpowers ecosystem: systematic-debugging, dispatching-parallel-agents, and 10 others |
+| [@intelligentcode-ai](https://github.com/intelligentcode-ai) | 8 — database-engineer, devops-engineer, security-engineer, and 5 others |
+| [@huggingface](https://github.com/huggingface) | 7 — hf-cli, llm-trainer, datasets, transformers-js, and 3 others |
+
+Community contributors (1–2 skills each): [@karpathy](https://github.com/karpathy), [@anthropic](https://github.com/anthropic), [@openai](https://github.com/openai), [@addy-osmani](https://github.com/addy-osmani), [@devin-ai](https://github.com/devin-ai), [@glincker](https://github.com/GLINCKER), [@spring-ai-alibaba](https://github.com/spring-ai-alibaba), [@pexp13](https://github.com/pexp13)
+
+### Evidence & Curation
+
+| Contributor | Contribution |
+|---|---|
 | [@balukosuri](https://github.com/balukosuri) | Evidence: community reproduction of Karpathy's autoresearch as a universal skill |
-| @gemini-cli | Curation: added generative-media, mathematical-animation, and other generic skills from Hermes ecosystem |
+| [@kriptoburak](https://github.com/kriptoburak) | Evidence evaluator: x-twitter-automation evidence review |
+
+### Bots
+
+| Bot | Contribution |
+|---|---|
+| [@jules](https://github.com/google-labs-jules) | Named skills via Google Jules AI: langgenius suite (backend-code-review, frontend-code-review, e2e-cucumber-playwright, and 2 others) |
+| @gaiabot | Internal Gaia bot: repo triage and docs-sync automation |
+| @gemini-cli | Curation: generative-media, mathematical-animation, and other generic skills from Hermes ecosystem |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -348,17 +348,25 @@ Thank you to everyone who has expanded the Gaia registry.
 | [@mbtiongson1](https://github.com/mbtiongson1) | Creator and maintainer: graph design, CLI, MCP server, curation pipeline |
 | [@rico-tiongson](https://github.com/rico-tiongson) | Coding cowork buddy and collaborator: early feature contributions and ongoing pair programming |
 | [@Juno](https://github.com/Juno) | Key contributor: graph browser expansion, function-calling skill, RAG pipeline evidence, and CLI DX improvements |
+| [@garrytan](https://github.com/garrytan) | Named skills: 47 skills across the gstack ecosystem — browse, benchmark, qa, ship, review, learn, canary, and 40 others |
+| [@google-deepmind](https://github.com/google-deepmind) | Named skills: 37 bioinformatics and AI research skills — alphafold, alphagenome, ensembl, clinvar, foldseek, and 32 others |
+| [@mattpocock](https://github.com/mattpocock) | Named skills: 20 skills — diagnose, tdd, to-prd, triage, zoom-out, grill-me, ubiquitous-language, and 13 others |
+| [@ruvnet](https://github.com/ruvnet) | Named skills: 48 skills — agentdb, flow-nexus, hive-mind-coordination, dual-collect, and 44 others |
+| [@obra](https://github.com/obra) | Named skills: 12 skills from the superpowers ecosystem — systematic-debugging, dispatching-parallel-agents, subagent-driven-development, and 9 others |
+| [@intelligentcode-ai](https://github.com/intelligentcode-ai) | Named skills: 8 skills — database-engineer, devops-engineer, mcp-client, security-engineer, requirements-engineer, and 3 others |
+| [@huggingface](https://github.com/huggingface) | Named skills: 7 skills — hf-cli, huggingface-llm-trainer, huggingface-datasets, transformers-js, and 3 others |
 | [@karpathy](https://github.com/karpathy) | Origin named skill: `karpathy/autoresearch` |
-| [@mattpocock](https://github.com/mattpocock) | Named skills: diagnose, tdd, to-prd, triage, zoom-out, and 6 others |
-| [@intelligentcode-ai](https://github.com/intelligentcode-ai) | Named skills: database-engineer, devops-engineer, mcp-client, security-engineer, and 5 others |
-| [@ruvnet](https://github.com/ruvnet) | Named skill: `ruvnet/flow-nexus-swarm` |
-| [@GLINCKER](https://github.com/GLINCKER) | Named skill: `glincker/readme-generator` |
+| [@devin-ai](https://github.com/devin-ai) | Named skill: `devin-ai/autonomous-swe` |
+| [@addy-osmani](https://github.com/addy-osmani) | Named skill: `addy-osmani/test-driven-development` |
+| [@anthropic](https://github.com/anthropic) | Named skills: `anthropic/pptx`, `anthropic/skill-creator` |
+| [@openai](https://github.com/openai) | Named skills: `openai/few-shot-learning`, `openai/self-consistency` |
+| [@jules](https://github.com/jules) | Named skills: `jules/gaia-triage`, `jules/repo-docs-before-pr` |
+| [@glincker](https://github.com/GLINCKER) | Named skill: `glincker/readme-generator` |
 | [@spring-ai-alibaba](https://github.com/spring-ai-alibaba) | Named skill: `spring-ai/readme-generate` |
 | [@pexp13](https://github.com/pexp13) | Named skill: `pexp13/sentiment-analysis` |
-| [@kriptoburak](https://github.com/kriptoburak) | Named skill: `kriptoburak/x-twitter-automation` |
+| [@kriptoburak](https://github.com/kriptoburak) | Evidence evaluator: `x-twitter-automation` evidence review |
 | [@balukosuri](https://github.com/balukosuri) | Evidence: community reproduction of Karpathy's autoresearch as a universal skill |
 | @gemini-cli | Curation: added generative-media, mathematical-animation, and other generic skills from Hermes ecosystem |
-| [@obra](https://github.com/obra) | Named skills: 11 skills from the superpowers ecosystem |
 
 ---
 


### PR DESCRIPTION
- Add @garrytan (47 gstack skills), @google-deepmind (37 bioinformatics skills),
  @huggingface (7 skills), @anthropic (2 skills), @openai (2 skills),
  @devin-ai, @addy-osmani, @jules — all missing from the previous table
- Fix @ruvnet: was listed as 1 skill, now correctly shows 48 skills
- Fix @mattpocock: was listed as ~11 skills, now correctly shows 20 skills
- Fix @obra: was listed as 11 skills, now correctly shows 12 skills
- Fix @intelligentcode-ai: count corrected to 8 skills
- Fix @kriptoburak: no named skill directory; updated to reflect evaluator role
- Fix @glincker capitalisation (was @GLINCKER)

https://claude.ai/code/session_01JaTHaZHWuzhzteFGKbxsWY