### PR TITLE
fix(cli): address non-dev command UX audit findings

### DIFF
--- a/.agents/skills/fp-iterate/scripts/ci-poll.sh
+++ b/.agents/skills/fp-iterate/scripts/ci-poll.sh
@@ -33,17 +33,17 @@ while [[ $round -lt $MAX ]]; do
   round=$((round + 1))
   echo -n "  [${round}/${MAX}] checking... "
 
-  result=$(gh pr checks "$PR" --json name,state,conclusion 2>/dev/null) || {
+  result=$(gh pr checks "$PR" --json name,state 2>/dev/null) || {
     echo "gh pr checks failed, retrying." >&2
     sleep "$INTERVAL"; continue
   }
 
   pending=$(echo "$result" | jq '[.[] | select(.state == "PENDING" or .state == "IN_PROGRESS")] | length')
-  failed=$(echo  "$result" | jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR" or .conclusion == "TIMED_OUT")] | length')
+  failed=$(echo  "$result" | jq '[.[] | select(.state == "FAILURE" or .state == "FAILING" or .state == "ERROR" or .state == "TIMED_OUT")] | length')
 
   if [[ "$failed" -gt 0 ]]; then
     echo "❌ $failed failed"
-    echo "$result" | jq -r '.[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR" or .conclusion == "TIMED_OUT") | "    FAIL: \(.name)"'
+    echo "$result" | jq -r '.[] | select(.state == "FAILURE" or .state == "FAILING" or .state == "ERROR" or .state == "TIMED_OUT") | "    FAIL: \(.name)"'
     exit 2
   fi
 

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -417,7 +417,7 @@ def build_named_index(check: bool) -> bool:
             if check:
                 print(f"diff registry/named-skills.json (regen failed: rc={rc})")
                 print(output)
-            return True
+            raise RuntimeError(f"named-skills.json regen failed: rc={rc}")
         if not committed.exists():
             if check:
                 print("diff registry/named-skills.json (missing committed file)")
@@ -460,7 +460,7 @@ def build_profile_pages(check: bool) -> bool:
             if check:
                 print(f"diff docs/u/ (regen failed: rc={rc})")
                 print(output)
-            return True
+            raise RuntimeError(f"docs/u/ regen failed: rc={rc}")
         if not committed.exists():
             if check:
                 print("diff docs/u/ (missing)")
@@ -494,7 +494,7 @@ def build_badges(check: bool) -> bool:
             if check:
                 print(f"diff docs/badges/ (regen failed: rc={rc})")
                 print(output)
-            return True
+            raise RuntimeError(f"docs/badges/ regen failed: rc={rc}")
         # Preserve hand-authored docs/badges/index.html across regeneration
         # by copying it into the candidate tree before diffing.
         sampler = committed / "index.html"
@@ -533,7 +533,7 @@ def build_og_cards(check: bool) -> bool:
             if check:
                 print(f"diff docs/og/ (regen failed: rc={rc})")
                 print(output)
-            return True
+            raise RuntimeError(f"docs/og/ regen failed: rc={rc}")
         if not committed.exists():
             if check:
                 print("diff docs/og/ (missing)")
@@ -592,7 +592,7 @@ def build_tree_md(check: bool) -> bool:
         if check:
             print(f"diff docs/tree.md (regen failed: rc={rc})")
             print(output)
-        return True
+        raise RuntimeError(f"docs/tree.md regen failed: rc={rc}")
 
     generated = ROOT / "generated-output" / "tree.md"
     committed = ROOT / "docs" / "tree.md"
@@ -638,7 +638,7 @@ def build_assembly(check: bool) -> bool:
         if check:
             print(f"diff registry/gaia.json (assembly failed: rc={rc})")
             print(output)
-        return True
+        raise RuntimeError(f"assembly failed: rc={rc}")
     return False
 
 def build_gexf(check: bool) -> bool:
@@ -647,7 +647,9 @@ def build_gexf(check: bool) -> bool:
     if not script.exists():
         return False
     rc, output = _run_script(script, [])
-    return rc != 0
+    if rc != 0:
+        raise RuntimeError(f"exportGexf.py failed: rc={rc}")
+    return False
 
 def build_svg(check: bool) -> bool:
     """Run renderGraphSvg.py."""
@@ -655,7 +657,9 @@ def build_svg(check: bool) -> bool:
     if not script.exists():
         return False
     rc, output = _run_script(script, ["--format", "svg"])
-    return rc != 0
+    if rc != 0:
+        raise RuntimeError(f"renderGraphSvg.py failed: rc={rc}")
+    return False
 
 def build_docs_graph_assets(check: bool) -> bool:
     """Run syncDocsGraphAssets.py."""
@@ -663,43 +667,61 @@ def build_docs_graph_assets(check: bool) -> bool:
     if not script.exists():
         return False
     rc, output = _run_script(script, [])
-    return rc != 0
+    if rc != 0:
+        raise RuntimeError(f"syncDocsGraphAssets.py failed: rc={rc}")
+    return False
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Build generated Gaia docs regions.")
     parser.add_argument("--check", action="store_true", help="Fail if generated docs are stale")
     args = parser.parse_args(argv)
 
+    # Track steps that may have failed (subscript errors return True = "stale"
+    # but swallow the root cause). We surface warnings so they aren't silent.
+    warnings: list[str] = []
+
+    def _run_step(name: str, func, check: bool) -> bool:
+        try:
+            return func(check)
+        except Exception as exc:
+            warnings.append(f"{name}: {exc}")
+            return False
+
     # Stage 0 — Core Graph Assembly
-    assembly_changed = build_assembly(args.check)
+    assembly_changed = _run_step("assembly", build_assembly, args.check)
 
     # Stage 4 — full asset pipeline. Each step regenerates into a tempdir and
     # diffs against the committed copy. CSS tokens are already covered above;
     # syncDocsGraphAssets fans out gaia.json / tree.md / named-index — the
     # named-index drift specifically is the one most likely to land out of sync.
-    named_index_changed = build_named_index(args.check)
-    docs_named_changed = build_docs_named_index(args.check)
-    profiles_changed = build_profile_pages(args.check)
-    badges_changed = build_badges(args.check)
-    og_changed = build_og_cards(args.check)
-    tree_changed = build_tree_md(args.check)
-    ruflo_curation_changed = build_ruflo_curation(args.check)
+    named_index_changed = _run_step("named-index", build_named_index, args.check)
+    docs_named_changed = _run_step("docs-named-index", build_docs_named_index, args.check)
+    profiles_changed = _run_step("profiles", build_profile_pages, args.check)
+    badges_changed = _run_step("badges", build_badges, args.check)
+    og_changed = _run_step("og-cards", build_og_cards, args.check)
+    tree_changed = _run_step("tree-md", build_tree_md, args.check)
+    ruflo_curation_changed = _run_step("ruflo-curation", build_ruflo_curation, args.check)
     
     # Extra artifacts
-    gexf_changed = build_gexf(args.check)
-    svg_changed = build_svg(args.check)
-    sync_assets_changed = build_docs_graph_assets(args.check)
+    gexf_changed = _run_step("gexf", build_gexf, args.check)
+    svg_changed = _run_step("svg", build_svg, args.check)
+    sync_assets_changed = _run_step("docs-graph-assets", build_docs_graph_assets, args.check)
 
     # Local sections (README + index.html stats + tokens.css).
     # README depends on tree.md (build_tree_md)
-    readme_changed = build_readme(args.check)
-    docs_index_changed = build_docs_index(args.check)
-    html_cache_busted = build_html_cache_busting(args.check)
-    css_tokens_changed = build_css_tokens(args.check)
+    readme_changed = _run_step("readme", build_readme, args.check)
+    docs_index_changed = _run_step("docs-index", build_docs_index, args.check)
+    html_cache_busted = _run_step("html-cache-busting", build_html_cache_busting, args.check)
+    css_tokens_changed = _run_step("css-tokens", build_css_tokens, args.check)
 
     # Wiki sync — updates ../gaia-wiki pages from README marker regions.
     # Advisory only: drift is reported but never blocks the build.
     build_wiki_sync(args.check)
+
+    if warnings:
+        print(f"\nWarning: {len(warnings)} build step(s) encountered errors:", file=sys.stderr)
+        for w in warnings:
+            print(f"  • {w}", file=sys.stderr)
 
     changed = (
         assembly_changed
@@ -718,13 +740,22 @@ def main(argv: list[str] | None = None) -> int:
         or svg_changed
         or sync_assets_changed
     )
-    if args.check and changed:
-        print("Generated documentation is stale. Run `gaia docs build --check` locally.")
-        print("If it reports drift, run `gaia docs build` and commit the updated files.")
-        print("Validation checks can be run with `gaia validate`.")
-        return 1
-    print("Documentation is up to date." if not changed else "Documentation regenerated.")
-    return 0
+    if args.check:
+        if changed or warnings:
+            if warnings:
+                print("\nError: Documentation build encountered errors in --check mode.", file=sys.stderr)
+            print("Generated documentation is stale. Run `gaia docs build --check` locally.")
+            print("If it reports drift, run `gaia docs build` and commit the updated files.")
+            print("Validation checks can be run with `gaia validate`.")
+            return 1
+        print("Documentation is up to date.")
+        return 0
+    else:
+        if warnings:
+            print("\nDocumentation build completed with warnings/errors.", file=sys.stderr)
+            return 0
+        print("Documentation is up to date." if not changed else "Documentation regenerated.")
+        return 0
 
 
 if __name__ == "__main__":

--- a/src/gaia_cli/cardRenderer.py
+++ b/src/gaia_cli/cardRenderer.py
@@ -561,6 +561,20 @@ def render_appraise_card(
         deriv_line = prefix + ", ".join(deriv_items)
         if len(derivatives) > 4:
             deriv_line += f" +{len(derivatives) - 4} more"
+        # Truncate at comma boundary instead of mid-word
+        if len(deriv_line) > inner:
+            truncated = prefix
+            for i, item in enumerate(deriv_items):
+                candidate = truncated + (", " if i > 0 else "") + item
+                if len(candidate) > inner - 2:  # leave room for " …"
+                    remaining = len(deriv_items) - i + (len(derivatives) - 4 if len(derivatives) > 4 else 0)
+                    truncated += f" +{remaining} more" if remaining > 0 else ""
+                    break
+                truncated = candidate
+            else:
+                if len(derivatives) > 4:
+                    truncated += f" +{len(derivatives) - 4} more"
+            deriv_line = truncated
         lines.append(f"{bc}{V}{r} {fg(*COLOR_MUTED)}{_pad(deriv_line, inner)}{r} {bc}{V}{r}")
     else:
         lines.append(f"{bc}{V}{r} {fg(*COLOR_MUTED)}{_pad('Unlocks: (terminal skill)', inner)}{r} {bc}{V}{r}")

--- a/src/gaia_cli/commands/stats.py
+++ b/src/gaia_cli/commands/stats.py
@@ -133,7 +133,9 @@ def collect_stats(registry_path: str | Path) -> dict:
         ]
 
     type_counts = Counter(skill.get("type", "unknown") for skill in skills)
-    level_counts = Counter(skill.get("level", "?") for skill in skills)
+    level_counts = Counter(
+        skill["level"] for skill in skills if "level" in skill
+    )
     effective_level_counts = Counter()
     demerit_counts: Counter[str] = Counter()
     skills_with_demerits = 0

--- a/src/gaia_cli/graph.py
+++ b/src/gaia_cli/graph.py
@@ -1205,7 +1205,7 @@ def graph_command(args: Any) -> None:
         pass  # Degrade gracefully to canon mode
 
     out_path = write_graph_artifact(registry_path, output=output, fmt=fmt, user_ctx=user_ctx)
-    print(f"  saved {os.path.basename(out_path)}")
+    print(f"  saved {out_path}")
 
     # Regenerate the GEXF from current node data
     if fmt == "html":

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -294,8 +294,8 @@ def init_command(args):
     config_dir = '.gaia'
     os.makedirs(config_dir, exist_ok=True)
     config_path = os.path.join(config_dir, 'config.toml')
-    if os.path.exists(config_path):
-        print("Gaia is already initialized in this repository.")
+    if os.path.exists(config_path) and not getattr(args, "force", False):
+        print("Gaia is already initialized in this repository. Use --force to overwrite.")
         return
 
     username = args.user or _detect_github_username()
@@ -1654,6 +1654,7 @@ def get_parser():
     init_parser.add_argument('--registry-ref', help='Gaia registry URL to write into .gaia/config.toml')
     init_parser.add_argument('--scan', action='append', help='Path to scan; repeat for multiple paths')
     init_parser.add_argument('--yes', action='store_true', help='Use non-interactive defaults')
+    init_parser.add_argument('--force', action='store_true', help='Overwrite existing .gaia/config.toml')
     init_parser.add_argument(
         '--auto-prompt-combinations',
         action='store_true',

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -537,7 +537,7 @@ def render_user_tree_outputs(username: str, tree: dict | None, graph_data: dict 
     with open(html_path, "w", encoding="utf-8") as f:
         f.write(html)
     if not quiet:
-        print(f"  saved {os.path.basename(html_path)} & {os.path.basename(md_path)}")
+        print(f"  saved {html_path} & {md_path}")
     return html_path, md_path
 
 

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -1362,7 +1362,7 @@ def skills_command(args):
 
 
     available = [
-        {"id": sid, "name": meta.get("name") or sid, "level": meta.get("level", "?"), "description": meta.get("description", "")}
+        {"id": sid, "name": meta.get("name") or sid, "level": meta.get("level", "?"), "type": meta.get("type", "basic"), "description": meta.get("description", "")}
         for sid, meta in list_available(args.registry)
     ]
     items = available + pending

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -599,7 +599,8 @@ def lookup_command(args):
         display = skill.get("name") or f"/{skill_id}"
     print(f"{display}")
     
-    print(f"Type: {skill.get('type', 'unknown')}    Level: {skill.get('level', '?')}")
+    user_level = ctx.skill_level(skill_id) if ctx else skill.get('level', '?')
+    print(f"Type: {skill.get('type', 'unknown')}    Level: {user_level}")
     if skill.get("description"):
         print(skill["description"])
 

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -1285,9 +1285,9 @@ def install_command(args):
         interactive_install(args.registry, location=location)
         return
     if not args.skill_id:
-        # Bare 'gaia install' -> update/sync all
-        update_skills(args.registry)
-        return
+        print("Usage: gaia install <skill_id>", file=sys.stderr)
+        print("  To update all installed skills, use: gaia update", file=sys.stderr)
+        sys.exit(2)
 
     # Use suite logic if flagged or implicitly requested
     if getattr(args, 'ultimate', False) or getattr(args, 'suite', False):

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -472,16 +472,20 @@ def scan_command(args):
         skill_map = {s['id']: s for s in graph_data.get('skills', [])}
         unlocked = [s.get('skillId') for s in tree.get('unlockedSkills', [])]
         combos = get_combinations(graph_data, unlocked, resolved)
-        if combos and not quiet:
-            print("\nNew fusion candidates:")
-            for c in combos:
-                result_skill = skill_map.get(c['candidateResult'], {})
-                result_type = result_skill.get('type', 'extra')
-                print(render_fusion_diagram(
-                    c['detectedSkills'], c['candidateResult'], result_type,
-                    canon=canon, ctx=ctx
-                ))
-            print("Run `gaia fuse <skill>` to confirm.")
+        if combos:
+            # Persist fusion candidates so `gaia fuse` can find them
+            tree['pendingCombinations'] = combos
+            save_tree(username, tree, registry_path=args.registry)
+            if not quiet:
+                print("\nNew fusion candidates:")
+                for c in combos:
+                    result_skill = skill_map.get(c['candidateResult'], {})
+                    result_type = result_skill.get('type', 'extra')
+                    print(render_fusion_diagram(
+                        c['detectedSkills'], c['candidateResult'], result_type,
+                        canon=canon, ctx=ctx
+                    ))
+                print("Run `gaia fuse <skill>` to confirm.")
 
         # Path engine integration
         old_paths = load_paths()

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -1300,7 +1300,7 @@ def install_command(args):
 
 def uninstall_command(args):
     from gaia_cli.install import uninstall_skill
-    success = uninstall_skill(args.skill_id)
+    success = uninstall_skill(args.skill_id.lstrip("/"))
     if not success:
         sys.exit(1)
 

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -1459,6 +1459,12 @@ def pull_command(args):
             print("Note: Registry could not be updated via git (no upstream configured). Local registry unchanged.", file=sys.stderr)
         else:
             print(f"Warning: git pull failed. Local registry unchanged.\n  {stderr}", file=sys.stderr)
+    else:
+        stdout = res.stdout.strip()
+        if "Already up to date" in stdout:
+            print("Registry is already up to date.")
+        else:
+            print("Registry updated successfully.")
 
 
 def update_command(args):

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -792,7 +792,7 @@ def promote_command(args):
             return
         if not skill_id:
             # Try interactive picker
-            candidates = promotable_candidates(username, args.registry)
+            candidates = promotable_candidates(args.registry, username)
             if candidates:
                 picked = select_promotion_candidate(candidates, "Select skill to promote:")
                 if picked:

--- a/src/gaia_cli/pathEngine.py
+++ b/src/gaia_cli/pathEngine.py
@@ -144,7 +144,12 @@ def render_unlock_path(
             total += c_total
         return owned, total
 
-    owned_count, total_count = _count(tree)
+    # Count prerequisites only (children of root — root is the target, not a prereq).
+    owned_count, total_count = 0, 0
+    for child in tree.get('children', []):
+        c_owned, c_total = _count(child)
+        owned_count += c_owned
+        total_count += c_total
 
     # Render root line manually.
     root_sid = tree['id']

--- a/src/gaia_cli/prWriter.py
+++ b/src/gaia_cli/prWriter.py
@@ -203,6 +203,11 @@ def open_intake_issue(username, batch_data, batch_path=None, repo_root="."):
 
     issue_url = issue.stdout.strip().splitlines()[-1] if issue.stdout.strip() else ""
     print(f"Success: intake issue opened ({issue_url}).")
+    # Clean up temp body file
+    try:
+        os.remove(body_path)
+    except OSError:
+        pass
     return issue_url or None
 
 

--- a/tests/test_card_renderer.py
+++ b/tests/test_card_renderer.py
@@ -18,6 +18,7 @@ from gaia_cli.cardRenderer import (
     load_and_render,
     _pad,
     _wrap_lines,
+    render_appraise_card,
 )
 
 
@@ -520,3 +521,29 @@ class TestRenderFusionDiagram:
         # First line (shorter name) should be padded
         assert "/ab" in lines[0]
         assert "/longername" in lines[2]
+
+
+def test_render_appraise_card_truncation():
+    skill_data = {
+        "id": "test-skill",
+        "name": "Test Skill",
+        "type": "basic",
+        "level": "0★",
+        "rarity": "common",
+        "description": "Short description.",
+    }
+    derivatives = [
+        {"id": "d1", "name": "First Derivative Skill Name"},
+        {"id": "d2", "name": "Second Derivative Skill Name"},
+        {"id": "d3", "name": "Third Derivative Skill Name"},
+    ]
+    output = render_appraise_card(
+        skill_data=skill_data,
+        prereq_status={},
+        derivatives=derivatives,
+        actions=[],
+    )
+    assert "First Derivative Skill Name" in output
+    assert "+2 more" in output
+    assert "Second Derivative" not in output
+

--- a/tests/test_dx.py
+++ b/tests/test_dx.py
@@ -445,3 +445,25 @@ def test_gaia_uninstall_command_removes_skill(tmp_path, monkeypatch):
     from gaia_cli.install import load_manifest
     manifest = load_manifest()
     assert not any(e["id"] == "testuser/test-skill" for e in manifest["installed"])
+
+
+def test_init_force_overwrite(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+
+    # First init
+    run_cli(monkeypatch, ["init", "--user", "firstuser", "--yes"])
+    config = parse_config(tmp_path / ".gaia" / "config.toml")
+    assert config["username"] == "firstuser"
+
+    # Second init without --force (should print message and not overwrite)
+    run_cli(monkeypatch, ["init", "--user", "seconduser", "--yes"])
+    output = capsys.readouterr().out
+    assert "Gaia is already initialized in this repository. Use --force to overwrite." in output
+    config = parse_config(tmp_path / ".gaia" / "config.toml")
+    assert config["username"] == "firstuser"  # unchanged
+
+    # Third init with --force (should overwrite)
+    run_cli(monkeypatch, ["init", "--user", "seconduser", "--yes", "--force"])
+    config = parse_config(tmp_path / ".gaia" / "config.toml")
+    assert config["username"] == "seconduser"  # overwritten
+

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -1,6 +1,7 @@
 import json
 import os
 import subprocess
+import sys
 import tempfile
 import unittest
 
@@ -15,7 +16,7 @@ def run_validate_intake(intake_dir, *extra_args):
     env["PYTHONIOENCODING"] = "utf-8"
     result = subprocess.run(
         [
-            "python3",
+            sys.executable,
             VALIDATE_INTAKE_SCRIPT,
             "--intake-dir",
             intake_dir,

--- a/tests/test_path_command.py
+++ b/tests/test_path_command.py
@@ -236,23 +236,23 @@ class TestRenderUnlockPath:
     def test_basic_leaf_renders(self, linear_graph):
         text = render_unlock_path(linear_graph, "a", set())
         assert "a" in text
-        # leaf has no children, summary should say 0 owned out of 1
-        assert "0 / 1" in text
+        # leaf has no children, summary should say 0 owned out of 0
+        assert "0 / 0" in text
 
     def test_footer_counts_correct(self, linear_graph):
         text = render_unlock_path(linear_graph, "c", set())
-        # 3 nodes total (a, b, c), 0 owned
-        assert "0 / 3" in text
-        assert "3 skill(s) needed" in text
+        # 2 prerequisites total (a, b), 0 owned
+        assert "0 / 2" in text
+        assert "2 skill(s) needed" in text
 
     def test_footer_with_owned(self, linear_graph):
         # unlock_path stops recursing into owned nodes, so the visible tree
         # for 'c' with owned={'a','b'} is: c(missing) + b(owned, no children).
         # 'a' is not in the tree because b is already owned → recursion stops.
-        # Count: 2 nodes total, 1 owned (b), 1 missing (c).
+        # Count: 1 prerequisite total (b), 1 owned (b).
         text = render_unlock_path(linear_graph, "c", {"a", "b"})
-        assert "1 / 2" in text
-        assert "1 skill(s) needed" in text
+        assert "1 / 1" in text
+        assert "0 skill(s) needed" in text
 
     def test_owned_only_prunes_owned_branches(self, linear_graph):
         """--owned-only prunes the display of owned 'b' from the output."""

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -37,7 +37,7 @@ class TestGaiaPush(unittest.TestCase):
             env["PYTHONIOENCODING"] = "utf-8"
             result = subprocess.run(
                 [
-                    "python3",
+                    sys.executable,
                     CLI_PATH,
                     "--registry",
                     REPO_ROOT,
@@ -83,7 +83,7 @@ class TestGaiaPush(unittest.TestCase):
             env["PYTHONIOENCODING"] = "utf-8"
             result = subprocess.run(
                 [
-                    "python3",
+                    sys.executable,
                     CLI_PATH,
                     "--registry",
                     registry,

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -114,3 +114,23 @@ def test_stats_cli_prints_summary(tmp_path, monkeypatch, capsys):
     assert "Gaia Registry — 4 skills  1 edges" in output
     assert "Class A" in output
     assert "Effective level breakdown" in output
+
+
+def test_collect_stats_missing_level(tmp_path):
+    registry = tmp_path / "registry"
+    registry.mkdir(parents=True, exist_ok=True)
+    (registry / "gaia.json").write_text(
+        json.dumps(
+            {
+                "skills": [
+                    {"id": "tokenize", "type": "basic", "evidence": []},  # No 'level' key
+                ],
+                "edges": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    stats = collect_stats(tmp_path)
+    assert "?" not in stats["level_counts"]
+    assert "level_counts" in stats
+

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -17,7 +17,7 @@ def run_validate(graph_path):
     env = os.environ.copy()
     env["PYTHONIOENCODING"] = "utf-8"
     result = subprocess.run(
-        ["python3", VALIDATE_SCRIPT, "--graph", graph_path],
+        [sys.executable, VALIDATE_SCRIPT, "--graph", graph_path],
         capture_output=True,
         text=True,
         encoding="utf-8",


### PR DESCRIPTION
## Problem Statement

The gaia non-dev CLI commands (init, scan, install, uninstall, lookup, path, stats, fuse, pull, docs build, and others) contain 14 distinct UX bugs and logic errors — from `gaia promote` always failing because it searches username-scoped directories, to `gaia stats` counting generic starless skills instead of named ones, to `gaia install` silently acting like `gaia update`. These defects collectively make the CLI unreliable for end-users: incorrect data display, broken interactive workflows, silent failures, and leftover temp files. A fix should address each finding with an atomic, testable commit.

Closes #608

## Plan (approved)

1. fix(uninstall): strip leading slash in top-level uninstall command
2. fix(pull): print confirmation on successful registry pull
3. fix(output): include directory path in save confirmation messages
4. fix(skills-list): preserve skill type in available skills listing
5. fix(promote): correct argument order in promotable_candidates call
6. fix(lookup): show user's skill level instead of generic registry level
7. fix(path): exclude target skill from prerequisite count
8. fix(install): require skill_id argument for bare gaia install
9. fix(init): allow config update when --force flag is provided [⚠ breaking]
10. fix(scan): persist fusion candidates to pendingCombinations
11. fix(stats): compute level breakdown from leveled skills only
12. fix(card): truncate unlocks list at comma boundary
13. fix(intake): clean up temp issue body file after creation
14. fix(docs-build): warn on sub-script failures instead of silently ignoring
