### PR TITLE
feat(ci): release channels (Production/Beta/Canary) — PyPI on major only

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,5 +1,13 @@
 name: Publish gaia-cli to PyPI
 
+# Triggers:
+#   • push tag v*       — legacy path (only fires for human/PAT-pushed tags).
+#   • workflow_dispatch — MANUAL PUBLISH. Actions tab → "Publish gaia-cli to
+#     PyPI" → Run workflow, and pick the branch *or tag* to build from. It
+#     builds whatever version is in pyproject.toml at that ref, so you can
+#     publish a specific past version by selecting its tag (e.g. v3.30.0).
+#   Automated production publishes are dispatched here by sync-artifacts.yml
+#   on MAJOR bumps (see CONTEXT.md § Release Channels).
 on:
   push:
     tags:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -37,3 +37,7 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # Idempotent: if this version is already on PyPI (e.g. a re-dispatch or
+          # an overlapping run), skip it instead of failing the job.
+          skip-existing: true

--- a/.github/workflows/sync-artifacts.yml
+++ b/.github/workflows/sync-artifacts.yml
@@ -1,14 +1,12 @@
 name: Auto-Sync Registry Artifacts
 
 on:
+  # Run on EVERY push to the default branch — not just registry/script changes —
+  # so that CLI-only and docs-only merges also get a version bump, a GitHub
+  # Release, and a PyPI publish. The job's `if:` already restricts execution to
+  # the default branch and skips bot/[skip-gen] commits, so this cannot loop.
   push:
-    branches: [main, 'dev/**', 'fix/**', 'feat/**', 'review/**', 'infra/**', 'workflow/**', 'chore/**', 'jules/**', 'claude/**', 'codex/**']
-    paths:
-      - 'registry/nodes/**'
-      - 'registry/named/**'
-      - 'registry/schema/**'
-      - 'registry/suites/**'
-      - 'scripts/**'
+    branches: [main]
   workflow_dispatch:
     inputs:
       deploy:
@@ -18,6 +16,13 @@ on:
 
 permissions:
   contents: write
+  actions: write   # dispatch publish-pypi.yml and cloudflare-deploy.yml (workflow_dispatch)
+
+# Serialize runs on the same ref. With the broadened trigger, several merges can
+# land close together; without this they would race on the version bump + push.
+concurrency:
+  group: sync-artifacts-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   sync:
@@ -163,6 +168,18 @@ jobs:
             echo "Created GitHub Release ${TAG}."
           fi
 
+      - name: Publish to PyPI
+        # publish-pypi.yml keys off `on: push tags: v*`, which never fires for a
+        # tag pushed by an automation token (same limitation that broke Releases)
+        # — so PyPI silently fell behind the tags. workflow_dispatch DOES start a
+        # workflow from a running job (with `actions: write`), so dispatch it here
+        # against the just-pushed default-branch commit (carrying the new version).
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run publish-pypi.yml --ref "${GITHUB_REF_NAME}" \
+            && echo "Dispatched publish-pypi.yml for ${GITHUB_REF_NAME}." \
+            || echo "::warning::Could not dispatch publish-pypi.yml — publish PyPI manually if needed."
 
       - name: Sync Wiki Pages
         if: github.event_name != 'pull_request' && github.repository == 'mbtiongson1/gaia-skill-tree'
@@ -176,10 +193,10 @@ jobs:
           python scripts/sync_wiki.py --wiki-dir ../gaia-wiki --push
 
       - name: Trigger Cloudflare Deploy
-        # Non-fatal: dispatching another workflow needs `actions: write`, which
-        # this job does not grant (it only has `contents: write`). Previously a
-        # 403 here marked every sync run as failed even though the version bump,
-        # tag, and release all succeeded. continue-on-error keeps the run green.
+        # Now that the job grants `actions: write`, this dispatch succeeds (it
+        # previously 403'd and reddened every run). Kept continue-on-error as a
+        # belt-and-suspenders guard so a transient dispatch hiccup never fails an
+        # otherwise-successful release run.
         if: github.event_name == 'push' || github.event.inputs.deploy == 'true'
         continue-on-error: true
         run: |

