### PR TITLE
fix: uninstall_skill returns False for non-existent skills

### DIFF
--- a/src/gaia_cli/install.py
+++ b/src/gaia_cli/install.py
@@ -323,7 +323,11 @@ def uninstall_skill(skill_id):
     manifest = load_manifest()
     entry = next((s for s in manifest["installed"] if s["id"] == skill_id), None)
     
-    if entry and "localPath" in entry:
+    if not entry:
+        print(f"Skill {skill_id} is not installed.")
+        return False
+
+    if "localPath" in entry:
         lp = entry["localPath"]
         if os.path.exists(lp) or os.path.islink(lp):
             if os.path.islink(lp):

--- a/tests/test_dx.py
+++ b/tests/test_dx.py
@@ -380,7 +380,7 @@ def test_skills_uninstall_removes_skill_via_cli(tmp_path, monkeypatch):
     assert not any(e["id"] == "testuser/test-skill" for e in manifest["installed"])
 
 
-def test_skills_uninstall_nonexistent_exits_zero_bug(tmp_path, monkeypatch):
+def test_skills_uninstall_nonexistent_exits_nonzero(tmp_path, monkeypatch):
     """BUG: gaia skills uninstall on a non-installed skill exits 0 (should exit 1).
 
     Because uninstall_skill() returns True for non-existent skills,
@@ -393,7 +393,9 @@ def test_skills_uninstall_nonexistent_exits_zero_bug(tmp_path, monkeypatch):
 
     # BUG: should raise SystemExit(1) but currently succeeds (exits 0 silently)
     # If the bug is fixed, this line will raise SystemExit, changing test behaviour.
-    run_cli(monkeypatch, ["skills", "uninstall", "nobody/not-installed"])
+    with pytest.raises(SystemExit) as excinfo:
+        run_cli(monkeypatch, ["skills", "uninstall", "nobody/not-installed"])
+    assert excinfo.value.code == 1
 
 
 def test_gaia_install_command_installs_skill(tmp_path, monkeypatch):

--- a/tests/test_suite_install.py
+++ b/tests/test_suite_install.py
@@ -635,23 +635,20 @@ class TestSuiteInstallBugs:
 class TestUninstallEdgeCases:
     """Edge-case and bug tests for uninstall_skill."""
 
-    def test_uninstall_nonexistent_skill_incorrectly_returns_true(
+    def test_uninstall_nonexistent_skill_returns_false(
         self, tmp_path, monkeypatch
     ):
-        """BUG (install.py:299-302): uninstall_skill returns True for skills never installed.
+        """uninstall_skill returns False for skills never installed.
 
-        When skill_id is not in the manifest, the filter is a no-op and the function
-        still prints "Uninstalled:" and returns True. Should return False.
+        When skill_id is not in the manifest, the function
+        prints "Skill not installed" and returns False.
         """
         monkeypatch.chdir(tmp_path)
         save_manifest({"installed": []})
 
         result = uninstall_skill("never/installed")
 
-        # BUG: should be False but is True
-        assert result is True, (
-            "BUG still present: uninstall of non-existent skill should return False"
-        )
+        assert result is False
         manifest = load_manifest()
         assert manifest["installed"] == []
 


### PR DESCRIPTION
Fixes an issue in `src/gaia_cli/install.py` where `uninstall_skill` incorrectly returned `True` for skills that weren't installed. The function has been updated to check for the entry before continuing and returns `False` if the skill is not found.

Also updated two related test cases to match the expected behavior.

---
*PR created automatically by Jules for task [16825340820636091322](https://jules.google.com/task/16825340820636091322) started by @mbtiongson1*

[skip-gen]