### PR TITLE
fix(cli): guardrails for non-public-repo and non-registry environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ packaging-specific tests are skipped locally with guidance to install developer 
 
 ```bash
 gaia init --user your-username
+# Detected repo: your-username/your-repo
+# Initialize Gaia on this repository? [Y/n]: Y
 gaia scan
 ```
 
@@ -172,9 +174,11 @@ Detects skills your agent demonstrates.
 
 ```bash
 gaia push
+# Push skills to gaia registry from your-username/your-repo? [Y/n]: Y
 ```
 
 A GitHub issue opens automatically. Maintainers review and promote; your name attaches at 2★.
+If no remote is detected, Gaia will guide you to add one.
 
 **4. Bond your agent (optional)**
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -315,7 +315,7 @@
             <span class="rite-numeral" aria-hidden="true">III.</span>
             <div class="rite-body">
               <strong>Push for review</strong>
-              <p>A GitHub issue is opened automatically.</p>
+              <p>A GitHub issue is opened automatically. You'll be asked to confirm the target repo.</p>
               <div class="os-tabs" role="tablist" aria-label="Operating System selection">
                 <button type="button" class="os-tab active" data-os="unix" onclick="switchOsTab(this)" role="tab" aria-selected="true">macOS · Linux</button>
                 <button type="button" class="os-tab" data-os="win" onclick="switchOsTab(this)" role="tab" aria-selected="false">Windows</button>

--- a/src/gaia_cli/graph.py
+++ b/src/gaia_cli/graph.py
@@ -39,6 +39,11 @@ def _registry_root(registry_path: str | os.PathLike[str]) -> Path:
 
 def load_graph(registry_path: str | os.PathLike[str] = ".") -> dict[str, Any]:
     graph_path = Path(registry_graph_path(_registry_root(registry_path)))
+    if not graph_path.exists():
+        raise FileNotFoundError(
+            f"Registry graph not found at {graph_path}. "
+            "Run gaia init from a gaia-skill-tree clone."
+        )
     with graph_path.open("r", encoding="utf-8") as f:
         return json.load(f)
 
@@ -1204,7 +1209,11 @@ def graph_command(args: Any) -> None:
     except Exception:
         pass  # Degrade gracefully to canon mode
 
-    out_path = write_graph_artifact(registry_path, output=output, fmt=fmt, user_ctx=user_ctx)
+    try:
+        out_path = write_graph_artifact(registry_path, output=output, fmt=fmt, user_ctx=user_ctx)
+    except FileNotFoundError as exc:
+        print(str(exc), file=sys.stderr)
+        return
     print(f"  saved {out_path}")
 
     # Regenerate the GEXF from current node data

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -834,7 +834,12 @@ def promote_command(args):
                 if picked:
                     skill_id = picked
             if not skill_id:
-                print("Usage: gaia promote <skill> or gaia promote --all", file=sys.stderr)
+                from gaia_cli.registry import promotion_candidates_path
+                if not os.path.exists(promotion_candidates_path(args.registry)):
+                    print("No promotion candidates found. Run `gaia scan` first to detect skills.",
+                          file=sys.stderr)
+                else:
+                    print("Usage: gaia promote <skill> or gaia promote --all", file=sys.stderr)
                 sys.exit(2)
         result = promote_from_candidates(username, skill_id, args.registry, new_display_name=display_name)
     except ValueError as exc:

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -381,6 +381,11 @@ def scan_command(args):
     scan_result = scan_repo_detailed()
     raw_tokens = {t.lstrip('/') for t in scan_result["tokens"]}
     graph_path = registry_graph_path(args.registry)
+
+    from gaia_cli.registry import bundled_registry_path
+    if not quiet and not use_json and str(args.registry) == str(bundled_registry_path()):
+        print("Note: using bundled registry (no local registry clone found).")
+
     resolved = resolve_skills(raw_tokens, registry_path=graph_path)
     
     username = config.get('gaiaUser')
@@ -410,6 +415,9 @@ def scan_command(args):
         if resolved:
             # Colored skill list with type glyphs
             graph_path_file = registry_graph_path(args.registry)
+            if not os.path.exists(graph_path_file):
+                print("Registry graph not found. Run `gaia init` from a gaia-skill-tree clone.")
+                return
             with open(graph_path_file, 'r', encoding='utf-8') as gf:
                 gdata = json.load(gf)
             smap = {s['id']: s for s in gdata.get('skills', [])}

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -1056,6 +1056,12 @@ def tree_command(args):
     show_tree(tree, graph_data=graph_data, registry_path=args.registry, mode=mode, canon=canon)
     if tree:
         render_user_tree_outputs(config.get('gaiaUser'), tree, graph_data, args.registry, quiet=False)
