### PR TITLE
🎨 Palette: Add keyboard focus-visible outlines to interactive elements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -29,3 +29,6 @@
 ## 2024-05-25 - Focus Rings for All Interactive Elements
 **Learning:** Found several missing focus-visible classes on various buttons and interactive elements (`.nav-search-btn-mobile`, `.pmq-changelog-btn`, `.scroll-to-top`, `.mr-pagination-prev`, `.mr-pagination-next`, `.hero-audit-btn`, `.propose-cta`, `.meta-btn-close`, `.se-close-x`, `.hoh-fs-overlay-restore`, `.hoh-fs-btn`, `.hoh-fs-btn--close`, `.hoh-fs-copy-btn`), impacting keyboard accessibility.
 **Action:** Always verify keyboard accessibility on all buttons by checking if they belong to the central grouped selector for `:focus-visible` in `styles.css` or `plaque.css`. Ensure new buttons receive `outline: 2px solid var(--tier-extra); outline-offset: 2px;`.
+## 2024-05-18 - Universal Focus Ring Consistency
+**Learning:** Many interactive components like inputs and custom buttons across badges and plaques were missing the standard focus ring used for keyboard accessibility. While standard buttons had the `focus-visible` rule, many custom classes did not inherit this.
+**Action:** Always verify that newly created custom interactive elements (buttons, inputs, chips) explicitly append their selector to the app-wide `focus-visible` rule using the standard outline: `outline: 2px solid var(--tier-extra); outline-offset: 2px;`.

--- a/docs/css/plaque.css
+++ b/docs/css/plaque.css
@@ -3715,3 +3715,13 @@ button.plaque__slug:focus-visible {
   .plaque__redacted-handle::after { animation: none; }
 }
 
+
+.sidebar-search-input:focus-visible,
+.sidebar-date-input:focus-visible,
+.profile-filter-chip:focus-visible,
+.profile-filter-reset:focus-visible,
+.plaque__share-btn:focus-visible,
+.plaque__claim-btn:focus-visible {
+  outline: 2px solid var(--tier-extra);
+  outline-offset: 2px;
+}

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -1107,6 +1107,15 @@ h1 em {
 .hero-audit-btn:focus-visible,
 .propose-cta:focus-visible,
 .meta-btn-close:focus-visible,
+.bd-clear-btn:focus-visible,
+.bd-go-btn:focus-visible,
+.bd-sampler-cycle:focus-visible,
+.bd-skill-remove:focus-visible,
+.bd-skill-add:focus-visible,
+.bd-skill-addall:focus-visible,
+.bd-skill-clear:focus-visible,
+.bd-copy-all:focus-visible,
+.bd-copy-perline:focus-visible,
 .se-close-x:focus-visible {
   outline: 2px solid var(--tier-extra);
   outline-offset: 2px;


### PR DESCRIPTION
🎨 Palette: Add keyboard focus-visible outlines to interactive elements

💡 What: Added the standard `outline: 2px solid var(--tier-extra); outline-offset: 2px;` to various interactive elements (`.bd-clear-btn`, `.bd-go-btn`, `.sidebar-search-input`, `.profile-filter-chip`, etc.) across `styles.css` and `plaque.css` when in the `:focus-visible` state. Also updated the UX journal `.jules/palette.md` with the learnings.
🎯 Why: To improve keyboard accessibility by ensuring interactive elements have a clear visual focus indicator.
♿ Accessibility: Ensures that users navigating via keyboard can see which element is currently focused.

---
*PR created automatically by Jules for task [11292443499992849306](https://jules.google.com/task/11292443499992849306) started by @mbtiongson1*

[skip-gen]