### PR TITLE
feat(schema): split evidence into Type + Grade + trustNumber (Refs #646)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -56,9 +56,37 @@ _Avoid_: upgrade, promote-up.
 The verb for dropping a skill back one or more stars when a demerit lands or evidence is retracted.
 _Avoid_: downgrade, demote-down.
 
-**Evidence Class**:
-The independently graded quality of a real-world demonstration: Class C (first sighting), Class B (reproducible, documented), Class A (battle-tested, peer-reviewed).
-_Avoid_: proof level, evidence tier.
+**Evidence Class** _(deprecated — see Evidence Type + Evidence Grade)_:
+The legacy single axis that conflated *provenance* and *quality* into one letter: Class C (first sighting), Class B (reproducible, documented), Class A (battle-tested, peer-reviewed). Superseded under the #646 trust model by **Evidence Type** (where a demonstration came from) plus **Evidence Grade** (how strong it is). The field stays valid in the schema until the next major release, then is removed; new evidence should carry a Type and a Grade instead. **Warning:** Class A/B are *not* Grade A/B — never read one axis as the other.
+_Avoid_: proof level, evidence tier; using Class for new evidence; equating Class letters with Grade letters.
+
+### Evidence and trust (the trust model)
+
+The #646 trust model splits the old single `class` letter into two orthogonal axes — **Evidence Type** (provenance) and **Evidence Grade** (quality) — and adds the skill-level **Overall Trust Grade**. These materialise in generated catalogs; they are computed by the build pipeline, never declared.
+
+**Evidence Type**:
+The provenance of one demonstration — *where* it comes from, not how good it is. Values are kebab-case and list-driven from `meta.json` `evidence.types` (initially `arxiv`, `repo`, `github-stars`), so new sources extend the list without a schema change. Always write the full phrase "Evidence Type"; never the bare word "type", which names the Basic/Extra/Unique/Ultimate taxonomy field.
+_Avoid_: reusing **Evidence Class** for provenance; "source class"; the bare "type" for provenance.
+
+**Evidence Grade**:
+The quality of one demonstration on an **S / A / B / C** axis — Platinum (S), Gold (A), Silver (B), Bronze (C) — derived from its **trust number**. A demonstration whose trust number falls below the C threshold is **ungraded**: on the record but counting toward no gate. The grade letters are deliberately distinct from the deprecated **Evidence Class** letters — Grade A ≠ Class A.
+_Avoid_: equating Grade A/B with Class A/B; "evidence tier"; "proof grade".
+
+**trust number**:
+The internal 0–100 score an **Evidence Grade** derives from, via `meta.json` `evidence.gradeThresholds` (S ≥ 90, A ≥ 80, B ≥ 60, C ≥ 40, ungraded < 40). An input to grading, **not user-facing** — surfaces show the grade it yields, never the raw number.
+_Avoid_: showing the trust number in copy; "trust score" (the term is "trust number").
+
+**Overall Trust Grade**:
+A skill's *aggregate* standing — the accumulation of its individual **Evidence Grades** that establishes the capability "beyond reasonable doubt." Computed from the evidence inventory at build time and **never stored in a node** (Programmatic-First); it materialises only in generated catalogs (`named-skills.json`, `docs/graph/gaia.json`). Distinct from a single demonstration's **Evidence Grade**.
+_Avoid_: storing it on a node; conflating it with one entry's Evidence Grade; "trust rating".
+
+**rank tenure**:
+How long a skill has held its current stars, derived from its timeline `rank_up` / `demote` events and rendered as "held the *[rank name]* rank since *[date]*." Computed, never stored. In copy always pair the word "rank" with the rank name (e.g. "the Hardened rank since 2026-03-01"); never write "rank" alone to mean the stars axis.
+_Avoid_: "rank since" with no rank name; storing tenure on a node; "rank age".
+
+**Verification levels**:
+The states an evidence entry passes through, orthogonal to its grade: **unverified** (default), **verified** (confirmed by a 4★+ **Verifier**; `evidence.verified: true`), and **disputed** (`evidence.disputed: true`). Verification attests that a demonstration is *real*; grading measures how *strong* it is — the two never substitute for each other.
+_Avoid_: treating "verified" as a grade; "verification stars" (verification is not on the stars axis).
 
 ### Rarity (the third axis — REMOVED)
 
@@ -138,7 +166,7 @@ current rank, or the build fails.
 - An **Extra Skill** can fuse with other **Extra Skills** to produce a more complex **Extra Skill**, or chain into an **Ultimate Skill**.
 - A **Unique Skill** is a **Basic Skill** that ranked up without ever fusing.
 - A skill becomes a **Named Skill** at 2★, attaching it to its **Origin Contributor**.
-- Every star above 1★ requires an **Evidence Class**; ranking up across stars gates on it.
+- Every star above 1★ requires graded evidence — an **Evidence Grade** (the **Evidence Class** axis it replaces is deprecated); ranking up across stars gates on it.
 - The **Registry** is the canonical graph; a **Skill Tree** is one user's view of that graph.
 
 ## Example dialogue

--- a/registry/schema/meta.json
+++ b/registry/schema/meta.json
@@ -141,7 +141,26 @@
     "ultimateRequiredClasses": [
       "A",
       "B"
-    ]
+    ],
+    "types": [
+      "arxiv",
+      "repo",
+      "github-stars"
+    ],
+    "gradeThresholds": {
+      "S": 90,
+      "A": 80,
+      "B": 60,
+      "C": 40
+    },
+    "ultimateGate": {
+      "minEvidencedComponents": 3,
+      "requiredComponentGrades": {
+        "S": 1,
+        "A": 2
+      },
+      "componentFloor": "C"
+    }
   },
   "demerits": {
     "order": [

--- a/registry/schema/namedSkill.schema.json
+++ b/registry/schema/namedSkill.schema.json
@@ -165,13 +165,33 @@
     "evidenceEntry": {
       "type": "object",
       "required": [
-        "class",
         "source",
         "evaluator",
         "date"
       ],
       "additionalProperties": false,
       "properties": {
+        "type": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+          "description": "Evidence Type — the provenance of the demonstration (where it came from, not how strong it is). Kebab-case, validated against meta.json evidence.types (initially arxiv, repo, github-stars); list-driven so new types can be added in meta.json without a schema change. Carries the provenance meaning that the deprecated `class` field used to conflate. Distinct from the skill `type` taxonomy (basic/extra/unique/ultimate)."
+        },
+        "grade": {
+          "type": "string",
+          "enum": [
+            "S",
+            "A",
+            "B",
+            "C"
+          ],
+          "description": "Evidence Grade — the quality of the demonstration, derived from trustNumber via meta.json evidence.gradeThresholds (S >= 90, A >= 80, B >= 60, C >= 40). Evidence whose trustNumber is below 40 is ungraded: this field is absent and the entry counts toward no gate. WARNING: grade A/B are NOT the deprecated class A/B — migration code must never read one as the other."
+        },
+        "trustNumber": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Internal 0–100 trust score that the Evidence Grade derives from via meta.json evidence.gradeThresholds. Not user-facing; surfaces show the grade, never the raw number."
+        },
         "class": {
           "type": "string",
           "enum": [
@@ -179,7 +199,7 @@
             "B",
             "C"
           ],
-          "description": "Evidence class: A (peer-reviewed), B (reproducible demo), C (credible demo)."
+          "description": "DEPRECATED — removed at the next major release. Legacy single axis that conflated provenance and quality into one letter (A peer-reviewed, B reproducible demo, C credible demo). Superseded by `type` (provenance) + `grade` (quality). Class A/B are NOT grade A/B. Retained for backward compatibility until the class-to-type migration completes; no longer required."
         },
         "source": {
           "type": "string",

--- a/registry/schema/skill.schema.json
+++ b/registry/schema/skill.schema.json
@@ -131,13 +131,33 @@
     "evidenceEntry": {
       "type": "object",
       "required": [
-        "class",
         "source",
         "evaluator",
         "date"
       ],
       "additionalProperties": false,
       "properties": {
+        "type": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+          "description": "Evidence Type — the provenance of the demonstration (where it came from, not how strong it is). Kebab-case, validated against meta.json evidence.types (initially arxiv, repo, github-stars); list-driven so new types can be added in meta.json without a schema change. Carries the provenance meaning that the deprecated `class` field used to conflate. Distinct from the skill `type` taxonomy (basic/extra/unique/ultimate)."
+        },
+        "grade": {
+          "type": "string",
+          "enum": [
+            "S",
+            "A",
+            "B",
+            "C"
+          ],
+          "description": "Evidence Grade — the quality of the demonstration, derived from trustNumber via meta.json evidence.gradeThresholds (S >= 90, A >= 80, B >= 60, C >= 40). Evidence whose trustNumber is below 40 is ungraded: this field is absent and the entry counts toward no gate. WARNING: grade A/B are NOT the deprecated class A/B — migration code must never read one as the other."
+        },
+        "trustNumber": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Internal 0–100 trust score that the Evidence Grade derives from via meta.json evidence.gradeThresholds. Not user-facing; surfaces show the grade, never the raw number."
+        },
         "class": {
           "type": "string",
           "enum": [
@@ -145,7 +165,7 @@
             "B",
             "C"
           ],
-          "description": "Evidence class: A (peer-reviewed), B (reproducible demo), C (credible demo)."
+          "description": "DEPRECATED — removed at the next major release. Legacy single axis that conflated provenance and quality into one letter (A peer-reviewed, B reproducible demo, C credible demo). Superseded by `type` (provenance) + `grade` (quality). Class A/B are NOT grade A/B. Retained for backward compatibility until the class-to-type migration completes; no longer required."
         },
         "source": {
           "type": "string",

--- a/src/gaia_cli/data/registry/schema/meta.json
+++ b/src/gaia_cli/data/registry/schema/meta.json
@@ -141,7 +141,26 @@
     "ultimateRequiredClasses": [
       "A",
       "B"
-    ]
+    ],
+    "types": [
+      "arxiv",
+      "repo",
+      "github-stars"
+    ],
+    "gradeThresholds": {
+      "S": 90,
+      "A": 80,
+      "B": 60,
+      "C": 40
+    },
+    "ultimateGate": {
+      "minEvidencedComponents": 3,
+      "requiredComponentGrades": {
+        "S": 1,
+        "A": 2
+      },
+      "componentFloor": "C"
+    }
   },
   "demerits": {
     "order": [

--- a/src/gaia_cli/data/registry/schema/namedSkill.schema.json
+++ b/src/gaia_cli/data/registry/schema/namedSkill.schema.json
@@ -165,13 +165,33 @@
     "evidenceEntry": {
       "type": "object",
       "required": [
-        "class",
         "source",
         "evaluator",
         "date"
       ],
       "additionalProperties": false,
       "properties": {
+        "type": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+          "description": "Evidence Type — the provenance of the demonstration (where it came from, not how strong it is). Kebab-case, validated against meta.json evidence.types (initially arxiv, repo, github-stars); list-driven so new types can be added in meta.json without a schema change. Carries the provenance meaning that the deprecated `class` field used to conflate. Distinct from the skill `type` taxonomy (basic/extra/unique/ultimate)."
+        },
+        "grade": {
+          "type": "string",
+          "enum": [
+            "S",
+            "A",
+            "B",
+            "C"
+          ],
+          "description": "Evidence Grade — the quality of the demonstration, derived from trustNumber via meta.json evidence.gradeThresholds (S >= 90, A >= 80, B >= 60, C >= 40). Evidence whose trustNumber is below 40 is ungraded: this field is absent and the entry counts toward no gate. WARNING: grade A/B are NOT the deprecated class A/B — migration code must never read one as the other."
+        },
+        "trustNumber": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Internal 0–100 trust score that the Evidence Grade derives from via meta.json evidence.gradeThresholds. Not user-facing; surfaces show the grade, never the raw number."
+        },
         "class": {
           "type": "string",
           "enum": [
@@ -179,7 +199,7 @@
             "B",
             "C"
           ],
-          "description": "Evidence class: A (peer-reviewed), B (reproducible demo), C (credible demo)."
+          "description": "DEPRECATED — removed at the next major release. Legacy single axis that conflated provenance and quality into one letter (A peer-reviewed, B reproducible demo, C credible demo). Superseded by `type` (provenance) + `grade` (quality). Class A/B are NOT grade A/B. Retained for backward compatibility until the class-to-type migration completes; no longer required."
         },
         "source": {
           "type": "string",

--- a/src/gaia_cli/data/registry/schema/skill.schema.json
+++ b/src/gaia_cli/data/registry/schema/skill.schema.json
@@ -131,13 +131,33 @@
     "evidenceEntry": {
       "type": "object",
       "required": [
-        "class",
         "source",
         "evaluator",
         "date"
       ],
       "additionalProperties": false,
       "properties": {
+        "type": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+          "description": "Evidence Type — the provenance of the demonstration (where it came from, not how strong it is). Kebab-case, validated against meta.json evidence.types (initially arxiv, repo, github-stars); list-driven so new types can be added in meta.json without a schema change. Carries the provenance meaning that the deprecated `class` field used to conflate. Distinct from the skill `type` taxonomy (basic/extra/unique/ultimate)."
+        },
+        "grade": {
+          "type": "string",
+          "enum": [
+            "S",
+            "A",
+            "B",
+            "C"
+          ],
+          "description": "Evidence Grade — the quality of the demonstration, derived from trustNumber via meta.json evidence.gradeThresholds (S >= 90, A >= 80, B >= 60, C >= 40). Evidence whose trustNumber is below 40 is ungraded: this field is absent and the entry counts toward no gate. WARNING: grade A/B are NOT the deprecated class A/B — migration code must never read one as the other."
+        },
+        "trustNumber": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Internal 0–100 trust score that the Evidence Grade derives from via meta.json evidence.gradeThresholds. Not user-facing; surfaces show the grade, never the raw number."
+        },
         "class": {
           "type": "string",
           "enum": [
@@ -145,7 +165,7 @@
             "B",
             "C"
           ],
-          "description": "Evidence class: A (peer-reviewed), B (reproducible demo), C (credible demo)."
+          "description": "DEPRECATED — removed at the next major release. Legacy single axis that conflated provenance and quality into one letter (A peer-reviewed, B reproducible demo, C credible demo). Superseded by `type` (provenance) + `grade` (quality). Class A/B are NOT grade A/B. Retained for backward compatibility until the class-to-type migration completes; no longer required."
         },
         "source": {
           "type": "string",


### PR DESCRIPTION
**PR-1 of the #646 trust model** — schema foundation. Refs #646.
Governing spec: `handovers/TRUST_MODEL_RFC.md` v2 (accepted 2026-06-10).

Splits the conflated evidence `class` axis into two orthogonal axes — **Evidence Type** (provenance) and **Evidence Grade** (quality) — and introduces the skill-level **Overall Trust Grade** (computed, not stored).

## Changes

### `evidenceEntry` (both `skill.schema.json` + `namedSkill.schema.json`)
- **`type`** — provenance; kebab-case, **list-driven** from `meta.json` `evidence.types` (`arxiv` / `repo` / `github-stars`), so new types extend without a schema PR (Refs #654). `github-stars`, not `stars`, to avoid the ★ rank collision.
- **`grade`** — quality `S` / `A` / `B` / `C`, derived from a trust number. Below the C threshold (40) evidence is **ungraded**: present, but counts toward no gate.
- **`trustNumber`** — internal `0–100` input to grade; not user-facing.
- **`class`** — marked **DEPRECATED** in-description and **dropped from `required`** so new entries need not carry it. Removed at the next **major** release. ⚠️ grade A/B are **not** class A/B — descriptions warn against reading one as the other.

### `meta.json` `evidence`
- **`types`**: `[arxiv, repo, github-stars]`
- **`gradeThresholds`**: `S ≥ 90, A ≥ 80, B ≥ 60, C ≥ 40` (ungraded `< 40`)
- **`ultimateGate`** (suite pillar rule, Option 1): `{ minEvidencedComponents: 3, requiredComponentGrades: { S: 1, A: 2 }, componentFloor: "C" }`
- Legacy `classes` / `ultimateMinSources` / `ultimateRequiredClasses` retained until the major release.

### `CONTEXT.md`
- New glossary terms: **Evidence Type**, **Evidence Grade**, **trust number**, **Overall Trust Grade**, **rank tenure**, **Verification levels**.
- **Evidence Class** marked deprecated; rank-up relationship line updated.

### Bundled schemas
- `src/gaia_cli/data/registry/schema/{skill,namedSkill,meta}.json` synced to canonical.

## ⚠️ `skip-scope-check` label required
`gaia validate` (`scripts/validate.py`) **enforces** bundled == canonical schema parity, so this `schema/` branch must also touch `src/gaia_cli/data/registry/schema/` — outside the `schema/` branch scope. Same situation as the #356 schema PR. Please keep the `skip-scope-check` label applied.

## Verification
- Schemas valid draft-07; old class-only **and** new type+grade evidence both validate; negatives (bad grade/type/trustNumber/missing source) correctly rejected.
- `gaia validate` ✅ (228 skills, all 10 checks + bundled-parity).
- Full test suite ✅ **752 passed**.
- **Backward compatible**: existing class-only evidence still validates. No registry data migrated in this PR (that's PR-3).

## Not in this PR (per handover)
- PR-2 (`cli/`): `gaia dev evidence --type/--trust`, grade auto-derivation, grade colors in `formatting.py`, `evidence_graded` timeline action, Overall Trust Grade aggregation in the build step.
- PR-3 (`review/meta/`): backfill / re-grade existing evidence.
- PR-4 (`design/`, #648): per-skill actionable reports.
- **Post-implementation obligation**: once the ultimate gate ships, open a recalibration RFC (~1 month out) to revisit the pillar thresholds against real grade distributions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)