### PR TITLE
docs: update gaia push workflow references from PR to issue

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Useful variants:
 
 ```bash
 gaia push --dry-run
-gaia push --no-pr
+gaia push --no-issue
 python3 scripts/validate_intake.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Detects skills your agent demonstrates.
 gaia push
 ```
 
-A GitHub PR opens automatically. Maintainers review; your name attaches at 2★.
+A GitHub issue opens automatically. Maintainers review and promote; your name attaches at 2★.
 
 **4. Bond your agent (optional)**
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -184,7 +184,7 @@
             <span class="rite-numeral" aria-hidden="true">III.</span>
             <div class="rite-body">
               <strong>Push for review</strong>
-              <p>A GitHub PR is opened automatically.</p>
+              <p>A GitHub issue is opened automatically.</p>
               <div class="os-tabs" role="tablist" aria-label="Operating System selection">
                 <button type="button" class="os-tab active" data-os="unix" onclick="switchOsTab(this)" role="tab" aria-selected="true">macOS · Linux</button>
                 <button type="button" class="os-tab" data-os="win" onclick="switchOsTab(this)" role="tab" aria-selected="false">Windows</button>


### PR DESCRIPTION
## Summary

- **README.md** — quick-start step III: "A GitHub PR opens automatically" → "A GitHub issue opens automatically"
- **CONTRIBUTING.md** — example variant: `gaia push --no-pr` → `gaia push --no-issue`
- **docs/index.html** — onboarding step III: "A GitHub PR is opened automatically" → "A GitHub issue is opened automatically"

`gaia push` now files a GitHub issue instead of a PR. These three entry-points still described the legacy PR workflow; this aligns them with the current issue-based intake flow.

## Test plan
- [ ] Verify `gaia push` in a dry-run shows issue creation, not PR creation
- [ ] Check rendered docs site step III reads "issue"
- [ ] Confirm `--no-issue` flag is accepted by `gaia push --help`

https://claude.ai/code/session_01XqbUnCEa3EEL75auzcCcdq

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqbUnCEa3EEL75auzcCcdq)_