--- a/.github/workflows/sync-artifacts.yml
+++ b/.github/workflows/sync-artifacts.yml
@@ -59,11 +59,26 @@ jobs:
 
       - name: Auto-Versioning and Regeneration
         run: |
-          # 1. Classify bump type from commit message
+          # 1. Classify bump type from commit message → release channel.
+          #    See CONTEXT.md § Release Channels for the full contract:
+          #      major  → production (published to PyPI, GitHub Release = latest)
+          #      minor  → beta       (GitHub pre-release only)
+          #      patch  → canary     (GitHub pre-release only)
           MSG=$(git log -1 --format=%B)
           BUMP="patch"
           if echo "$MSG" | grep -Eq 'BREAKING CHANGE|^[a-zA-Z]+(\([^)]*\))?!:'; then BUMP="major"; fi
           if echo "$MSG" | grep -Eq '^feat(\([^)]*\))?:'; then BUMP="minor"; fi
+
+          case "$BUMP" in
+            major) CHANNEL="production" ;;
+            minor) CHANNEL="beta" ;;
+            *)     CHANNEL="canary" ;;
+          esac
+
+          # Export for later steps (GitHub Release labeling + PyPI gating).
+          echo "GAIA_BUMP=$BUMP" >> "$GITHUB_ENV"
+          echo "GAIA_CHANNEL=$CHANNEL" >> "$GITHUB_ENV"
+          echo "Bump: $BUMP → channel: $CHANNEL"
 
           # 2. Apply version bump and regenerate artifacts via CLI
           # We use --no-push because gaia release uses GITHUB_TOKEN by default,
@@ -161,24 +176,37 @@ jobs:
             git push origin "${TAG}" || echo "::warning::Could not push ${TAG}; release may target an existing tag."
           fi
 
+          # Channel labeling: only production (major) is marked --latest; beta
+          # (minor) and canary (patch) are GitHub pre-releases. See CONTEXT.md.
+          if [ "${GAIA_CHANNEL}" = "production" ]; then
+            CHANNEL_FLAGS="--latest"
+          else
+            CHANNEL_FLAGS="--prerelease --latest=false"
+          fi
+
           if gh release view "${TAG}" --json tagName -q .tagName &>/dev/null; then
             echo "Release ${TAG} already exists — skipping."
           else
-            gh release create "${TAG}" --title "${TAG}" --generate-notes --latest
-            echo "Created GitHub Release ${TAG}."
+            gh release create "${TAG}" \
+              --title "${TAG} (${GAIA_CHANNEL})" \
+              --generate-notes \
+              $CHANNEL_FLAGS
+            echo "Created GitHub Release ${TAG} on the ${GAIA_CHANNEL} channel."
           fi
 
       - name: Publish to PyPI
+        # Production channel only: PyPI publishes happen on MAJOR bumps. beta and
+        # canary stay as GitHub pre-releases (install from a tag/source instead).
         # publish-pypi.yml keys off `on: push tags: v*`, which never fires for a
         # tag pushed by an automation token (same limitation that broke Releases)
-        # — so PyPI silently fell behind the tags. workflow_dispatch DOES start a
-        # workflow from a running job (with `actions: write`), so dispatch it here
-        # against the just-pushed default-branch commit (carrying the new version).
+        # — so we dispatch it via workflow_dispatch, which DOES start a workflow
+        # from a running job (with `actions: write`).
+        if: env.GAIA_CHANNEL == 'production'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh workflow run publish-pypi.yml --ref "${GITHUB_REF_NAME}" \
-            && echo "Dispatched publish-pypi.yml for ${GITHUB_REF_NAME}." \
+            && echo "Dispatched publish-pypi.yml (production) for ${GITHUB_REF_NAME}." \
             || echo "::warning::Could not dispatch publish-pypi.yml — publish PyPI manually if needed."
 
       - name: Sync Wiki Pages

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -265,6 +265,35 @@ _Avoid_: Dual CTA, A/B paths.
 
 ---
 
