### PR TITLE
fix(badges): restore run_worker_first = true (required alongside the _assets relocate)

### DIFF
--- a/docs/CLOUDFLARE-SETUP.md
+++ b/docs/CLOUDFLARE-SETUP.md
@@ -15,31 +15,31 @@ This document explains the **Worker** that gates Gaia README badges on a
 - 24-hour `max-age` so GitHub camo (which keys on the full URL incl. query)
   caches each `(handle, file, repo)` image for ~24h.
 
-## The design — relocated assets, no `run_worker_first`
+## The design — `run_worker_first` + relocated assets
 
 This project deploys as a **Cloudflare Worker with Static Assets**
-(`wrangler deploy`, `[assets] directory = "docs"`). Two hard facts shaped the
-design:
+(`wrangler deploy`, `[assets] directory = "docs"`). Three facts shaped the
+design (the last two verified on PR **preview deploys**):
 
 1. **`functions/` is Pages-only** — a Pages Function is never deployed by
    `wrangler deploy`.
-2. **Static assets are served before the Worker.** `run_worker_first` is
-   supposed to flip that, but it proved unreliable across this project's deploy
-   pipeline (silently not applied, so the worker only ran as the no-asset
-   fallback and real badges bypassed validation).
+2. **The Worker only runs when `run_worker_first = true`.** Without it, a
+   request that doesn't match a static asset returns 404 and the Worker is
+   never invoked (a preview deploy with it removed 404'd every
+   `/badges/<handle>/<file>.svg`).
+3. **A committed static asset is served *ahead of* the Worker** even with
+   `run_worker_first`. So a badge that exists as a static SVG would still
+   bypass validation.
 
-So rather than depend on `run_worker_first`, we **remove the conflict**:
+The fix uses **both** levers together:
 
+- Keep `run_worker_first = true` (so the Worker runs).
 - `generateBadges.py` writes the real SVGs to **`docs/badges/_assets/<handle>/`**
-  (a 3-segment path).
-- The public badge URL stays **`/badges/<handle>/<file>.svg`** (2-segment),
-  which now has **no static asset**.
-- The Worker therefore runs as the normal **no-asset fallback** for every
-  `/badges/<handle>/<file>.svg` request — the one behaviour that works reliably
-  in production — validates `?repo=`, and serves the real SVG from the
-  `_assets` source (or `not-found.svg` on a mismatch).
+  (a 3-segment path), so the public **`/badges/<handle>/<file>.svg`**
+  (2-segment) path has **no static asset** to be served ahead of the Worker.
 
-`wrangler.toml` needs only `main` + the asset binding (no `run_worker_first`):
+The Worker then runs for `/badges/<handle>/<file>.svg`, validates `?repo=`, and
+serves the real SVG from the `_assets` source (or `not-found.svg` on a mismatch).
 
 ```toml
 name = "gaia-skill-tree"
@@ -49,6 +49,7 @@ compatibility_date = "2026-05-22"
 [assets]
 directory = "docs"
 binding = "ASSETS"
+run_worker_first = true
 ```
 
 ### Routing summary

--- a/tests/test_badges_function.md
+++ b/tests/test_badges_function.md
@@ -3,13 +3,13 @@
 The site Worker at `worker/index.js` gates badge serving on a `?repo=` query
 matching the contributor's approved repos in `docs/badges/registry.json`.
 
-It does **not** use `run_worker_first`. The real SVGs are generated under
-`docs/badges/_assets/<handle>/`, so the public `/badges/<handle>/<file>.svg`
-path has no static asset and the Worker runs as the no-asset fallback for it,
-serving the real SVG from `_assets` (or `not-found.svg` on a mismatch). Worker
-fetch handlers don't run under pytest, so this is a manual smoke-test list — run
-it locally before merging changes to the Worker or to `generateBadges.py`'s
-output layout.
+It needs **both** `run_worker_first = true` (so the Worker runs at all in this
+deploy) **and** the real SVGs relocated to `docs/badges/_assets/<handle>/` (so
+the public `/badges/<handle>/<file>.svg` path has no static asset shadowing the
+Worker). The Worker serves the real SVG from `_assets` (or `not-found.svg` on a
+mismatch). Worker fetch handlers don't run under pytest, so this is a manual
+smoke-test list — run it locally (`wrangler dev`) and against the PR preview
+deploy before merging changes to the Worker or to `generateBadges.py`'s layout.
 
 ## Setup
 

--- a/worker/index.js
+++ b/worker/index.js
@@ -4,17 +4,20 @@
  * Deploy model: Cloudflare **Worker with Static Assets** (`wrangler deploy`,
  * `[assets] directory = "docs"`).
  *
- * ## Why this design (no run_worker_first)
+ * ## Why this design (run_worker_first + relocated assets)
  *
