### PR TITLE
feat(cli): gaia share bundle + guided gaia install <bundle>

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,9 +84,15 @@ When a gap forces a direct edit, always:
 
 ## CLI Shape
 
-Top-level commands are lifecycle-oriented: `init`, `scan`, `pull`, `push`, `appraise`, `promote`, `release`, `version`, `whoami`, `mcp`, `tree`, `graph`, `docs`, `update`, and `help`.
+Top-level commands are lifecycle-oriented: `init`, `scan`, `pull`, `push`, `appraise`, `promote`, `release`, `version`, `whoami`, `mcp`, `tree`, `graph`, `docs`, `update`, `share`, and `help`.
 
 Named skill actions live under `gaia skills`: `list`, `search`, `install`, `uninstall`, and `info`. The old flat verbs are intentionally removed.
+
+### Share bundles (`gaia share` / `gaia install <bundle>`)
+
+`gaia share` exports a self-contained **share bundle** JSON (`generated-output/share/<user>-share-bundle.json`, or `--stdout`) carrying a snapshot of the sharer's tree, a flat install manifest pointing each skill at its source repo via `links.github` (`blob/branch/subpath`, `tree/`→`blob/` normalized), and pre-resolved metadata to re-render the sharer's tree preview. A bundle can span multiple repos and still present as one tree.
+
+`gaia install` detects a bundle argument (a `.json` path or an http(s) URL) and walks a guided flow: render the sharer's tree → prompt `[A]ll / [P]ick / [V]iew only / [Q]uit` → resolve each chosen skill (reusing the `gaia skills install` resolution path when the consumer's registry knows it, else installing directly from the bundle's source URL) → print an installed / skipped / unresolved summary. Non-TTY defaults to view-only. Implemented in `src/gaia_cli/share.py`. The static `docs/share/` copy-link page is a deferred fast-follow (Issue #128).
 
 All commands default to **local-first** output — showing the user's own skill levels, detected skills, and named forms when available. Pass `--canon` to any command to view canonical registry data instead.
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Requires `textual` (included with `pip install gaia-cli`).
 <!-- gaia:cli-start -->
 ```text
 usage: gaia [-h] [--registry REGISTRY] [--global] [--version]
-            {help,init,scan,fetch,pull,update,install,uninstall,tree,push,propose,version,whoami,reset,mcp,release,graph,stats,appraise,promote,fuse,docs,lookup,path,dev,validate,test,skills}
+            {help,init,scan,fetch,pull,update,install,uninstall,share,tree,push,propose,version,whoami,reset,mcp,release,graph,stats,appraise,promote,fuse,docs,lookup,path,dev,validate,test,skills}
             ...
 
 Gaia Registry CLI
@@ -259,6 +259,10 @@ Skills:
   gaia skills info <skill_id> [--exclude-pending]
   gaia skills install <skill> [--global | --local]
   gaia skills uninstall <skill_id>
+
+Share:
+  gaia share [--user <name>] [-o <path>] [--stdout]
+  gaia install <bundle.json|url>   Preview & install a shared tree (guided)
 
 Utilities:
   gaia whoami

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -187,6 +187,10 @@ Skills:
   {_rainbow_text("gaia skills install")} <skill> [--global | --local]
   {_rainbow_text("gaia skills uninstall")} <skill_id>
 
+Share:
+  {_fg(*COLOR_LOCAL_USER)}gaia share{_reset()} [--user <name>] [-o <path>] [--stdout]
+  {_fg(*C2)}gaia install{_reset()} <bundle.json|url>   Preview & install a shared tree (guided)
+
 Utilities:
   {_fg(*C2)}gaia whoami{_reset()}
   {_fg(*C1)}gaia version{_reset()}
@@ -245,6 +249,7 @@ PUBLIC_COMMANDS = (
     "update",
     "install",
     "uninstall",
+    "share",
     "tree",
     "push",
     "propose",
@@ -2247,11 +2252,21 @@ def install_command(args):
         install_suite,
         update_skills,
     )
+    from gaia_cli.share import _looks_like_bundle_ref, install_bundle
 
     location = _resolve_install_location(args)
 
     if args.list:
         interactive_install(args.registry, location=location)
+        return
+    # A bundle ref (a .json path or an http(s) URL) routes to the guided
+    # share-bundle flow; a bare slug or contributor/slug is a named skill.
+    if args.skill_id and _looks_like_bundle_ref(args.skill_id):
+        try:
+            install_bundle(args.skill_id, args.registry, location=location)
+        except ValueError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
         return
     if not args.skill_id:
         print("Usage: gaia install <skill_id>", file=sys.stderr)
@@ -2277,6 +2292,49 @@ def uninstall_command(args):
     success = uninstall_skill(args.skill_id.lstrip("/"))
     if not success:
         sys.exit(1)
+
+
+def share_command(args):
+    from gaia_cli.share import build_share_bundle, default_bundle_path, write_bundle
+
+    config = load_config()
+    if not config:
+        print("Gaia not initialized. Run `gaia init` first.", file=sys.stderr)
+        sys.exit(1)
+    username = getattr(args, "user", None) or config.get("gaiaUser")
+    if not username:
+        print(
+            "No Gaia user configured. Run `gaia init --user <name>`.", file=sys.stderr
+        )
+        sys.exit(1)
+
+    try:
+        bundle = build_share_bundle(username, args.registry)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if getattr(args, "stdout", False):
+        print(json.dumps(bundle, indent=2))
+        return
+
+    out_path = getattr(args, "output", None) or default_bundle_path(
+        username, args.registry
+    )
+    write_bundle(bundle, out_path)
+
+    n_skills = len(bundle.get("skillMeta", {}))
+    n_install = len(bundle.get("install", []))
+    try:
+        rel = os.path.relpath(out_path)
+    except ValueError:
+        rel = out_path
+    print(f"\n{_fg(*COLOR_LOCAL_USER)}✓ Share bundle written:{_reset()} {rel}")
+    print(f"  {n_skills} skill(s), {n_install} installable")
+    print("\nShare it — anyone with the file can preview your tree and install:")
+    print(f"  gaia install {rel}")
+    print("\nOr host the file and share the URL:")
+    print("  gaia install https://<host>/<file>.json")
 
 
 def _load_json_file(path: str, default=None):
@@ -2794,6 +2852,21 @@ def get_parser():
         "uninstall", help="Uninstall a named skill"
     )
     uninstall_parser.add_argument("skill_id", help="Skill ID to uninstall")
+
+    share_parser = subparsers.add_parser(
+        "share", help="Export a portable share bundle of your skill tree"
+    )
+    share_parser.add_argument(
+        "--user", help="User whose tree to share (default: configured gaiaUser)"
+    )
+    share_parser.add_argument(
+        "-o", "--output", help="Path to write the bundle JSON (default: generated-output/share/)"
+    )
+    share_parser.add_argument(
+        "--stdout",
+        action="store_true",
+        help="Print the bundle JSON to stdout instead of writing a file",
+    )
 
     tree_parser = subparsers.add_parser("tree", help="Show your Gaia skill tree")
     tree_parser.add_argument(
@@ -3507,6 +3580,8 @@ def main():
         install_command(args)
     elif args.command == "uninstall":
         uninstall_command(args)
+    elif args.command == "share":
+        share_command(args)
     elif args.command == "tree":
         tree_command(args)
     elif args.command == "push":

--- a/src/gaia_cli/share.py
+++ b/src/gaia_cli/share.py
@@ -1,0 +1,512 @@
+"""Portable share bundles — `gaia share` producer and `gaia install <bundle>` consumer.
+
+A *share bundle* is a single, self-contained JSON artifact that travels anywhere
+(Issue #128). It carries three things:
+
+1. A snapshot of the sharer's local skill tree (`unlockedSkills` + levels), so a
+   bundle from *any* repo's state shares 100% — even if those skills are not yet
+   canonical.
+2. A flat **install manifest** that points each installable skill at its *source*
+   repository via the existing `links.github` `blob/branch/subpath` path, so
+   `gaia install` consumes it through the same resolution code that
+   `gaia skills install` already uses (no rebuild — see install.py).
+3. Pre-resolved **skill metadata** (name / level / type / owned-prereq edges) so
+   the consumer can re-render the sharer's tree preview with zero dependency on
+   their own registry. A bundle can span multiple repos and still present as one
+   tree at the user level (the "mattpocock's collection" case).
+
+The producer does the heavy lifting (canonical→named prereq translation, source
+resolution) at `gaia share` time; the consumer renderer is intentionally dumb so
+the preview is always faithful to the sharer regardless of the consumer's setup.
+"""
+
+import json
+import os
+import re
+from datetime import datetime, timezone
+
+from gaia_cli.registry import (
+    generated_output_dir,
+    named_skills_index_path,
+    registry_graph_path,
+)
+from gaia_cli.treeManager import load_tree
+
+BUNDLE_KIND = "gaia-share-bundle"
+BUNDLE_VERSION = "1"
+
+_TYPE_SYMBOL = {"basic": "○", "extra": "◇", "ultimate": "◆", "unique": "◉"}
+
+
+# ─── github url normalization ──────────────────────────────────────────────────
+
+
+def _normalize_github_url(url):
+    """Convert a GitHub directory-view URL (``tree/``) to the installer's ``blob/``.
+
+    ``install.py::_parse_github_url`` only recognises ``blob/branch/subpath``. A
+    ``tree/`` URL (what GitHub's directory view produces) would otherwise install
+    to the repo root and make the skill undiscoverable. See CLAUDE.md §1.
+    """
+    if not url or not isinstance(url, str):
+        return None
+    return url.replace("/tree/", "/blob/", 1)
+
+
+# ─── registry data loaders ─────────────────────────────────────────────────────
+
+
+def _load_canonical_skill_map(registry_path):
+    """{canonical_id -> skill dict} from gaia.json, or {} if unavailable."""
+    path = registry_graph_path(registry_path)
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return {s["id"]: s for s in data.get("skills", []) if s.get("id")}
+
+
+def _load_named_by_id(registry_path):
+    """{named_id -> index entry} from named-skills.json, or {} if unavailable."""
+    path = named_skills_index_path(registry_path)
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return {}
+    result = {}
+    for bucket in data.get("buckets", {}).values():
+        for entry in bucket:
+            if entry.get("id"):
+                result[entry["id"]] = entry
+    for entry in data.get("awaitingClassification", []):
+        if entry.get("id"):
+            result[entry["id"]] = entry
+    return result
+
+
+# ─── producer ──────────────────────────────────────────────────────────────────
+
+
+def build_share_bundle(username, registry_path, source_repo=None, now=None):
+    """Assemble a self-contained share bundle for ``username``.
+
+    Returns the bundle dict. Raises ValueError if the user has no skill tree.
+    """
+    tree = load_tree(username, registry_path=registry_path)
+    if not tree:
+        raise ValueError(f"No skill tree found for user '{username}'.")
+
+    canon = _load_canonical_skill_map(registry_path)
+    named_by_id = _load_named_by_id(registry_path)
+
+    unlocked = tree.get("unlockedSkills", [])
+    owned_ids = {u.get("skillId") for u in unlocked if u.get("skillId")}
+
+    # First pass: resolve per-skill metadata + generic ref.
+    skill_meta = {}
+    generic_to_owned = {}  # canonical genericSkillRef -> owned named id
+    for u in unlocked:
+        sid = u.get("skillId")
+        if not sid:
+            continue
+        named_entry = named_by_id.get(sid)
+        canon_entry = canon.get(sid, {})
+
+        generic_ref = None
+        if named_entry:
+            name = named_entry.get("name") or sid
+            stype = named_entry.get("type") or canon_entry.get("type", "basic")
+            generic_ref = named_entry.get("genericSkillRef")
+            is_named = True
+        else:
+            name = canon_entry.get("name") or sid
+            stype = canon_entry.get("type", "basic")
+            # A bare canonical id is its own generic ref.
+            generic_ref = sid if "/" not in sid else None
+            is_named = "/" in sid
+
+        level = u.get("level") or (named_entry or {}).get("level") or canon_entry.get("level", "?")
+
+        skill_meta[sid] = {
+            "name": name,
+            "level": level,
+            "type": stype,
+            "named": is_named,
+            "genericRef": generic_ref,
+            "prereqs": [],
+        }
+        if generic_ref and generic_ref not in generic_to_owned:
+            generic_to_owned[generic_ref] = sid
+
+    # Second pass: translate canonical prerequisites into owned-skill edges so the
+    # preview shows the structure among the sharer's own skills.
+    for sid, meta in skill_meta.items():
+        generic_ref = meta.get("genericRef")
+        if not generic_ref:
+            continue
+        canon_prereqs = canon.get(generic_ref, {}).get("prerequisites", [])
+        edges = set()
+        for p in canon_prereqs:
+            if p in owned_ids:  # canonical prereq owned directly
+                edges.add(p)
+            owned = generic_to_owned.get(p)  # prereq owned under a named id
+            if owned:
+                edges.add(owned)
+        edges.discard(sid)
+        meta["prereqs"] = sorted(edges)
+
+    # Build the flat install manifest (only skills with a resolvable source).
+    install_manifest = []
+    for u in unlocked:
+        sid = u.get("skillId")
+        if not sid:
+            continue
+        named_entry = named_by_id.get(sid)
+        if not named_entry:
+            continue  # no named implementation → not installable, preview-only
+        github = _normalize_github_url((named_entry.get("links") or {}).get("github"))
+        suite_components = named_entry.get("suiteComponents") or []
+        if not github and not suite_components:
+            continue  # neither a source nor a suite → can't install
+        entry = {
+            "id": sid,
+            "name": named_entry.get("name") or sid,
+            "level": skill_meta[sid]["level"],
+            "type": named_entry.get("type", "basic"),
+        }
+        if github:
+            entry["github"] = github
+        if suite_components:
+            entry["suiteComponents"] = suite_components
+        if named_entry.get("genericSkillRef"):
+            entry["genericSkillRef"] = named_entry["genericSkillRef"]
+        install_manifest.append(entry)
+
+    timestamp = now or datetime.now(timezone.utc)
+    generated_at = timestamp.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+    return {
+        "kind": BUNDLE_KIND,
+        "bundleVersion": BUNDLE_VERSION,
+        "generatedAt": generated_at,
+        "sharer": username,
+        "sourceRepo": source_repo or tree.get("sourceRepo"),
+        "tree": {
+            "userId": tree.get("userId", username),
+            "updatedAt": tree.get("updatedAt"),
+            "unlockedSkills": unlocked,
+            "stats": tree.get("stats", {}),
+        },
+        "skillMeta": skill_meta,
+        "install": install_manifest,
+    }
+
+
+def default_bundle_path(username, registry_path):
+    return os.path.join(
+        generated_output_dir(registry_path), "share", f"{username}-share-bundle.json"
+    )
+
+
+def write_bundle(bundle, path):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(bundle, f, indent=2)
+        f.write("\n")
+    return path
+
+
+# ─── consumer: bundle loading + validation ─────────────────────────────────────
+
+
+def _looks_like_bundle_ref(ref):
+    """True if ``ref`` should be treated as a share bundle rather than a skill id.
+
+    Skill ids are bare slugs or ``contributor/slug`` — never URLs and never
+    ``.json`` paths, so those two shapes unambiguously signal a bundle.
+    """
+    if not ref:
+        return False
+    return ref.startswith(("http://", "https://")) or ref.endswith(".json")
+
+
+def load_bundle(ref):
+    """Load a bundle dict from a local file path or an http(s) URL.
+
+    Raises ValueError if it does not parse or is not a share bundle.
+    """
+    if ref.startswith(("http://", "https://")):
+        import urllib.request
+
+        try:
+            with urllib.request.urlopen(ref, timeout=30) as resp:  # noqa: S310 (user-provided URL)
+                raw = resp.read().decode("utf-8")
+        except Exception as exc:  # noqa: BLE001
+            raise ValueError(f"Could not fetch bundle from {ref}: {exc}") from exc
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Bundle at {ref} is not valid JSON: {exc}") from exc
+    else:
+        try:
+            with open(ref, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except FileNotFoundError as exc:
+            raise ValueError(f"Bundle file not found: {ref}") from exc
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Bundle file {ref} is not valid JSON: {exc}") from exc
+
+    if not isinstance(data, dict) or data.get("kind") != BUNDLE_KIND:
+        raise ValueError(
+            f"{ref} is not a Gaia share bundle (missing kind == '{BUNDLE_KIND}')."
+        )
+    return data
+
+
+# ─── consumer: tree preview renderer ───────────────────────────────────────────
+
+
+def render_bundle_tree_lines(bundle, color=False):
+    """Render the sharer's tree as a list of lines, self-contained from skillMeta."""
+    meta = bundle.get("skillMeta", {})
+    sharer = bundle.get("sharer", bundle.get("tree", {}).get("userId", "unknown"))
+
+    # Roots: owned skills that are not a prereq of any other owned skill.
+    prereq_targets = set()
+    for m in meta.values():
+        prereq_targets.update(m.get("prereqs", []))
+    roots = sorted(sid for sid in meta if sid not in prereq_targets)
+    # Fallback: if every node is someone's prereq (a cycle), show them all flat.
+    if not roots and meta:
+        roots = sorted(meta)
+
+    lines = [_color_sharer(sharer) if color else sharer]
+    seen = set()
+
+    def render(sid, prefix, is_last):
+        m = meta.get(sid, {})
+        stype = m.get("type", "basic")
+        symbol = _TYPE_SYMBOL.get(stype, "○")
+        level = m.get("level", "?")
+        star = f" {level}" if level and level not in ("0★", "?") else ""
+        label = f"{symbol} {sid}{star}"
+        connector = "└── " if is_last else "├── "
+        if sid in seen:
+            lines.append(prefix + connector + label + " (see above)")
+            return
+        seen.add(sid)
+        if color:
+            lines.append(_dim(prefix + connector) + _color_label(label, level, m.get("named")))
+        else:
+            lines.append(prefix + connector + label)
+        children = sorted(c for c in m.get("prereqs", []) if c in meta)
+        child_prefix = prefix + ("    " if is_last else "│   ")
+        for i, child in enumerate(children):
+            render(child, child_prefix, i == len(children) - 1)
+
+    for i, root in enumerate(roots):
+        render(root, "", i == len(roots) - 1)
+    return lines
+
+
+def _color_sharer(text):
+    try:
+        from gaia_cli.formatting import _fg, _reset, COLOR_CONTRIBUTOR
+
+        return f"{_fg(*COLOR_CONTRIBUTOR)}{text}{_reset()}"
+    except Exception:  # noqa: BLE001
+        return text
+
+
+def _dim(text):
+    try:
+        from gaia_cli.formatting import _use_color
+
+        return f"\033[2m{text}\033[22m" if _use_color() else text
+    except Exception:  # noqa: BLE001
+        return text
+
+
+def _color_label(label, level, named):
+    try:
+        from gaia_cli.formatting import _fg, _reset, RANK_COLORS, COLOR_CONTRIBUTOR
+
+        if named:
+            color = COLOR_CONTRIBUTOR
+        else:
+            color = RANK_COLORS.get(level, RANK_COLORS.get("0★", (148, 163, 184)))
+        return f"{_fg(*color)}{label}{_reset()}"
+    except Exception:  # noqa: BLE001
+        return label
+
+
+def render_bundle_tree(bundle, color=False):
+    return "\n".join(render_bundle_tree_lines(bundle, color=color))
+
+
+# ─── consumer: guided install flow ─────────────────────────────────────────────
+
+
+def _prompt_choice(input_fn):
+    prompt = "Install? [A]ll  [P]ick  [V]iew only  [Q]uit: "
+    try:
+        raw = (input_fn(prompt) or "").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        return "quit"
+    if raw in ("a", "all"):
+        return "all"
+    if raw in ("p", "pick"):
+        return "pick"
+    if raw in ("q", "quit", ""):
+        return "quit"
+    return "view"
+
+
+def _prompt_picks(manifest, input_fn):
+    try:
+        raw = input_fn("Enter numbers to install (space/comma separated): ").strip()
+    except (EOFError, KeyboardInterrupt):
+        return []
+    picks = []
+    for tok in re.split(r"[\s,]+", raw):
+        if not tok:
+            continue
+        try:
+            idx = int(tok) - 1
+        except ValueError:
+            continue
+        if 0 <= idx < len(manifest):
+            picks.append(idx)
+    return picks
+
+
+def _install_entry(entry, registry_path, location):
+    """Resolve and install a single manifest entry.
+
+    Reuse the registry resolution path (`gaia skills install`) when the skill
+    exists in the consumer's registry; otherwise install directly from the
+    bundle's source URL (the multi-repo / foreign-skill case).
+
+    Returns "installed", "failed", or "unresolved".
+    """
+    from gaia_cli.install import (
+        _install_single,
+        install_skill,
+        resolve_named_skill_reference,
+    )
+
+    sid = entry.get("id")
+    resolved_id, _meta = resolve_named_skill_reference(sid, registry_path)
+    if resolved_id:
+        return "installed" if install_skill(resolved_id, registry_path, location=location) else "failed"
+
+    github = entry.get("github")
+    if github:
+        meta = {"links": {"github": github}}
+        if entry.get("suiteComponents"):
+            meta["suiteComponents"] = entry["suiteComponents"]
+        return "installed" if _install_single(sid, meta, registry_path, set(), location=location) else "failed"
+
+    return "unresolved"
+
+
+def install_bundle(
+    bundle_ref,
+    registry_path,
+    location="local",
+    auto=None,
+    input_fn=None,
+    out=print,
+):
+    """Render the sharer's tree, then walk the A/P/V/Q install flow.
+
+    Args:
+        bundle_ref: file path, URL, or an already-loaded bundle dict.
+        auto: skip the prompt with a fixed choice ("all"/"pick"/"view"/"quit").
+            When None and stdin is not a TTY, defaults to "view" (no surprise
+            installs in automation).
+        input_fn: injectable input() for tests.
+
+    Returns a summary dict: {installed, skipped, unresolved, failed} lists of ids.
+    """
+    import sys
+
+    if input_fn is None:
+        input_fn = input
+
+    bundle = bundle_ref if isinstance(bundle_ref, dict) else load_bundle(bundle_ref)
+
+    sharer = bundle.get("sharer", "someone")
+    manifest = bundle.get("install", [])
+
+    out(f"\nShared skill tree from {sharer}:\n")
+    for line in render_bundle_tree_lines(bundle, color=_can_color()):
+        out(line)
+    out("")
+
+    if not manifest:
+        out("This bundle has no installable skills (preview only).")
+        return {"installed": [], "skipped": [], "unresolved": [], "failed": []}
+
+    out(f"{len(manifest)} installable skill(s):")
+    for i, entry in enumerate(manifest, 1):
+        src = entry.get("github", "suite" if entry.get("suiteComponents") else "?")
+        out(f"  {i:>2}. {entry['id']}  ({entry.get('level', '?')})  → {src}")
+    out("")
+
+    choice = auto
+    if choice is None:
+        choice = _prompt_choice(input_fn) if sys.stdin.isatty() else "view"
+
+    if choice == "quit":
+        out("Quit — nothing installed.")
+        return {
+            "installed": [],
+            "skipped": [e["id"] for e in manifest],
+            "unresolved": [],
+            "failed": [],
+        }
+    if choice == "view":
+        out("View only — nothing installed.")
+        return {
+            "installed": [],
+            "skipped": [e["id"] for e in manifest],
+            "unresolved": [],
+            "failed": [],
+        }
+
+    if choice == "pick":
+        picks = _prompt_picks(manifest, input_fn)
+        chosen_idx = set(picks)
+    else:  # all
+        chosen_idx = set(range(len(manifest)))
+
+    summary = {"installed": [], "skipped": [], "unresolved": [], "failed": []}
+    for i, entry in enumerate(manifest):
+        if i not in chosen_idx:
+            summary["skipped"].append(entry["id"])
+            continue
+        result = _install_entry(entry, registry_path, location)
+        summary[result].append(entry["id"])
+
+    _print_summary(summary, out)
+    return summary
+
+
+def _print_summary(summary, out):
+    out("\nSummary:")
+    out(f"  installed:  {len(summary['installed'])}  {', '.join(summary['installed'])}".rstrip())
+    out(f"  skipped:    {len(summary['skipped'])}  {', '.join(summary['skipped'])}".rstrip())
+    unresolved = summary["unresolved"] + summary["failed"]
+    out(f"  unresolved: {len(unresolved)}  {', '.join(unresolved)}".rstrip())
+
+
+def _can_color():
+    try:
+        from gaia_cli.formatting import _use_color
+
+        return _use_color()
+    except Exception:  # noqa: BLE001
+        return False

--- a/tests/test_share.py
+++ b/tests/test_share.py
@@ -1,0 +1,364 @@
+"""Tests for the share-bundle producer (`gaia share`) and the guided
+bundle-install consumer (`gaia install <bundle>`) — Issue #128 (CLI half).
+
+NOTE: like test_install.py, these tests drive install resolution through
+named-skills.json (pure JSON, no YAML), and mock _run_git so no network or
+real clone happens.
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from gaia_cli.share import (
+    BUNDLE_KIND,
+    BUNDLE_VERSION,
+    _looks_like_bundle_ref,
+    _normalize_github_url,
+    build_share_bundle,
+    install_bundle,
+    load_bundle,
+    render_bundle_tree,
+    render_bundle_tree_lines,
+    write_bundle,
+)
+from gaia_cli.install import load_manifest
+
+
+# ─── fixtures ───────────────────────────────────────────────────────────────
+
+
+def _write_registry(tmp_path, canonical_skills, named_entries):
+    """Write registry/gaia.json and registry/named-skills.json."""
+    registry = tmp_path / "registry"
+    registry.mkdir(parents=True, exist_ok=True)
+    (registry / "gaia.json").write_text(
+        json.dumps({"version": "9.9.9", "skills": canonical_skills}),
+        encoding="utf-8",
+    )
+    buckets: dict = {}
+    for meta in named_entries:
+        ref = meta.get("genericSkillRef", meta["id"].replace("/", "-"))
+        buckets.setdefault(ref, []).append(meta)
+    (registry / "named-skills.json").write_text(
+        json.dumps({"buckets": buckets, "awaitingClassification": []}),
+        encoding="utf-8",
+    )
+
+
+def _write_tree(tmp_path, username, unlocked):
+    tree_dir = tmp_path / "skill-trees" / username
+    tree_dir.mkdir(parents=True, exist_ok=True)
+    (tree_dir / "skill-tree.json").write_text(
+        json.dumps(
+            {
+                "userId": username,
+                "updatedAt": "2026-06-10",
+                "unlockedSkills": unlocked,
+                "stats": {"totalUnlocked": len(unlocked)},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _basic_world(tmp_path, username="alice"):
+    """A two-skill tree where b depends on a (canonical prereq edge)."""
+    _write_registry(
+        tmp_path,
+        canonical_skills=[
+            {"id": "feat-a", "name": "Feature A", "type": "basic", "level": "2★", "prerequisites": []},
+            {"id": "feat-b", "name": "Feature B", "type": "extra", "level": "3★", "prerequisites": ["feat-a"]},
+        ],
+        named_entries=[
+            {
+                "id": "alice/skill-a",
+                "name": "Skill A",
+                "genericSkillRef": "feat-a",
+                "level": "2★",
+                "type": "basic",
+                "links": {"github": "https://github.com/alice/repo/blob/main/skill-a/SKILL.md"},
+            },
+            {
+                "id": "alice/skill-b",
+                "name": "Skill B",
+                "genericSkillRef": "feat-b",
+                "level": "3★",
+                "type": "extra",
+                "links": {"github": "https://github.com/alice/repo/blob/main/skill-b/SKILL.md"},
+            },
+        ],
+    )
+    _write_tree(
+        tmp_path,
+        username,
+        [
+            {"skillId": "alice/skill-a", "level": "2★"},
+            {"skillId": "alice/skill-b", "level": "3★"},
+        ],
+    )
+
+
+# ─── producer ─────────────────────────────────────────────────────────────────
+
+
+class TestBundleProducer:
+    def test_build_bundle_shape_and_roundtrip(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _basic_world(tmp_path)
+
+        bundle = build_share_bundle("alice", str(tmp_path))
+        assert bundle["kind"] == BUNDLE_KIND
+        assert bundle["bundleVersion"] == BUNDLE_VERSION
+        assert bundle["sharer"] == "alice"
+        assert len(bundle["skillMeta"]) == 2
+        assert len(bundle["install"]) == 2
+
+        # Round-trip through disk.
+        path = write_bundle(bundle, str(tmp_path / "out" / "alice.json"))
+        loaded = load_bundle(path)
+        assert loaded == bundle
+
+    def test_prereq_edges_translated_to_owned_named_ids(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _basic_world(tmp_path)
+
+        bundle = build_share_bundle("alice", str(tmp_path))
+        # feat-b depends on feat-a; alice owns both under named ids → edge b→a.
+        assert bundle["skillMeta"]["alice/skill-b"]["prereqs"] == ["alice/skill-a"]
+        assert bundle["skillMeta"]["alice/skill-a"]["prereqs"] == []
+
+    def test_install_manifest_carries_blob_url(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _basic_world(tmp_path)
+
+        bundle = build_share_bundle("alice", str(tmp_path))
+        entry = next(e for e in bundle["install"] if e["id"] == "alice/skill-a")
+        assert entry["github"].endswith("/blob/main/skill-a/SKILL.md")
+        assert entry["level"] == "2★"
+
+    def test_starless_skill_is_preview_only(self, tmp_path, monkeypatch):
+        """A canonical skill with no named implementation appears in the preview
+        but never in the install manifest (it has no installable source)."""
+        monkeypatch.chdir(tmp_path)
+        _write_registry(
+            tmp_path,
+            canonical_skills=[
+                {"id": "starless-thing", "name": "Starless", "type": "basic", "level": "0★", "prerequisites": []},
+            ],
+            named_entries=[],
+        )
+        _write_tree(tmp_path, "bob", [{"skillId": "starless-thing", "level": "1★"}])
+
+        bundle = build_share_bundle("bob", str(tmp_path))
+        assert "starless-thing" in bundle["skillMeta"]
+        assert bundle["install"] == []
+
+    def test_tree_url_normalized_to_blob(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_registry(
+            tmp_path,
+            canonical_skills=[{"id": "x", "name": "X", "type": "basic", "level": "1★", "prerequisites": []}],
+            named_entries=[
+                {
+                    "id": "carol/x",
+                    "name": "X",
+                    "genericSkillRef": "x",
+                    "level": "1★",
+                    "type": "basic",
+                    # tree/ directory-view URL — must be converted to blob/
+                    "links": {"github": "https://github.com/carol/repo/tree/main/x"},
+                }
+            ],
+        )
+        _write_tree(tmp_path, "carol", [{"skillId": "carol/x", "level": "1★"}])
+
+        bundle = build_share_bundle("carol", str(tmp_path))
+        assert bundle["install"][0]["github"] == "https://github.com/carol/repo/blob/main/x"
+
+    def test_missing_tree_raises(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_registry(tmp_path, [], [])
+        try:
+            build_share_bundle("nobody", str(tmp_path))
+            assert False, "expected ValueError"
+        except ValueError:
+            pass
+
+
+# ─── detection + loading ────────────────────────────────────────────────────
+
+
+class TestBundleDetectionAndLoad:
+    def test_looks_like_bundle_ref(self):
+        assert _looks_like_bundle_ref("/tmp/x.json")
+        assert _looks_like_bundle_ref("https://example.com/x.json")
+        assert _looks_like_bundle_ref("http://example.com/share")
+        assert not _looks_like_bundle_ref("alice/skill-a")
+        assert not _looks_like_bundle_ref("unique-skill")
+        assert not _looks_like_bundle_ref("")
+
+    def test_normalize_github_url(self):
+        assert _normalize_github_url("https://github.com/o/r/tree/main/p") == (
+            "https://github.com/o/r/blob/main/p"
+        )
+        assert _normalize_github_url("https://github.com/o/r/blob/main/p") == (
+            "https://github.com/o/r/blob/main/p"
+        )
+        assert _normalize_github_url(None) is None
+
+    def test_load_bundle_rejects_non_bundle_json(self, tmp_path):
+        p = tmp_path / "notabundle.json"
+        p.write_text(json.dumps({"hello": "world"}), encoding="utf-8")
+        try:
+            load_bundle(str(p))
+            assert False, "expected ValueError"
+        except ValueError as exc:
+            assert "share bundle" in str(exc)
+
+    def test_load_bundle_missing_file(self, tmp_path):
+        try:
+            load_bundle(str(tmp_path / "nope.json"))
+            assert False, "expected ValueError"
+        except ValueError as exc:
+            assert "not found" in str(exc)
+
+
+# ─── preview renderer ─────────────────────────────────────────────────────────
+
+
+class TestBundlePreview:
+    def test_render_nests_prereqs_under_dependent(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _basic_world(tmp_path)
+        bundle = build_share_bundle("alice", str(tmp_path))
+
+        text = render_bundle_tree(bundle)
+        assert "alice" in text.splitlines()[0]
+        # skill-b is the root (nothing depends on it); skill-a is its child.
+        lines = render_bundle_tree_lines(bundle)
+        b_idx = next(i for i, l in enumerate(lines) if "alice/skill-b" in l)
+        a_idx = next(i for i, l in enumerate(lines) if "alice/skill-a" in l)
+        assert b_idx < a_idx, "dependent should render before its prerequisite"
+        # The child line is indented relative to the root.
+        assert lines[a_idx].startswith((" ", "│", "└", "├")) or "    " in lines[a_idx]
+
+
+# ─── consumer install flow ─────────────────────────────────────────────────────
+
+
+def _mock_git(monkeypatch, tmp_path):
+    """Mock git clone + cache dir so install runs offline."""
+    def mock_run_git(args, cwd=None):
+        if args and args[0] == "clone":
+            os.makedirs(args[-1], exist_ok=True)
+        return True
+
+    monkeypatch.setattr("gaia_cli.install._run_git", mock_run_git)
+    monkeypatch.setattr(
+        "gaia_cli.install.get_global_cache_dir",
+        lambda: str(tmp_path / ".gaia" / "skills"),
+    )
+
+
+class TestBundleInstallFlow:
+    def test_view_only_installs_nothing(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _basic_world(tmp_path)
+        bundle = build_share_bundle("alice", str(tmp_path))
+        path = write_bundle(bundle, str(tmp_path / "b.json"))
+
+        out = install_bundle(path, str(tmp_path), auto="view", out=lambda *a: None)
+        assert out["installed"] == []
+        assert set(out["skipped"]) == {"alice/skill-a", "alice/skill-b"}
+
+    def test_quit_installs_nothing(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _basic_world(tmp_path)
+        bundle = build_share_bundle("alice", str(tmp_path))
+        out = install_bundle(bundle, str(tmp_path), auto="quit", out=lambda *a: None)
+        assert out["installed"] == []
+
+    def test_all_installs_via_registry_resolution(self, tmp_path, monkeypatch):
+        """When the consumer registry knows the skills, install reuses the
+        registry resolution path (install_skill)."""
+        monkeypatch.chdir(tmp_path)
+        _basic_world(tmp_path)
+        _mock_git(monkeypatch, tmp_path)
+
+        bundle = build_share_bundle("alice", str(tmp_path))
+        out = install_bundle(bundle, str(tmp_path), auto="all", out=lambda *a: None)
+
+        assert set(out["installed"]) == {"alice/skill-a", "alice/skill-b"}
+        assert out["unresolved"] == [] and out["failed"] == []
+        manifest = load_manifest()
+        assert {e["id"] for e in manifest["installed"]} == {"alice/skill-a", "alice/skill-b"}
+
+    def test_multi_repo_foreign_install_uses_bundle_urls(self, tmp_path, monkeypatch):
+        """A bundle spanning repos the consumer's registry does NOT contain
+        installs each skill directly from its own source URL."""
+        monkeypatch.chdir(tmp_path)
+        # Consumer registry is empty → no resolution; must use bundle URLs.
+        _write_registry(tmp_path, [], [])
+        _mock_git(monkeypatch, tmp_path)
+
+        bundle = {
+            "kind": BUNDLE_KIND,
+            "bundleVersion": BUNDLE_VERSION,
+            "sharer": "dan",
+            "skillMeta": {
+                "dan/one": {"name": "One", "level": "2★", "type": "basic", "named": True, "prereqs": []},
+                "erin/two": {"name": "Two", "level": "3★", "type": "extra", "named": True, "prereqs": []},
+            },
+            "install": [
+                {"id": "dan/one", "name": "One", "level": "2★", "type": "basic",
+                 "github": "https://github.com/dan/repo-one/blob/main/one/SKILL.md"},
+                {"id": "erin/two", "name": "Two", "level": "3★", "type": "extra",
+                 "github": "https://github.com/erin/repo-two/blob/main/two/SKILL.md"},
+            ],
+        }
+        out = install_bundle(bundle, str(tmp_path), auto="all", out=lambda *a: None)
+
+        assert set(out["installed"]) == {"dan/one", "erin/two"}
+        manifest = load_manifest()
+        repos = {e["repoUrl"] for e in manifest["installed"]}
+        assert repos == {
+            "https://github.com/dan/repo-one.git",
+            "https://github.com/erin/repo-two.git",
+        }
+
+    def test_pick_installs_only_chosen(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _basic_world(tmp_path)
+        _mock_git(monkeypatch, tmp_path)
+        bundle = build_share_bundle("alice", str(tmp_path))
+
+        # Pick only the first listed skill.
+        fake_inputs = iter(["1"])
+        out = install_bundle(
+            bundle,
+            str(tmp_path),
+            auto="pick",
+            input_fn=lambda *a: next(fake_inputs),
+            out=lambda *a: None,
+        )
+        assert len(out["installed"]) == 1
+        assert len(out["skipped"]) == 1
+
+    def test_unresolvable_entry_reported(self, tmp_path, monkeypatch):
+        """A chosen entry with neither a registry match nor a github URL is
+        reported as unresolved, not silently dropped."""
+        monkeypatch.chdir(tmp_path)
+        _write_registry(tmp_path, [], [])
+        bundle = {
+            "kind": BUNDLE_KIND,
+            "bundleVersion": BUNDLE_VERSION,
+            "sharer": "z",
+            "skillMeta": {"z/ghost": {"name": "Ghost", "level": "1★", "type": "basic", "named": True, "prereqs": []}},
+            "install": [{"id": "z/ghost", "name": "Ghost", "level": "1★", "type": "basic"}],
+        }
+        out = install_bundle(bundle, str(tmp_path), auto="all", out=lambda *a: None)
+        assert out["unresolved"] == ["z/ghost"]
+        assert out["installed"] == []


### PR DESCRIPTION
## Summary

Implements the **CLI half** of `gaia share` / `gaia install` per the [Issue #128 design note](https://github.com/mbtiongson1/gaia-skill-tree/issues/128) and the decision (CLI-first, then static `docs/share/` page as a fast follow).

A **share bundle** is one self-contained JSON artifact that travels anywhere:
- a snapshot of the sharer's local tree (`unlockedSkills` + levels) — shares 100% even when not canonical;
- a **flat install manifest** pointing each skill at its source repo via the existing `links.github` `blob/branch/subpath` path (reusing `src/gaia_cli/install.py`), so multi-repo bundles install through the same code `gaia skills install` already uses;
- pre-resolved metadata (name / level / type / owned-prereq edges) so the consumer re-renders the sharer's tree preview with **zero dependency on their own registry**.

### `gaia share`
Emits the bundle to `generated-output/share/<user>-share-bundle.json` (or `--stdout`) plus a copy-pastable `gaia install <path>` one-liner. `tree/` URLs are normalized to `blob/`; suites keep `suiteComponents` and never require `links.github`.

### `gaia install <bundle.json | url>`
Detected by a `.json` suffix or `http(s)://` prefix (skill ids are never either). Renders the sharer's tree, then walks the guided flowchart:
```
fetch bundle → render sharer's tree preview
prompt: [A]ll  [P]ick  [V]iew only  [Q]uit
for each chosen skill → resolve (registry path first, else bundle source URL) → install
summary: installed / skipped / unresolved
```
Non-TTY defaults to **view-only** (no surprise installs in automation).

## Tests
`tests/test_share.py` (17 tests) — bundle round-trip, canonical→named prereq-edge translation, `tree/`→`blob/` normalization, bundle detection/validation, **multi-repo foreign install**, and pick/view/quit/unresolved outcomes. Full suite: **752 passing**.

## Scope / closing note
This is the **CLI half only** — therefore `Refs #128`, **not** `Closes`. The static `docs/share/` copy-link page (hosting option a) remains and is the fast-follow that will close the issue (separate `design/` branch). OAuth-bound variant deferred to #155.

Follow-up backlog (not in this PR, per handover): the bundle's tree snapshot could drive the narrow-path rendering in #642 once `scripts/generateProjections.py` is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)