### PR TITLE
design: hero peek + nav vein animation sample

### DIFF
--- a/docs/css/hero-veins.css
+++ b/docs/css/hero-veins.css
@@ -1,0 +1,215 @@
+/* hero-veins.css
+ *
+ * Cursor-following peek + glow on the hero, and a procedurally-generated
+ * branching-vein texture revealed in a soft aperture around the cursor in
+ * the nav. Hovering the Gaia logo expands the aperture across the entire
+ * nav AND simultaneously widens the hero peek hole, treating the top band
+ * of the page as one continuous reveal.
+ *
+ * All selectors are gated behind body[data-hero-veins], so this file is
+ * harmless when linked but not activated. To turn it on for a page, add
+ * the attribute to <body> and inject:
+ *   - <div class="nav-veins" aria-hidden="true"></div> after the .nav-logo
+ *   - <div class="hero-cursor-glow" aria-hidden="true"></div> inside #hero
+ *
+ * The companion JS module docs/js/hero-veins.js generates the SVG inside
+ * .nav-veins and writes --hero-mx/my and --nav-mx/my CSS vars on
+ * pointermove (rAF-throttled).
+ *
+ * Decisions documented in
+ *   ~/.claude/plans/i-need-animation-on-spicy-nygaard.md
+ */
+
+/* Register --hero-peek-r so the logo-hover sweep can transition it
+ * smoothly. Without @property, custom-property transitions are stepwise.
+ * Falls back gracefully (instant change) on unsupporting browsers. */
+@property --hero-peek-r {
+  syntax: '<length>';
+  inherits: true;
+  initial-value: 220px;
+}
+
+/* ════════════════════════════════════════════════════════════════════
+ * Hero — peek hole + diffuse red glow
+ * ════════════════════════════════════════════════════════════════════ */
+
+body[data-hero-veins] #hero {
+  /* Tunable defaults (overridden by debug-panel sliders in the sample). */
+  --hero-mx: -9999px;
+  --hero-my: -9999px;
+  --hero-peek-r: 220px;
+  --hero-glow-r: 500px;
+  --hero-glow-a: 0.35;
+}
+
+/* Decision 1: mask the BLUR only — keep noise grain inside the peek hole.
+ * The mask makes a soft transparent disc that punches through the dark
+ * blur curtain so #canvas3d shows through, while .hero-glass-noise stays
+ * intact across the disc. */
+body[data-hero-veins] #hero .hero-glass-blur {
+  mask-image: radial-gradient(circle var(--hero-peek-r) at var(--hero-mx) var(--hero-my),
+                              transparent 0%,
+                              transparent 40%,
+                              black 80%);
+  -webkit-mask-image: radial-gradient(circle var(--hero-peek-r) at var(--hero-mx) var(--hero-my),
+                                      transparent 0%,
+                                      transparent 40%,
+                                      black 80%);
+}
+
+/* Soft red glow that follows the cursor. Wider and softer than the peek
+ * hole. Mix-blend-mode: screen keeps the dark UI from being washed out. */
+body[data-hero-veins] .hero-cursor-glow {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  background: radial-gradient(circle var(--hero-glow-r) at var(--hero-mx) var(--hero-my),
+                              rgba(var(--honor-red-rgb), var(--hero-glow-a)) 0%,
+                              rgba(var(--honor-red-rgb), 0) 70%);
+  mix-blend-mode: screen;
+  opacity: 0;
+  transition: opacity 0.4s ease;
+}
+
+body[data-hero-veins] #hero[data-hover="1"] .hero-cursor-glow {
+  opacity: 1;
+}
+
+/* When the pointer is outside the hero, drop the mask entirely so the
+ * curtain is uniformly opaque (no stale aperture frozen at the last
+ * cursor position). */
+body[data-hero-veins] #hero:not([data-hover="1"]) .hero-glass-blur {
+  mask-image: none;
+  -webkit-mask-image: none;
+}
+
+/* ════════════════════════════════════════════════════════════════════
+ * Nav — branching vein texture, mouse-following aperture
+ * ════════════════════════════════════════════════════════════════════ */
+
+body[data-hero-veins] nav {
+  /* Make sure absolutely-positioned vein layer can anchor to the nav. */
+  position: relative;
+
+  --nav-mx: -9999px;
+  --nav-my: -9999px;
+  --nav-aperture-r: 140px;
+  --nav-flow-dur: 16s;
+  --nav-vein-a: 0.35;
+  --nav-reveal-dur-in: 600ms;
+  --nav-reveal-dur-out: 400ms;
+}
+
+body[data-hero-veins] .nav-veins {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  mask-image: radial-gradient(circle var(--nav-aperture-r) at var(--nav-mx) var(--nav-my),
+                              black 0%,
+                              transparent 75%);
+  -webkit-mask-image: radial-gradient(circle var(--nav-aperture-r) at var(--nav-mx) var(--nav-my),
+                                      black 0%,
+                                      transparent 75%);
+  opacity: 0;
+  transition: opacity 0.35s ease,
+              mask-image var(--nav-reveal-dur-out) ease,
+              -webkit-mask-image var(--nav-reveal-dur-out) ease;
+}
+
+body[data-hero-veins] nav[data-hover="1"] .nav-veins {
+  opacity: 1;
+}
+
+/* Make sure the actual nav links/buttons sit above the vein layer. */
+body[data-hero-veins] nav .nav-logo,
+body[data-hero-veins] nav > ul,
+body[data-hero-veins] nav .nav-menu-toggle,
+body[data-hero-veins] nav .nav-search-back,
+body[data-hero-veins] nav .nav-mobile-search {
+  position: relative;
+  z-index: 1;
+}
+
+body[data-hero-veins] .nav-veins svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+body[data-hero-veins] .nav-veins svg path {
+  fill: none;
+  stroke: rgba(var(--apex-gold-rgb), var(--nav-vein-a));
+  stroke-width: 1;
+  stroke-dasharray: 6 4;
+  animation: nav-vein-flow var(--nav-flow-dur) linear infinite;
+  animation-delay: calc(var(--i, 0) * -0.7s);
+  transition: stroke 350ms ease;
+}
+
+body[data-hero-veins] .nav-veins svg circle {
+  fill: none;
+  stroke: rgba(var(--honor-red-rgb), calc(var(--nav-vein-a) * 0.7));
+  stroke-width: 1;
+  animation: nav-node-pulse 4.2s ease-in-out infinite;
+  animation-delay: calc(var(--ni, 0) * -0.3s);
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+@keyframes nav-vein-flow {
+  to { stroke-dashoffset: -200; }
+}
+
+@keyframes nav-node-pulse {
+  0%, 100% { opacity: 0.7; }
+  50%      { opacity: 1.0; }
+}
+
+/* ════════════════════════════════════════════════════════════════════
+ * Effect 3 — Hovering the Gaia logo expands aperture across the nav AND
+ * widens the hero peek hole. Pure CSS via :hover/:focus-visible + ~ for
+ * the nav, and :has() for the cross-region hero widening (Decision 2).
+ * ════════════════════════════════════════════════════════════════════ */
+
+body[data-hero-veins] .nav-logo:hover ~ .nav-veins,
+body[data-hero-veins] .nav-logo:focus-visible ~ .nav-veins {
+  /* Full-nav sweep: a wide soft band rather than a pin-spotlight. */
+  mask-image: radial-gradient(circle 120vw at 50% 50%,
+                              black 0%, black 95%, transparent 100%);
+  -webkit-mask-image: radial-gradient(circle 120vw at 50% 50%,
+                                      black 0%, black 95%, transparent 100%);
+  opacity: 1;
+  transition: mask-image var(--nav-reveal-dur-in) cubic-bezier(0.2, 0.8, 0.2, 1),
+              -webkit-mask-image var(--nav-reveal-dur-in) cubic-bezier(0.2, 0.8, 0.2, 1),
+              opacity var(--nav-reveal-dur-in) ease;
+}
+
+body[data-hero-veins] .nav-logo:hover ~ .nav-veins svg path,
+body[data-hero-veins] .nav-logo:focus-visible ~ .nav-veins svg path {
+  stroke: rgba(var(--apex-gold-rgb), 0.6);
+}
+
+/* Decision 2: simultaneously widen the hero peek hole. :has() lets the
+ * logo-hover signal cross the nav→hero boundary. */
+body[data-hero-veins]:has(nav .nav-logo:hover) #hero,
+body[data-hero-veins]:has(nav .nav-logo:focus-visible) #hero {
+  --hero-peek-r: 60vw;
+  transition: --hero-peek-r var(--nav-reveal-dur-in) cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+/* ════════════════════════════════════════════════════════════════════
+ * Reduced motion — pause the vein flow and disable transitions, but
+ * keep the cursor-following effects since they communicate state.
+ * ════════════════════════════════════════════════════════════════════ */
+
+@media (prefers-reduced-motion: reduce) {
+  body[data-hero-veins] .nav-veins svg path { animation: none; }
+  body[data-hero-veins] .nav-veins svg circle { animation: none; }
+  body[data-hero-veins] .hero-cursor-glow,
+  body[data-hero-veins] .nav-veins,
+  body[data-hero-veins] #hero .hero-glass-blur {
+    transition: none;
+  }
+}