- * Cloudflare serves a matching static asset *before* invoking the Worker, and
- * `run_worker_first` (which would flip that) proved unreliable across this
- * project's deploy pipeline. So instead of fighting precedence, we remove the
- * conflict: the real badge SVGs are generated to /badges/_assets/<handle>/
- * (a 3-segment path), leaving the public /badges/<handle>/<file>.svg
- * (2-segment) path with NO static asset. The Worker therefore runs as the
- * normal no-asset fallback for every badge request — the one behaviour that
- * works reliably in production — validates `?repo=`, and serves the real SVG
- * from the _assets source (or the validating badge on a mismatch).
+ * Two facts about this project's Cloudflare deploy, both verified empirically
+ * on PR preview deploys:
+ *   - The Worker is only invoked when `run_worker_first = true` is set in
+ *     wrangler.toml. Without it, non-asset paths 404 and the Worker never runs.
+ *   - Even with run_worker_first, a committed static asset is served ahead of
+ *     the Worker, so badges that exist as static SVGs bypass validation.
+ *
+ * The fix uses BOTH levers: keep `run_worker_first = true`, AND generate the
+ * real badge SVGs to /badges/_assets/<handle>/ (a 3-segment path) so the public
+ * /badges/<handle>/<file>.svg (2-segment) path has NO static asset. The Worker
+ * then runs for that path, validates `?repo=`, and serves the real SVG from the
+ * _assets source (or the validating badge on a mismatch).
  *
  * Routes:
  *   /badges/<handle>/<file>.svg              → validated (this worker)

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,13 +2,18 @@ name = "gaia-skill-tree"
 main = "worker/index.js"
 compatibility_date = "2026-05-22"
 
-# Static assets live in docs/. The badge validator (worker/index.js) does NOT
-# rely on run_worker_first: the real badge SVGs are generated under
-# /badges/_assets/<handle>/, so the public /badges/<handle>/<file>.svg path has
-# no static asset and the worker runs as the normal no-asset fallback for it
-# (the behaviour that works reliably in production). Every other path resolves
-# to a static asset and is served directly. `binding = "ASSETS"` exposes
-# env.ASSETS.fetch() so the worker can read the real SVGs / registry.json.
+# Badge validation needs BOTH of these together:
+#   1. run_worker_first = true — in this project's deploy, the worker is only
+#      invoked when this is set (without it, non-asset paths 404 and the worker
+#      never runs — verified on a PR preview deploy).
+#   2. the real SVGs relocated to /badges/_assets/<handle>/ (see generateBadges.py)
+#      so the public /badges/<handle>/<file>.svg path has NO static asset to be
+#      served ahead of the worker.
+# With both, the worker runs for /badges/<handle>/<file>.svg, validates ?repo=,
+# and serves the real SVG from _assets. Other paths resolve to static assets;
+# the worker delegates to env.ASSETS.fetch for them. `binding = "ASSETS"`
+# exposes env.ASSETS.fetch() so the worker can read the real SVGs / registry.json.
 [assets]
 directory = "docs"
 binding = "ASSETS"
+run_worker_first = true


### PR DESCRIPTION
## Urgent follow-up to #500

#500 relocated the badge SVGs to `/badges/_assets/` (correct) but **also removed `run_worker_first`** — and a PR **preview deploy** proved that combination is broken:

- `/badges/_assets/<handle>/<file>.svg` → 200 (relocation worked)
- `/badges/<handle>/<file>.svg` and unknown handles → **404** (the worker is never invoked)

So `main` as it stands would **404 all badges** if deployed. In this project's Cloudflare setup the worker is only invoked when **`run_worker_first = true`** is set; without it, non-asset paths 404 and the worker never runs. (On production *with* it, unknown handles validated — that was the worker running for no-asset paths.)

## Fix

Validation needs **both** levers together:
1. `run_worker_first = true` → the worker actually runs.
2. relocated `_assets` (from #500) → no static SVG shadows the public `/badges/<handle>/<file>.svg` path.

This PR restores `run_worker_first = true` in `wrangler.toml` and updates `worker/index.js`, `docs/CLOUDFLARE-SETUP.md`, and `tests/test_badges_function.md` to document that both are required.

## Verify on this PR's preview before merging
Once the Cloudflare bot posts the preview URL for this branch:
```bash
H=<branch-preview-url>
curl -s "$H/badges/mbtiongson1/handle.svg?repo=evil/repo" | grep -o validating   # expect: validating
curl -s "$H/badges/mbtiongson1/handle.svg?repo=mbtiongson1/gaia-skill-tree" | md5sum  # real badge, differs
curl -sI "$H/badges/mbtiongson1/handle.svg?repo=evil/repo" | grep -i x-gaia-badge-state
```
I'll test the preview automatically and report before you merge.

https://claude.ai/code/session_01AaEudjaZ9cHCjgypc4KKQv

---
_Generated by [Claude Code](https://claude.ai/code/session_01AaEudjaZ9cHCjgypc4KKQv)_