+    try:
+        detect_source_repo(config)
+    except NonPublicRepoError:
+        print("\nTip: link a public GitHub repo and approved skills will start at 2★ once named.")
+    except Exception:
+        pass
 
 def fuse_command(args):
     config = load_config()

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -800,7 +800,11 @@ def promote_command(args):
 
     tree = load_tree(username, registry_path=args.registry)
     if not tree:
-        print(f"No skill tree found for user '{username}'.")
+        if not os.path.exists(promotion_candidates_path(args.registry)):
+            print("No promotion candidates found. Run `gaia scan` first to detect skills.",
+                  file=sys.stderr)
+        else:
+            print(f"No skill tree found for user '{username}'.", file=sys.stderr)
         return
 
     skill_id = getattr(args, 'skillId', None)

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -321,6 +321,29 @@ def init_command(args):
     print(f"  user:       {username}")
     print(f"  scanPaths:  {scan_paths}")
 
+    try:
+        source = detect_source_repo({"gaiaUser": username})
+        if sys.stdin.isatty() and not getattr(args, 'yes', False):
+            try:
+                ans = input(f"Detected repo: {source}\nInitialize Gaia on this repository? [Y/n]: ").strip().lower()
+            except (KeyboardInterrupt, EOFError):
+                print()
+                import shutil; shutil.rmtree(config_dir, ignore_errors=True)
+                sys.exit(1)
+            if ans == 'n':
+                import shutil; shutil.rmtree(config_dir, ignore_errors=True)
+                print("Aborted.")
+                return
+    except NonPublicRepoError:
+        print(
+            "\nNo GitHub remote detected in this directory.\n"
+            "  → To unlock the full workflow:\n"
+            "     • Add a remote:  git remote add origin https://github.com/<you>/<repo>\n"
+            "     • Or clone the gaia-skill-tree registry and run gaia init there\n"
+            "Your skills are still scannable and pushable — once linked to a public repo,\n"
+            "approved skills will start at 2★ instead of 1★.\n"
+        )
+
     # If we're inside a registry clone, register its path globally so that
     # commands like `gaia push` work from any project without --registry.
     tree_path = user_tree_path(".", username)

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -14,7 +14,7 @@ from gaia_cli.resolver import resolve_skills
 from gaia_cli.combinator import get_combinations
 from gaia_cli.treeManager import load_tree, save_tree, show_status, show_tree
 from gaia_cli.prWriter import open_pr, open_intake_issue
-from gaia_cli.push import build_skill_batch, write_skill_batch, build_proposed_skill, detect_source_repo
+from gaia_cli.push import build_skill_batch, write_skill_batch, build_proposed_skill, detect_source_repo, NonPublicRepoError
 from gaia_cli.embeddings import generate_embeddings
 from gaia_cli.semantic_search import search as semantic_search, load_embeddings
 from gaia_cli.name import find_awakened_skill, promote_to_named, update_batch_lifecycle
@@ -1160,7 +1160,28 @@ def push_command(args):
         sys.exit(1)
 
     raw_tokens = scan_repo()
-    batch = build_skill_batch(raw_tokens, config, args.registry)
+    try:
+        batch = build_skill_batch(raw_tokens, config, args.registry)
+        source_repo = batch["sourceRepo"]
+        if sys.stdin.isatty() and not getattr(args, 'yes', False):
+            try:
+                ans = input(f"Push skills to gaia registry from {source_repo}? [Y/n]: ").strip().lower()
+            except (KeyboardInterrupt, EOFError):
+                print()
+                sys.exit(1)
+            if ans == 'n':
+                print("Aborted.")
+                return
+    except NonPublicRepoError as exc:
+        print(
+            "\nYour skills are ready for review!\n"
+            "Skills pushed from outside a public GitHub repo start at 1★ in the registry.\n"
+            "Once you link a public repo, approved skills will start at 2★ instead.\n"
+            "  → Add a remote:  git remote add origin https://github.com/<you>/<repo>\n"
+        )
+        username_fallback = str(exc)
+        batch = build_skill_batch(raw_tokens, config, args.registry,
+                                  source_repo=f"{username_fallback}/local-repo")
 
     # Guard 1: check if empty initially
     if not batch.get("proposedSkills") and not batch.get("knownSkills"):
@@ -1689,6 +1710,7 @@ def get_parser():
     push_parser.add_argument('--dry-run', action='store_true', help="Print the skill batch without writing it")
     push_parser.add_argument('--no-issue', action='store_true', dest='no_issue', help="Write intake record without creating a GitHub issue")
     push_parser.add_argument('--no-pr', action='store_true', dest='no_issue', help=argparse.SUPPRESS)  # backward compat alias
