### PR TITLE
design(badges): include ?repo= in Honesty Mode URLs

### DIFF
--- a/docs/badges/CLAUDE.md
+++ b/docs/badges/CLAUDE.md
@@ -53,7 +53,7 @@ The fix has two parts and both ship in `index.html`:
 
    | Mode | URL emitted into copied markdown | Where it works |
    |---|---|---|
-   | **`HONESTY_MODE = true`** *(current default)* | `https://gaia.tiongson.co/badges/_assets/<handle>/<file>.svg` | Anywhere — bypasses worker entirely, no `?repo=` |
+   | **`HONESTY_MODE = true`** *(current default)* | `https://gaia.tiongson.co/badges/_assets/<handle>/<file>.svg?repo=<repo>` | Anywhere — bypasses worker, `?repo=` still included for camo caching |
    | **`HONESTY_MODE = false`** | `https://gaia.tiongson.co/badges/<handle>/<file>.svg?repo=<repo>` | Only when worker is deployed; enforces `?repo=` validation |
 
    The pill renders green with state `ON` when `HONESTY_MODE === true` and slate

--- a/docs/badges/index.html
+++ b/docs/badges/index.html
@@ -1252,8 +1252,9 @@
     // the route between the validated public path and the direct _assets path.
     function badgeMarkdownUrl(handle, file, repoQuery) {
       if (HONESTY_MODE) {
-        // Static, no worker, no ?repo=. Renders identically from any context.
-        return `${BASE}/badges/_assets/${handle}/${file}`;
+        // Direct static path, bypasses the worker. Still appends ?repo= so
+        // GitHub's camo proxy caches per (handle, file, repo) tuple.
+        return `${BASE}/badges/_assets/${handle}/${file}${repoQuery}`;
       }
       return `${BASE}/badges/${handle}/${file}${repoQuery}`;
     }


### PR DESCRIPTION
## What

Small follow-up to #513.

`badgeMarkdownUrl()` was stripping `?repo=` from the Honesty-Mode-ON path, emitting:

```
https://gaia.tiongson.co/badges/_assets/<handle>/<file>.svg
```

Both modes should include `?repo=` — the static `_assets/` path is just the route, not a signal to drop the query param. GitHub's camo proxy uses the full URL as a cache key, so `?repo=` still matters for per-repo cache isolation.

Fixed to:

```
https://gaia.tiongson.co/badges/_assets/<handle>/<file>.svg?repo=<repo>
```

OFF mode was already correct. One-line change to `badgeMarkdownUrl()` and a matching update to the `docs/badges/CLAUDE.md` table.

`[skip-gen]`