### PR TITLE
refactor(mcp): unify advisor interfaces

### DIFF
--- a/packages/mcp/package-lock.json
+++ b/packages/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gaia-registry/mcp-server",
-  "version": "3.26.3",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gaia-registry/mcp-server",
-      "version": "3.26.3",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/packages/mcp/src/advisor/detector.ts
+++ b/packages/mcp/src/advisor/detector.ts
@@ -1,3 +1,5 @@
+import { AbstractAdvisor, type AdvisorContext } from "./types.js";
+
 const TOOL_SKILL_MAP: Record<string, string[]> = {
   web_search: ["web-search"],
   brave_search: ["web-search"],
@@ -51,6 +53,13 @@ const TOOL_SKILL_MAP: Record<string, string[]> = {
   reference: ["cite-sources"],
 };
 
+export interface SkillDetectionResult {
+  fromTools: string[];
+  fromSignals: string[];
+  allDetected: string[];
+  context: AdvisorContext;
+}
+
 const PATTERN_MAP: Array<[RegExp, string[]]> = [
   [/embed/i, ["embed-text"]],
   [/chunk/i, ["chunk-document"]],
@@ -67,7 +76,7 @@ const PATTERN_MAP: Array<[RegExp, string[]]> = [
   [/format/i, ["format-output"]],
 ];
 
-export function detectSkillsFromTools(toolNames: string[]): string[] {
+function detectSkillsFromToolNames(toolNames: string[]): string[] {
   const detected = new Set<string>();
 
   for (const tool of toolNames) {
@@ -89,7 +98,7 @@ export function detectSkillsFromTools(toolNames: string[]): string[] {
   return [...detected];
 }
 
-export function detectSkillsFromSignals(signals: string[]): string[] {
+function detectSkillsFromSignalText(signals: string[]): string[] {
   const detected = new Set<string>();
   const joined = signals.join(" ").toLowerCase();
 
@@ -100,4 +109,40 @@ export function detectSkillsFromSignals(signals: string[]): string[] {
   }
 
   return [...detected];
+}
+
+export class SkillDetector extends AbstractAdvisor<SkillDetectionResult> {
+  constructor() {
+    super("skill-detector");
+  }
+
+  analyze(context: AdvisorContext): SkillDetectionResult {
+    const fromTools = detectSkillsFromToolNames(context.connectedTools ?? []);
+    const fromSignals = detectSkillsFromSignalText(context.projectSignals ?? []);
+    const allDetected = this.dedupe([
+      ...this.detectedSkillIds(context),
+      ...fromTools,
+      ...fromSignals,
+    ]);
+
+    return {
+      fromTools,
+      fromSignals,
+      allDetected,
+      context: {
+        ...context,
+        detectedSkillIds: allDetected,
+      },
+    };
+  }
+}
+
+export const skillDetector = new SkillDetector();
+
+export function detectSkillsFromTools(toolNames: string[]): string[] {
+  return skillDetector.analyze({ connectedTools: toolNames }).fromTools;
+}
+
+export function detectSkillsFromSignals(signals: string[]): string[] {
+  return skillDetector.analyze({ projectSignals: signals }).fromSignals;
 }

--- a/packages/mcp/src/advisor/fusionEngine.ts
+++ b/packages/mcp/src/advisor/fusionEngine.ts
@@ -1,7 +1,8 @@
 import type { GaiaGraph, FusionCandidate } from "../graph/types.js";
 import { effectiveLevel } from "../graph/levels.js";
+import { AbstractAdvisor, type AdvisorContext } from "./types.js";
 
-export function detectCombinations(
+function findFusionCandidates(
   graph: GaiaGraph,
   ownedSkillIds: string[],
   detectedSkillIds: string[]
@@ -47,4 +48,28 @@ export function detectCombinations(
     const bIdx = rarityOrder.indexOf(bSkill?.rarity ?? "common");
     return aIdx - bIdx;
   });
+}
+
+export class FusionEngine extends AbstractAdvisor<FusionCandidate[]> {
+  constructor() {
+    super("fusion-engine");
+  }
+
+  analyze(context: AdvisorContext): FusionCandidate[] {
+    return findFusionCandidates(
+      this.requireGraph(context),
+      this.ownedSkillIds(context),
+      this.detectedSkillIds(context)
+    );
+  }
+}
+
+export const fusionEngine = new FusionEngine();
+
+export function detectCombinations(
+  graph: GaiaGraph,
+  ownedSkillIds: string[],
+  detectedSkillIds: string[]
+): FusionCandidate[] {
+  return fusionEngine.analyze({ graph, ownedSkillIds, detectedSkillIds });
 }

--- a/packages/mcp/src/advisor/noveltyScorer.ts
+++ b/packages/mcp/src/advisor/noveltyScorer.ts
@@ -1,4 +1,5 @@
 import type { GaiaGraph } from "../graph/types.js";
+import { AbstractAdvisor, type AdvisorContext } from "./types.js";
 
 function tokenize(text: string): Set<string> {
   return new Set(
@@ -25,10 +26,7 @@ export interface NoveltyResult {
   confidence: number;
 }
 
-export function scoreNovelty(
-  description: string,
-  graph: GaiaGraph
-): NoveltyResult {
+function scoreNoveltyDescription(description: string, graph: GaiaGraph): NoveltyResult {
   const queryTokens = tokenize(description);
   let bestMatch: { id: string; name: string; similarity: number } | null = null;
   let bestScore = 0;
@@ -47,4 +45,24 @@ export function scoreNovelty(
     closestMatch: bestMatch,
     confidence: bestScore < 0.1 ? 0.9 : bestScore < 0.2 ? 0.7 : bestScore < 0.3 ? 0.5 : 0.2,
   };
+}
+
+export class NoveltyScorer extends AbstractAdvisor<NoveltyResult> {
+  constructor() {
+    super("novelty-scorer");
+  }
+
+  analyze(context: AdvisorContext): NoveltyResult {
+    const description = context.proposedDescription ?? context.projectSignals?.join(" ") ?? "";
+    return scoreNoveltyDescription(description, this.requireGraph(context));
+  }
+}
+
+export const noveltyScorer = new NoveltyScorer();
+
+export function scoreNovelty(
+  description: string,
+  graph: GaiaGraph
+): NoveltyResult {
+  return noveltyScorer.analyze({ graph, proposedDescription: description });
 }

--- a/packages/mcp/src/advisor/types.ts
+++ b/packages/mcp/src/advisor/types.ts
@@ -1,0 +1,41 @@
+import type { GaiaGraph, UserSkillTree } from "../graph/types.js";
+
+export interface AdvisorContext {
+  graph?: GaiaGraph;
+  userTree?: UserSkillTree | null;
+  ownedSkillIds?: string[];
+  connectedTools?: string[];
+  projectSignals?: string[];
+  detectedSkillIds?: string[];
+  proposedDescription?: string;
+}
+
+export abstract class AbstractAdvisor<TResult> {
+  constructor(public readonly id: string) {}
+
+  abstract analyze(context: AdvisorContext): TResult;
+
+  protected requireGraph(context: AdvisorContext): GaiaGraph {
+    if (!context.graph) {
+      throw new Error(`${this.id} requires AdvisorContext.graph`);
+    }
+    return context.graph;
+  }
+
+  protected ownedSkillIds(context: AdvisorContext): string[] {
+    return this.dedupe(
+      context.ownedSkillIds ??
+        context.userTree?.unlockedSkills.map((skill) => skill.skillId) ??
+        []
+    );
+  }
+
+  protected detectedSkillIds(context: AdvisorContext): string[] {
+    return this.dedupe(context.detectedSkillIds ?? []);
+  }
+
+  protected dedupe(items: string[]): string[] {
+    return [...new Set(items.filter((item) => item.length > 0))];
+  }
+}
+

--- a/packages/mcp/src/tools/propose.ts
+++ b/packages/mcp/src/tools/propose.ts
@@ -1,7 +1,7 @@
 import { loadGraph, loadUserTree } from "../graph/loader.js";
 import { resolveIdentity } from "../config/identity.js";
 import { createPullRequest } from "../utils/github.js";
-import { scoreNovelty } from "../advisor/noveltyScorer.js";
+import { noveltyScorer } from "../advisor/noveltyScorer.js";
 import type { UserSkillTree, Skill, GaiaGraph } from "../graph/types.js";
 
 interface ProposeInput {
@@ -99,7 +99,10 @@ async function proposeNovel(
   token: string,
   graph: GaiaGraph
 ): Promise<string> {
-  const novelty = scoreNovelty(input.description!, graph);
+  const novelty = noveltyScorer.analyze({
+    graph,
+    proposedDescription: input.description!,
+  });
 
   if (!novelty.isNovel && novelty.closestMatch) {
     return `This skill closely matches existing skill **${novelty.closestMatch.name}** (${Math.round(novelty.closestMatch.similarity * 100)}% similar). Did you mean to fuse "${novelty.closestMatch.id}" instead? If this is genuinely different, rephrase the description to be more specific.`;

--- a/packages/mcp/src/tools/scanContext.ts
+++ b/packages/mcp/src/tools/scanContext.ts
@@ -1,9 +1,10 @@
 import { loadGraph, loadUserTree } from "../graph/loader.js";
 import { resolveIdentity } from "../config/identity.js";
-import { detectCombinations } from "../advisor/fusionEngine.js";
-import { detectSkillsFromTools, detectSkillsFromSignals } from "../advisor/detector.js";
-import { scoreNovelty } from "../advisor/noveltyScorer.js";
+import { fusionEngine } from "../advisor/fusionEngine.js";
+import { skillDetector } from "../advisor/detector.js";
+import { noveltyScorer } from "../advisor/noveltyScorer.js";
 import { runGaia } from "../utils/gaia.js";
+import type { AdvisorContext } from "../advisor/types.js";
 import type { UserSkillTree, GaiaGraph } from "../graph/types.js";
 
 export async function scanContext(
@@ -14,9 +15,25 @@ export async function scanContext(
   const graph = await loadGraph();
   const user = resolveIdentity();
 
-  const detectedFromTools = connectedTools ? detectSkillsFromTools(connectedTools) : [];
-  const detectedFromSignals = projectSignals ? detectSkillsFromSignals(projectSignals) : [];
-  let allDetected = [...new Set([...detectedFromTools, ...detectedFromSignals])];
+  let ownedSkillIds: string[] = [];
+  let tree: UserSkillTree | null = null;
+  if (user) {
+    const rawTree = await loadUserTree(user);
+    if (rawTree) {
+      tree = rawTree as unknown as UserSkillTree;
+      ownedSkillIds = tree.unlockedSkills.map((s) => s.skillId);
+    }
+  }
+
+  let advisorContext: AdvisorContext = {
+    graph,
+    userTree: tree,
+    ownedSkillIds,
+    connectedTools: connectedTools ?? [],
+    projectSignals: projectSignals ?? [],
+  };
+  const detection = skillDetector.analyze(advisorContext);
+  let allDetected = detection.allDetected;
 
   if (deepScan) {
     try {
@@ -33,17 +50,12 @@ export async function scanContext(
   }
 
   allDetected = [...new Set(allDetected)];
+  advisorContext = {
+    ...detection.context,
+    detectedSkillIds: allDetected,
+  };
 
-  let ownedSkillIds: string[] = [];
-  if (user) {
-    const rawTree = await loadUserTree(user);
-    if (rawTree) {
-      const tree = rawTree as unknown as UserSkillTree;
-      ownedSkillIds = tree.unlockedSkills.map((s) => s.skillId);
-    }
-  }
-
-  const candidates = detectCombinations(graph, ownedSkillIds, allDetected);
+  const candidates = fusionEngine.analyze(advisorContext);
   const lines: string[] = [];
 
   lines.push(`## Skill Scan Results\n`);
@@ -74,7 +86,10 @@ export async function scanContext(
 
   if (projectSignals && projectSignals.length > 0) {
     const combined = projectSignals.join(" ");
-    const novelty = scoreNovelty(combined, graph);
+    const novelty = noveltyScorer.analyze({
+      ...advisorContext,
+      proposedDescription: combined,
+    });
     if (novelty.isNovel) {
       lines.push("### Novel Capability Detected\n");
       lines.push(`This project appears to implement a capability not yet in the Gaia registry.`);

--- a/packages/mcp/src/tools/suggest.ts
+++ b/packages/mcp/src/tools/suggest.ts
@@ -1,7 +1,8 @@
 import { loadGraph, loadUserTree } from "../graph/loader.js";
 import { resolveIdentity } from "../config/identity.js";
-import { detectCombinations } from "../advisor/fusionEngine.js";
-import { detectSkillsFromTools, detectSkillsFromSignals } from "../advisor/detector.js";
+import { fusionEngine } from "../advisor/fusionEngine.js";
+import { skillDetector } from "../advisor/detector.js";
+import type { AdvisorContext } from "../advisor/types.js";
 import type { UserSkillTree, FusionCandidate, GaiaGraph } from "../graph/types.js";
 
 function formatCandidate(c: FusionCandidate, graph: GaiaGraph): string {
@@ -23,23 +24,30 @@ export async function suggest(
   const user = resolveIdentity();
 
   let ownedSkillIds: string[] = [];
+  let tree: UserSkillTree | null = null;
   if (user) {
     const rawTree = await loadUserTree(user);
     if (rawTree) {
-      const tree = rawTree as unknown as UserSkillTree;
+      tree = rawTree as unknown as UserSkillTree;
       ownedSkillIds = tree.unlockedSkills.map((s) => s.skillId);
     }
   }
 
-  const detectedFromTools = tools ? detectSkillsFromTools(tools) : [];
-  const detectedFromSignals = context ? detectSkillsFromSignals(context) : [];
-  const allDetected = [...new Set([...detectedFromTools, ...detectedFromSignals])];
+  const advisorContext: AdvisorContext = {
+    graph,
+    userTree: tree,
+    ownedSkillIds,
+    connectedTools: tools ?? [],
+    projectSignals: context ?? [],
+  };
+  const detection = skillDetector.analyze(advisorContext);
+  const allDetected = detection.allDetected;
 
   if (allDetected.length === 0 && ownedSkillIds.length === 0) {
     return "No skills detected yet. Connect more MCP tools or use gaia_scan_context with project signals to detect your skills.";
   }
 
-  const candidates = detectCombinations(graph, ownedSkillIds, allDetected);
+  const candidates = fusionEngine.analyze(detection.context);
 
   const lines: string[] = [];
 

--- a/packages/mcp/tests/detector.test.ts
+++ b/packages/mcp/tests/detector.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { detectSkillsFromTools, detectSkillsFromSignals } from "../src/advisor/detector.js";
+import { detectSkillsFromTools, detectSkillsFromSignals, skillDetector } from "../src/advisor/detector.js";
 
 describe("detector", () => {
   describe("detectSkillsFromTools", () => {
@@ -43,6 +43,21 @@ describe("detector", () => {
     it("returns empty for unrelated signals", () => {
       const result = detectSkillsFromSignals(["configuring database connection pooling"]);
       expect(result).toHaveLength(0);
+    });
+  });
+
+  describe("SkillDetector", () => {
+    it("returns a shared context with combined detected skills", () => {
+      const result = skillDetector.analyze({
+        connectedTools: ["web_search"],
+        projectSignals: ["using cheerio to parse HTML"],
+        detectedSkillIds: ["summarize"],
+      });
+
+      expect(result.fromTools).toEqual(["web-search"]);
+      expect(result.fromSignals).toEqual(["parse-html"]);
+      expect(result.allDetected).toEqual(["summarize", "web-search", "parse-html"]);
+      expect(result.context.detectedSkillIds).toEqual(result.allDetected);
     });
   });
 });

--- a/packages/mcp/tests/fusionEngine.test.ts
+++ b/packages/mcp/tests/fusionEngine.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { detectCombinations } from "../src/advisor/fusionEngine.js";
+import { detectCombinations, fusionEngine } from "../src/advisor/fusionEngine.js";
 import type { GaiaGraph } from "../src/graph/types.js";
 
 const mockGraph: GaiaGraph = {
@@ -71,5 +71,15 @@ describe("fusionEngine", () => {
     const result = detectCombinations(mockGraph, [], ["summarize"]);
     const ready = result.filter((c) => c.status === "ready");
     expect(ready).toHaveLength(0);
+  });
+
+  it("reads graph, owned skills, and detected skills from AdvisorContext", () => {
+    const result = fusionEngine.analyze({
+      graph: mockGraph,
+      ownedSkillIds: ["web-search", "summarize"],
+      detectedSkillIds: ["cite-sources"],
+    });
+
+    expect(result.some((c) => c.candidateResult === "research" && c.status === "ready")).toBe(true);
   });
 });

--- a/packages/mcp/tests/noveltyScorer.test.ts
+++ b/packages/mcp/tests/noveltyScorer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { scoreNovelty } from "../src/advisor/noveltyScorer.js";
+import { scoreNovelty, noveltyScorer } from "../src/advisor/noveltyScorer.js";
 import type { GaiaGraph } from "../src/graph/types.js";
 
 const mockGraph: GaiaGraph = {
@@ -30,5 +30,14 @@ describe("noveltyScorer", () => {
     const result = scoreNovelty("summarizes text content into brief overviews", mockGraph);
     expect(result.closestMatch).not.toBeNull();
     expect(result.closestMatch!.similarity).toBeGreaterThan(0);
+  });
+
+  it("scores novelty from AdvisorContext project signals", () => {
+    const result = noveltyScorer.analyze({
+      graph: mockGraph,
+      projectSignals: ["summarizes text content into brief overviews"],
+    });
+
+    expect(result.closestMatch?.id).toBe("summarize");
   });
 });


### PR DESCRIPTION
Closes #335 in the sense of implementing the requested refactor.

Summary:
- Add a shared  and  base in 
- Convert detector, fusion, and novelty logic to class-backed advisors with compatibility wrappers
- Update , , and  to pass a shared context through the pipeline
- Add tests for the new advisor API while preserving the legacy function-level contracts

Verification:
- 
> @gaia-registry/mcp-server@4.0.0 build
> tsc
- 
> @gaia-registry/mcp-server@4.0.0 test
> vitest run


 RUN  v4.1.5 /private/tmp/gaia-fix-212/packages/mcp


 Test Files  10 passed (10)
      Tests  96 passed (96)
   Start at  04:30:02
   Duration  1.79s (transform 884ms, setup 0ms, import 1.39s, tests 1.21s, environment 2ms)