### PR TITLE
design(badges): add .nojekyll, fix Hide-Gaia seed regression, shrink Honesty pill

### DIFF
--- a/docs/badges/CLAUDE.md
+++ b/docs/badges/CLAUDE.md
@@ -12,6 +12,26 @@ This split is intentional and load-bearing — see the long doc-comment at the t
 `worker/index.js` for the full reasoning. **Do not** create files at the 2-segment public
 path; that would shadow the worker and bypass `?repo=` validation.
 
+### `docs/.nojekyll` is load-bearing
+
+Production traffic for `gaia.tiongson.co` is served by **GitHub Pages** (Cloudflare is
+a CDN/proxy in front; the worker config in `wrangler.toml` is a separate deploy lane
+that isn't currently in the request path — confirm with `curl -sI https://gaia.tiongson.co/`
+and look for the `X-Github-Request-Id` / `Via: 1.1 varnish` headers).
+
+GitHub Pages runs Jekyll by default, and **Jekyll silently strips any path segment that
+starts with `_`**. Without `docs/.nojekyll`, the entire `_assets/` directory is dropped
+from the deploy and every Honesty-Mode-ON URL 404s. That cascades into:
+
+- `exists()` HEAD probes return false → page says "No badges yet for @<handle>".
+- `<img src="./_assets/...">` 404s → live strip + variant cards + README simulator
+  show broken images.
+- `chkSeal` flip swaps to `*-seal.svg` URLs that also 404 → "Hide Gaia breaks rank.svg".
+
+**Do not delete `docs/.nojekyll`.** If `_assets/` ever stops resolving in production,
+that's the first thing to check (`curl -sI https://gaia.tiongson.co/badges/_assets/<handle>/handle.svg`
+should return 200, not 404 with a GitHub-Pages 404 body).
+
 ## Honesty Mode toggle (the page-visible switch)
 
 Without the Worker (local dev, any preview deploy that doesn't run the worker, or any

--- a/docs/badges/index.html
+++ b/docs/badges/index.html
@@ -42,48 +42,58 @@
       margin-right: .4rem;
     }
 
-    /* ── Honesty Mode pill (read-only indicator) ── */
+    /* ── Honesty Mode pill (tiny read-only indicator, top-right of hero) ── */
     .bd-honesty-pill {
+      position: absolute;
+      top: 5.4rem;
+      right: 1.4rem;
       display: inline-flex;
       align-items: center;
-      gap: .55rem;
-      margin-top: .9rem;
-      padding: .45rem .85rem .45rem .7rem;
-      background: rgba(34, 197, 94, .08);
-      border: 1px solid rgba(34, 197, 94, .35);
+      gap: .35rem;
+      padding: .2rem .55rem .2rem .45rem;
+      background: rgba(34, 197, 94, .06);
+      border: 1px solid rgba(34, 197, 94, .25);
       border-radius: 999px;
-      color: var(--text);
+      color: var(--muted);
       font-family: var(--font-mono);
-      font-size: .76rem;
+      font-size: .62rem;
       letter-spacing: .04em;
       cursor: help;
+      opacity: .75;
+      transition: opacity .15s;
+      z-index: 2;
     }
+    .bd-honesty-pill:hover { opacity: 1; }
     .bd-honesty-pill[data-state="off"] {
-      background: rgba(148, 163, 184, .08);
-      border-color: rgba(148, 163, 184, .3);
-      color: var(--muted);
+      background: rgba(148, 163, 184, .06);
+      border-color: rgba(148, 163, 184, .22);
     }
     .bd-honesty-dot {
-      width: 8px;
-      height: 8px;
+      width: 5px;
+      height: 5px;
       border-radius: 50%;
       background: #22c55e;
-      box-shadow: 0 0 0 3px rgba(34, 197, 94, .15);
+      box-shadow: 0 0 0 2px rgba(34, 197, 94, .14);
       flex-shrink: 0;
     }
     .bd-honesty-pill[data-state="off"] .bd-honesty-dot {
       background: #94a3b8;
-      box-shadow: 0 0 0 3px rgba(148, 163, 184, .12);
+      box-shadow: 0 0 0 2px rgba(148, 163, 184, .12);
     }
     .bd-honesty-label {
       text-transform: uppercase;
-      letter-spacing: .1em;
-      font-size: .68rem;
+      letter-spacing: .09em;
+      font-size: .58rem;
       color: var(--muted);
     }
     .bd-honesty-state {
       font-weight: 600;
-      letter-spacing: .08em;
+      letter-spacing: .06em;
+      color: var(--text);
+    }
+    .bd-honesty-pill[data-state="off"] .bd-honesty-state { color: var(--muted); }
+    @media (max-width: 640px) {
+      .bd-honesty-pill { top: 4.6rem; right: .8rem; }
     }
 
     /* ── Generator Layout & Simulator ── */
