### PR TITLE
fix(infra): configure git identity before gaia release commit

### DIFF
--- a/.github/workflows/sync-artifacts.yml
+++ b/.github/workflows/sync-artifacts.yml
@@ -45,6 +45,13 @@ jobs:
       - name: Install dependencies
         run: pip install -e ".[dev]"
 
+      - name: Configure git identity
+        # Must run BEFORE `gaia release`, which creates its own version-bump
+        # commit. Without an identity here git aborts with "empty ident name".
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Auto-Versioning and Regeneration
         run: |
           # 1. Classify bump type from commit message
@@ -59,9 +66,6 @@ jobs:
 
       - name: Commit and Push Changes
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-
           if [[ -n "$(git status --porcelain)" ]]; then
             git add .
             git commit -m "chore(auto): regenerate registry artifacts and sync docs [skip-gen]"


### PR DESCRIPTION
Follow-up to the earlier sync-artifacts fix (already merged). Carries one
remaining commit that `main` is missing.

## Problem
The live run failed with:

```
fatal: empty ident name (for <runner@...>) not allowed
Gaia version bumped to 3.25.3.
Creating release commit…
```

`gaia release` creates its **own** version-bump commit during the
`Auto-Versioning and Regeneration` step, but git's author identity was not
configured until the later `Commit and Push` step — so the bump commit
aborted before any of our code ran.

## Fix
- Add a dedicated `Configure git identity` step immediately after checkout
  (before `gaia release`), setting `github-actions[bot]` name/email.
- Remove the now-redundant identity config from the `Commit and Push` step.

Validated with `actionlint` (clean) and YAML parse.

## Note on state
The failed run logged `bumped to 3.25.3` but died before pushing, and the
runner is ephemeral — so `main` is still at `3.25.2` and no `v3.25.3` tag was
pushed. The next run will cleanly bump to `3.25.3` and tag it, no collision.

https://claude.ai/code/session_01VCfJSEZozDUJW7pGyB88XP

---
_Generated by [Claude Code](https://claude.ai/code/session_01VCfJSEZozDUJW7pGyB88XP)_