### PR TITLE
design(badges): fix variant column clipping wide badges

### DIFF
--- a/docs/badges/index.html
+++ b/docs/badges/index.html
@@ -731,7 +731,7 @@
       border-radius: 10px;
       padding: .85rem 1.1rem;
       display: grid;
-      grid-template-columns: 180px 1fr;
+      grid-template-columns: minmax(160px, max-content) 1fr;
       gap: 1.4rem;
       align-items: center;
     }


### PR DESCRIPTION
## Summary

- Changes `.bd-variant` grid column from fixed `180px` to `minmax(160px, max-content)` so the preview column grows to fit badges wider than 180px (e.g. the 271px `gaia-curate` badge) instead of truncating them.

## Test plan

- [ ] Open the Variants section and verify wide badges render fully
- [ ] Verify the layout doesn't break for narrow badges