### PR TITLE
fix(ci): replace git pull --rebase --autosquash with fetch + rebase

### DIFF
--- a/.github/workflows/sync-artifacts.yml
+++ b/.github/workflows/sync-artifacts.yml
@@ -110,7 +110,7 @@ jobs:
             n=0
             until [[ $n -ge 4 ]]; do
               # Rebase with autosquash to merge fixups into the release commit
-              if git pull --rebase --autosquash origin "${GITHUB_REF_NAME}" && git push; then
+              if git fetch origin "${GITHUB_REF_NAME}" && git rebase --autosquash "origin/${GITHUB_REF_NAME}" && git push; then
                 echo "Successfully pushed changes to origin/${GITHUB_REF_NAME}."
                 break
               fi


### PR DESCRIPTION
## Summary

- `--autosquash` is a `git rebase` flag — `git pull` rejects it with `error: unknown option 'autosquash'`
- This caused every `Auto-Sync Registry Artifacts` run to fail on all 4 retry attempts, never pushing
- Fix: split into `git fetch origin` + `git rebase --autosquash origin/<branch>` which is the correct invocation

## Test plan

- [ ] Merge to `main` and confirm the next `sync-artifacts` run reaches **Tag Release** / **Create GitHub Release** steps without failing at **Commit and Push Changes**