@@ -855,7 +865,20 @@
   </nav>
 
   <main>
-    <section class="process-hero" style="min-height: auto; padding-top: 5rem; padding-bottom: 2rem;">
+    <section class="process-hero" style="min-height: auto; padding-top: 5rem; padding-bottom: 2rem; position: relative;">
+      <!-- Honesty Mode indicator — tiny, read-only, top-right of the hero.
+           The mode itself is a build-time config constant (HONESTY_MODE) set
+           in the script below; flip it via PR. ON bypasses the Cloudflare
+           Worker entirely and emits direct _assets/ URLs into the copied
+           markdown. OFF restores worker-validated URLs with ?repo= binding.
+           See docs/badges/CLAUDE.md. -->
+      <span id="bd-honesty-pill" class="bd-honesty-pill" data-state="on"
+            title="Honesty Mode reflects the current build config — ON means copied markdown points at the static _assets/ path (no Cloudflare Worker, no ?repo= validation). Change via PR.">
+        <span class="bd-honesty-dot" aria-hidden="true"></span>
+        <span class="bd-honesty-label">Honesty</span>
+        <span class="bd-honesty-state">ON</span>
+      </span>
+
       <p class="process-kicker">For those who have named their skill</p>
       <h1>Github Badges</h1>
       <p class="process-lede">
@@ -878,18 +901,6 @@
         <span class="bd-live-label">seal-only</span>
         <img src="./_assets/mbtiongson1/handle-seal.svg" alt="Owner identity badge — seal-only variant" onerror="this.style.display='none'">
       </div>
-
-      <!-- Honesty Mode indicator — read-only visibility chip. The mode itself
-           is a config constant (HONESTY_MODE) set in the script below; flip it
-           via PR. ON bypasses the Cloudflare Worker entirely and emits direct
-           _assets/ URLs into the copied markdown. OFF restores worker-validated
-           URLs with ?repo= binding. See docs/badges/CLAUDE.md. -->
-      <span id="bd-honesty-pill" class="bd-honesty-pill" data-state="on"
-            title="Honesty Mode reflects the current build config — ON means copied markdown points at the static _assets/ path (no Cloudflare Worker, no ?repo= validation). Change via PR.">
-        <span class="bd-honesty-dot" aria-hidden="true"></span>
-        <span class="bd-honesty-label">Honesty Mode</span>
-        <span class="bd-honesty-state">ON</span>
-      </span>
     </section>
 
     <!-- Priority 1: Generate Yours -->
@@ -1368,7 +1379,19 @@
     }
 
     // ── Checkbox change → re-render rows ─────────────────────────────────────
