### PR TITLE
design: move mobile notification below hamburger menu

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -819,13 +819,13 @@ button.nav-copy-agent {
     display: none !important
   }
 
-  /* Push meta notification down so it doesn't cover the hamburger menu */
+  /* Lower further and make bigger for mobile clickability */
   .hero-audit-btn {
-    top: 3.5rem;
-    right: 0;
-    border-radius: 0;
-    padding: 0.4rem 0.75rem;
-    font-size: 0.7rem;
+    top: 5.5rem;
+    right: 1rem;
+    padding: 0.8rem 1.2rem;
+    font-size: 0.85rem;
+    z-index: 101;
   }
 }
 

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -819,9 +819,9 @@ button.nav-copy-agent {
     display: none !important
   }
 
-  /* Push meta notification to the very top so it doesn't overlap Field View */
+  /* Push meta notification down so it doesn't cover the hamburger menu */
   .hero-audit-btn {
-    top: 0;
+    top: 3.5rem;
     right: 0;
     border-radius: 0;
     padding: 0.4rem 0.75rem;

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -819,9 +819,9 @@ button.nav-copy-agent {
     display: none !important
   }
 
-  /* Lower further and make bigger for mobile clickability */
+  /* Lifted slightly to clear the field view toggle below it */
   .hero-audit-btn {
-    top: 5.5rem;
+    top: 4.8rem;
     right: 1rem;
     padding: 0.8rem 1.2rem;
     font-size: 0.85rem;


### PR DESCRIPTION
Moves the hero audit notification button down in mobile view to prevent it from covering the navigation hamburger menu.