### PR TITLE
docs(badges): remove copy-paste snippets, direct to generation page

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,7 @@
 
 # NEW! Badges
 
-Have a named skill? Get yours now! Should look like this:
-
-[![Gaia](https://gaia.tiongson.co/badges/mbtiongson1/gaia-curate.svg?repo=mbtiongson1%2Fgaia-skill-tree)](https://gaia.tiongson.co/u/mbtiongson1/)
-[![Gaia rank](https://gaia.tiongson.co/badges/mbtiongson1/rank.svg?repo=mbtiongson1%2Fgaia-skill-tree)](https://gaia.tiongson.co/u/mbtiongson1/)
-[![Gaia skills](https://gaia.tiongson.co/badges/mbtiongson1/skills.svg?repo=mbtiongson1%2Fgaia-skill-tree)](https://gaia.tiongson.co/u/mbtiongson1/)
+Have a named skill? Get yours at **[gaia.tiongson.co/badges/](https://gaia.tiongson.co/badges/)**.
 
 **Brand & product:** [PRODUCT.md](PRODUCT.md) · [CONTEXT.md](CONTEXT.md) · [DESIGN.md](DESIGN.md)
 
@@ -331,23 +327,7 @@ Contributors with named skills can wear their rank in their own repo READMEs. Ba
 | **Skills** — total unlocked (7) | [![Gaia skills](https://gaia.tiongson.co/badges/mbtiongson1/skills.svg?repo=mbtiongson1/gaia-skill-tree)](https://gaia.tiongson.co/u/mbtiongson1/) |
 | **Powered by Gaia** — generic fallback for non-contributors | [![Powered by Gaia](https://gaia.tiongson.co/badges/powered-by-gaia.svg)](https://gaia.tiongson.co/badges/) |
 
-Copy-paste for this repo:
-
-```markdown
-[![Gaia rank](https://gaia.tiongson.co/badges/mbtiongson1/rank.svg?repo=mbtiongson1/gaia-skill-tree)](https://gaia.tiongson.co/u/mbtiongson1/)
-[![Gaia skills](https://gaia.tiongson.co/badges/mbtiongson1/skills.svg?repo=mbtiongson1/gaia-skill-tree)](https://gaia.tiongson.co/u/mbtiongson1/)
-[![Powered by Gaia](https://gaia.tiongson.co/badges/powered-by-gaia.svg)](https://gaia.tiongson.co/badges/)
-```
-
-Template for any contributor:
-
-```markdown
-[![Gaia](https://gaia.tiongson.co/badges/<handle>/handle.svg?repo=<owner/name>)](https://gaia.tiongson.co/u/<handle>/)
-[![Gaia rank](https://gaia.tiongson.co/badges/<handle>/rank.svg?repo=<owner/name>)](https://gaia.tiongson.co/u/<handle>/)
-[![Gaia skills](https://gaia.tiongson.co/badges/<handle>/skills.svg?repo=<owner/name>)](https://gaia.tiongson.co/u/<handle>/)
-```
-
-Replace `<handle>` with your Gaia username and `<owner/name>` with the GitHub repo the badge is embedded in — the forthcoming edge validator flags badges in repos not on the contributor's `links.github` list. Preview every variant — including the single-line `@handle/skill · N★` identity badge — at [https://gaia.tiongson.co/badges/](https://gaia.tiongson.co/badges/).
+Generate your badge snippet at **[gaia.tiongson.co/badges/](https://gaia.tiongson.co/badges/)** — preview every variant and get the ready-to-paste Markdown for your repo.
 <!-- gaia:badges-end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@
 
 # NEW! Badges
 
-Have a named skill? Get yours at **[gaia.tiongson.co/badges/](https://gaia.tiongson.co/badges/)**.
+Have a named skill? Get yours now! Should look like this:
+
+[![Gaia](https://gaia.tiongson.co/badges/mbtiongson1/gaia-curate.svg?repo=mbtiongson1%2Fgaia-skill-tree)](https://gaia.tiongson.co/u/mbtiongson1/)
+[![Gaia rank](https://gaia.tiongson.co/badges/mbtiongson1/rank.svg?repo=mbtiongson1%2Fgaia-skill-tree)](https://gaia.tiongson.co/u/mbtiongson1/)
+[![Gaia skills](https://gaia.tiongson.co/badges/mbtiongson1/skills.svg?repo=mbtiongson1%2Fgaia-skill-tree)](https://gaia.tiongson.co/u/mbtiongson1/)
+
+Generate yours at **[gaia.tiongson.co/badges/](https://gaia.tiongson.co/badges/)**.
 
 **Brand & product:** [PRODUCT.md](PRODUCT.md) · [CONTEXT.md](CONTEXT.md) · [DESIGN.md](DESIGN.md)
 


### PR DESCRIPTION
## Summary

- Removes the two copy-paste Markdown code blocks from the `## Get your Gaia badge` section (the repo-specific snippet and the generic template).
- Removes the hardcoded badge examples from the `# NEW! Badges` teaser at the top of the README.
- Replaces both with a single link to **https://gaia.tiongson.co/badges/** where users can generate and preview their own badges.

This prevents the README from becoming a source of stale, copy-paste-prone URLs and keeps badge generation centralised on the generation page.

## Test plan

- [x] Confirm `# NEW! Badges` section now just links to the generation page.
- [x] Confirm `## Get your Gaia badge` section has no code blocks — only the badge preview table and the link.
- [x] No CI doc-drift failures expected (`README.md` is not regenerated by `gaia docs build`).