### PR TITLE
🔒 Fix argument injection in open_path

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -16,3 +16,8 @@
 **Vulnerability:** Found multiple instances of `innerHTML` being set with unsanitized data (e.g. `skill.name`, `skill.id`) in `docs/js/skill-graph.js`, specifically when rendering tooltips, neighbor cards, and the skill panel.
 **Learning:** While the primary data source (`graph/gaia.json`) is considered trusted registry data, relying solely on upstream data trust creates a defense-in-depth gap. If the registry data generation is compromised or modified to contain malicious HTML, the UI will execute it.
 **Prevention:** Always implement and use an HTML escaping function (like `esc`) when dynamically building HTML strings for `innerHTML`, even if the data source is nominally "trusted".
+## 2024-05-20 - Argument Injection Vulnerability
+
+**Vulnerability:** Argument injection when running `xdg-open` or `open` with `subprocess.run()`. Directly passing user-supplied input to these commands could result in arguments beginning with a hyphen (`-`) being treated as options instead of arguments.
+**Learning:** Using `str(path)` directly allows an attacker to supply a path starting with `-` (e.g., `-a`) leading to arbitrary option execution.
+**Prevention:** Resolve paths to absolute paths `path.resolve()` when passing them to commands so they always begin with `/` or drive letter instead of `-`. Alternatively, prefix the argument with `--`.

--- a/src/gaia_cli/graph.py
+++ b/src/gaia_cli/graph.py
@@ -1017,11 +1017,11 @@ def open_path(path: Path) -> None:
     if opened:
         return
     if sys.platform == "darwin":
-        subprocess.run(["open", str(path)], check=False)
+        subprocess.run(["open", str(path.resolve())], check=False)
     elif os.name == "nt":
-        os.startfile(str(path))  # type: ignore[attr-defined]
+        os.startfile(str(path.resolve()))  # type: ignore[attr-defined]
     else:
-        subprocess.run(["xdg-open", str(path)], check=False)
+        subprocess.run(["xdg-open", str(path.resolve())], check=False)
 
 
 def graph_command(args: Any) -> None:


### PR DESCRIPTION
🎯 **What:** Fix an argument injection vulnerability in `open_path` (src/gaia_cli/graph.py).
⚠️ **Risk:** Directly passing `path` strings to `xdg-open` or `open` using `subprocess.run()` could allow arbitrary arguments to be injected if the path string begins with a hyphen (`-`). For instance, a path named `-a` could be treated as an option flag rather than a path argument, leading to unexpected behavior or arbitrary command execution.
🛡️ **Solution:** Resolve paths to absolute paths using `path.resolve()` when passing them to commands so they always begin with `/` or a drive letter instead of `-`. This mitigates the risk of injection.

---
*PR created automatically by Jules for task [9599162009850223459](https://jules.google.com/task/9599162009850223459) started by @mbtiongson1*

[skip-gen]