### PR TITLE
fix(crawlers): align bot crawler config and skill with current META/CONTRIBUTING

### DIFF
--- a/.agents/skills/gaia-bot-curate/SKILL.md
+++ b/.agents/skills/gaia-bot-curate/SKILL.md
@@ -5,7 +5,7 @@ description: Curate Gaia bot crawler branches into real-skill catalog entries. U
 
 # gaia-bot-curate
 
-Curate remote `bot/*` crawler branches into `registry/real-skills.json` from a fresh `origin/main` review branch.
+Curate remote `bot/*` crawler branches into `registry/nodes/` via `gaia dev` commands from a fresh `origin/main` review branch.
 
 ## Workflow
 
@@ -35,13 +35,19 @@ Curate remote `bot/*` crawler branches into `registry/real-skills.json` from a f
      - `heavyweight-dependency`: Only if it requires massive infrastructure (e.g., full Airflow stack, 10GB+ Docker) that a typical dev can't run locally.
      - `niche-integration`: Only if restricted to a specific non-portable OS or IDE (e.g., Windows-only Visual Studio).
      - **Reward Generality**: If a high-level skill remains demerit-free, prioritize it for **Named Promotion**.
-   - **Named Promotion**: If the item has a clear playbook and high quality, propose it as a **Named Skill** (2★+) in `registry/named/` with a unique Title (e.g., "The Digital Pathweaver").
+   - **Named Promotion**: If the item has a clear playbook and high quality, propose it as a **Named Skill** in `registry/named/` with a unique Title (e.g., "The Digital Pathweaver"). Before assigning any star level, verify the `links.github` URL uses the `blob/<branch>/subpath` format (not a bare repo root or `tree/` URL). If no valid blob link can be confirmed, the skill must be submitted at **1★ (Awakened)** — this is a hard reset per META.md §2.4 (updated 2026-06-02), not a soft step-down to 2★.
 
 5. **Integrate and Promote**
-   - Main agent executes `gaia dev add` and `gaia dev evidence` commands for accepted entries (the mutation verbs live under `gaia dev`, not at the top level).
+   - Main agent executes `gaia dev` commands for accepted entries (the mutation verbs live under `gaia dev`, not at the top level).
    - **For generic (starless) nodes**: `gaia dev add "Skill Name" --id <id> --type extra --description "..."` — generic skills have no `--level` flag; they are rank-less taxonomy.
    - **For named skills**: `gaia dev add "Skill Name" --id <id> --named --contributor <user> --generic-ref <ref> --status awakened` — named skills are submitted with `status: awakened` (enum `{awakened, named}`); a reviewer later promotes to `named` and calibrates stars (2★–6★). Do not hand-set `title`/`catalogRef`.
    - Use `gaia dev evidence` to attach the payload URLs and details to the appropriate skill (generic or named, as applicable).
+   - Use `gaia dev calibrate <id> "<star>"` to set or adjust the star level on a named skill after evidence is attached.
+   - Use `gaia dev link <target-id> <prereq-id-1>,<prereq-id-2>` to wire prerequisites for Extra or Ultimate skills.
+   - Use `gaia dev reclassify <id> <type>` if the skill type needs to change (e.g., `basic` → `extra`).
+   - Use `gaia dev update-named <contributor/skill> --status awakened` (or other flags) to patch named-skill frontmatter.
+   - When batching multiple adds, pass `--no-build` on each command and run `gaia dev build` once at the end to avoid redundant regeneration.
+   - Use `gaia dev rm <id>` to remove a skill that was added in error.
    - NEVER hand-edit files in `registry/`.
 
 6. **Clean remote bot branches**

--- a/.github/workflows/crawl-github.yml
+++ b/.github/workflows/crawl-github.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Push proposal branch
         if: steps.check.outputs.has_proposals == 'true'
         run: |
-          git config --global user.name "mbtiongson1"
-          git config --global user.email "marco.tngsn@gmail.com"
+          git config --global user.name "gaiabot"
+          git config --global user.email "gaiabot@users.noreply.github.com"
 
           DATE=$(date +%Y-%m-%d)
           BRANCH="bot/github/$DATE"

--- a/.github/workflows/crawl-hf.yml
+++ b/.github/workflows/crawl-hf.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Push proposal branch
         if: steps.check.outputs.has_proposals == 'true'
         run: |
-          git config --global user.name "mbtiongson1"
-          git config --global user.email "marco.tngsn@gmail.com"
+          git config --global user.name "gaiabot"
+          git config --global user.email "gaiabot@users.noreply.github.com"
 
           DATE=$(date +%Y-%m-%d)
           BRANCH="bot/huggingface/$DATE"

--- a/.github/workflows/crawl-mcp.yml
+++ b/.github/workflows/crawl-mcp.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Push proposal branch
         if: steps.check.outputs.has_proposals == 'true'
         run: |
-          git config --global user.name "mbtiongson1"
-          git config --global user.email "marco.tngsn@gmail.com"
+          git config --global user.name "gaiabot"
+          git config --global user.email "gaiabot@users.noreply.github.com"
 
           DATE=$(date +%Y-%m-%d)
           BRANCH="bot/mcp-registry/$DATE"

--- a/.github/workflows/crawl-npm.yml
+++ b/.github/workflows/crawl-npm.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Push proposal branch
         if: steps.check.outputs.has_proposals == 'true'
         run: |