--- a/docs/js/hero-veins.js
+++ b/docs/js/hero-veins.js
@@ -1,0 +1,292 @@
+/* hero-veins.js
+ *
+ * Pointer-tracking + procedural SVG generation for the hero peek/glow
+ * and nav vein effects defined in docs/css/hero-veins.css.
+ *
+ * Public API:
+ *   initHeroVeins(heroEl)              — pointer tracker on #hero
+ *   initNavVeins(navEl, opts)          — generate veins + tracker on <nav>
+ *   regenerateNavVeins(navEl, opts)    — for resize / debug-panel re-runs
+ *
+ * Auto-initializes on DOMContentLoaded if document.body has the
+ * [data-hero-veins] attribute. The sample page (docs/samples/nav.html)
+ * deliberately omits that attribute and calls the named exports directly,
+ * so the sample owns the lifecycle.
+ *
+ * Decisions documented in
+ *   ~/.claude/plans/i-need-animation-on-spicy-nygaard.md
+ */
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+/* On touch-only devices, pointerleave fires the moment the finger lifts.
+ * That kills the aperture instantly and feels broken. Decision 4: linger
+ * for a beat after the last touch event. */
+const TOUCH_LINGER_MS = 1600;
+
+/* ── Pointer tracker ──────────────────────────────────────────────── */
+
+function attachPointerTracker(el, varX, varY) {
+  let pendingX = 0;
+  let pendingY = 0;
+  let queued = false;
+  const isTouchOnly =
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(hover: none)').matches;
+
+  const flush = () => {
+    el.style.setProperty(varX, pendingX + 'px');
+    el.style.setProperty(varY, pendingY + 'px');
+    queued = false;
+  };
+
+  const onMove = (e) => {
+    const r = el.getBoundingClientRect();
+    pendingX = e.clientX - r.left;
+    pendingY = e.clientY - r.top;
+    if (!queued) {
+      queued = true;
+      requestAnimationFrame(flush);
+    }
+    // Any movement counts as "still hovering" on touch.
+    if (isTouchOnly) {
+      el.dataset.hover = '1';
+      scheduleLingerOff();
+    }
+  };
+
+  let lingerTimer = 0;
+  const scheduleLingerOff = () => {
+    if (lingerTimer) clearTimeout(lingerTimer);
+    lingerTimer = setTimeout(() => {
+      el.dataset.hover = '0';
+      lingerTimer = 0;
+    }, TOUCH_LINGER_MS);
+  };
+
+  el.addEventListener('pointermove', onMove, { passive: true });
+
+  if (isTouchOnly) {
+    // Tap-driven: treat any pointerdown as enter, fade out on linger.
+    el.addEventListener(
+      'pointerdown',
+      (e) => {
+        const r = el.getBoundingClientRect();
+        pendingX = e.clientX - r.left;
+        pendingY = e.clientY - r.top;
+        if (!queued) {
+          queued = true;
+          requestAnimationFrame(flush);
+        }
+        el.dataset.hover = '1';
+        scheduleLingerOff();
+      },
+      { passive: true }
+    );
+  } else {
+    el.addEventListener('pointerenter', () => {
+      el.dataset.hover = '1';
+    });
+    el.addEventListener('pointerleave', () => {
+      el.dataset.hover = '0';
+    });
+  }
+}
+
+/* ── Hero ─────────────────────────────────────────────────────────── */
+
+export function initHeroVeins(heroEl) {
+  if (!heroEl) return;
+  if (heroEl.dataset.heroVeinsBound === '1') return;
+  heroEl.dataset.heroVeinsBound = '1';
+  // Make sure the hover attribute starts in a known state (CSS gates the
+  // mask removal on [data-hover="1"], not on the absence of the attribute).
+  heroEl.dataset.hover = heroEl.dataset.hover || '0';
+  attachPointerTracker(heroEl, '--hero-mx', '--hero-my');
+}
+
+/* ── Nav: SVG vein generator ──────────────────────────────────────── */
+
+/* Deterministic-ish jitter that doesn't depend on Math.random per call —
+ * useful so two runs at the same width produce visually similar layouts.
+ * (Math.random is fine here; just keep it predictable enough that resize
+ * regen doesn't strobe.) */
+function jitter(amount, seed) {
+  const x = Math.sin(seed * 12.9898) * 43758.5453;
+  return (x - Math.floor(x) - 0.5) * 2 * amount;
+}
+
+function buildVeinSvg(width, height, opts) {
+  const {
+    nodeCount = 18,
+    columns = 5,
+    rows = 3,
+    yJitter = 12,
+    xJitter = 14,
+  } = opts;
+
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+  svg.setAttribute('preserveAspectRatio', 'xMidYMid slice');
+  svg.setAttribute('aria-hidden', 'true');
+
+  // Lay nodes onto a column×row lattice with jitter.
+  const padX = 24;
+  const usableW = Math.max(1, width - padX * 2);
+  const colGap = usableW / Math.max(1, columns - 1);
+  const padY = Math.max(8, height * 0.18);
+  const usableH = Math.max(1, height - padY * 2);
+  const rowGap = usableH / Math.max(1, rows - 1);
+
+  const nodes = [];
+  let seed = 1;
+  // Distribute nodeCount across columns roughly evenly.
+  const perColumnCounts = new Array(columns).fill(0);
+  for (let i = 0; i < nodeCount; i++) {
+    perColumnCounts[i % columns]++;
+  }
+
+  for (let c = 0; c < columns; c++) {
+    const count = perColumnCounts[c];
+    for (let i = 0; i < count; i++) {
+      const baseX = padX + c * colGap + jitter(xJitter, seed++);
+      // Spread the column's nodes vertically across the rows.
+      const rowSlot = count === 1 ? (rows - 1) / 2 : (i * (rows - 1)) / (count - 1);
+      const baseY = padY + rowSlot * rowGap + jitter(yJitter, seed++);
+      nodes.push({ col: c, x: baseX, y: baseY });
+    }
+  }
+
+  // Build edges: each node connects to 1-2 nodes in the next column.
+  const byColumn = new Map();
+  nodes.forEach((n) => {
+    if (!byColumn.has(n.col)) byColumn.set(n.col, []);
+    byColumn.get(n.col).push(n);
+  });
+
+  const edges = [];
+  for (let c = 0; c < columns - 1; c++) {
+    const fromCol = byColumn.get(c) || [];
+    const toCol = byColumn.get(c + 1) || [];
+    if (toCol.length === 0) continue;
+    fromCol.forEach((from, idx) => {
+      // Primary connection: nearest in the next column.
+      const sorted = [...toCol].sort(
+        (a, b) => Math.abs(a.y - from.y) - Math.abs(b.y - from.y)
+      );
+      edges.push({ from, to: sorted[0] });
+      // Optional Y-branch: ~50% of nodes get a second forward link.
+      if (sorted.length > 1 && (idx + c) % 2 === 0) {
+        edges.push({ from, to: sorted[1] });
+      }
+    });
+  }
+
+  // Render edges first so nodes draw on top.
+  edges.forEach((edge, i) => {
+    const path = document.createElementNS(SVG_NS, 'path');
+    const dx = edge.to.x - edge.from.x;
+    const handle = Math.max(40, dx * 0.5);
+    const verticalOffset = jitter(8, i + 100);
+    const cx1 = edge.from.x + handle;
+    const cy1 = edge.from.y + verticalOffset;
+    const cx2 = edge.to.x - handle;
+    const cy2 = edge.to.y - verticalOffset;
+    path.setAttribute(
+      'd',
+      `M ${edge.from.x.toFixed(1)} ${edge.from.y.toFixed(1)} ` +
+        `C ${cx1.toFixed(1)} ${cy1.toFixed(1)}, ` +
+        `${cx2.toFixed(1)} ${cy2.toFixed(1)}, ` +
+        `${edge.to.x.toFixed(1)} ${edge.to.y.toFixed(1)}`
+    );
+    path.setAttribute('style', `--i: ${i};`);
+    svg.appendChild(path);
+  });
+
+  nodes.forEach((node, i) => {
+    const circle = document.createElementNS(SVG_NS, 'circle');
+    circle.setAttribute('cx', node.x.toFixed(1));
+    circle.setAttribute('cy', node.y.toFixed(1));
+    circle.setAttribute('r', '3.5');
+    circle.setAttribute('style', `--ni: ${i};`);
+    svg.appendChild(circle);
+  });
+
+  return svg;
+}
+
+/* ── Nav: init + regenerate ───────────────────────────────────────── */
+
+const navResizeObservers = new WeakMap();
+
+export function initNavVeins(navEl, opts = {}) {
+  if (!navEl) return;
+
+  let host = navEl.querySelector(':scope > .nav-veins');
+  if (!host) {
+    host = document.createElement('div');
+    host.className = 'nav-veins';
+    host.setAttribute('aria-hidden', 'true');
+    // Insert AFTER .nav-logo so the sibling-combinator CSS (Effect 3)
+    // works. If .nav-logo is missing, fall back to the start of the nav.
+    const logo = navEl.querySelector(':scope > .nav-logo');
+    if (logo && logo.nextSibling) {
+      navEl.insertBefore(host, logo.nextSibling);
+    } else if (logo) {
+      navEl.appendChild(host);
+    } else {
+      navEl.insertBefore(host, navEl.firstChild);
+    }
+  }
+
+  regenerateNavVeins(navEl, opts);
+
+  if (navEl.dataset.heroVeinsBound !== '1') {
+    navEl.dataset.heroVeinsBound = '1';
+    navEl.dataset.hover = navEl.dataset.hover || '0';
+    attachPointerTracker(navEl, '--nav-mx', '--nav-my');
+
+    // Resize: regenerate when the nav width changes meaningfully.
+    if (typeof ResizeObserver !== 'undefined') {
+      let lastWidth = navEl.clientWidth;
+      let resizeTimer = 0;
+      const ro = new ResizeObserver(() => {
+        if (resizeTimer) clearTimeout(resizeTimer);
+        resizeTimer = setTimeout(() => {
+          if (Math.abs(navEl.clientWidth - lastWidth) >= 40) {
+            lastWidth = navEl.clientWidth;
+            regenerateNavVeins(navEl, opts);
+          }
+        }, 250);
+      });
+      ro.observe(navEl);
+      navResizeObservers.set(navEl, ro);
+    }
+  }
+}
+
+export function regenerateNavVeins(navEl, opts = {}) {
+  const host = navEl.querySelector(':scope > .nav-veins');
+  if (!host) return;
+  const width = Math.max(navEl.clientWidth || 1200, 320);
+  const height = Math.max(navEl.clientHeight || 64, 48);
+  const svg = buildVeinSvg(width, height, opts);
+  // Replace contents in one shot.
+  host.replaceChildren(svg);
+}
+
+/* ── Auto-init ────────────────────────────────────────────────────── */
+
+function autoInit() {
+  if (!document.body || !document.body.hasAttribute('data-hero-veins')) return;
+  const hero = document.getElementById('hero') || document.querySelector('[data-hero]');
+  const nav = document.querySelector('nav');
+  if (hero) initHeroVeins(hero);
+  if (nav) initNavVeins(nav);
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', autoInit, { once: true });
+} else {
+  autoInit();
+}

