### PR TITLE
[cli] Add gaia-curate-dynamic workflow; fix outdated curate skills

### DIFF
--- a/.agents/skills/feature-pipeline/SKILL.md
+++ b/.agents/skills/feature-pipeline/SKILL.md
@@ -296,7 +296,7 @@ Then ends its turn. It does not proceed to the next phase.
 | **Plan approval** | Zero implementation code before explicit user approval of the HEAVIER plan. |
 | **No force-pushes** | Commits append only. Rebase on explicit user request only. |
 | **CI loop** | Phase 4 has no exit until all required checks pass, or a 3× failure escalation surfaces to ORCHESTRATOR. |
-| **Programmatic-First** | Registry mutations via `gaia add` / `gaia merge` / `gaia split`. Never hand-edit `registry/nodes/`. |
+| **Programmatic-First** | Registry mutations via `gaia dev add` / `gaia dev merge` / `gaia dev split`. Never hand-edit `registry/nodes/`. |
 | **Single PR** | One PR per `/feature-pipeline` run, covering all Phase 1 issues. |
 | **Drift pause** | Phase 5 drift detected → warn and pause, never auto-fix. |
 

--- a/.agents/skills/fp-implement/SKILL.md
+++ b/.agents/skills/fp-implement/SKILL.md
@@ -87,6 +87,6 @@ Print M2 stop hook and end your turn:
 
 - One commit per plan step — no squashing.
 - Never commit secrets, generated registry artifacts, or unrelated files.
-- `gaia add`/`gaia merge`/`gaia split` for any registry mutations —
+- `gaia dev add`/`gaia dev merge`/`gaia dev split` for any registry mutations —
   never hand-edit `registry/nodes/`.
 - No force-pushes.

--- a/.agents/skills/gaia-bot-curate/SKILL.md
+++ b/.agents/skills/gaia-bot-curate/SKILL.md
@@ -38,10 +38,10 @@ Curate remote `bot/*` crawler branches into `registry/real-skills.json` from a f
    - **Named Promotion**: If the item has a clear playbook and high quality, propose it as a **Named Skill** (2★+) in `registry/named/` with a unique Title (e.g., "The Digital Pathweaver").
 
 5. **Integrate and Promote**
-   - Main agent executes `gaia add` and `gaia evidence` commands for accepted entries.
-   - **For generic (starless) nodes**: `gaia add "Skill Name" --id <id> --type extra --description "..."` — generic skills have no `--level` flag; they are rank-less taxonomy.
-   - **For named skills**: `gaia add "Skill Name" --id <id> --named --contributor <user> --generic-ref <ref>` — named skills receive star levels (2★–6★) in their YAML frontmatter.
-   - Use `gaia evidence` to attach the payload URLs and details to the appropriate skill (generic or named, as applicable).
+   - Main agent executes `gaia dev add` and `gaia dev evidence` commands for accepted entries (the mutation verbs live under `gaia dev`, not at the top level).
+   - **For generic (starless) nodes**: `gaia dev add "Skill Name" --id <id> --type extra --description "..."` — generic skills have no `--level` flag; they are rank-less taxonomy.
+   - **For named skills**: `gaia dev add "Skill Name" --id <id> --named --contributor <user> --generic-ref <ref> --status awakened` — named skills are submitted with `status: awakened` (enum `{awakened, named}`); a reviewer later promotes to `named` and calibrates stars (2★–6★). Do not hand-set `title`/`catalogRef`.
+   - Use `gaia dev evidence` to attach the payload URLs and details to the appropriate skill (generic or named, as applicable).
    - NEVER hand-edit files in `registry/`.
 
 6. **Clean remote bot branches**