-          git config --global user.name "mbtiongson1"
-          git config --global user.email "marco.tngsn@gmail.com"
+          git config --global user.name "gaiabot"
+          git config --global user.email "gaiabot@users.noreply.github.com"
 
           DATE=$(date +%Y-%m-%d)
           BRANCH="bot/npm/$DATE"

--- a/.github/workflows/crawl-papers.yml
+++ b/.github/workflows/crawl-papers.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Push proposal branch
         if: steps.check.outputs.has_proposals == 'true'
         run: |
-          git config --global user.name "mbtiongson1"
-          git config --global user.email "marco.tngsn@gmail.com"
+          git config --global user.name "gaiabot"
+          git config --global user.email "gaiabot@users.noreply.github.com"
 
           DATE=$(date +%Y-%m-%d)
           BRANCH="bot/papers/$DATE"

--- a/.github/workflows/crawl-skillsmp.yml
+++ b/.github/workflows/crawl-skillsmp.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Push proposal branch
         if: steps.check.outputs.has_proposals == 'true'
         run: |
-          git config --global user.name "mbtiongson1"
-          git config --global user.email "marco.tngsn@gmail.com"
+          git config --global user.name "gaiabot"
+          git config --global user.email "gaiabot@users.noreply.github.com"
 
           DATE=$(date +%Y-%m-%d)
           BRANCH="bot/skillsmp/$DATE"

--- a/.github/workflows/crawl-vscode.yml
+++ b/.github/workflows/crawl-vscode.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Push proposal branch
         if: steps.check.outputs.has_proposals == 'true'
         run: |
-          git config --global user.name "mbtiongson1"
-          git config --global user.email "marco.tngsn@gmail.com"
+          git config --global user.name "gaiabot"
+          git config --global user.email "gaiabot@users.noreply.github.com"
 
           DATE=$(date +%Y-%m-%d)
           BRANCH="bot/vscode/$DATE"

--- a/scripts/crawlers/common/candidate_builder.py
+++ b/scripts/crawlers/common/candidate_builder.py
@@ -19,8 +19,6 @@ def build_candidate(
         "id": id,
         "name": name,
         "type": skill_type,
-        "level": "1★",
-        "rarity": "common",
         "description": description,
         "prerequisites": [],
         "derivatives": [],

--- a/scripts/crawlers/config.yaml
+++ b/scripts/crawlers/config.yaml
@@ -45,18 +45,6 @@ crawlers:
     min_downloads: 1000
     batch_size: 20
 
-evidence_thresholds:
-  auto_merge_score: 60
-  human_review_score: 30
-
-pr_settings:
-  owner: "mbtiongson1"
-  repo: "gaia-skill-tree"
-  bot_user: "gaiabot"
-  labels:
-    - "bot-proposal"
-  stale_days: 30
-
   github:
     topics:
       - "web-scraping"
@@ -92,3 +80,15 @@ pr_settings:
     min_citations: 10
     max_age_years: 3
     batch_size: 25
+
+evidence_thresholds:
+  auto_merge_score: 60
+  human_review_score: 30
+
+pr_settings:
+  owner: "mbtiongson1"
+  repo: "gaia-skill-tree"
+  bot_user: "gaiabot"
+  labels:
+    - "bot-proposal"
+  stale_days: 30


### PR DESCRIPTION
## Summary

- **`config.yaml`**: Move `github`, `skillsmp`, and `papers` crawler sections out of `pr_settings` and into the `crawlers` block where they belong — they were previously unreachable by the crawlers, which fell back to hardcoded defaults.
- **All 7 `crawl-*.yml`**: Commit as `gaiabot` identity (matching `pr_settings.bot_user`) instead of the repo-owner account, so bot commits are distinguishable in history.
- **`candidate_builder.py`**: Drop deprecated `rarity: "common"` field (on its way out per CLAUDE.md §Vocabulary) and hardcoded `level: "1★"` (generic refs must be starless per META.md §1) from every proposal.
- **`gaia-bot-curate/SKILL.md`**:
  - Header: fix stale target (`registry/real-skills.json` → `registry/nodes/` via `gaia dev`)
  - Step 4: add blob-URL installability gate — missing `blob/` link = hard-demote to **1★** per META.md §2.4 (updated 2026-06-02), not soft step-down to 2★
  - Step 5: document six new `gaia dev` sub-commands (`calibrate`, `link`, `reclassify`, `update-named`, `build`, `rm`) introduced in CONTRIBUTING.md §C

## Test plan

- [ ] `config.yaml`: confirm `github`, `skillsmp`, `papers` sections now parse correctly under `crawlers:` key
- [ ] Crawler YMLs: trigger any crawler via `workflow_dispatch` and verify the resulting commit shows `gaiabot` as author
- [ ] `candidate_builder.py`: run a crawler locally and confirm proposal JSON contains no `rarity` or `level` fields
- [ ] `gaia-bot-curate/SKILL.md`: run `/gaia-bot-curate` on a live bot branch and confirm it checks for `blob/` URLs before assigning star level, and uses `--no-build` + `gaia dev build` for batch operations

https://claude.ai/code/session_01CWCofwUS84v57AxZsUe8cN

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWCofwUS84v57AxZsUe8cN)_