### PR TITLE
🧪 Add missing tests for getSkillsByType

### DIFF
--- a/packages/mcp/tests/dag.test.ts
+++ b/packages/mcp/tests/dag.test.ts
@@ -99,5 +99,10 @@ describe("dag", () => {
       expect(basics.every((s) => s.type === "basic")).toBe(true);
       expect(basics.length).toBe(5);
     });
+
+    it("returns empty array for types not in the graph", () => {
+      const emptyResult = getSkillsByType(mockGraph, "fusion" as any);
+      expect(emptyResult).toHaveLength(0);
+    });
   });
 });


### PR DESCRIPTION
🎯 **What:** Added a missing test for the `getSkillsByType` function in `packages/mcp/tests/dag.test.ts`. This fills a testing gap where the scenario of searching for a type not present in the graph was untested.
📊 **Coverage:** Covered the scenario where `getSkillsByType` is called with a type that has zero matching skills in the graph, ensuring it correctly returns an empty array.
✨ **Result:** Improved test coverage for `getSkillsByType` to include empty/negative cases, ensuring greater reliability in the dag module.

---
*PR created automatically by Jules for task [10546858113871295665](https://jules.google.com/task/10546858113871295665) started by @mbtiongson1*

[skip-gen]