--- a/.agents/skills/gaia-curate-dynamic/SKILL.md
+++ b/.agents/skills/gaia-curate-dynamic/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: gaia-curate-dynamic
+description: >-
+  Dynamic-workflow curation for the Gaia registry. Instead of a fixed pipeline,
+  the orchestrator analyses the request at runtime, writes its own orchestration
+  plan, fans out tens-to-hundreds of parallel sub-agents across sources and
+  candidates, and validates every proposal convergently — proposer agents argue
+  for a skill while refuter agents try to disprove its evidence/level/novelty,
+  iterating until they agree. State is persisted to a resumable ledger so a
+  large sweep survives interruption. Use for big, open-ended curation —
+  "sweep every source for agent skills", "curate the whole <domain> space",
+  "find and verify everything new since <date>" — or /gaia-curate-dynamic.
+  Prefer /gaia-curate for a quick pass and /gaia-curate-chain for a small,
+  fixed, gated batch.
+version: 1.0.0
+argument-hint: "<broad-curation-goal>"
+---
+
+# gaia-curate-dynamic
+
+A **dynamic-workflow** implementation of registry curation, modelled on
+[Introducing dynamic workflows in Claude Code](https://claude.com/blog/introducing-dynamic-workflows-in-claude-code).
+
+> *Claude dynamically writes orchestration scripts that run tens to hundreds of
+> parallel sub-agents in a single session, checking its work before anything
+> reaches you. Multiple agents address a problem from independent angles while
+> others attempt refutation, iterating until the answers converge — which is how
+> a workflow reaches results a single pass can't.*
+
+Where `/gaia-curate` is one linear pass and `/gaia-curate-chain` is a fixed
+six-link prompt chain, this skill is **composed at runtime**: the orchestrator
+reads the goal and the registry, decides how much to fan out and how to
+partition the work, dispatches many sub-agents in parallel, and converges their
+findings adversarially. It is built for breadth (every source at once) and for
+trust (nothing ships until a refuter failed to break it).
+
+## The three curation models
+
+| Skill | Pattern | Topology | Best for |
+|-------|---------|----------|----------|
+| `gaia-curate` | Single pass | one agent | fast, low-stakes batches |
+| `gaia-curate-chain` | Prompt chaining + gates | fixed L1→L6 | small batch, schema-critical |
+| **`gaia-curate-dynamic`** | **Dynamic workflow** | **runtime-composed, massively parallel, convergent** | wide sweeps, high-stakes verification |
+
+## Core principles
+
+1. **Runtime composition.** There is no hard-coded phase list. The orchestrator
+   writes a **run plan** for *this* goal (how many discovery shards, how many
+   candidates to deep-dive, how many validation rounds) and stores it in the
+   ledger. The plan adapts as findings arrive — a source yielding 60 candidates
+   gets more shards than one yielding 3.
+2. **Parallel fan-out.** Independent work runs concurrently: one sub-agent per
+   source during discovery, one per candidate during deep-dive. Dispatch in
+   batches (multiple `Agent` calls in a single turn). Scale the count to the
+   work, not to a fixed number.
+3. **Convergent validation.** Every surviving candidate is argued by a
+   **proposer** and attacked by an **independent refuter**. They iterate until
+   they converge on the same accept/level/evidence verdict (or the refuter wins
+   and the candidate is dropped). Convergence — not a single judgement — is the
+   bar for shipping.
+4. **Persistent, resumable ledger.** All state lives in
+   `generated-output/curate-dynamic-ledger.json` (gitignored). Every stage
+   writes atomically so a multi-hour sweep resumes exactly where it stopped
+   after any interruption. On invocation, **read the ledger first** and resume
+   the earliest unfinished stage rather than restarting.
+
+## Ledger shape
+
+```json
+{
+  "goal": "<argument>",
+  "startedAt": "<iso>",
+  "stage": "plan|discover|deepdive|converge|synthesize|review|ship",
+  "plan": { "sources": [], "discoverShards": 0, "validationRounds": 2 },
+  "existingIds": [],
+  "discoveries": [ { "source": "...", "rawCandidates": [] } ],
+  "candidates": [
+    { "id": "...", "name": "...", "evidence": [],
+      "proposer": { "verdict": "", "type": "", "level": null },
+      "refuter":  { "verdict": "", "objections": [] },
+      "converged": false, "rounds": 0, "decision": "" }
+  ],
+  "batch": [],
+  "prUrl": null
+}
+```
+
+---
+
+## Stage 0 — Plan synthesis (orchestrator, runtime-composed)
+
+The orchestrator does this itself — it is the dynamic part:
+
+1. Read `registry/skill-sources.md` and `registry/gaia.json`; record
+   `existingIds` (for dedupe) into the ledger.
+2. From the goal, **write the run plan**: which sources to shard, how many
+   discovery sub-agents, and the validation round budget (default 2, raise to 3
+   for Level II+ / ultimate proposals). Store it under `plan`.
+3. Print a one-paragraph plan summary so the user can see the shape of the run
+   before the fan-out begins.
+
+The plan is a living object — later stages may add shards when a source proves
+unexpectedly rich.
+
+## Stage 1 — Parallel discovery (fan-out: one sub-agent per source shard)
+
+Dispatch all discovery sub-agents in a single turn. Each shard gets one source
+and this brief:
+
+> Enumerate skill-shaped artifacts in `{{source}}` relevant to `{{goal}}`.
+> **Local runs**: use the `gh` CLI; inspect each repo for a `skills/` directory
+> and record the raw `blob/<branch>/<subpath>/SKILL.md` URL. **Cloud/remote
+> runs**: use the GitHub MCP tools — never claim GitHub is unreachable without
+> checking MCP. Supplement with SkillsMP and arXiv. Return `rawCandidates[]`
+> with `{name, source, url, oneLineCapability}`. Do not judge or rank — just
+> harvest. Drop anything whose `name` slug already appears in `existingIds`.
+
+Write each shard's output to `discoveries[]` as it returns.
+
+## Stage 2 — Parallel candidate deep-dive (fan-out: one proposer per candidate)
+
+Flatten and dedupe `discoveries` into a candidate set. Dispatch a **proposer**
+sub-agent per candidate (batch the `Agent` calls), brief:
+
+> Build the strongest honest case for adding `{{candidate}}` to Gaia. Gather
+> evidence as `{class, source}` (arXiv abs = A, reproducible repo blob = B,
+> vendor/community = C; every URL must resolve). Propose `type`
+> (basic/extra/ultimate), `named` (+ `genericSkillRef`), and a star level for
+> named. Emit a `proposer` verdict. Be concrete; unsupported claims will be
+> attacked in the next stage.
+
+## Stage 3 — Convergent validation (proposer ⇄ refuter until they agree)
+
+For each candidate with a proposer verdict, dispatch an **independent refuter**
+(fresh context, must not see the proposer's reasoning, only its claims):
+
+> Try to **break** the case for `{{candidate}}`. Check: is each evidence URL
+> real and on-topic? Is it a duplicate of an existing Gaia skill or another
+> candidate? Is the level inflated for the evidence class? Is it vendor-locked
+> (a demerit) or non-novel (Fusion-First: should it collapse into an existing
+> generic)? Return `objections[]` and a verdict: `uphold` / `lower-level` /
+> `merge-into <id>` / `reject`.
+
+The orchestrator reconciles each round:
+- **Converged** when proposer and refuter agree on accept + type + level (or
+  both agree on reject/merge). Mark `converged: true`, set `decision`.
+- **Not converged** → run another round (proposer answers the objections,
+  refuter re-attacks), up to `plan.validationRounds`. If still split after the
+  budget, mark `decision: needs-evidence` and carry both views to the human.
+
+Independent shards run in parallel; only divergent candidates consume extra
+rounds. This is the convergent-validation loop that makes the dynamic workflow
+worth its cost.
+
+## Stage 4 — Synthesis & Fusion-First (orchestrator)
+
+Merge converged candidates into `batch[]`:
+- Apply **Fusion-First**: collapse vendor variants onto one generic
+  (`literature-search`, not `pubmed`+`arxiv`+`biorxiv`); orchestrate
+  specialised capabilities as an `extra` with the basics as prerequisites.
+- Set schema-correct fields: `type` ↔ prereq arity (basic/unique 0, extra ≥2,
+  ultimate ≥3); generics carry **no level**; named skills get
+  `status: awakened`.
+- Run the same deterministic pre-flight as the chain skill (IDs match their
+  pattern, no DAG cycles) before presenting anything.
+
+## Stage 5 — Single human checkpoint
+
+Present one consolidated table — converged accepts, plus any `needs-evidence`
+rows with the proposer/refuter split shown — and collect
+`accept`/`rename`/`duplicate`/`needs-evidence`/`reject`. One approval gate for
+the whole sweep; proceed only with ≥1 `accept`.
+
+## Stage 6 — Mutation, validation & ship
+
+Deterministic, programmatic-only:
+```bash
+# generic (no --level)
+gaia dev add "Skill Name" --id <id> --type <type> --description "..."
+# named (awakened intake; reviewer assigns title/catalogRef/stars later)
+gaia dev add "Skill Name" --id <id> --named --contributor <user> \
+  --generic-ref <ref> --status awakened
+gaia dev evidence <skill-id> "<url>" --class <A|B|C>
+
+gaia validate                      # must exit 0
+gaia docs build                    # regenerate docs/projections
+gaia docs build --check            # must be clean before push
+```
+Branch `review/meta/<slug>`, commit `[meta] <title>` + a `[skip-gen]` docs
+commit, push (retry on network error 2s/4s/8s/16s), open the PR, and add the
+contributor to `README.md` `## Contributors`. Report the ledger path, fan-out
+counts (sources sharded, candidates deep-dived, rounds spent), converged vs
+dropped tallies, and the PR URL.
+
+---
+
+## Resume protocol
+
+On every invocation: if `generated-output/curate-dynamic-ledger.json` exists and
+its `stage` is not `ship`, print a one-line resume summary and continue from the
+earliest unfinished stage. Never restart a completed fan-out — re-dispatch only
+the sub-agents whose ledger entries are missing or unconverged.
+
+## Constraints
+
+| Rule | Detail |
+|------|--------|
+| **Dynamic, not fixed** | The orchestrator writes and adapts the run plan; fan-out scales to the work. Stages 1–3 may re-shard. |
+| **Convergence is the bar** | No candidate ships on a single verdict — a proposer and an independent refuter must converge (or the human breaks a tie). |
+| **Parallelism** | Dispatch independent sub-agents in one turn. Refuters must not see proposer reasoning. |
+| **Programmatic-First** | All mutations via `gaia dev add/merge/split/evidence`. Never hand-edit `registry/nodes/` or `gaia.json`. |
+| **Named = awakened** | Named skills submitted `status: awakened`; `title`/`catalogRef`/stars are reviewer-only. Generics carry no level. |
+| **Evidence reality** | Every `source` resolves (arXiv abs = A, repo blob URL = B, vendor/community = C). |
+| **Edges** | `sourceSkillId`/`targetSkillId`; `edgeType ∈ {prerequisite, corequisite, enhances}`. No `derivative` — use `enhances`. |
+| **Encoding** | All Python `open()` uses `encoding='utf-8'`. |
+| **Resumable** | Ledger writes are atomic; a run survives interruption and resumes without redoing finished work. |
+| **One PR** | A whole sweep lands as a single review PR. |
+
+## Invocation
+
+```
+/gaia-curate-dynamic <broad-curation-goal>
+```
+If the goal is omitted, ask what domain or time-window to sweep before writing
+the run plan.

--- a/.agents/skills/gaia-curate/SKILL.md
+++ b/.agents/skills/gaia-curate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gaia-curate
 description: Expand the Gaia skill registry with new popular AI agent skills, fully evidenced and validated, then push a PR. Use this skill when the user asks to "update the tree", "add new skills to Gaia", "curate the registry", "expand the skill graph", or explicitly types /gaia-curate.
-version: 1.6.0
+version: 1.7.0
 ---
 
 # gaia-curate
@@ -16,7 +16,7 @@ Expand the Gaia skill registry (`registry/gaia.json`) with new popular AI agent 
 2. **Research** — for each candidate skill, gather concrete evidence using ALL of the following channels (in order of priority):
 
    **2a. GitHub search (50% of research effort — Evidence Tier B):**
-   Search for actual repos implementing the skill:
+   Search for actual repos implementing the skill. **Local runs** use the `gh` CLI; **cloud/remote runs** (where `gh` is unavailable) use the GitHub MCP tools (`search_repositories`, `get_file_contents`) — never report GitHub as unreachable without first checking MCP.
    ```bash
    gh search repos --topic="<skill-topic>" --sort=stars --limit=20
    gh search repos "<skill-name> agent" --sort=stars --limit=10
@@ -76,11 +76,11 @@ Expand the Gaia skill registry (`registry/gaia.json`) with new popular AI agent 
    - **Fusion-First Design & Semantic Mapping Rationale**: 
      - *No Made-up Generics*: Avoid creating a new, separate generic skill for every vendor API or service (e.g., do not create distinct generic skills for `pubmed`, `arxiv`, `biorxiv`, `europepmc` etc.). Map multiple named implementations of identical concepts to a single elegant basic generic skill (e.g. `literature-search`) to prevent registry bloat and maintain a high-quality global graph.
      - *Master Skill Fusion*: When multiple distinct named skills represent specialized capabilities that can be combined or orchestrated in a multi-step workflow (e.g., fetching structures, aligning sequences, rendering structures), define a composite **Extra** skill (like `computational-biology-workflows`) and link the basic skills as its prerequisites. Calibrate the advanced named implementations (e.g. AlphaFold, AlphaGenome) to higher levels (`3★` or `4★` max) referencing that composite Extra skill.
-   - **Note on generic skill levels**: Generic (starless) skills have no star level — they are rank-less taxonomy. Only the *named* implementations (e.g. `contributor/AlphaFold`) receive star levels (2★–6★). When proposing a generic, omit `--level` flag from `gaia add`; the generic's effective rank is the top star among its named children.
+   - **Note on generic skill levels**: Generic (starless) skills have no star level — they are rank-less taxonomy. Only the *named* implementations (e.g. `contributor/AlphaFold`) receive star levels (2★–6★). When proposing a generic, omit `--level` flag from `gaia dev add`; the generic's effective rank is the top star among its named children.
    - Prerequisites and derivatives (must reference existing IDs).
    - **Demerit Check (Strategic)**: Identify `heavyweight-dependency`, `niche-integration`, or `experimental-feature`. Only strictly apply these to skills at **3★+**. If a high-level skill is cross-platform and "Universal," reward it by omitting demerits.
    - **Named Promotion**: Determine if the specific implementation should be promoted to a **Named Skill** in `registry/named/`.
-   - Do **not** ask the contributor to choose a rarity value — the rarity axis is deprecated (see `CONTEXT.md` § Rarity). `gaia add` writes the legacy default automatically; the field will disappear once the schema migration lands.
+   - Do **not** ask the contributor to choose a rarity value — the rarity axis is deprecated (see `CONTEXT.md` § Rarity). `gaia dev add` writes the legacy default automatically; the field will disappear once the schema migration lands.
 4. **Present draft for review** — before writing any code or committing, display the full proposed skills table:
 
    | ID | Name | Type | Stars | Prereqs | Demerits | Named Promotion? |
@@ -96,19 +96,19 @@ Expand the Gaia skill registry (`registry/gaia.json`) with new popular AI agent 
 
    **Do not proceed to step 5 until the user has reviewed and the batch contains at least one `accept`.** Incorporate all `rename` decisions before writing the script. Drop everything that is not `accept`/`rename`.
 
-5. **Execute meta shifts via CLI** — for each accepted skill from step 4, use the `gaia add` command. This ensures timeline logging, schema integrity, and automated assembly.
+5. **Execute meta shifts via CLI** — for each accepted skill from step 4, use the `gaia dev add` command (the mutation verbs live under `gaia dev`, not at the top level). This ensures timeline logging, schema integrity, and automated assembly.
    
    **For generic (starless) skills**, use:
    ```bash
-   gaia add "Skill Name" --id <id> --type <type> --description "..."
+   gaia dev add "Skill Name" --id <id> --type <type> --description "..."
    ```
    Do NOT pass `--level` — generics are rank-less; the schema will not accept a level on a generic node.
    
    **For named implementations**, use:
    ```bash
-   gaia add "Skill Name" --id <id> --named --contributor <user> --generic-ref <ref>
+   gaia dev add "Skill Name" --id <id> --named --contributor <user> --generic-ref <ref> --status awakened
    ```
-   Named skills receive their `--level` (2★–6★) in the YAML frontmatter, not via CLI.
+   Named skills **must** be submitted with `status: awakened` — the schema's named-status enum is `{awakened, named}`. Only a reviewer later promotes a skill to `named` and assigns its `title`/`catalogRef`; never hand-set those during curation. Calibrate stars (2★–6★) with `gaia dev calibrate` once evidence is reviewed.
 6. **Run validation** — `gaia validate` must exit 0.
 
 7. **Regenerate derived files** — run `gaia docs build`. This ensures `registry.md`, `combinations.md`, `skills/**/*.md`, `registry/gaia.gexf`, and `skill-trees/*/skill-tree.md` stay in sync.
@@ -136,7 +136,7 @@ gaia validate --intake
 
 ## Constraints
 
-- **Programmatic Registry Management**: NEVER hand-edit files in `registry/nodes/` or `registry/gaia.json`. Use `gaia add`, `gaia merge`, `gaia split`, and `gaia evidence`.
+- **Programmatic Registry Management**: NEVER hand-edit files in `registry/nodes/` or `registry/gaia.json`. Use `gaia dev add`, `gaia dev merge`, `gaia dev split`, and `gaia dev evidence`.
 - All evidence `source` values must be real, resolvable URLs (arXiv abs pages or GitHub repos).
 - Ultimate skills at `status: validated` require ≥3 Evidence Tier A/B entries; new ultimates should land as `provisional` until the maintainer merges.
 - No cycles in the DAG. No orphaned composite nodes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,13 +112,14 @@ Project-local agent skills live in two directories and are actively used by cont
 
 - `.agents/skills/gaia-curate/` — `/gaia-curate`: expand the registry with new skills and open a PR (single linear pass).
 - `.agents/skills/gaia-curate-chain/` — `/gaia-curate-chain`: the same curation work as a **prompt-chaining** workflow (six gated links, one sub-agent per link), per Anthropic's *Building Effective Agents*. Use when evidence quality and schema correctness matter more than latency.
+- `.agents/skills/gaia-curate-dynamic/` — `/gaia-curate-dynamic`: curation as a **dynamic workflow** (runtime-composed plan, massively parallel sub-agent fan-out, proposer⇄refuter convergent validation, resumable ledger), per *Introducing dynamic workflows in Claude Code*. Use for wide sweeps and high-stakes verification.
 - `.agents/skills/gaia-meta-audit/` — `/gaia-meta-audit`: prioritized queue of skills/catalog items needing review.
 - `.agents/skills/gaia-audit/` — `/gaia-audit`: focused source-level correction for one target.
 - `.agents/skills/gaia-draft-curate/`, `gaia-docs-sync/`, `gaia-integrity/`, `gaia-triage/`, `gaia-wiki-sync/`, `graphify-triage/` — supporting curation, doc-sync, integrity, and triage workflows.
 - `.agents/skills/gaia-bot-curate/` — bot-driven curation pass.
 - `.claude/skills/gaia-fuse-full-suite/` — `/gaia-fuse-full-suite`: fuse one contributor's named skills into a single ultimate.
 
-When touching any of these, route registry mutations through `gaia add` / `gaia merge` / `gaia split` / `gaia evidence` (Programmatic-First Policy) rather than hand-edits.
+When touching any of these, route registry mutations through `gaia dev add` / `gaia dev merge` / `gaia dev split` / `gaia dev evidence` (Programmatic-First Policy) rather than hand-edits.
 
 ## gstack
 


### PR DESCRIPTION
## Summary

Adds a third curation model and updates the outdated curate skills to the current schema/CLI.

### New: `/gaia-curate-dynamic`
A **dynamic-workflow** implementation of registry curation, modelled on [Introducing dynamic workflows in Claude Code](https://claude.com/blog/introducing-dynamic-workflows-in-claude-code):
- **Runtime composition** — the orchestrator writes its own run plan instead of following a fixed phase list.
- **Parallel fan-out** — one sub-agent per source (discovery) and per candidate (deep-dive).
- **Convergent validation** — a proposer argues for each skill while an independent refuter attacks its evidence/level/novelty, iterating until they agree.
- **Resumable ledger** — atomic state in `generated-output/curate-dynamic-ledger.json` survives interruption.

Completes the trio: `gaia-curate` (single pass) · `gaia-curate-chain` (prompt chaining + gates) · `gaia-curate-dynamic` (dynamic workflow).

### Fixes to outdated curate skills
- **Namespace**: `gaia add/merge/split/evidence` → `gaia dev …` (top-level forms do not exist) in `gaia-curate`, `gaia-bot-curate`, `feature-pipeline`, `fp-implement`, and `CLAUDE.md`.
- **Named status**: submitted with `status: awakened` (enum `{awakened, named}`); `title`/`catalogRef`/stars flagged reviewer-only; generics carry no `--level`.
- **Portability**: GitHub MCP fallback note for cloud runs where `gh` is unavailable.
- Bumped `gaia-curate` to v1.7.0; registered `gaia-curate-dynamic` in `CLAUDE.md`.

No registry data or generated artifacts touched — docs-only skill changes.

https://claude.ai/code/session_01Jr2LmCruWmsjv5BwhWLeY1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jr2LmCruWmsjv5BwhWLeY1)_