--- a/docs/samples/nav.html
+++ b/docs/samples/nav.html
@@ -1,0 +1,385 @@
+<!DOCTYPE html>
+<html lang="en" data-icon-base="../assets/icons.svg">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Nav + Hero Veins Sampler — Gaia</title>
+  <meta name="description" content="Prototype: cursor peek + red glow on the hero, branching DAG-vein texture revealed in a soft aperture under the nav. Hover the Gaia wordmark to expand the reveal across the top of the page.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+  <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="../css/hero-veins.css">
+  <script src="../js/icons.js"></script>
+  <style>
+    /* Sampler-only chrome. Production never sees these styles. */
+    body { margin: 0; min-height: 100vh; }
+
+    .sampler-banner {
+      position: fixed;
+      top: 4.5rem; left: 50%; transform: translateX(-50%);
+      z-index: 50;
+      padding: .35rem .9rem;
+      background: rgba(0, 0, 0, 0.6);
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      font-family: var(--font-mono);
+      font-size: .7rem;
+      letter-spacing: .12em;
+      text-transform: uppercase;
+      color: var(--muted);
+      pointer-events: none;
+    }
+    .sampler-banner b { color: var(--honor-red); font-weight: 500; }
+
+    /* Mock hero — stand-in for the live #canvas3d. Uses the static
+       gaia.svg as the "atlas behind" so we can prototype peek + glow
+       without booting Three.js. The real glass + noise layers are
+       cloned 1:1 from index.html so the masked CSS hits the same
+       selectors. */
+    #hero {
+      position: relative;
+      min-height: 100vh;
+      display: flex; flex-direction: column;
+      align-items: center; justify-content: center;
+      text-align: center;
+      padding: 8rem 1.5rem 4rem;
+      overflow: hidden;
+    }
+    #hero .mock-atlas {
+      position: absolute; inset: 0;
+      width: 100%; height: 100%;
+      object-fit: cover;
+      pointer-events: none;
+      filter: brightness(0.85) saturate(1.1);
+    }
+    /* These two layers match the production CSS for .hero-glass-blur
+       and .hero-glass-noise. Replicated locally so the sample doesn't
+       depend on the production rules existing alongside the cursor
+       effect. */
+    .hero-glass-blur {
+      position: absolute; inset: 0;
+      z-index: 1;
+      backdrop-filter: blur(8px) brightness(0.65);
+      -webkit-backdrop-filter: blur(8px) brightness(0.65);
+      pointer-events: none;
+      transition: backdrop-filter 0.5s ease, opacity 0.5s ease;
+    }
+    .hero-glass-noise {
+      position: absolute; inset: 0;
+      z-index: 1;
+      background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");
+      opacity: 0.18;
+      mix-blend-mode: overlay;
+      pointer-events: none;
+    }
+    .hero-content { position: relative; z-index: 2; max-width: 720px; }
+    .hero-content h1 {
+      font-family: var(--font-display);
+      font-size: clamp(2.4rem, 6vw, 4rem);
+      font-weight: 600;
+      line-height: 1.1;
+      margin: 0 0 1.2rem;
+    }
+    .hero-content h1 em {
+      font-style: italic; font-weight: 400; color: var(--apex-gold);
+    }
+    .hero-content h1 span {
+      border-bottom: 1px solid var(--apex-gold);
+      padding-bottom: 0.06em;
+    }
+    .hero-content p {
+      font-family: var(--font-body);
+      font-size: 1.15rem;
+      color: var(--muted);
+      max-width: 540px;
+      margin: 0 auto 2.4rem;
+    }
+    .mock-doors {
+      display: flex; gap: 1rem;
+      margin: 2.5rem auto 0;
+      max-width: 28rem;
+    }
+    .mock-doors a {
+      flex: 1;
+      padding: 1.25rem 1rem;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      background: rgba(255, 255, 255, .03);
+      color: var(--text);
+      text-decoration: none;
+      font-family: var(--font-body);
+      font-size: 1rem;
+      transition: border-color .25s, box-shadow .25s;
+    }
+    .mock-doors a:hover {
+      border-color: rgba(255, 255, 255, .15);
+      box-shadow: 0 4px 24px rgba(0, 0, 0, .4);
+    }
+
+    /* Debug panel — sample-only. */
+    .debug-panel {
+      position: fixed;
+      bottom: 1.25rem; right: 1.25rem;
+      z-index: 200;
+      width: 280px;
+      background: rgba(15, 23, 42, 0.95);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 1rem;
+      font-family: var(--font-mono);
+      font-size: .72rem;
+      color: var(--text);
+      box-shadow: 0 8px 32px rgba(0, 0, 0, .5);
+      backdrop-filter: blur(6px);
+    }
+    .debug-panel h3 {
+      margin: 0 0 .75rem;
+      font-size: .68rem;
+      letter-spacing: .14em;
+      text-transform: uppercase;
+      color: var(--muted);
+      font-weight: 500;
+    }
+    .debug-panel label {
+      display: flex;
+      flex-direction: column;
+      gap: .25rem;
+      margin-bottom: .65rem;
+    }
+    .debug-panel .row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .debug-panel .row .name { color: var(--muted); }
+    .debug-panel .row .value { color: var(--apex-gold); font-variant-numeric: tabular-nums; }
+    .debug-panel input[type="range"] {
+      width: 100%;
+      accent-color: var(--honor-red);
+    }
+    .debug-panel button {
+      margin-top: .35rem;
+      width: 100%;
+      padding: .4rem .75rem;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--text);
+      font-family: inherit;
+      font-size: .7rem;
+      cursor: pointer;
+      transition: border-color .15s;
+    }
+    .debug-panel button:hover {
+      border-color: var(--honor-red);
+    }
+    .debug-panel .toggle-collapse {
+      position: absolute;
+      top: .5rem; right: .65rem;
+      background: transparent;
+      border: none;
+      color: var(--muted);
+      font-size: 1rem;
+      width: auto;
+      margin: 0;
+      padding: 0;
+      cursor: pointer;
+    }
+    .debug-panel.collapsed > *:not(h3):not(.toggle-collapse) {
+      display: none;
+    }
+    .debug-panel.collapsed h3 { margin-bottom: 0; }
+  </style>
+</head>
+<!-- The data-hero-veins attribute activates all the gated selectors in
+     hero-veins.css. Auto-init in hero-veins.js will also bind based on
+     this attribute. -->
+<body class="home-page" data-hero-veins>
+
+  <div class="sampler-banner"><b>Sample</b> · nav.html · move/hover/tap to test</div>
+
+  <!-- ─── NAV ─── (cloned from docs/index.html lines 155-184) -->
+  <nav>
+    <a href="#" class="nav-logo" aria-label="Gaia home">
+      <svg class="ico nav-seal" aria-hidden="true" focusable="false"><use href="../assets/icons.svg#seal-diamond"/></svg>
+      <span class="nav-wordmark">Gaia</span>
+    </a>
+    <!-- .nav-veins is injected here by hero-veins.js so it's the next
+         sibling of .nav-logo (Effect 3 needs the sibling-combinator). -->
+    <button class="nav-menu-toggle" type="button" aria-label="Open navigation" aria-expanded="false">
+      <span></span><span></span><span></span>
+    </button>
+    <ul class="nav-primary">
+      <li style="--nav-i:0"><a href="#" style="color: var(--text);">Home</a></li>
+      <li style="--nav-i:1"><a href="#" style="color: var(--apex-gold);">About</a></li>
+      <li style="--nav-i:2"><a href="#" style="color: var(--tier-unique);">GitHub Badges</a></li>
+      <li style="--nav-i:3"><a href="#" style="color: var(--honor-red);">Skills</a></li>
+      <li style="--nav-i:4"><a href="#" style="color: var(--tier-basic);">Docs</a></li>
+    </ul>
+  </nav>
+
+  <!-- ─── HERO ─── (mock — uses ../graph/gaia.svg as a static atlas
+       stand-in for the live #canvas3d) -->
+  <section id="hero">
+    <img class="mock-atlas" src="../graph/gaia.svg" alt="" aria-hidden="true">
+    <div class="hero-glass-blur"></div>
+    <div class="hero-glass-noise"></div>
+    <!-- New layer: red diffuse glow that follows the cursor -->
+    <div class="hero-cursor-glow" aria-hidden="true"></div>
+    <div class="hero-content">
+      <h1>Skills are catalogued.<br>Names are <em>earned</em>.<br>Apex is <span>rare</span>.</h1>
+      <p>Move the cursor across the hero to peek through the curtain. Hover <b>Gaia</b> in the nav to widen the reveal across the top of the page.</p>
+      <div class="mock-doors">
+        <a href="#">Register repo</a>
+        <a href="#">Claim Ultimate</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- ─── DEBUG PANEL ─── -->
+  <div class="debug-panel" id="debugPanel">
+    <h3>Veins · debug</h3>
+    <button class="toggle-collapse" id="toggleCollapse" aria-label="Collapse panel">−</button>
+
+    <label>
+      <span class="row"><span class="name">Peek radius</span><span class="value" data-value="heroPeekR">220px</span></span>
+      <input type="range" id="heroPeekR" min="100" max="400" step="10" value="220">
+    </label>
+    <label>
+      <span class="row"><span class="name">Glow radius</span><span class="value" data-value="heroGlowR">500px</span></span>
+      <input type="range" id="heroGlowR" min="200" max="900" step="20" value="500">
+    </label>
+    <label>
+      <span class="row"><span class="name">Glow alpha</span><span class="value" data-value="heroGlowA">0.35</span></span>
+      <input type="range" id="heroGlowA" min="0" max="0.8" step="0.05" value="0.35">
+    </label>
+    <label>
+      <span class="row"><span class="name">Vein flow</span><span class="value" data-value="navFlowDur">16s</span></span>
+      <input type="range" id="navFlowDur" min="4" max="30" step="1" value="16">
+    </label>
+    <label>
+      <span class="row"><span class="name">Vein alpha</span><span class="value" data-value="navVeinA">0.35</span></span>
+      <input type="range" id="navVeinA" min="0.1" max="0.8" step="0.05" value="0.35">
+    </label>
+    <label>
+      <span class="row"><span class="name">Aperture R</span><span class="value" data-value="navApertureR">140px</span></span>
+      <input type="range" id="navApertureR" min="60" max="260" step="10" value="140">
+    </label>
+    <label>
+      <span class="row"><span class="name">Sweep in</span><span class="value" data-value="navRevealIn">600ms</span></span>
+      <input type="range" id="navRevealIn" min="200" max="1200" step="50" value="600">
+    </label>
+    <label>
+      <span class="row"><span class="name">Node count</span><span class="value" data-value="navNodes">18</span></span>
+      <input type="range" id="navNodes" min="10" max="30" step="2" value="18">
+    </label>
+    <button id="resetDefaults">Reset defaults</button>
+  </div>
+
+  <!-- The module also auto-inits on data-hero-veins, but we also call
+       the named exports below so we can pass options + react to the
+       debug panel's "Node count" slider. -->
+  <script type="module">
+    import {
+      initHeroVeins,
+      initNavVeins,
+      regenerateNavVeins,
+    } from '../js/hero-veins.js';
+
+    const hero = document.getElementById('hero');
+    const nav = document.querySelector('nav');
+    let nodeCount = 18;
+    initHeroVeins(hero);
+    initNavVeins(nav, { nodeCount });
+
+    /* ── Debug panel wiring ─────────────────────────────────────── */
+    const STORAGE_KEY = 'gaia_veins_debug';
+    const sliders = {
+      heroPeekR:    { el: '#hero', cssVar: '--hero-peek-r',     unit: 'px',  format: (v) => v + 'px' },
+      heroGlowR:    { el: '#hero', cssVar: '--hero-glow-r',     unit: 'px',  format: (v) => v + 'px' },
+      heroGlowA:    { el: '#hero', cssVar: '--hero-glow-a',     unit: '',    format: (v) => Number(v).toFixed(2) },
+      navFlowDur:   { el: 'nav',   cssVar: '--nav-flow-dur',    unit: 's',   format: (v) => v + 's' },
+      navVeinA:     { el: 'nav',   cssVar: '--nav-vein-a',      unit: '',    format: (v) => Number(v).toFixed(2) },
+      navApertureR: { el: 'nav',   cssVar: '--nav-aperture-r',  unit: 'px',  format: (v) => v + 'px' },
+      navRevealIn:  { el: 'nav',   cssVar: '--nav-reveal-dur-in', unit: 'ms', format: (v) => v + 'ms' },
+    };
+    const defaults = {
+      heroPeekR: 220, heroGlowR: 500, heroGlowA: 0.35,
+      navFlowDur: 16, navVeinA: 0.35, navApertureR: 140,
+      navRevealIn: 600, navNodes: 18,
+    };
+
+    function applyValue(key, raw) {
+      if (key === 'navNodes') {
+        nodeCount = parseInt(raw, 10);
+        regenerateNavVeins(nav, { nodeCount });
+      } else {
+        const cfg = sliders[key];
+        const target = document.querySelector(cfg.el);
+        const val = cfg.format(raw);
+        target.style.setProperty(cfg.cssVar, val);
+      }
+      const valueEl = document.querySelector(`[data-value="${key}"]`);
+      if (valueEl) {
+        valueEl.textContent = key === 'navNodes' ? String(raw) : (sliders[key]?.format(raw) ?? raw);
+      }
+    }
+
+    function loadStored() {
+      try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return null;
+        return JSON.parse(raw);
+      } catch (_) {
+        return null;
+      }
+    }
+
+    function saveStored(state) {
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+      } catch (_) { /* ignore quota */ }
+    }
+
+    const stored = loadStored() || {};
+    const initial = { ...defaults, ...stored };
+    Object.entries(initial).forEach(([key, val]) => {
+      const input = document.getElementById(key);
+      if (input) {
+        input.value = val;
+        applyValue(key, val);
+      }
+    });
+
+    Object.keys({ ...sliders, navNodes: 1 }).forEach((key) => {
+      const input = document.getElementById(key);
+      if (!input) return;
+      input.addEventListener('input', (e) => {
+        const v = e.target.value;
+        applyValue(key, v);
+        const next = loadStored() || {};
+        next[key] = parseFloat(v);
+        saveStored(next);
+      });
+    });
+
+    document.getElementById('resetDefaults').addEventListener('click', () => {
+      localStorage.removeItem(STORAGE_KEY);
+      Object.entries(defaults).forEach(([key, val]) => {
+        const input = document.getElementById(key);
+        if (input) {
+          input.value = val;
+          applyValue(key, val);
+        }
+      });
+    });
+
+    document.getElementById('toggleCollapse').addEventListener('click', (e) => {
+      const panel = document.getElementById('debugPanel');
+      panel.classList.toggle('collapsed');
+      e.currentTarget.textContent = panel.classList.contains('collapsed') ? '+' : '−';
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Prototype for cursor-following animations on the hero and nav, scoped to a samples-only sandbox. Production (docs/index.html, docs/css/styles.css) is untouched.

## What's in this PR

Three new files, no edits to existing ones:

- **`docs/css/hero-veins.css`** — All selectors gated behind `body[data-hero-veins]` so the file is harmless when linked but not activated.
  - Peek-mask on `.hero-glass-blur` (noise grain deliberately stays in the hole — Decision 1)
  - `.hero-cursor-glow` with `mix-blend-mode: screen`
  - `.nav-veins` layer with mouse-following aperture
  - `.nav-logo:hover ~ .nav-veins` + `body:has(nav .nav-logo:hover) #hero` so hovering Gaia expands across both nav AND hero (Decision 2)
  - `@property --hero-peek-r` for smooth length transitions
  - `prefers-reduced-motion` pauses flow but keeps cursor tracking
- **`docs/js/hero-veins.js`** — ES module: `initHeroVeins`, `initNavVeins`, `regenerateNavVeins`. rAF-throttled `pointermove` writes `--hero-mx/my` and `--nav-mx/my`. Procedural SVG generator (5 cols × 3 rows lattice, cubic-Bezier edges with horizontal handles, dash-flow desync via `--i`, node pulse via `--ni`). `ResizeObserver` regen ≥40px width-change, debounced 250ms. `(hover: none)` tap-linger 1.6s fallback (Decision 4).
- **`docs/samples/nav.html`** — Sandbox with mock hero (uses `graph/gaia.svg` as static atlas stand-in for `#canvas3d`), real cloned nav, and bottom-right collapsible debug panel: 8 sliders persisted to `localStorage.gaia_veins_debug`.

## Verify

> Note: ES modules don't load over `file://` in Chrome/Edge. Open via a local server:
> ```
> python -m http.server 8000
> # → http://localhost:8000/docs/samples/nav.html
> ```
> Or wait for Pages preview.

1. Move pointer over hero — soft circle reveals atlas through the blur, noise grain stays inside the hole. Red glow trails wider/softer.
2. Move pointer over nav — branching veins reveal in a soft circle, dashes flow leftward, nodes pulse out of phase.
3. Hover or Tab-focus the **Gaia** wordmark — nav aperture sweeps across the whole nav AND hero peek widens to 60vw simultaneously.
4. DevTools → Rendering → Emulate `prefers-reduced-motion: reduce` — flow pauses, transitions disabled, cursor tracking stays.
5. Mobile (DevTools device toolbar) — tap-drag drives the aperture; on lift, lingers 1.6s before fading.
6. Drag debug-panel sliders → live response, refresh persists state.
7. Resize window — veins regenerate cleanly.

## Phase B (separate PR after this is approved)

Five tiny insertions in `docs/index.html`:
- `<link rel="stylesheet" href="css/hero-veins.css">`
- `<body class="home-page" data-hero-veins>`
- `<div class="nav-veins"></div>` after `</a>` of `.nav-logo`
- `<div class="hero-cursor-glow"></div>` between `.hero-glass-noise` and `.hero-content`
- `<script type="module" src="js/hero-veins.js"></script>` before `</body>`

Removal cost if rolled back: delete one link tag, one attribute, two divs, one script tag, two new files. No `styles.css` revert needed.

## Decisions locked

1. Peek hole keeps noise grain (mask blur only)
2. Logo hover extends across nav + hero top
3. Glow stays red on all CTAs (no tint shift)
4. Mobile is full effects, tap-driven (1.6s linger)

Plan reference: `~/.claude/plans/i-need-animation-on-spicy-nygaard.md` (local-only).