### PR TITLE
fix(cli): correct promotion card label, command, and rename hint (#118)

### DIFF
--- a/src/gaia_cli/cardRenderer.py
+++ b/src/gaia_cli/cardRenderer.py
@@ -697,7 +697,7 @@ def render_promotion_prompt(skill_data: dict, proposed_level: str, canon: bool =
         f"  {gc}┌─ Promotion Available ─────────────────────────────────┐{r}",
         f"  {gc}│{r}  {display_colored} can rank up to {b}Level {proposed_level}{r} ({level_name})",
         f"  {gc}│{r}  Run: {b}gaia promote {skill_id}{r}",
-        f"  {gc}│{r}  Rename? {b}gaia promote {skill_id} --name \"{display}\"{r}",
+        f"  {gc}│{r}  Rename? {b}gaia promote {skill_id} --name \"{display.lstrip('/')}\"{r}",
         f"  {gc}└───────────────────────────────────────────────────────┘{r}",
         "",
     ])

--- a/src/gaia_cli/cardRenderer.py
+++ b/src/gaia_cli/cardRenderer.py
@@ -694,10 +694,11 @@ def render_promotion_prompt(skill_data: dict, proposed_level: str, canon: bool =
         display_colored = f"{tc}{b}{display}{r}"
     
     lines.extend([
-        f"  {gc}┌─ Fusion ──────────────────────────────┐{r}",
+        f"  {gc}┌─ Promotion Available ─────────────────────────────────┐{r}",
         f"  {gc}│{r}  {display_colored} can rank up to {b}Level {proposed_level}{r} ({level_name})",
-        f"  {gc}│{r}  Run: {b}gaia fuse {skill_id}{r}",
-        f"  {gc}└───────────────────────────────────────────┘{r}",
+        f"  {gc}│{r}  Run: {b}gaia promote {skill_id}{r}",
+        f"  {gc}│{r}  Rename? {b}gaia promote {skill_id} --name \"{display}\"{r}",
+        f"  {gc}└───────────────────────────────────────────────────────┘{r}",
         "",
     ])
     return "\n".join(lines)

--- a/tests/test_card_renderer.py
+++ b/tests/test_card_renderer.py
@@ -363,12 +363,12 @@ class TestRenderPromotionPrompt:
             "4★",
         )
         assert "/plan-and-execute" in prompt
-        assert "gaia fuse plan-and-execute" in prompt
+        assert "gaia promote plan-and-execute" in prompt
 
     def test_shows_level_and_rank_name(self):
         prompt = render_promotion_prompt({"id": "research-agent", "type": "extra", "prerequisites": ["x"]}, "3★")
         assert "3★" in prompt
-        assert "gaia fuse research-agent" in prompt
+        assert "gaia promote research-agent" in prompt
 
     def test_shows_fusion_diagram_when_prereqs_exist(self):
         prompt = render_promotion_prompt(


### PR DESCRIPTION
- Header changed from "Fusion" to "Promotion Available"
- Command changed from `gaia fuse` to `gaia promote`
- Add rename hint line using slash-skill form (e.g. /research) instead of Title case
- Fix asymmetric box borders: both top and bottom now 57 chars wide

https://claude.ai/code/session_01JpXP8huB45fyVeSjvTJpb7