### PR TITLE
[curation] Add mcp-builder from sickn33/antigravity-awesome-skills

### DIFF
--- a/registry/named/sickn33/mcp-builder.md
+++ b/registry/named/sickn33/mcp-builder.md
@@ -1,0 +1,21 @@
+---
+id: sickn33/mcp-builder
+name: sickn33 MCP Builder
+contributor: sickn33
+origin: false
+genericSkillRef: mcp-server-creation
+status: awakened
+level: 3★
+description: A community implementation of the MCP builder skill from the antigravity-awesome-skills
+  repository, capable of creating Model Context Protocol servers in Python and Node.js.
+createdAt: '2026-05-27'
+updatedAt: '2026-05-27'
+timeline:
+- timestamp: '2026-05-27T23:24:24Z'
+  action: add
+  contributor: unknown
+  details: Added named skill sickn33/mcp-builder
+---
+
+## Installation
+Add installation instructions here.

--- a/registry/nodes/extra/mcp-server-creation.json
+++ b/registry/nodes/extra/mcp-server-creation.json
@@ -30,6 +30,12 @@
       "evaluator": "codex",
       "date": "2026-05-10",
       "notes": "Official MCP Python SDK is active and provides FastMCP server examples for exposing tools, resources, prompts, structured outputs, transports, and inspector-based testing."
+    },
+    {
+      "class": "B",
+      "source": "https://raw.githubusercontent.com/sickn33/antigravity-awesome-skills/main/skills/mcp-builder/SKILL.md",
+      "evaluator": "codex",
+      "date": "2026-05-27"
     }
   ],
   "knownAgents": [
@@ -37,6 +43,14 @@
   ],
   "status": "provisional",
   "createdAt": "2026-05-10",
-  "updatedAt": "2026-05-10",
-  "version": "0.1.0"
+  "updatedAt": "2026-05-27",
+  "version": "0.1.0",
+  "timeline": [
+    {
+      "timestamp": "2026-05-27T23:24:31Z",
+      "action": "evidence_added",
+      "contributor": "unknown",
+      "details": "Added B evidence from https://raw.githubusercontent.com/sickn33/antigravity-awesome-skills/main/skills/mcp-builder/SKILL.md"
+    }
+  ]
 }

--- a/registry/skills/extra/mcp-server-creation.md
+++ b/registry/skills/extra/mcp-server-creation.md
@@ -28,6 +28,7 @@ Requires an integration target, a supported MCP SDK, tool schemas, authenticatio
 |---|---|---|---|
 | B | https://github.com/anthropics/skills/blob/main/skills/mcp-builder/SKILL.md | codex | 2026-05-10 |
 | B | https://github.com/modelcontextprotocol/python-sdk | codex | 2026-05-10 |
+| B | https://raw.githubusercontent.com/sickn33/antigravity-awesome-skills/main/skills/mcp-builder/SKILL.md | codex | 2026-05-27 |
 
 ## Known Agents
 - Claude


### PR DESCRIPTION
This PR adds the community implementation `mcp-builder` from the `sickn33/antigravity-awesome-skills` repository to the registry.

- Registers the `sickn33/mcp-builder` named skill pointing to the generic `mcp-server-creation`.
- Associates Class B evidence to the base skill `mcp-server-creation`.
- Appends the repository to `registry/skill-sources.md`.
- Appends `@sickn33` to the contributors in `README.md`.
- Regenerates all docs and graphs.
- Includes cleanups for unused imports in Python scripts.

---
*PR created automatically by Jules for task [10230604712471387523](https://jules.google.com/task/10230604712471387523) started by @mbtiongson1*