### PR TITLE
ci(deploy): pin wrangler 4.95.0 so run_worker_first is honored in production

### DIFF
--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -27,4 +27,10 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # Pin wrangler so the deploy uses a version that honours
+          # [assets] run_worker_first (the badge ?repo= validator in
+          # worker/index.js). The action's default wrangler was too old to
+          # apply it, so the worker only ran as the no-asset fallback and
+          # real badges bypassed validation.
+          wranglerVersion: "4.95.0"
           command: deploy --minify


### PR DESCRIPTION
## Problem

After #486 + #497, the badge `?repo=` validator (`worker/index.js` + `[assets] run_worker_first = true`) works locally (wrangler 4.95) but **still doesn't intercept real badges in production**.

Verified against the live `workers.dev` deploy:
- Unknown handle (no static asset) → worker runs, returns the validating badge ✅
- A real badge on a **cold `cf-cache-status: MISS`** (e.g. `obra/handle.svg?repo=evil/repo`) → raw SVG, **no `x-gaia-badge-state` header** ❌

That means `run_worker_first` is not being applied by the deploy — the worker only runs as the no-asset fallback. The Manual Cloudflare Deploy uses `cloudflare/wrangler-action@v3` with **no `wranglerVersion`**, so it installs a wrangler too old to honor `[assets] run_worker_first`.

## Fix

Pin `wranglerVersion: "4.95.0"` in `.github/workflows/cloudflare-deploy.yml` (verified locally to honor `run_worker_first = true`), so the deploy reliably runs the worker ahead of static assets.

## After merge — required steps
1. Re-run **Manual Cloudflare Deploy** on `main` (now uses the pinned wrangler).
2. **Purge the Cloudflare cache** for the worker once — the raw badge SVGs were already cached (`cf-cache-status: HIT`, query string ignored), so stale entries would otherwise mask the fix.
3. Verify: `curl -s 'https://gaia-skill-tree.marco-tngsn.workers.dev/badges/mbtiongson1/handle.svg?repo=evil/repo' | grep -o validating`

If `run_worker_first` is honored but the same badge path still serves one cached response across different `?repo=` values, the follow-up is to make the worker's `/badges/*` responses cache per-query (or bypass CDN cache and rely on GitHub camo's caching) — tracked separately.

https://claude.ai/code/session_01AaEudjaZ9cHCjgypc4KKQv

---
_Generated by [Claude Code](https://claude.ai/code/session_01AaEudjaZ9cHCjgypc4KKQv)_