### PR TITLE
fix(badges): use run_worker_first = true so validation runs in production

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,11 +2,15 @@ name = "gaia-skill-tree"
 main = "worker/index.js"
 compatibility_date = "2026-05-22"
 
-# Static assets live in docs/. The worker (worker/index.js) runs FIRST only for
-# /badges/* so it can validate the ?repo= query before the static SVG is served
-# (run_worker_first). Every other path is served straight from static assets —
-# the worker isn't invoked. `binding = "ASSETS"` exposes env.ASSETS.fetch().
+# Static assets live in docs/. The worker (worker/index.js) runs FIRST for every
+# request (run_worker_first = true) so it can validate the ?repo= query on
+# /badges/* before the static SVG is served. We use the boolean form (not a
+# path-glob list) for the widest wrangler-version compatibility — the glob form
+# is silently ignored by older wranglers, which leaves assets served ahead of
+# the worker (validation never runs). For non-/badges paths the worker
+# immediately delegates to env.ASSETS.fetch, so there's no behavioural change
+# elsewhere. `binding = "ASSETS"` exposes env.ASSETS.fetch().
 [assets]
 directory = "docs"
 binding = "ASSETS"
-run_worker_first = ["/badges/*"]
+run_worker_first = true


### PR DESCRIPTION
## Problem

The badge `?repo=` validation worker (shipped in #486) deploys and runs, but **real badges still bypass it in production**.

Root cause: `run_worker_first = ["/badges/*"]` (the **glob-array** form) is silently ignored by the wrangler version in the production deploy environment. The worker then only runs as the *no-asset fallback*, so any badge that has a committed static SVG is served straight from static assets and the validation never executes.

### Evidence (against the live deploy)
- `…/badges/zzz-nobody/handle.svg?repo=x/y` (no static asset) → **200, `x-gaia-badge-state: validating`** ✅ — worker runs as fallback.
- `…/badges/karpathy/rank.svg?repo=evil/repo` on a **cold `cf-cache-status: MISS`** → raw SVG, **no `x-gaia` header**, `max-age=0` ❌ — worker did *not* intercept. (Cold MISS rules out stale cache.)

The glob form works on recent wrangler (verified locally on 4.95), which is why this passed local testing but not production.

## Fix

Switch to the boolean form `run_worker_first = true`. It has far wider wrangler-version support and makes the worker run first for **every** request; non-`/badges` paths delegate immediately to `env.ASSETS.fetch`, so there is no behavioural change elsewhere.

## Verification
- **Local (`wrangler dev`)**: a real existing badge with a wrong `?repo=` now returns the validating badge (`x-gaia-badge-state: validating`, body contains `validating`); correct/absent `?repo=` returns the real badge (`valid`); homepage and other paths pass through with no `x-gaia` header.
- **Post-deploy**: re-run cases #2/#3 from `tests/test_badges_function.md` against the `workers.dev` URL first, then the custom domain.

## Note — likely follow-up (separate from this PR)
The `workers.dev` URL runs the worker, but `gaia.tiongson.co` currently returns 404 for the unknown-handle probe — suggesting the custom domain may not be bound to this Worker. If `workers.dev` validates after this merge but `gaia.tiongson.co` doesn't, check that `gaia.tiongson.co` is a **Custom Domain on the `gaia-skill-tree` Worker** (not an assets-only/Pages route).

https://claude.ai/code/session_01AaEudjaZ9cHCjgypc4KKQv

---
_Generated by [Claude Code](https://claude.ai/code/session_01AaEudjaZ9cHCjgypc4KKQv)_