### PR TITLE
🎨 Palette: Add keyboard focus styles to share and claim buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -29,3 +29,6 @@
 ## 2024-05-25 - Focus Rings for All Interactive Elements
 **Learning:** Found several missing focus-visible classes on various buttons and interactive elements (`.nav-search-btn-mobile`, `.pmq-changelog-btn`, `.scroll-to-top`, `.mr-pagination-prev`, `.mr-pagination-next`, `.hero-audit-btn`, `.propose-cta`, `.meta-btn-close`, `.se-close-x`, `.hoh-fs-overlay-restore`, `.hoh-fs-btn`, `.hoh-fs-btn--close`, `.hoh-fs-copy-btn`), impacting keyboard accessibility.
 **Action:** Always verify keyboard accessibility on all buttons by checking if they belong to the central grouped selector for `:focus-visible` in `styles.css` or `plaque.css`. Ensure new buttons receive `outline: 2px solid var(--tier-extra); outline-offset: 2px;`.
+## 2025-02-18 - Focus Ring on Share Modal Buttons
+**Learning:** Custom UI modal buttons and interactive actions often miss the global keyboard accessibility styles.
+**Action:** Always ensure that custom modals, share actions, and standard action buttons explicitly implement the app-wide focus ring using the `:focus-visible` rule in the main or component CSS (using `outline: 2px solid var(--tier-extra); outline-offset: 2px;`).

--- a/docs/css/plaque.css
+++ b/docs/css/plaque.css
@@ -481,7 +481,11 @@ button.plaque__slug:focus-visible {
 .hoh-fs-overlay-restore:focus-visible,
 .hoh-fs-btn:focus-visible,
 .hoh-fs-btn--close:focus-visible,
-.hoh-fs-copy-btn:focus-visible {
+.hoh-fs-copy-btn:focus-visible,
+.share-modal__close:focus-visible,
+.share-action:focus-visible,
+.plaque__share-btn:focus-visible,
+.plaque__claim-btn:focus-visible {
   outline: 2px solid var(--tier-extra);
   outline-offset: 2px;
 }


### PR DESCRIPTION
🎨 Palette: Add keyboard focus styles to share and claim buttons

**What:** 
Added `:focus-visible` styles to the share modal's close button, the "Share" action buttons, and the "Share/Claim" buttons in the plaque components.

**Why:**
Custom UI modal buttons and interactive actions missed the global keyboard accessibility styles (`outline: 2px solid var(--tier-extra)`). This change ensures they can be accessed properly when navigating with a keyboard.

**Accessibility:**
Added app-wide focus ring explicit rule implementation to components `share-modal__close`, `share-action`, `plaque__share-btn`, and `plaque__claim-btn`.

---
*PR created automatically by Jules for task [5736597079271259533](https://jules.google.com/task/5736597079271259533) started by @mbtiongson1*

[skip-gen]