### PR TITLE
🧪 [testing improvement] Add edge case tests for merge_evidence

### DIFF
--- a/tests/test_evidence_inheritance.py
+++ b/tests/test_evidence_inheritance.py
@@ -5,7 +5,9 @@ import os
 import sys
 import unittest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+)
 
 from gaia_cli.evidence import (
     inherited_evidence,
@@ -18,15 +20,35 @@ REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 class TestInheritedEvidence(unittest.TestCase):
     def test_named_inherits_generic_capability_evidence(self):
-        generic = {"id": "automated-testing", "evidence": [
-            {"class": "A", "source": "https://arxiv.org/abs/0001"},
-        ]}
-        named = {"id": "x/pytest", "evidence": [
-            {"class": "C", "source": "https://github.com/x/pytest"},
-        ]}
+        generic = {
+            "id": "automated-testing",
+            "evidence": [
+                {"class": "A", "source": "https://arxiv.org/abs/0001"},
+            ],
+        }
+        named = {
+            "id": "x/pytest",
+            "evidence": [
+                {"class": "C", "source": "https://github.com/x/pytest"},
+            ],
+        }
         pool = inherited_evidence(named, generic)
         sources = {e["source"] for e in pool}
-        self.assertEqual(sources, {"https://arxiv.org/abs/0001", "https://github.com/x/pytest"})
+        self.assertEqual(
+            sources, {"https://arxiv.org/abs/0001", "https://github.com/x/pytest"}
+        )
+
+    def test_merge_evidence_edge_cases(self):
+        self.assertEqual(merge_evidence(), [])
+        self.assertEqual(merge_evidence(None, None), [])
+        self.assertEqual(merge_evidence([], []), [])
+        self.assertEqual(merge_evidence([{}], [{}]), [{}])
+        self.assertEqual(
+            merge_evidence(
+                None, [{"source": "s1"}], [], [{"source": "s1"}, {"source": "s2"}]
+            ),
+            [{"source": "s1"}, {"source": "s2"}],
+        )
 
     def test_dedup_by_source(self):
         shared = {"class": "A", "source": "https://arxiv.org/abs/0001"}
@@ -46,16 +68,29 @@ class TestInheritedEvidence(unittest.TestCase):
 
 class TestRanklessGenerics(unittest.TestCase):
     def test_no_generic_node_has_level_or_demerits(self):
-        graph = json.load(open(os.path.join(REPO_ROOT, "registry", "gaia.json"), encoding="utf-8"))
-        bad = [s["id"] for s in graph["skills"] if "level" in s or "demerits" in s or "realVariants" in s]
+        graph = json.load(
+            open(os.path.join(REPO_ROOT, "registry", "gaia.json"), encoding="utf-8")
+        )
+        bad = [
+            s["id"]
+            for s in graph["skills"]
+            if "level" in s or "demerits" in s or "realVariants" in s
+        ]
         self.assertEqual(bad, [], f"Generic refs must be rank-less; offenders: {bad}")
 
     def test_named_skills_retain_levels(self):
-        idx = json.load(open(os.path.join(REPO_ROOT, "registry", "named-skills.json"), encoding="utf-8"))
+        idx = json.load(
+            open(
+                os.path.join(REPO_ROOT, "registry", "named-skills.json"),
+                encoding="utf-8",
+            )
+        )
         valid = {"1★", "2★", "3★", "4★", "5★", "6★"}
         for entries in idx["buckets"].values():
             for e in entries:
-                self.assertIn(e["level"], valid, f"{e['id']} has invalid level {e['level']}")
+                self.assertIn(
+                    e["level"], valid, f"{e['id']} has invalid level {e['level']}"
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
🎯 **What:** `merge_evidence` in `src/gaia_cli/evidence.py` was missing tests for edge cases like `None` inputs, empty lists, and lists containing dictionaries without a `source` key.

📊 **Coverage:** Added tests for the following scenarios in `test_merge_evidence_edge_cases`:
* `merge_evidence()`
* `merge_evidence(None, None)`
* `merge_evidence([], [])`
* `merge_evidence([{}], [{}])`
* `merge_evidence(None, [{"source": "s1"}], [], [{"source": "s1"}, {"source": "s2"}])`

✨ **Result:** Increased test coverage for `merge_evidence` by testing different permutations of missing or empty inputs and properties without sources.

---
*PR created automatically by Jules for task [7890089665505090373](https://jules.google.com/task/7890089665505090373) started by @mbtiongson1*

[skip-gen]