### PR TITLE
feat(tui): auto-responsive mobile layout

### DIFF
--- a/.agents/skills/agentdb
+++ b/.agents/skills/agentdb
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/agentdb-advanced
+++ b/.agents/skills/agentdb-advanced
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/agentdb-learning
+++ b/.agents/skills/agentdb-learning
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/agentdb-memory-patterns
+++ b/.agents/skills/agentdb-memory-patterns
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/agentdb-optimization
+++ b/.agents/skills/agentdb-optimization
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/agentdb-vector-search
+++ b/.agents/skills/agentdb-vector-search
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/agentic-jujutsu
+++ b/.agents/skills/agentic-jujutsu
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/brainstorming
+++ b/.agents/skills/brainstorming
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/obra/superpowers/skills/brainstorming

--- a/.agents/skills/browser
+++ b/.agents/skills/browser
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/caveman
+++ b/.agents/skills/caveman
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/mattpocock/skills/skills/productivity/caveman

--- a/.agents/skills/diagnose
+++ b/.agents/skills/diagnose
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/mattpocock/skills/skills/engineering/diagnose

--- a/.agents/skills/dispatching-parallel-agents
+++ b/.agents/skills/dispatching-parallel-agents
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/obra/superpowers/skills/dispatching-parallel-agents

--- a/.agents/skills/dual-collect
+++ b/.agents/skills/dual-collect
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/dual-coordinate
+++ b/.agents/skills/dual-coordinate
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/dual-mode
+++ b/.agents/skills/dual-mode
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/dual-spawn
+++ b/.agents/skills/dual-spawn
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/edit-article
+++ b/.agents/skills/edit-article
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/mattpocock/skills/skills/personal/edit-article

--- a/.agents/skills/executing-plans
+++ b/.agents/skills/executing-plans
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/obra/superpowers/skills/executing-plans

--- a/.agents/skills/finishing-a-development-branch
+++ b/.agents/skills/finishing-a-development-branch
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/obra/superpowers/skills/finishing-a-development-branch

--- a/.agents/skills/flow-nexus
+++ b/.agents/skills/flow-nexus
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/flow-nexus-neural
+++ b/.agents/skills/flow-nexus-neural
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/flow-nexus-platform
+++ b/.agents/skills/flow-nexus-platform
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/flow-nexus-swarm
+++ b/.agents/skills/flow-nexus-swarm
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/github-code-review
+++ b/.agents/skills/github-code-review
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/github-multi-repo
+++ b/.agents/skills/github-multi-repo
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/github-project-management
+++ b/.agents/skills/github-project-management
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/github-release-management
+++ b/.agents/skills/github-release-management
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/github-suite
+++ b/.agents/skills/github-suite
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/github-workflow-automation
+++ b/.agents/skills/github-workflow-automation
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/graphify
+++ b/.agents/skills/graphify
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/safishamsi/graphify/

--- a/.agents/skills/grill-me
+++ b/.agents/skills/grill-me
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/mattpocock/skills/skills/productivity/grill-me

--- a/.agents/skills/grill-with-docs
+++ b/.agents/skills/grill-with-docs
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/mattpocock/skills/skills/engineering/grill-with-docs

--- a/.agents/skills/handoff
+++ b/.agents/skills/handoff
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/mattpocock/skills/skills/productivity/handoff

--- a/.agents/skills/hive-mind-coordination
+++ b/.agents/skills/hive-mind-coordination
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/hooks-automation
+++ b/.agents/skills/hooks-automation
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/improve-codebase-architecture
+++ b/.agents/skills/improve-codebase-architecture
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/mattpocock/skills/skills/engineering/improve-codebase-architecture

--- a/.agents/skills/obsidian-vault
+++ b/.agents/skills/obsidian-vault
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/mattpocock/skills/skills/personal/obsidian-vault

--- a/.agents/skills/pair-programming
+++ b/.agents/skills/pair-programming
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/performance-analysis
+++ b/.agents/skills/performance-analysis
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/prototype
+++ b/.agents/skills/prototype
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/mattpocock/skills/skills/engineering/prototype

--- a/.agents/skills/reasoningbank
+++ b/.agents/skills/reasoningbank
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/reasoningbank-agentdb
+++ b/.agents/skills/reasoningbank-agentdb
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/reasoningbank-intelligence
+++ b/.agents/skills/reasoningbank-intelligence
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/receiving-code-review
+++ b/.agents/skills/receiving-code-review
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/obra/superpowers/skills/receiving-code-review

--- a/.agents/skills/requesting-code-review
+++ b/.agents/skills/requesting-code-review
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/obra/superpowers/skills/requesting-code-review

