### PR TITLE
fix(ci): add fix/* to unrestricted branch scope

### DIFF
--- a/.github/workflows/branch-scope.yml
+++ b/.github/workflows/branch-scope.yml
@@ -48,6 +48,7 @@ jobs:
             claude/*)           PREFIX="unrestricted" ;;
             codex/*)            PREFIX="unrestricted" ;;
             dev/*)              PREFIX="unrestricted" ;;
+            fix/*)              PREFIX="unrestricted" ;;
             infra/*)            PREFIX="infra" ;;
             *)                  PREFIX="other" ;;
           esac


### PR DESCRIPTION
Maps fix/* branches to the 'unrestricted' prefix, matching dev/* behavior. Allows broad changes while still enforcing repository-wide schema protection.