### PR TITLE
⚡ Bolt: Optimize trigram similarity search

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -16,3 +16,7 @@
 ## 2025-03-04 - Eliminate O(N^2) file I/O in meta split and remove commands
 **Learning:** The Gaia CLI's `meta_split_command` and `meta_remove_command` historically performed multiple distinct passes over the entire nodes directory using `.glob("**/*.json")`. This resulted in O(M * N) file operations where M is the number of passes and N is the total number of skills, creating a significant I/O bottleneck.
 **Action:** When performing cross-cutting meta updates in `src/gaia_cli/commands/dev.py`, always read and cache the entire node set into memory during the first pass. Store the file paths and parsed JSON data in a list or dictionary, then iterate over this in-memory collection for all subsequent checks and updates before finally writing back only the modified files. Check specifically to avoid mutating source nodes that were just deleted.
+
+## 2026-06-07 - Optimize string metric calculations in loops
+**Learning:** In string similarity search (e.g. `similarity` scoring using trigrams), recalculating the properties of the static query (like computing trigrams) for every comparison against N items in the registry yields significant redundant CPU cost. Further, iterating over sets blindly can be suboptimal.
+**Action:** Pre-compute the query string properties (like trigrams `Set`) outside the inner loop and pass it down. Additionally, optimize set intersection by identifying the smaller set and only iterating over that one to check `has()` against the larger one.

--- a/packages/mcp/src/graph/search.ts
+++ b/packages/mcp/src/graph/search.ts
@@ -17,12 +17,14 @@ function trigrams(s: string): Set<string> {
   return set;
 }
 
-function similarity(a: string, b: string): number {
-  const ta = trigrams(a);
-  const tb = trigrams(b);
+function similarity(a: string | Set<string>, b: string | Set<string>): number {
+  const ta = typeof a === "string" ? trigrams(a) : a;
+  const tb = typeof b === "string" ? trigrams(b) : b;
   let intersection = 0;
-  for (const t of ta) {
-    if (tb.has(t)) intersection++;
+  const smaller = ta.size < tb.size ? ta : tb;
+  const larger = ta.size < tb.size ? tb : ta;
+  for (const t of smaller) {
+    if (larger.has(t)) intersection++;
   }
   const union = ta.size + tb.size - intersection;
   return union === 0 ? 0 : intersection / union;
@@ -36,13 +38,15 @@ export function searchSkills(graph: GaiaGraph, query: string, limit = 5): Skill[
   );
   if (exact) return [exact];
 
+  const qTrigrams = trigrams(q);
+
   const scored = graph.skills
     .map((skill) => ({
       skill,
       score: Math.max(
-        similarity(q, skill.id),
-        similarity(q, skill.name),
-        similarity(q, skill.description.slice(0, 80))
+        similarity(qTrigrams, skill.id),
+        similarity(qTrigrams, skill.name),
+        similarity(qTrigrams, skill.description.slice(0, 80))
       ),
     }))
     .filter((x) => x.score > 0.15)
@@ -115,14 +119,15 @@ export function searchAll(
 ): SearchResult[] {
   const q = query.toLowerCase().trim();
   const results: SearchResult[] = [];
+  const qTrigrams = trigrams(q);
 
   const genericResults = graph.skills
     .map((skill) => ({
       skill,
       score: Math.max(
-        similarity(q, skill.id),
-        similarity(q, skill.name),
-        similarity(q, skill.description.slice(0, 80))
+        similarity(qTrigrams, skill.id),
+        similarity(qTrigrams, skill.name),
+        similarity(qTrigrams, skill.description.slice(0, 80))
       ),
     }))
     .filter((x) => x.score > 0.15);
@@ -134,9 +139,9 @@ export function searchAll(
   const namedResults = searchNamedSkills(query);
   for (const ns of namedResults) {
     const score = Math.max(
-      similarity(q, ns.id),
-      similarity(q, ns.name),
-      similarity(q, ns.description.slice(0, 80))
+      similarity(qTrigrams, ns.id),
+      similarity(qTrigrams, ns.name),
+      similarity(qTrigrams, ns.description.slice(0, 80))
     );
     results.push({ type: "named", namedSkill: ns, score: Math.max(score, 0.5) });
   }


### PR DESCRIPTION
💡 What:
Optimized the string similarity search logic in `packages/mcp/src/graph/search.ts`.
1. Updated `similarity` to accept either `string` or `Set<string>`.
2. Modified the set intersection calculation in `similarity` to dynamically iterate over the smaller set.
3. Extracted redundant trigram computation out of inner mapping loops in `searchSkills` and `searchAll` by precomputing the query's trigrams once and passing the `Set` to `similarity`.

🎯 Why:
Recalculating the trigrams for a static search query `q` inside a `.map` loop over `N` generic or named skills is highly inefficient, taking $O(N \cdot \text{len}(q))$ extra processing time. Set intersection was also iterating over the first set blindly, which could be the larger set. This refactoring limits duplicate computations and boosts lookup speed.

📊 Impact:
Significantly reduces time complexity inside the inner loops of `searchSkills` and `searchAll` by turning redundant repeated parsing into a single pre-computation step.

🔬 Measurement:
Run `cd packages/mcp && pnpm test` to verify that search correctness holds, and verify that tests such as `tests/search.test.ts` pass without issue. Also `uv run pytest tests/` validates there are no breakages across the broader CLI if it references the MCP bindings.

---
*PR created automatically by Jules for task [7444579668966293116](https://jules.google.com/task/7444579668966293116) started by @mbtiongson1*

[skip-gen]