+## Release Channels
+
+Gaia ships on three channels, derived automatically from the Conventional-Commit
+type of each merge to `main`. The version bump determines the channel:
+
+| Channel | Bump | Trigger (merge commit) | Where it lands |
+|---|---|---|---|
+| **Production** | major | `feat!:` / `fix!:` / `BREAKING CHANGE` | GitHub Release (marked **latest**) **and published to PyPI** |
+| **Beta** | minor | `feat:` | GitHub **pre-release** only |
+| **Canary** | patch | anything else (`fix:`, `chore:`, `docs:`, …) | GitHub **pre-release** only |
+
+- **PyPI is production-only.** `pip install gaia-cli` always resolves to the
+  latest **Production** (major) release. Beta and canary are installable from
+  their git tag/source but never reach PyPI by default.
+- The channel is decided in `.github/workflows/sync-artifacts.yml` (every merge
+  to `main` bumps, tags, and creates a channel-labelled GitHub Release). Production
+  merges additionally dispatch `publish-pypi.yml`.
+- **Manual publish:** Actions → *Publish gaia-cli to PyPI* → Run workflow, picking
+  the branch **or tag** to build from (publishes whatever version is in
+  `pyproject.toml` at that ref; idempotent via `skip-existing`).
+- Because the channel keys off the **merge commit message**, only a breaking-change
+  commit (`!:` or `BREAKING CHANGE`) cuts a Production/PyPI release. Use `feat:` for
+  Beta and ordinary types for Canary.
+
+Copy rules: write the channel names capitalised — **Production**, **Beta**,
+**Canary**. Do not coin synonyms (`stable`, `nightly`, `edge`, `RC`).
+
+---
+
 ## Banned synonyms
 
 Single source of truth for CI grep. Any term below appearing in user-facing copy (`docs/**.html`, `docs/js/`, `docs/css/`, generated artifacts under `docs/`, `scripts/generate*.py`, `src/gaia_cli/`) fails the lint. Alphabetised.


### PR DESCRIPTION
## Summary

Turns the auto-release pipeline into a three-channel model and fixes the PyPI deployment gap. PyPI now publishes **only on major (Production)** releases.

Follows the earlier fix that made GitHub Releases reliable (in-job creation + self-discovering backfill). This PR adds the channel taxonomy and gates PyPI accordingly.

## Release channels (see `CONTEXT.md § Release Channels`)

| Channel | Bump | Trigger (merge commit) | Lands |
|---|---|---|---|
| **Production** | major | `feat!:` / `fix!:` / `BREAKING CHANGE` | GitHub Release (**latest**) + **PyPI** |
| **Beta** | minor | `feat:` | GitHub **pre-release** |
| **Canary** | patch | anything else | GitHub **pre-release** |

`pip install gaia-cli` resolves to the latest **Production** (major) release. Beta/canary stay installable from their git tag/source but never reach PyPI by default.

## Changes

- **`sync-artifacts.yml`** — classify bump → channel and export to `GITHUB_ENV`; label the GitHub Release by channel (only Production is `--latest`, others `--prerelease`); gate the PyPI dispatch behind `env.GAIA_CHANNEL == 'production'`.
- **`publish-pypi.yml`** — document the **manual-publish** path (`workflow_dispatch` from any branch *or tag*); keep `skip-existing: true` for idempotency.
- **`CONTEXT.md`** — add the Release Channels contract + naming rules (Production / Beta / Canary; no synonyms).

## Why PyPI was stuck

`publish-pypi.yml` keyed off `on: push tags: v*`, which never fires for automation-pushed tags — the same limitation that broke Releases. PyPI was frozen at `3.25.2` while tags reached `v3.28.0`. It's now dispatched via `workflow_dispatch` from the running sync job (reliable cross-workflow trigger), but only on major bumps.

## Notes / follow-ups for the maintainer

- **PyPI cleanup (clean slate, majors only):** PyPI has no delete API — remove versions manually at *Manage project → Releases → (version) → Options → Delete*. ⚠️ A deleted version number is **permanently burned** (can never be re-uploaded), which is fine going forward.
- **`pypi` environment:** if it has required reviewers, each production publish pauses for approval (a nice safety gate).
- Channel detection reads the **merge commit message**, so only a breaking-change commit cuts a Production/PyPI release.

https://claude.ai/code/session_01CjpviX4E8iZYwRXLiWV2FM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CjpviX4E8iZYwRXLiWV2FM)_