--- a/.agents/skills/ruflo
+++ b/.agents/skills/ruflo
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/ruflo-v3
+++ b/.agents/skills/ruflo-v3
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/setup-matt-pocock-skills
+++ b/.agents/skills/setup-matt-pocock-skills
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/mattpocock/skills/skills/engineering/setup-matt-pocock-skills

--- a/.agents/skills/skill-builder
+++ b/.agents/skills/skill-builder
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/sparc-methodology
+++ b/.agents/skills/sparc-methodology
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/stream-chain
+++ b/.agents/skills/stream-chain
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/subagent-driven-development
+++ b/.agents/skills/subagent-driven-development
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/obra/superpowers/skills/subagent-driven-development

--- a/.agents/skills/superpowers
+++ b/.agents/skills/superpowers
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/obra/superpowers/

--- a/.agents/skills/swarm-advanced
+++ b/.agents/skills/swarm-advanced
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/swarm-orchestration
+++ b/.agents/skills/swarm-orchestration
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/systematic-debugging
+++ b/.agents/skills/systematic-debugging
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/obra/superpowers/skills/systematic-debugging

--- a/.agents/skills/to-issues
+++ b/.agents/skills/to-issues
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/mattpocock/skills/skills/engineering/to-issues

--- a/.agents/skills/to-prd
+++ b/.agents/skills/to-prd
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/mattpocock/skills/skills/engineering/to-prd

--- a/.agents/skills/triage
+++ b/.agents/skills/triage
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/mattpocock/skills/skills/engineering/triage

--- a/.agents/skills/ubiquitous-language
+++ b/.agents/skills/ubiquitous-language
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/mattpocock/skills/skills/engineering/ubiquitous-language

--- a/.agents/skills/using-git-worktrees
+++ b/.agents/skills/using-git-worktrees
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/obra/superpowers/skills/using-git-worktrees

--- a/.agents/skills/v3-cli-modernization
+++ b/.agents/skills/v3-cli-modernization
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/v3-core-implementation
+++ b/.agents/skills/v3-core-implementation
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/v3-ddd-architecture
+++ b/.agents/skills/v3-ddd-architecture
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/v3-integration-deep
+++ b/.agents/skills/v3-integration-deep
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/v3-mcp-optimization
+++ b/.agents/skills/v3-mcp-optimization
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/v3-memory-unification
+++ b/.agents/skills/v3-memory-unification
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/v3-performance-optimization
+++ b/.agents/skills/v3-performance-optimization
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/v3-security-overhaul
+++ b/.agents/skills/v3-security-overhaul
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/v3-swarm-coordination
+++ b/.agents/skills/v3-swarm-coordination
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/verification-before-completion
+++ b/.agents/skills/verification-before-completion
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/obra/superpowers/skills/verification-before-completion

--- a/.agents/skills/verification-quality
+++ b/.agents/skills/verification-quality
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/worker-benchmarks
+++ b/.agents/skills/worker-benchmarks
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/worker-integration
+++ b/.agents/skills/worker-integration
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/ruvnet/ruflo/

--- a/.agents/skills/write-a-skill
+++ b/.agents/skills/write-a-skill
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/mattpocock/skills/skills/productivity/write-a-skill

--- a/.agents/skills/writing-plans
+++ b/.agents/skills/writing-plans
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/obra/superpowers/skills/writing-plans

--- a/.agents/skills/zoom-out
+++ b/.agents/skills/zoom-out
@@ -1,0 +1,1 @@
+/data/data/com.termux/files/home/.gaia/skills/mattpocock/skills/skills/engineering/zoom-out

--- a/src/gaia_cli/tui/screens/agent.py
+++ b/src/gaia_cli/tui/screens/agent.py
@@ -16,7 +16,7 @@ from textual.screen import Screen, ModalScreen
 from textual.widgets import Input, ListView, ListItem, Label, Static, RichLog, Button
 from textual.reactive import reactive
 from textual.message import Message
-from textual import on, work
+from textual import events, on, work
 from rich.text import Text
 
 from gaia_cli.tui import tokens as T
@@ -277,6 +277,14 @@ class AgentScreen(Screen):
     def on_mount(self) -> None:
         self._load_data()
         self.query_one("#search-input", Input).focus()
+
+    @on(events.Resize)
+    def on_resize(self, event: events.Resize) -> None:
+        """Handle screen resize to toggle mobile layout."""
+        if event.size.width < 85:
+            self.add_class("-mobile")
+        else:
+            self.remove_class("-mobile")
 
     @work(thread=True)
     def _load_data(self) -> None:

--- a/src/gaia_cli/tui/screens/scan.py
+++ b/src/gaia_cli/tui/screens/scan.py
@@ -13,7 +13,7 @@ from textual.binding import Binding
 from textual.screen import Screen
 from textual.widgets import Static, RichLog
 from textual.reactive import reactive
