### PR TITLE
docs(home): update Path B subtitle to clarify claim/implement flow

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -248,7 +248,7 @@
       <div class="path-b" id="ultimates">
         <div class="path-plate-num">Path B — Unclaimed Ultimates</div>
         <h2>Claim an Ultimate</h2>
-        <p class="path-intro mt-sm">The highest-tier skills in the registry. Claim one, build a real implementation, and your handle goes on the registry permanently — then drop your badge in your README.</p>
+        <p class="path-intro mt-sm">The highest-tier skills in the registry. If you own an ultimate, claim your badge for your README — or implement a new one to get on the list.</p>
         <div class="ultimates-list" id="ultimatesList" aria-live="polite">
           <div class="ult-loading">Loading ultimates…</div>
         </div>


### PR DESCRIPTION
Updates the Path B (Unclaimed Ultimates) subtitle on the home page to state that ultimate owners can claim their badge and new implementations can get on the list.