+    push_parser.add_argument('--yes', '-y', action='store_true', dest='yes', help="Skip confirmation prompts")
     propose_parser = subparsers.add_parser('propose', help="Propose a single canonical skill as a named PR")
     propose_parser.add_argument('skillId', help="Canonical skill ID (accepts /skill-id form)")
     propose_parser.add_argument('--target', help="Named skill target in contributor/skill-name format")

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -1219,7 +1219,8 @@ def push_command(args):
             "\nYour skills are ready for review!\n"
             "Skills pushed from outside a public GitHub repo start at 1★ in the registry.\n"
             "Once you link a public repo, approved skills will start at 2★ instead.\n"
-            "  → Add a remote:  git remote add origin https://github.com/<you>/<repo>\n"
+            "  → Add a remote:  git remote add origin https://github.com/<you>/<repo>\n",
+            file=sys.stderr,
         )
         username_fallback = str(exc)
         batch = build_skill_batch(raw_tokens, config, args.registry,

--- a/src/gaia_cli/push.py
+++ b/src/gaia_cli/push.py
@@ -15,6 +15,12 @@ from gaia_cli.registry import registry_graph_path, skill_batches_dir
 
 
 SKILL_ID_RE = re.compile(r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$")
+
+
+class NonPublicRepoError(RuntimeError):
+    """Raised when no public GitHub remote is detected for the working directory."""
+
+
 MIN_PROPOSED_TOKEN_LENGTH = 3
 PROPOSED_STOPWORDS = {
     "a", "an", "and", "are", "as", "at", "be", "by", "for", "from", "in", "is", "it", "of", "on", "or", "that", "the", "to", "was", "were", "with", "already",
@@ -68,7 +74,7 @@ def detect_source_repo(config):
         if host == "github.com" or host.endswith(".github.com"):
             return parsed.path.lstrip("/")
 
-    return f"{config.get('gaiaUser', 'unknown')}/local-repo"
+    raise NonPublicRepoError(config.get('gaiaUser', 'unknown'))
 
 
 def build_proposed_skill(skill_id, source_repo):
@@ -126,11 +132,12 @@ def filter_proposed_ids(valid_tokens, canonical_ids):
     return filtered
 
 
-def build_skill_batch(raw_tokens, config, registry_root, now=None):
+def build_skill_batch(raw_tokens, config, registry_root, now=None, source_repo=None):
     graph_path = registry_graph_path(registry_root)
     canonical_ids = load_canonical_skills(graph_path)
     canonical_map = load_canonical_skill_map(graph_path)
-    source_repo = detect_source_repo(config)
+    if source_repo is None:
+        source_repo = detect_source_repo(config)
     timestamp = now or datetime.now(timezone.utc)
     generated_at = timestamp.replace(microsecond=0).isoformat().replace("+00:00", "Z")
 

--- a/src/gaia_cli/registry.py
+++ b/src/gaia_cli/registry.py
@@ -6,7 +6,7 @@ from importlib import resources
 from pathlib import Path
 
 
-WRITE_COMMANDS = {"push", "propose", "name", "fuse", "embed", "sync", "promote", "graph", "release", "docs", "merge", "split", "add", "evidence"}
+WRITE_COMMANDS = {"push", "propose", "name", "fuse", "embed", "sync", "promote", "release", "docs", "merge", "split", "add", "evidence"}
 
 
 def _gaia_home_dir() -> Path:


### PR DESCRIPTION
## Problem Statement

Users who run `gaia init` outside a public GitHub repo are silently led into a broken
workflow. `scan_command` falls back to the bundled registry without telling the user,
then crashes on a missing graph file. `push_command` silently falls back to
`local-repo`, writes an orphaned batch, then fails at intake issue creation. When a
repo IS detected there is no ceremony — users get no confirmation of which repo they're
operating on.

Closes #625
Closes #626
Closes #627
Closes #628
Closes #629
Closes #630
Closes #631
Parent: #624

## Plan

1. `push.py` — raise `NonPublicRepoError` instead of silent local-repo fallback; add `source_repo` param to `build_skill_batch`
2. `push_command` — celebratory message when no remote; Y/n ceremony when remote detected; add `--yes` / `-y` flag
3. `init_command` — Y/n ceremony when remote detected; setup nudge when no remote
4. `scan_command` — show active registry source; guard missing graph file
5. `promote_command` — clear message when candidates file absent
6. `tree_command` — soft upgrade-path tip when no public remote
7. `graph.py` — guard `load_graph` against missing registry file
8. `README.md` / `docs/index.html` — add Y to init/push examples; note about no-remote guidance

## Pre-existing test failure

`tests/test_install.py::TestInstallFlow::test_install_creates_symlink_pointing_to_cache`
fails on the base branch (Windows symlink permissions) — not caused by this PR.