-from textual import work
+from textual import events, on, work
 from rich.text import Text
 
 from gaia_cli.tui import tokens as T
@@ -57,6 +57,14 @@ class ScanScreen(Screen):
 
     def on_mount(self) -> None:
         self._run_scan()
+
+    @on(events.Resize)
+    def on_resize(self, event: events.Resize) -> None:
+        """Handle screen resize to toggle mobile layout."""
+        if event.size.width < 85:
+            self.add_class("-mobile")
+        else:
+            self.remove_class("-mobile")
 
     def action_rescan(self) -> None:
         log = self.query_one("#scan-log", RichLog)

--- a/src/gaia_cli/tui/screens/tree.py
+++ b/src/gaia_cli/tui/screens/tree.py
@@ -12,12 +12,12 @@ from typing import Any
 
 from textual.app import ComposeResult
 from textual.binding import Binding
-from textual.containers import Horizontal, Vertical, ScrollableContainer
+from textual.containers import Container, Vertical, ScrollableContainer
 from textual.screen import Screen
 from textual.widgets import Tree, Static, Label, Rule, Input
 from textual.widgets.tree import TreeNode
 from textual.reactive import reactive
-from textual import on
+from textual import events, on
 from rich.text import Text
 
 from gaia_cli.tui import tokens as T
@@ -223,7 +223,7 @@ class SkillTreeScreen(Screen):
         with Static(id="search-container"):
             yield Input(placeholder="Search skills…", id="tree-search")
 
-        with Horizontal(id="tree-layout"):
+        with Container(id="tree-layout"):
             with ScrollableContainer(id="tree-panel"):
                 yield Tree("Skills", id="skill-tree")
             yield SkillDetail({}, id="detail-panel")
@@ -248,8 +248,16 @@ class SkillTreeScreen(Screen):
         detected = len(self._detected)
         total = len(skills)
         self.query_one("#status-counts", Static).update(
-            f"{total} skills  ·  {owned} owned  ·  {detected} detected"
+            f"  [b]{owned}[/] owned  [b]{detected}[/] detected  [dim]of {total}[/]"
         )
+
+    @on(events.Resize)
+    def on_resize(self, event: events.Resize) -> None:
+        """Handle screen resize to toggle mobile layout."""
+        if event.size.width < 85:
+            self.add_class("-mobile")
+        else:
+            self.remove_class("-mobile")
 
     def _populate_tree(self, query: str = "") -> None:
         tree = self.query_one("#skill-tree", Tree)

--- a/src/gaia_cli/tui/theme.tcss
+++ b/src/gaia_cli/tui/theme.tcss
@@ -129,10 +129,22 @@ InstallModal {
 
 #install-dialog {
     width: 60;
+    max-width: 95%;
     height: auto;
     background: $gaia-surface;
     border: solid $gaia-border;
     padding: 2 3;
+}
+
+/* Hide extra info in header/status on mobile */
+.-mobile #header-user, 
+.-mobile #header-version,
+.-mobile #header-section {
+    display: none;
+}
+
+.-mobile #status-hints {
+    display: none;
 }
 
 #install-title {
@@ -191,12 +203,30 @@ InstallModal {
 /* ── Tree screen ──────────────────────────────────────────── */
 #tree-layout {
     height: 1fr;
+    layout: horizontal;
 }
 
 #tree-panel {
     width: 1fr;
     background: $gaia-bg;
     border-right: solid $gaia-border;
+}
+
+/* Responsive tweaks for thin terminals */
+TreeScreen.-mobile #tree-layout {
+    layout: vertical;
+}
+
+TreeScreen.-mobile #tree-panel {
+    height: 1fr;
+    border-right: none;
+    border-bottom: solid $gaia-border;
+}
+
+TreeScreen.-mobile #detail-panel {
+    width: 100%;
+    height: 1fr;
+    border-left: none;
 }
 
 Tree {


### PR DESCRIPTION
## Problem Statement
The Gaia TUI currently uses a side-by-side layout for the Skill Tree that breaks or becomes unreadable on narrow terminals (e.g. mobile terminals, thin side-panes).

## Solution
This PR implements an auto-responsive layout that:
- Detects terminal width and toggles a `-mobile` CSS class.
- Switches the Skill Tree to a vertical stacked layout on narrow screens (< 85 cols).
- Hides non-essential header/status elements to optimize space.
- Ensures modals are responsive and don't overflow.

## Plan
1. Handle Resize events in Python screens (Tree, Agent, Scan).
2. Update TCSS with `-mobile` specific layout overrides.
3. Optimize header/status bar for space efficiency.