-    [chkHandle, chkRank, chkSkills, chkSeal].forEach(cb => cb.addEventListener("change", renderRows));
+    // In seed state (no real handle entered) currentState.handle is "gaia-bot",
+    // which has no `_assets/gaia-bot/` directory. renderRows() would happily
+    // emit `./_assets/gaia-bot/rank-seal.svg` and break the README simulator
+    // and the per-row thumbnail. Re-route through seedSample() in that case so
+    // the sampler/seed previews stay in sync with the Hide-Gaia toggle.
+    function onCheckboxChange() {
+      if (currentState.handle === "gaia-bot") {
+        seedSample();
+        return;
+      }
+      renderRows();
+    }
+    [chkHandle, chkRank, chkSkills, chkSeal].forEach(cb => cb.addEventListener("change", onCheckboxChange));
 
     // ── Per-badge rows renderer ───────────────────────────────────────────────
     function renderRows() {
@@ -1851,7 +1874,11 @@
       const code = document.createElement("code");
       code.className = "usp-cmd";
       const seedFile = chkSeal.checked ? "rank-seal.svg" : "rank.svg";
-      code.textContent = `[![Gaia rank](${BASE}/badges/gaia-bot/${seedFile})](${linkTarget})`;
+      // Use the same Honesty-Mode-aware URL builder as the real generator so
+      // the seed clipboard text matches what real handles emit (and stays a
+      // valid URL — pre-Honesty this hardcoded the worker route, which 404s
+      // when the worker isn't intercepting).
+      code.textContent = `[![Gaia rank](${badgeMarkdownUrl("gaia-bot", seedFile, "")})](${linkTarget})`;
       row.appendChild(code);
       item.appendChild(row);
       rowsEl.appendChild(item);


### PR DESCRIPTION
## Why this is a draft

Investigating four bugs reported on the live badges page after PR #512 merged. All four trace back to a single root cause that wasn't visible until this PR was deployed and probed in production.

## Root cause — the live site is served by GitHub Pages, not Cloudflare Workers

`curl -sI https://gaia.tiongson.co/` shows `X-Github-Request-Id` and `Via: 1.1 varnish` — this is **GitHub Pages**, with Cloudflare in front as a CDN/proxy. The `wrangler.toml` Worker deploy is a separate lane that isn't currently in the request path.

GitHub Pages runs **Jekyll** by default, and Jekyll **silently strips any path segment beginning with `_`**. So `docs/badges/_assets/` — where every real badge SVG lives — was never deployed. With Honesty Mode ON shipping `_assets/` URLs, every preview HEAD probe and `<img>` tag 404'd in production.

That cascades into the four reported bugs:

| # | Symptom | Cause |
|---|---|---|
| 1 | Preview says "No badges yet for @<handle>" | `exists()` HEAD probe of `/badges/_assets/<handle>/handle.svg` returns false (path 404s in prod) |
| 2 | Live + Seal-only strips show no owner badges | `<img src="./_assets/...">` 404s |
| 3 | Rank sampler works | `samples/` has no underscore — Jekyll didn't strip it |
| 4 | Hide-Gaia breaks rank.svg in README + seed sample | (a) seal-only `_assets/` URLs also 404, AND (b) `chkSeal` change handler ran `renderRows()` even in seed state, emitting a broken `./_assets/gaia-bot/rank-seal.svg` URL |

## Changes

### 1. `docs/.nojekyll` *(new, empty file)*

Single most impactful fix. Disables Jekyll on GitHub Pages so `_assets/` deploys literally. Resolves bugs 1, 2, and the URL-resolution part of bug 4.

### 2. `chkSeal` no longer corrupts the seed sample (`docs/badges/index.html`)

The Hide-Gaia checkbox listener was wired straight to `renderRows()`, which assumes a real handle. In seed state `currentState.handle === "gaia-bot"` (no `_assets/gaia-bot/` exists), so flipping the checkbox once replaced the working sample with a broken `_assets/gaia-bot/rank-seal.svg`. New `onCheckboxChange()` re-routes through `seedSample()` while in seed state. The seed clipboard markdown now also uses `badgeMarkdownUrl()`, so it honours Honesty Mode like every other emitted URL.

### 3. Honesty Mode pill is now discreet (top-right of hero)

Per request: pulled out of the hero body, absolute-positioned at the top-right of the hero, .62rem mono font, .75 base opacity → 1 on hover. Label trimmed from "Honesty Mode" to just "Honesty". Still read-only and still colour-coded by mode (green/slate). Mobile breakpoint nudges it inward.

### 4. `docs/badges/CLAUDE.md` documents the GH-Pages reality

A new "`docs/.nojekyll` is load-bearing" subsection warns future agents not to delete it, gives the curl command to verify `_assets/` is still resolving, and clarifies that the live site is on GitHub Pages even though `wrangler.toml` exists.

## Verification

- `curl -sI https://gaia.tiongson.co/badges/_assets/mbtiongson1/handle.svg` currently returns 404 with a GitHub Pages 404 body (the deploy strips `_assets/`).
- Once this PR merges and the next GH Pages build runs, the same curl should return 200 `Content-Type: image/svg+xml`. **That's the smoke test for the merge — please confirm before flipping out of draft.**
- Open the page locally: live strip should show the owner badges, the seal-only strip should show the wordmark-less variant, the README simulator should keep painting through Hide-Gaia toggles, the per-row thumbnails should match the simulator.

## Out of scope

- The pre-existing 5-vs-4 `<section>` tag imbalance in this file (present on origin/main).
- Any Cloudflare Worker re-deploy. The worker still exists in `worker/index.js` and `wrangler.toml` for the day production cuts over to it; it just isn't the active deploy.

`[skip-gen]` is on the commit.