### PR TITLE
chore: audit and curate browser-control skill

### DIFF
--- a/docs/graph/gaia.json
+++ b/docs/graph/gaia.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/skill.schema.json",
   "version": "3.25.0",
-  "generatedAt": "2026-05-25T06:41:59.483698Z",
+  "generatedAt": "2026-05-25T09:57:51.753344Z",
   "meta": {
     "typeLabels": {
       "basic": "Basic Skill",
@@ -1296,7 +1296,10 @@
       "type": "basic",
       "level": "2★",
       "rarity": "uncommon",
-      "description": "Directly controls a web browser via low-level protocols (like CDP) to manipulate DOM, manage cookies, and intercept network traffic.",
+      "summary": "A foundational skill for interacting directly with the web browser using Chrome DevTools Protocol (CDP).",
+      "description": "Directly controls a web browser via low-level protocols (like CDP) to manipulate the DOM, manage cookies, intercept network traffic, and simulate user interactions (clicking via coordinates, taking screenshots) without relying on heavy wrapper frameworks like Playwright or Puppeteer.",
+      "useCase": "When an agent needs to autonomously browse web pages, extract visual and structural information via screenshots or DOM parsing, and interact with the page by firing synthetic mouse and keyboard events using the browser's compositor level.",
+      "directives": "- Prioritize visual verification via screenshots before executing clicks or DOM interactions.\n- Use coordinate-based interactions rather than complex selector-based DOM queries when possible.\n- Rely on HTTP requests for bulk data fetching rather than browser navigation when applicable.\n- Assume the browser runs either via a local debug connection (CDP on port 9222) or through a remote session using Browser Use.",
       "prerequisites": [],
       "derivatives": [
         "browser-automation",

--- a/registry/gaia.json
+++ b/registry/gaia.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/skill.schema.json",
   "version": "3.25.0",
-  "generatedAt": "2026-05-25T06:41:59.483698Z",
+  "generatedAt": "2026-05-25T09:57:51.753344Z",
   "meta": {
     "typeLabels": {
       "basic": "Basic Skill",
@@ -89,9 +89,65 @@
       "heavyweight-dependency": "Heavyweight dependencies"
     },
     "clusterNames": {
-      "0": "Analysis & Agent"
+      "0": "Code & Generation",
+      "1": "Text & Generate",
+      "2": "Agent & Browser",
+      "3": "Analysis & Tool",
+      "4": "Retrieval & Web",
+      "5": "Coordination & Platform",
+      "6": "Reasoning & Chain-of-thought",
+      "7": "Pattern & Memory"
     },
-    "centroids": []
+    "centroids": [
+      [
+        -0.08567232346614126,
+        -0.3441682030074648,
+        0.07924053675417546,
+        0.29303183754893897
+      ],
+      [
+        0.4722866565900627,
+        -0.2239240905007686,
+        -0.009032397236642233,
+        -0.06418031095135893
+      ],
+      [
+        -0.38136581873571834,
+        -0.020280771027904147,
+        -0.13863480501805991,
+        0.04295866442225787
+      ],
+      [
+        -0.27582576153198185,
+        0.020846119351635987,
+        0.3216303719194823,
+        -0.08369383425603684
+      ],
+      [
+        0.6810858711027364,
+        0.30372124298936487,
+        0.16616056891214626,
+        -0.06524777218174681
+      ],
+      [
+        -0.2876522237754483,
+        0.4995536277670454,
+        -0.18328144584210868,
+        -0.16990025691782956
+      ],
+      [
+        0.057186868623233925,
+        -0.3501630704873034,
+        -0.3137406292809759,
+        -0.011721563433835331
+      ],
+      [
+        0.06126689682595106,
+        0.09896343298185689,
+        -0.4339825553745209,
+        0.26176772834890805
+      ]
+    ]
   },
   "skills": [
     {
@@ -841,7 +897,10 @@
       "type": "basic",
       "level": "2★",
       "rarity": "uncommon",
-      "description": "Directly controls a web browser via low-level protocols (like CDP) to manipulate DOM, manage cookies, and intercept network traffic.",
+      "summary": "A foundational skill for interacting directly with the web browser using Chrome DevTools Protocol (CDP).",
+      "description": "Directly controls a web browser via low-level protocols (like CDP) to manipulate the DOM, manage cookies, intercept network traffic, and simulate user interactions (clicking via coordinates, taking screenshots) without relying on heavy wrapper frameworks like Playwright or Puppeteer.",
+      "useCase": "When an agent needs to autonomously browse web pages, extract visual and structural information via screenshots or DOM parsing, and interact with the page by firing synthetic mouse and keyboard events using the browser's compositor level.",
+      "directives": "- Prioritize visual verification via screenshots before executing clicks or DOM interactions.\n- Use coordinate-based interactions rather than complex selector-based DOM queries when possible.\n- Rely on HTTP requests for bulk data fetching rather than browser navigation when applicable.\n- Assume the browser runs either via a local debug connection (CDP on port 9222) or through a remote session using Browser Use.",
       "prerequisites": [],
       "derivatives": [
         "browser-automation",

--- a/registry/nodes/basic/browser-control.json
+++ b/registry/nodes/basic/browser-control.json
@@ -4,7 +4,10 @@
   "type": "basic",
   "level": "2★",
   "rarity": "uncommon",
-  "description": "Directly controls a web browser via low-level protocols (like CDP) to manipulate DOM, manage cookies, and intercept network traffic.",
+  "summary": "A foundational skill for interacting directly with the web browser using Chrome DevTools Protocol (CDP).",
+  "description": "Directly controls a web browser via low-level protocols (like CDP) to manipulate the DOM, manage cookies, intercept network traffic, and simulate user interactions (clicking via coordinates, taking screenshots) without relying on heavy wrapper frameworks like Playwright or Puppeteer.",
+  "useCase": "When an agent needs to autonomously browse web pages, extract visual and structural information via screenshots or DOM parsing, and interact with the page by firing synthetic mouse and keyboard events using the browser's compositor level.",
+  "directives": "- Prioritize visual verification via screenshots before executing clicks or DOM interactions.\n- Use coordinate-based interactions rather than complex selector-based DOM queries when possible.\n- Rely on HTTP requests for bulk data fetching rather than browser navigation when applicable.\n- Assume the browser runs either via a local debug connection (CDP on port 9222) or through a remote session using Browser Use.",
   "prerequisites": [],
   "derivatives": [
     "browser-automation",

--- a/registry/skills/basic/browser-control.md
+++ b/registry/skills/basic/browser-control.md
@@ -7,8 +7,19 @@
 
 ---
 
+**Summary:** A foundational skill for interacting directly with the web browser using Chrome DevTools Protocol (CDP).
+
 ## Description
-Directly controls a web browser via low-level protocols (like CDP) to manipulate DOM, manage cookies, and intercept network traffic.
+Directly controls a web browser via low-level protocols (like CDP) to manipulate the DOM, manage cookies, intercept network traffic, and simulate user interactions (clicking via coordinates, taking screenshots) without relying on heavy wrapper frameworks like Playwright or Puppeteer.
+
+## Use Case
+When an agent needs to autonomously browse web pages, extract visual and structural information via screenshots or DOM parsing, and interact with the page by firing synthetic mouse and keyboard events using the browser's compositor level.
+
+## Directives
+- Prioritize visual verification via screenshots before executing clicks or DOM interactions.
+- Use coordinate-based interactions rather than complex selector-based DOM queries when possible.
+- Rely on HTTP requests for bulk data fetching rather than browser navigation when applicable.
+- Assume the browser runs either via a local debug connection (CDP on port 9222) or through a remote session using Browser Use.
 
 ## Prerequisites
 _None._


### PR DESCRIPTION
## Daily Curation: Browser Control

### 🛠 Installation Report
- **Status:** Success
- **Bugs Found:** None. The `uv run gaia skills install /browser-use/browser-harness` command successfully clones the repo and makes it available to the agent workspace. The tool also effectively provides debugging via `--doctor` which shows clear status of active remote debug sessions.

### 🧪 Testing & Use Case
- **Experimental Findings:** `browser-control` runs natively as an executable tool. It connects directly with the user's running browser process using Chrome DevTools Protocol. It avoids framework abstractions (like Puppeteer) and has strict usage paradigms: e.g. using screenshots for hit-testing to click, using simple `http_get` requests when full visual testing isn't required.
- **Recommended Use Case:** When an agent needs to autonomously browse web pages, extract visual and structural information via screenshots or DOM parsing, and interact with the page by firing synthetic mouse and keyboard events using the browser's compositor level.

### 📝 Documentation Improvements
- Refined directives in `registry/skills/` to prioritize coordinate-based UI interaction and visual confirmation via screenshots rather than complex DOM queries. 
- Synced metadata in `registry/nodes/` by adding the missing `summary`, `useCase`, and stringified `directives` fields.

### ⚖️ Audit & Meta Changes
- No critical audit metadata failures were recorded beyond standard field expansion recommendations.
- Validated the DAG successfully via `python3 scripts/validate.py`.

---
*PR created automatically by Jules for task [2476731985530381210](https://jules.google.com/task/2476731985530381210) started by @mbtiongson1*

[skip-gen]