### PR TITLE
refactor(docs): migrate skill-graph.js tooltip and neighbor cards from innerHTML to DOM API (#411)

### DIFF
--- a/docs/js/skill-graph.js
+++ b/docs/js/skill-graph.js
@@ -1141,43 +1141,88 @@
             const col = PALETTE[skill.type] || PALETTE.basic;
             const typeClass = `skill-tooltip-type-${skill.type}`;
             const rm = skill.level ? RANK_META[skill.level] : null;
-            const rankPill = rm
-              ? `<span style="display:inline-block;padding:.12rem .42rem;border-radius:999px;font-size:.62rem;font-weight:700;background:${rm.bg};color:${rm.hex}">${skill.level}</span>`
-              : '';
-            const effectivePill = (skill.effectiveLevel && skill.effectiveLevel !== skill.level)
-              ? `<span class="gst-effective-pill">effective ${skill.effectiveLevel}</span>`
-              : '';
-            const demeritNote = skill.demerits && skill.demerits.length
-              ? `<div class="gst-demerit-note">${skill.demerits.length} demerit${skill.demerits.length === 1 ? '' : 's'}</div>`
-              : '';
+            
+            state.tooltipEl.textContent = '';
+            
+            const nameDiv = document.createElement('div');
+            nameDiv.className = 'skill-tooltip-name';
+            nameDiv.style.color = `rgba(${col.rgb},1)`;
+            nameDiv.textContent = skill.name;
+            state.tooltipEl.appendChild(nameDiv);
+
             const namedId = (state.namedMap && state.namedMap[skill.id]) || null;
             // Tooltip rows route through CSS classes (.gst-named-id /
             // .gst-skill-id) so Honor Red / muted slate / mono font
             // come from tokens.css. The slug half is colour-locked to
             // the skill's rank token per DESIGN.md (Honor Red is for
             // the @handle only).
-            let namedLine = '';
             if (namedId) {
               const parts = namedId.split('/');
+              const namedLineDiv = document.createElement('div');
+              namedLineDiv.className = 'gst-named-id';
+              
+              const handleSpan = document.createElement('span');
+              handleSpan.className = 'gst-named-handle';
+              handleSpan.textContent = '@' + parts[0];
+              namedLineDiv.appendChild(handleSpan);
+
               if (parts.length === 2) {
                 const rm2 = skill.level ? RANK_META[skill.level] : null;
                 const slugColor = rm2 ? rm2.hex : `rgba(${col.rgb},1)`;
-                namedLine = `<div class="gst-named-id"><span class="gst-named-handle">@${esc(parts[0])}</span><span class="gst-named-slug" style="color:${slugColor}">/${esc(parts[1])}</span></div>`;
-              } else {
-                namedLine = `<div class="gst-named-id"><span class="gst-named-handle">@${esc(namedId)}</span></div>`;
+                const slugSpan = document.createElement('span');
+                slugSpan.className = 'gst-named-slug';
+                slugSpan.style.color = slugColor;
+                slugSpan.textContent = '/' + parts[1];
+                namedLineDiv.appendChild(slugSpan);
               }
+              state.tooltipEl.appendChild(namedLineDiv);
             }
-            state.tooltipEl.innerHTML =
-              `<div class="skill-tooltip-name" style="color:rgba(${col.rgb},1)">${esc(skill.name)}</div>` +
-              namedLine +
-              `<div class="gst-skill-id">${esc(skill.id)}</div>` +
-              `<div class="skill-tooltip-row"><span class="skill-tooltip-badge ${typeClass}">${esc(skill.type.toUpperCase())}</span>${rankPill}${effectivePill}</div>` +
-              demeritNote +
-              `<button class="graph-tooltip-add" title="Add to collection" aria-label="Add to collection">+</button>`;
+
+            const idDiv = document.createElement('div');
+            idDiv.className = 'gst-skill-id';
+            idDiv.textContent = skill.id;
+            state.tooltipEl.appendChild(idDiv);
+
+            const rowDiv = document.createElement('div');
+            rowDiv.className = 'skill-tooltip-row';
+            
+            const badgeSpan = document.createElement('span');
+            badgeSpan.className = `skill-tooltip-badge ${typeClass}`;
+            badgeSpan.textContent = skill.type.toUpperCase();
+            rowDiv.appendChild(badgeSpan);
+
+            if (rm) {
+              const rankSpan = document.createElement('span');
+              rankSpan.style.cssText = `display:inline-block;padding:.12rem .42rem;border-radius:999px;font-size:.62rem;font-weight:700;background:${rm.bg};color:${rm.hex}`;
+              rankSpan.textContent = skill.level;
+              rowDiv.appendChild(rankSpan);
+            }
+            
+            if (skill.effectiveLevel && skill.effectiveLevel !== skill.level) {
+              const effSpan = document.createElement('span');
+              effSpan.className = 'gst-effective-pill';
+              effSpan.textContent = 'effective ' + skill.effectiveLevel;
+              rowDiv.appendChild(effSpan);
+            }
+            state.tooltipEl.appendChild(rowDiv);
+
+            if (skill.demerits && skill.demerits.length) {
+              const demeritDiv = document.createElement('div');
+              demeritDiv.className = 'gst-demerit-note';
+              demeritDiv.textContent = `${skill.demerits.length} demerit${skill.demerits.length === 1 ? '' : 's'}`;
+              state.tooltipEl.appendChild(demeritDiv);
+            }
+
+            const addBtn = document.createElement('button');
+            addBtn.className = 'graph-tooltip-add';
+            addBtn.title = 'Add to collection';
+            addBtn.setAttribute('aria-label', 'Add to collection');
+            addBtn.textContent = '+';
+            state.tooltipEl.appendChild(addBtn);
+
             if (skill.level) state.tooltipEl.setAttribute('data-level', skill.level);
             else state.tooltipEl.removeAttribute('data-level');
             state.lastHoveredId = displayId;
-            const addBtn = state.tooltipEl.querySelector('.graph-tooltip-add');
             if (addBtn) {
               addBtn.addEventListener('mousedown', e => { e.stopPropagation(); e.preventDefault(); });
               addBtn.addEventListener('click', e => {
@@ -1216,7 +1261,7 @@
           const neighbors = [...neighborSet].filter(id => id !== state.pinnedId);
           if (state._neighborIds !== neighbors.join(',')) {
             state._neighborIds = neighbors.join(',');
-            state.neighborCardsEl.innerHTML = '';
+            state.neighborCardsEl.textContent = '';
             neighbors.forEach(nid => {
               const ns = state.skills.find(s => s.id === nid);
               if (!ns) return;
@@ -1225,7 +1270,12 @@
               card.className = 'graph-neighbor-card';
               card.dataset.nid = nid;
               card.dataset.type = ns.type || 'basic';
-              card.innerHTML = `<span style="color:rgba(${col.rgb},.9)">${esc(ns.name)}</span>`;
+              
+              const span = document.createElement('span');
+              span.style.color = `rgba(${col.rgb},.9)`;
+              span.textContent = ns.name;
+              card.appendChild(span);
+              
               card.addEventListener('mousedown', e => e.stopPropagation());
               card.addEventListener('click', e => {
                 e.stopPropagation();
@@ -1252,7 +1302,7 @@
         } else {
           if (state._neighborIds) {
             state._neighborIds = null;
-            state.neighborCardsEl.innerHTML = '';
+            state.neighborCardsEl.textContent = '';
           }
           state.neighborCardsEl.style.display = 'none';
         }
@@ -2166,7 +2216,7 @@
         state.lastHoveredId = null;
         state.dragging = false;
         if (state.tooltipEl) state.tooltipEl.style.display = 'none';
-        if (state.neighborCardsEl) { state.neighborCardsEl.style.display = 'none'; state.neighborCardsEl.innerHTML = ''; state._neighborIds = null; }
+        if (state.neighborCardsEl) { state.neighborCardsEl.style.display = 'none'; state.neighborCardsEl.textContent = ''; state._neighborIds = null; }
         if (state.skillPanelEl) state.skillPanelEl.style.display = 'none';
       }
     }


### PR DESCRIPTION
Addresses #411 by refactoring the most dynamic targets in skill-graph.js to use safer DOM APIs. Tooltips and neighbor cards now use createElement and textContent. This provides better defense-in-depth against XSS.