### PR TITLE
design(nav): ceremonial nav animations — logo, links, dropdown, footer

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script>window.GAIA_VERSION = "4.1.2";</script>
+  <script>window.GAIA_VERSION = "4.7.5";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>About — Gaia Skill Registry</title>
@@ -14,11 +14,11 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
   <link rel="icon" type="image/svg+xml" href="assets/marks/diamond-seal.svg">
-  <link rel="stylesheet" href="css/styles.css?v=4.1.2">
-  <link rel="stylesheet" href="css/plaque.css?v=4.1.2">
-  <script src="js/icons.js?v=4.1.2"></script>
-  <script src="js/atlas-helpers.js?v=4.1.2"></script>
-  <script src="js/rank-badge.js?v=4.1.2"></script>
+  <link rel="stylesheet" href="css/styles.css?v=4.7.5">
+  <link rel="stylesheet" href="css/plaque.css?v=4.7.5">
+  <script src="js/icons.js?v=4.7.5"></script>
+  <script src="js/atlas-helpers.js?v=4.7.5"></script>
+  <script src="js/rank-badge.js?v=4.7.5"></script>
 
   <style>
     /* ─── about.html — atlas frontispiece layout ───────────────── */
@@ -893,35 +893,8 @@
 <body class="about-page">
 
   <!-- ─── NAV ─── -->
-  <nav>
-    <a href="index.html" class="nav-logo" aria-label="Gaia home">
-      <svg class="ico nav-seal" aria-hidden="true" focusable="false"><use href="assets/icons.svg#seal-diamond"/></svg>
-      <span class="nav-wordmark">Gaia</span>
-    </a>
-    <button type="button" class="nav-search-btn-mobile" id="navSearchBtnMobile" aria-label="Search named" hidden><svg class="ico" width="18" height="18" aria-hidden="true"><use href="assets/icons.svg#search"/></svg></button>
-    <button class="nav-menu-toggle" type="button" aria-label="Open navigation" aria-expanded="false">
-      <span></span>
-      <span></span>
-      <span></span>
-    </button>
-    <ul class="nav-primary">
-      <li><a href="index.html" style="color: var(--text);">Home</a></li>
-      <li><a href="about.html" style="color: var(--apex-gold);" aria-current="page">About</a></li>
-      <li><a href="badges/" style="color: var(--tier-unique);"><svg class="ico" width="13" height="13" aria-hidden="true" style="vertical-align: -2px; margin-right: .35em;"><use href="assets/icons.svg#github"/></svg>GitHub Badges</a></li>
-      <li><a href="named/" style="color: var(--honor-red);">Skills</a></li>
-      <li class="nav-more-dropdown">
-        <button class="nav-more-toggle" aria-label="More options" aria-expanded="false">More</button>
-        <ul class="nav-more-menu">
-          <li><button type="button" class="nav-tree" id="treeNavBtn" style="color: #34d399;">Skill Tree</button></li>
-          <li><a href="index.html?field=1" class="nav-graph-trigger" style="color: #38bdf8;">Skill Graph</a></li>
-          <li><a href="codex.html" style="color: var(--tier-basic);">The Codex</a></li>
-          <li><a href="starless.html" style="color: var(--muted);">Starless</a></li>
-          <li><a href="u/" style="color: var(--honor-red);">Named Contributors</a></li>
-          <li><a href="meta.html" class="nav-meta" id="metaNavBtn">Meta Reports</a></li>
-        </ul>
-      </li>
-    </ul>
-  </nav>
+  <nav id="site-nav"></nav>
+  <script src="js/site-nav.js?v=4.7.5"></script>
 
   <!-- ─── BACK ─── -->
   <div class="profile-back-row">
@@ -1255,83 +1228,10 @@
   </main>
 
   <!-- ─── FOOTER v2 ─── -->
-  <footer class="footer-v2">
-    <div class="footer-inner">
+  <div id="site-footer-mount"></div>
+  <script src="js/site-footer.js?v=4.7.5"></script>
 
-      <!-- Brand column -->
-      <div class="footer-brand-col">
-        <div class="footer-brand-mark">
-          <svg class="ico footer-seal" aria-hidden="true" focusable="false">
-            <use href="assets/icons.svg#seal-diamond"/>
-          </svg>
-          <span class="footer-wordmark">Gaia</span>
-        </div>
-        <p class="footer-tagline">An evidence-backed atlas<br>of agent capabilities.</p>
-      </div>
-
-      <!-- Link columns -->
-      <nav class="footer-cols" aria-label="Site navigation">
-
-        <div class="footer-col">
-          <span class="footer-col-heading">Registry</span>
-          <ul>
-            <li><a href="index.html">Home</a></li>
-            <li><a href="index.html">Skill Tree</a></li>
-            <li><a href="index.html?field=1">Skill Graph</a></li>
-            <li><a href="starless.html">Starless</a></li>
-            <li><a href="meta.html">Meta Reports</a></li>
-          </ul>
-        </div>
-
-        <div class="footer-col">
-          <span class="footer-col-heading">Discover</span>
-          <ul>
-            <li><a href="codex.html">The Codex</a></li>
-            <li><a href="named/">Named Skills</a></li>
-            <li><a href="index.html#hall-of-heroes">Hall of Heroes</a></li>
-            <li><a href="u/">Named Contributors</a></li>
-            <li><a href="badges/">GitHub Badges</a></li>
-            <li><a href="samples/index.html">Samples</a></li>
-          </ul>
-        </div>
-
-        <div class="footer-col">
-          <span class="footer-col-heading">Contribute</span>
-          <ul>
-            <li><a href="index.html#paths">Push a skill</a></li>
-            <li><a href="https://github.com/mbtiongson1/gaia-skill-tree" target="_blank" rel="noopener" class="footer-ext">GitHub</a></li>
-            <li><a href="https://github.com/mbtiongson1/gaia-skill-tree/issues" target="_blank" rel="noopener" class="footer-ext">Open Issues</a></li>
-          </ul>
-        </div>
-
-        <div class="footer-col">
-          <span class="footer-col-heading">About</span>
-          <ul>
-            <li><a href="about.html">About Gaia</a></li>
-            <li><a href="u/mbtiongson1/" class="footer-link-honor">@mbtiongson1</a></li>
-            <li><a href="privacy.html">Privacy</a></li>
-            <li>
-              <button id="copyAgentFooterBtn" type="button" class="footer-link-btn" aria-label="Copy page context for agents">
-                Copy Page
-              </button>
-            </li>
-          </ul>
-        </div>
-
-      </nav>
-    </div>
-
-    <!-- Bottom strip -->
-    <div class="footer-bottom">
-      <span>MIT License</span>
-      <span class="footer-bottom-sep" aria-hidden="true">·</span>
-      <span id="footerVersion">v4.1.2</span>
-      <span class="footer-bottom-sep" aria-hidden="true">·</span>
-      <span>© 2026 Gaia</span>
-    </div>
-  </footer>
-
-  <script src="js/ui.js?v=4.1.2" defer></script>
+  <script src="js/ui.js?v=4.7.5" defer></script>
 
   <!-- Hydrate rank badges from the canonical component (no inline star markup). -->
   <script>

--- a/docs/badges/index.html
+++ b/docs/badges/index.html
@@ -846,37 +846,11 @@
       white-space: nowrap;
     }
   </style>
+  <link rel="stylesheet" href="../css/plaque.css?v=4.7.5">
 </head>
 <body class="process-page">
-  <nav>
-    <a href="../" class="nav-logo" aria-label="Gaia home">
-      <svg class="ico nav-seal" aria-hidden="true" focusable="false"><use href="../assets/icons.svg#seal-diamond"/></svg>
-      <span class="nav-wordmark">Gaia</span>
-    </a>
-    <button type="button" class="nav-search-btn-mobile" id="navSearchBtnMobile" aria-label="Search named" hidden><svg class="ico" width="18" height="18" aria-hidden="true"><use href="../assets/icons.svg#search"/></svg></button>
-    <button class="nav-menu-toggle" type="button" aria-label="Open navigation" aria-expanded="false">
-      <span></span>
-      <span></span>
-      <span></span>
-    </button>
-    <ul class="nav-primary">
-      <li><a href="../index.html" style="color: var(--text);">Home</a></li>
-      <li><a href="../about.html" style="color: var(--apex-gold);">About</a></li>
-      <li><a href="./" style="color: var(--tier-unique);" aria-current="page"><svg class="ico" width="13" height="13" aria-hidden="true" style="vertical-align: -2px; margin-right: .35em;"><use href="../assets/icons.svg#github"/></svg>GitHub Badges</a></li>
-      <li><a href="../named/" style="color: var(--honor-red);">Skills</a></li>
-      <li class="nav-more-dropdown">
-        <button class="nav-more-toggle" aria-label="More options" aria-expanded="false">More</button>
-        <ul class="nav-more-menu">
-          <li><button type="button" class="nav-tree" id="treeNavBtn" style="color: #34d399;">Skill Tree</button></li>
-          <li><a href="../index.html?field=1" class="nav-graph-trigger" style="color: #38bdf8;">Skill Graph</a></li>
-          <li><a href="../codex.html" style="color: var(--tier-basic);">The Codex</a></li>
-          <li><a href="../starless.html" style="color: var(--muted);">Starless</a></li>
-          <li><a href="../u/" style="color: var(--honor-red);">Named Contributors</a></li>
-          <li><a href="../meta.html" class="nav-meta" id="metaNavBtn">Meta Reports</a></li>
-        </ul>
-      </li>
-    </ul>
-  </nav>
+  <nav id="site-nav"></nav>
+  <script src="../js/site-nav.js?v=4.7.5"></script>
 
   <main>
     <!-- ─── BACK ─── -->
@@ -1934,81 +1908,8 @@
   </script>
 
   <!-- ─── FOOTER v2 ─── -->
-  <footer class="footer-v2">
-    <div class="footer-inner">
-
-      <!-- Brand column -->
-      <div class="footer-brand-col">
-        <div class="footer-brand-mark">
-          <svg class="ico footer-seal" aria-hidden="true" focusable="false">
-            <use href="../assets/icons.svg#seal-diamond"/>
-          </svg>
-          <span class="footer-wordmark">Gaia</span>
-        </div>
-        <p class="footer-tagline">An evidence-backed atlas<br>of agent capabilities.</p>
-      </div>
-
-      <!-- Link columns -->
-      <nav class="footer-cols" aria-label="Site navigation">
-
-        <div class="footer-col">
-          <span class="footer-col-heading">Registry</span>
-          <ul>
-            <li><a href="../index.html">Home</a></li>
-            <li><a href="../index.html">Skill Tree</a></li>
-            <li><a href="../index.html?field=1">Skill Graph</a></li>
-            <li><a href="../starless.html">Starless</a></li>
-            <li><a href="../meta.html">Meta Reports</a></li>
-          </ul>
-        </div>
-
-        <div class="footer-col">
-          <span class="footer-col-heading">Discover</span>
-          <ul>
-            <li><a href="../codex.html">The Codex</a></li>
-            <li><a href="../named/">Named Skills</a></li>
-            <li><a href="../index.html#hall-of-heroes">Hall of Heroes</a></li>
-            <li><a href="../u/">Named Contributors</a></li>
-            <li><a href="./">GitHub Badges</a></li>
-            <li><a href="../samples/index.html">Samples</a></li>
-          </ul>
-        </div>
-
-        <div class="footer-col">
-          <span class="footer-col-heading">Contribute</span>
-          <ul>
-            <li><a href="../index.html#paths">Push a skill</a></li>
-            <li><a href="https://github.com/mbtiongson1/gaia-skill-tree" target="_blank" rel="noopener" class="footer-ext">GitHub</a></li>
-            <li><a href="https://github.com/mbtiongson1/gaia-skill-tree/issues" target="_blank" rel="noopener" class="footer-ext">Open Issues</a></li>
-          </ul>
-        </div>
-
-        <div class="footer-col">
-          <span class="footer-col-heading">About</span>
-          <ul>
-            <li><a href="../about.html">About Gaia</a></li>
-            <li><a href="../u/mbtiongson1/" class="footer-link-honor">@mbtiongson1</a></li>
-            <li><a href="../privacy.html">Privacy</a></li>
-            <li>
-              <button id="copyAgentFooterBtn" type="button" class="footer-link-btn" aria-label="Copy page context for agents">
-                Copy Page
-              </button>
-            </li>
-          </ul>
-        </div>
-
-      </nav>
-    </div>
-
-    <!-- Bottom strip -->
-    <div class="footer-bottom">
-      <span>MIT License</span>
-      <span class="footer-bottom-sep" aria-hidden="true">·</span>
-      <span id="footerVersion">v4.1.2</span>
-      <span class="footer-bottom-sep" aria-hidden="true">·</span>
-      <span>© 2026 Gaia</span>
-    </div>
-  </footer>
+  <div id="site-footer-mount"></div>
+  <script src="../js/site-footer.js?v=4.7.5"></script>
 
   <!-- ─── TREE DIALOG ─── -->
   <a id="tree" tabindex="-1" aria-hidden="true"></a>

--- a/docs/codex.html
+++ b/docs/codex.html
@@ -429,38 +429,12 @@
   }
 }
 </style>
+  <link rel="stylesheet" href="css/plaque.css?v=4.7.5">
 </head>
 <body class="process-page">
 
-<nav>
-    <a href="index.html" class="nav-logo" aria-label="Gaia home">
-      <svg class="ico nav-seal" aria-hidden="true" focusable="false"><use href="assets/icons.svg#seal-diamond"/></svg>
-      <span class="nav-wordmark">Gaia</span>
-    </a>
-    <button type="button" class="nav-search-btn-mobile" id="navSearchBtnMobile" aria-label="Search named" hidden><svg class="ico" width="18" height="18" aria-hidden="true"><use href="assets/icons.svg#search"/></svg></button>
-    <button class="nav-menu-toggle" type="button" aria-label="Open navigation" aria-expanded="false">
-      <span></span>
-      <span></span>
-      <span></span>
-    </button>
-    <ul class="nav-primary">
-      <li><a href="index.html" style="color: var(--text);">Home</a></li>
-      <li><a href="about.html" style="color: var(--apex-gold);">About</a></li>
-      <li><a href="badges/" style="color: var(--tier-unique);"><svg class="ico" width="13" height="13" aria-hidden="true" style="vertical-align: -2px; margin-right: .35em;"><use href="assets/icons.svg#github"/></svg>GitHub Badges</a></li>
-      <li><a href="named/" style="color: var(--honor-red);">Skills</a></li>
-      <li class="nav-more-dropdown">
-        <button class="nav-more-toggle" aria-label="More options" aria-expanded="false">More</button>
-        <ul class="nav-more-menu">
-          <li><button type="button" class="nav-tree" id="treeNavBtn" style="color: #34d399;">Skill Tree</button></li>
-          <li><a href="index.html?field=1" class="nav-graph-trigger" style="color: #38bdf8;">Skill Graph</a></li>
-          <li><a href="codex.html" style="color: var(--tier-basic);" aria-current="page">The Codex</a></li>
-          <li><a href="starless.html" style="color: var(--muted);">Starless</a></li>
-          <li><a href="u/" style="color: var(--honor-red);">Named Contributors</a></li>
-          <li><a href="meta.html" class="nav-meta" id="metaNavBtn">Meta Reports</a></li>
-        </ul>
-      </li>
-    </ul>
-  </nav>
+  <nav id="site-nav"></nav>
+  <script src="js/site-nav.js?v=4.7.5"></script>
 
 <main>
   <!-- ─── BACK ─── -->
@@ -1081,81 +1055,8 @@
 </main>
 
 <!-- ─── FOOTER v2 ─── -->
-  <footer class="footer-v2">
-    <div class="footer-inner">
-
-      <!-- Brand column -->
-      <div class="footer-brand-col">
-        <div class="footer-brand-mark">
-          <svg class="ico footer-seal" aria-hidden="true" focusable="false">
-            <use href="assets/icons.svg#seal-diamond"/>
-          </svg>
-          <span class="footer-wordmark">Gaia</span>
-        </div>
-        <p class="footer-tagline">An evidence-backed atlas<br>of agent capabilities.</p>
-      </div>
-
-      <!-- Link columns -->
-      <nav class="footer-cols" aria-label="Site navigation">
-
-        <div class="footer-col">
-          <span class="footer-col-heading">Registry</span>
-          <ul>
-            <li><a href="index.html">Home</a></li>
-            <li><a href="index.html">Skill Tree</a></li>
-            <li><a href="index.html?field=1">Skill Graph</a></li>
-            <li><a href="starless.html">Starless</a></li>
-            <li><a href="meta.html">Meta Reports</a></li>
-          </ul>
-        </div>
-
-        <div class="footer-col">
-          <span class="footer-col-heading">Discover</span>
-          <ul>
-            <li><a href="codex.html">The Codex</a></li>
-            <li><a href="named/">Named Skills</a></li>
-            <li><a href="index.html#hall-of-heroes">Hall of Heroes</a></li>
-            <li><a href="u/">Named Contributors</a></li>
-            <li><a href="badges/">GitHub Badges</a></li>
-            <li><a href="samples/index.html">Samples</a></li>
-          </ul>
-        </div>
-
-        <div class="footer-col">
-          <span class="footer-col-heading">Contribute</span>
-          <ul>
-            <li><a href="index.html#paths">Push a skill</a></li>
-            <li><a href="https://github.com/mbtiongson1/gaia-skill-tree" target="_blank" rel="noopener" class="footer-ext">GitHub</a></li>
-            <li><a href="https://github.com/mbtiongson1/gaia-skill-tree/issues" target="_blank" rel="noopener" class="footer-ext">Open Issues</a></li>
-          </ul>
-        </div>
-
-        <div class="footer-col">
-          <span class="footer-col-heading">About</span>
-          <ul>
-            <li><a href="about.html">About Gaia</a></li>
-            <li><a href="u/mbtiongson1/" class="footer-link-honor">@mbtiongson1</a></li>
-            <li><a href="privacy.html">Privacy</a></li>
-            <li>
-              <button id="copyAgentFooterBtn" type="button" class="footer-link-btn" aria-label="Copy page context for agents">
-                Copy Page
-              </button>
-            </li>
-          </ul>
-        </div>
-
-      </nav>
-    </div>
-
-    <!-- Bottom strip -->
-    <div class="footer-bottom">
-      <span>MIT License</span>
-      <span class="footer-bottom-sep" aria-hidden="true">·</span>
-      <span id="footerVersion">v4.1.2</span>
-      <span class="footer-bottom-sep" aria-hidden="true">·</span>
-      <span>© 2026 Gaia</span>
-    </div>
-  </footer>
+  <div id="site-footer-mount"></div>
+  <script src="js/site-footer.js?v=4.7.5"></script>
 
   <!-- ─── TREE DIALOG ─── -->
   <a id="tree" tabindex="-1" aria-hidden="true"></a>

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -676,16 +676,16 @@ button.nav-copy-agent {
    neutralized globally in the Phase 5 block below.
    ═══════════════════════════════════════════════ */
 
-/* Stagger entrance: nav items rise into place on first paint. */
+/* Stagger entrance: nav items fade in with a gentle 4px drift — soft, not theatrical. */
 @keyframes nav-item-rise {
-  0%   { opacity: 0; transform: translateY(-8px); filter: blur(2px); }
-  100% { opacity: 1; transform: translateY(0);    filter: blur(0); }
+  0%   { opacity: 0; transform: translateY(-4px); }
+  100% { opacity: 1; transform: translateY(0); }
 }
 
-/* Underline pulse for the active route — gentle rebreathe of the glow. */
+/* Underline pulse for the active route — very gentle, slow breathe. */
 @keyframes nav-underline-pulse {
-  0%, 100% { box-shadow: 0 0 10px currentColor, 0 0 20px currentColor; }
-  50%      { box-shadow: 0 0 18px currentColor, 0 0 36px currentColor; }
+  0%, 100% { box-shadow: 0 0 6px currentColor, 0 0 14px currentColor; }
+  50%      { box-shadow: 0 0 12px currentColor, 0 0 24px currentColor; }
 }
 
 nav ul.nav-primary > li > a,
@@ -696,14 +696,14 @@ nav.docs-nav .nav-logo {
   display: inline-block;
   letter-spacing: .01em;
   transition:
-    color .26s cubic-bezier(0.16, 1, 0.3, 1),
-    transform .34s cubic-bezier(0.16, 1, 0.3, 1),
-    letter-spacing .34s cubic-bezier(0.16, 1, 0.3, 1),
-    text-shadow .26s cubic-bezier(0.16, 1, 0.3, 1),
-    filter .26s cubic-bezier(0.16, 1, 0.3, 1);
+    color .32s ease,
+    transform .4s cubic-bezier(0.16, 1, 0.3, 1),
+    letter-spacing .4s cubic-bezier(0.16, 1, 0.3, 1),
+    text-shadow .4s ease,
+    opacity .32s ease;
   will-change: transform;
-  animation: nav-item-rise .55s cubic-bezier(0.16, 1, 0.3, 1) both;
-  animation-delay: calc(var(--nav-i, 0) * 60ms);
+  animation: nav-item-rise .7s ease both;
+  animation-delay: calc(var(--nav-i, 0) * 70ms);
 }
 
 /* Underline: 2px hairline that wipes from center outward, with a
@@ -719,12 +719,12 @@ nav.docs-nav .nav-logo::after {
   bottom: -5px;
   height: 2px;
   background: currentColor;
-  opacity: .95;
+  opacity: .85;
   transform: scaleX(0);
   transform-origin: center;
   transition:
-    transform .46s cubic-bezier(0.16, 1, 0.3, 1),
-    box-shadow .34s cubic-bezier(0.16, 1, 0.3, 1);
+    transform .5s ease,
+    box-shadow .4s ease;
   pointer-events: none;
   border-radius: 1px;
 }
@@ -745,13 +745,13 @@ nav.docs-nav .nav-crumb::before {
   opacity: 0;
   transform: translate(.45em, -50%) scale(.5);
   transition:
-    transform .38s cubic-bezier(0.16, 1, 0.3, 1),
-    opacity .26s cubic-bezier(0.16, 1, 0.3, 1),
-    box-shadow .26s cubic-bezier(0.16, 1, 0.3, 1);
+    transform .45s ease,
+    opacity .35s ease,
+    box-shadow .35s ease;
   pointer-events: none;
 }
 
-/* Hover / focus state — lift, widen, glow. */
+/* Hover / focus state — gentle lift, soft bloom, slight tracking widen. */
 nav ul.nav-primary > li > a:hover,
 nav ul.nav-primary > li > button:hover,
 nav ul.nav-primary > li > a:focus-visible,
@@ -761,8 +761,8 @@ nav.docs-nav .nav-crumb:focus-visible,
 nav.docs-nav .nav-logo:hover,
 nav.docs-nav .nav-logo:focus-visible {
   transform: translateY(-2px);
-  letter-spacing: .05em;
-  text-shadow: 0 0 14px currentColor, 0 0 28px currentColor;
+  letter-spacing: .04em;
+  text-shadow: 0 0 10px currentColor, 0 0 20px currentColor;
 }
 
 nav ul.nav-primary > li > a:hover::after,
@@ -777,13 +777,13 @@ nav ul.nav-primary > li > a[aria-current="page"]::after,
 nav ul.nav-primary > li > button[aria-expanded="true"]::after,
 nav.docs-nav .nav-crumb.current::after {
   transform: scaleX(1);
-  box-shadow: 0 0 12px currentColor, 0 0 24px currentColor;
+  box-shadow: 0 0 8px currentColor, 0 0 18px currentColor;
 }
 
-/* The active route's underline gently breathes. */
+/* The active route's underline very gently breathes. */
 nav ul.nav-primary > li > a[aria-current="page"]::after,
 nav.docs-nav .nav-crumb.current::after {
-  animation: nav-underline-pulse 2.6s cubic-bezier(0.16, 1, 0.3, 1) infinite;
+  animation: nav-underline-pulse 3.5s ease infinite;
 }
 
 nav ul.nav-primary > li > a:hover::before,

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -319,11 +319,36 @@ nav:not(.footer-cols) {
   gap: .5rem;
   text-decoration: none;
   color: var(--text);
-  transition: opacity .2s;
+  transition:
+    transform .42s cubic-bezier(0.16, 1, 0.3, 1),
+    filter .32s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .nav-logo:hover {
-  opacity: .8
+  transform: translateY(-1px);
+  filter: drop-shadow(0 0 10px rgba(var(--apex-gold-rgb), .35));
+}
+
+/* Diamond Seal — ceremonial breathe, intensified ceremonial spin on hover.
+   Apex Gold is reserved for Diamond-Seal moments per DESIGN.md, so the
+   halo lives only here (and on Apex CTAs elsewhere). */
+@keyframes seal-breathe {
+  0%, 100% {
+    filter:
+      drop-shadow(0 0 4px rgba(var(--apex-gold-rgb), .35))
+      drop-shadow(0 0 10px rgba(var(--apex-gold-rgb), .15));
+  }
+  50% {
+    filter:
+      drop-shadow(0 0 8px rgba(var(--apex-gold-rgb), .55))
+      drop-shadow(0 0 18px rgba(var(--apex-gold-rgb), .25));
+  }
+}
+
+@keyframes seal-spin {
+  0%   { transform: rotate(0deg)   scale(1); }
+  50%  { transform: rotate(180deg) scale(1.12); }
+  100% { transform: rotate(360deg) scale(1); }
 }
 
 .nav-seal {
@@ -331,6 +356,17 @@ nav:not(.footer-cols) {
   height: 26px;
   color: var(--apex-gold);
   flex-shrink: 0;
+  animation: seal-breathe 4.2s cubic-bezier(0.45, 0, 0.55, 1) infinite;
+  transition: transform .6s cubic-bezier(0.16, 1, 0.3, 1);
+  transform-origin: center;
+  will-change: transform, filter;
+}
+
+.nav-logo:hover .nav-seal,
+.nav-logo:focus-visible .nav-seal {
+  animation:
+    seal-breathe 4.2s cubic-bezier(0.45, 0, 0.55, 1) infinite,
+    seal-spin .9s cubic-bezier(0.16, 1, 0.3, 1) 1;
 }
 
 .nav-wordmark {
@@ -339,6 +375,44 @@ nav:not(.footer-cols) {
   font-weight: 600;
   letter-spacing: .05em;
   color: var(--text);
+  background: linear-gradient(90deg,
+    var(--text) 0%,
+    var(--text) 50%,
+    var(--apex-gold) 100%);
+  background-size: 200% 100%;
+  background-position: 0% 50%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  transition:
+    letter-spacing .42s cubic-bezier(0.16, 1, 0.3, 1),
+    background-position .6s cubic-bezier(0.16, 1, 0.3, 1),
+    text-shadow .32s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.nav-logo:hover .nav-wordmark,
+.nav-logo:focus-visible .nav-wordmark {
+  letter-spacing: .12em;
+  background-position: 100% 50%;
+  -webkit-text-fill-color: transparent;
+  text-shadow: 0 0 18px rgba(var(--apex-gold-rgb), .35);
+}
+
+/* Docs nav: <a class="nav-logo">Gaia <span>◆</span></a>. The span is the
+   seal stand-in. Match the same ceremonial treatment as the SVG seal. */
+nav.docs-nav .nav-logo > span {
+  display: inline-block;
+  color: var(--apex-gold);
+  animation: seal-breathe 4.2s cubic-bezier(0.45, 0, 0.55, 1) infinite;
+  transition: transform .6s cubic-bezier(0.16, 1, 0.3, 1);
+  transform-origin: center;
+  will-change: transform, filter;
+}
+
+nav.docs-nav .nav-logo:hover > span,
+nav.docs-nav .nav-logo:focus-visible > span {
+  animation:
+    seal-breathe 4.2s cubic-bezier(0.45, 0, 0.55, 1) infinite,
+    seal-spin .9s cubic-bezier(0.16, 1, 0.3, 1) 1;
 }
 
 nav ul.nav-primary {
@@ -437,6 +511,67 @@ nav ul.nav-primary {
   color: var(--text) !important;
 }
 
+/* ── Dropdown items get the same motion as top-level nav, scaled for
+     a vertical menu (left wipe instead of center, slide-right instead
+     of lift). Override the white !important above so each item keeps
+     its inline tier hue and the currentColor glow has something to
+     broadcast. The menu has no overflow:hidden, so glow bleeds free. */
+.nav-more-menu {
+  /* Ensure glow can extend outside the rounded box on hover. */
+  overflow: visible;
+}
+
+.nav-more-menu li a,
+.nav-more-menu li button {
+  position: relative;
+  letter-spacing: .005em;
+  transition:
+    color .26s cubic-bezier(0.16, 1, 0.3, 1),
+    transform .32s cubic-bezier(0.16, 1, 0.3, 1),
+    letter-spacing .32s cubic-bezier(0.16, 1, 0.3, 1),
+    text-shadow .26s cubic-bezier(0.16, 1, 0.3, 1),
+    background .26s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.nav-more-menu li a::before,
+.nav-more-menu li button::before {
+  content: "";
+  position: absolute;
+  left: .5rem;
+  top: 50%;
+  width: 3px;
+  height: 0;
+  border-radius: 1.5px;
+  background: currentColor;
+  transform: translateY(-50%);
+  transition:
+    height .32s cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow .32s cubic-bezier(0.16, 1, 0.3, 1);
+  pointer-events: none;
+}
+
+/* Override the white !important hover above — keep tier hue. */
+.nav-more-menu li a:hover,
+.nav-more-menu li button:hover,
+.nav-more-menu li a:focus-visible,
+.nav-more-menu li button:focus-visible {
+  color: inherit !important;
+  letter-spacing: .03em;
+  transform: translateX(4px);
+  text-shadow: 0 0 10px currentColor, 0 0 22px currentColor;
+  background: linear-gradient(90deg,
+    rgba(255, 255, 255, 0) 0%,
+    rgba(255, 255, 255, .03) 100%);
+}
+
+.nav-more-menu li a:hover::before,
+.nav-more-menu li button:hover::before,
+.nav-more-menu li a:focus-visible::before,
+.nav-more-menu li button:focus-visible::before {
+  height: 60%;
+  box-shadow: 0 0 8px currentColor, 0 0 16px currentColor;
+}
+
 .nav-mobile-search {
   display: none
 }
@@ -529,6 +664,165 @@ button.nav-copy-agent {
   color: var(--text);
   outline: none;
   box-shadow: 0 0 0 2px rgba(var(--tier-basic-rgb), .4);
+}
+
+/* ═══════════════════════════════════════════════
+   NAV MOTION — universal across .nav-primary (main
+   site) and .docs-nav (en/* docs pages). Underline
+   wipe + glow + tracking widen + lift, all in
+   currentColor so each link's tier hue carries.
+   Plate dot marker on the left. Initial stagger
+   entrance on first paint. Reduced-motion is
+   neutralized globally in the Phase 5 block below.
+   ═══════════════════════════════════════════════ */
+
+/* Stagger entrance: nav items rise into place on first paint. */
+@keyframes nav-item-rise {
+  0%   { opacity: 0; transform: translateY(-8px); filter: blur(2px); }
+  100% { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}
+
+/* Underline pulse for the active route — gentle rebreathe of the glow. */
+@keyframes nav-underline-pulse {
+  0%, 100% { box-shadow: 0 0 10px currentColor, 0 0 20px currentColor; }
+  50%      { box-shadow: 0 0 18px currentColor, 0 0 36px currentColor; }
+}
+
+nav ul.nav-primary > li > a,
+nav ul.nav-primary > li > button,
+nav.docs-nav .nav-crumb,
+nav.docs-nav .nav-logo {
+  position: relative;
+  display: inline-block;
+  letter-spacing: .01em;
+  transition:
+    color .26s cubic-bezier(0.16, 1, 0.3, 1),
+    transform .34s cubic-bezier(0.16, 1, 0.3, 1),
+    letter-spacing .34s cubic-bezier(0.16, 1, 0.3, 1),
+    text-shadow .26s cubic-bezier(0.16, 1, 0.3, 1),
+    filter .26s cubic-bezier(0.16, 1, 0.3, 1);
+  will-change: transform;
+  animation: nav-item-rise .55s cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation-delay: calc(var(--nav-i, 0) * 60ms);
+}
+
+/* Underline: 2px hairline that wipes from center outward, with a
+   currentColor halo so the underline reads ceremonial, not utility. */
+nav ul.nav-primary > li > a::after,
+nav ul.nav-primary > li > button::after,
+nav.docs-nav .nav-crumb::after,
+nav.docs-nav .nav-logo::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -5px;
+  height: 2px;
+  background: currentColor;
+  opacity: .95;
+  transform: scaleX(0);
+  transform-origin: center;
+  transition:
+    transform .46s cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow .34s cubic-bezier(0.16, 1, 0.3, 1);
+  pointer-events: none;
+  border-radius: 1px;
+}
+
+/* Plate-style leading mark: a small currentColor dot fades in to the
+   left of the label. Reads as an atlas plate marker, not a bullet. */
+nav ul.nav-primary > li > a::before,
+nav ul.nav-primary > li > button::before,
+nav.docs-nav .nav-crumb::before {
+  content: "";
+  position: absolute;
+  left: -.85em;
+  top: 50%;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0;
+  transform: translate(.45em, -50%) scale(.5);
+  transition:
+    transform .38s cubic-bezier(0.16, 1, 0.3, 1),
+    opacity .26s cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow .26s cubic-bezier(0.16, 1, 0.3, 1);
+  pointer-events: none;
+}
+
+/* Hover / focus state — lift, widen, glow. */
+nav ul.nav-primary > li > a:hover,
+nav ul.nav-primary > li > button:hover,
+nav ul.nav-primary > li > a:focus-visible,
+nav ul.nav-primary > li > button:focus-visible,
+nav.docs-nav .nav-crumb:hover,
+nav.docs-nav .nav-crumb:focus-visible,
+nav.docs-nav .nav-logo:hover,
+nav.docs-nav .nav-logo:focus-visible {
+  transform: translateY(-2px);
+  letter-spacing: .05em;
+  text-shadow: 0 0 14px currentColor, 0 0 28px currentColor;
+}
+
+nav ul.nav-primary > li > a:hover::after,
+nav ul.nav-primary > li > button:hover::after,
+nav ul.nav-primary > li > a:focus-visible::after,
+nav ul.nav-primary > li > button:focus-visible::after,
+nav.docs-nav .nav-crumb:hover::after,
+nav.docs-nav .nav-crumb:focus-visible::after,
+nav.docs-nav .nav-logo:hover::after,
+nav.docs-nav .nav-logo:focus-visible::after,
+nav ul.nav-primary > li > a[aria-current="page"]::after,
+nav ul.nav-primary > li > button[aria-expanded="true"]::after,
+nav.docs-nav .nav-crumb.current::after {
+  transform: scaleX(1);
+  box-shadow: 0 0 12px currentColor, 0 0 24px currentColor;
+}
+
+/* The active route's underline gently breathes. */
+nav ul.nav-primary > li > a[aria-current="page"]::after,
+nav.docs-nav .nav-crumb.current::after {
+  animation: nav-underline-pulse 2.6s cubic-bezier(0.16, 1, 0.3, 1) infinite;
+}
+
+nav ul.nav-primary > li > a:hover::before,
+nav ul.nav-primary > li > button:hover::before,
+nav ul.nav-primary > li > a:focus-visible::before,
+nav ul.nav-primary > li > button:focus-visible::before,
+nav.docs-nav .nav-crumb:hover::before,
+nav.docs-nav .nav-crumb:focus-visible::before,
+nav ul.nav-primary > li > a[aria-current="page"]::before,
+nav ul.nav-primary > li > button[aria-expanded="true"]::before,
+nav.docs-nav .nav-crumb.current::before {
+  opacity: .95;
+  transform: translate(0, -50%) scale(1);
+  box-shadow: 0 0 8px currentColor;
+}
+
+/* Logo gets the lift but no underline pulse (no tier hue to glow with).
+   Kill the ::after on .nav-logo so the wordmark stays clean. */
+.nav-logo::after,
+nav.docs-nav .nav-logo::after {
+  display: none;
+}
+
+/* Docs breadcrumbs: each page sets .nav-crumb to var(--muted) inline.
+   Give the hover/current state a tier hue so currentColor-driven glow
+   has something to broadcast. .nav-logo amber stays from inline rule. */
+nav.docs-nav .nav-crumb:hover,
+nav.docs-nav .nav-crumb:focus-visible {
+  color: var(--tier-basic, #38bdf8);
+}
+nav.docs-nav .nav-crumb.current {
+  color: var(--apex-gold, #fbbf24);
+}
+nav.docs-nav .nav-sep {
+  transition: color .26s cubic-bezier(0.16, 1, 0.3, 1),
+              transform .34s cubic-bezier(0.16, 1, 0.3, 1);
+}
+nav.docs-nav:hover .nav-sep {
+  color: var(--tier-basic, #38bdf8);
 }
 
 /* Global search icon — red, subtle */
@@ -5674,6 +5968,76 @@ footer.footer-v2::before {
   color: var(--text);
 }
 
+/* ── Footer link motion: each column gets a tier hue, links adopt it
+     on hover via currentColor — underline wipe + glow + 1px shift.
+     Honor handle stays Honor Red end-to-end. ─────────────────────── */
+.footer-v2 .footer-col              { --col-hue: var(--tier-basic, #38bdf8); }
+.footer-v2 .footer-col:nth-child(1) { --col-hue: var(--tier-basic, #38bdf8); }
+.footer-v2 .footer-col:nth-child(2) { --col-hue: var(--tier-extra, #c084fc); }
+.footer-v2 .footer-col:nth-child(3) { --col-hue: var(--tier-basic, #38bdf8); }
+.footer-v2 .footer-col:nth-child(4) { --col-hue: var(--apex-gold, #fbbf24); }
+.footer-v2 .footer-col:nth-child(5) { --col-hue: var(--honor-red, #ef4444); }
+
+.footer-v2 .footer-col ul li a,
+.footer-v2 .footer-col ul li button.footer-link-btn {
+  position: relative;
+  display: inline-block;
+  letter-spacing: .005em;
+  transition:
+    color .26s cubic-bezier(0.16, 1, 0.3, 1),
+    transform .32s cubic-bezier(0.16, 1, 0.3, 1),
+    letter-spacing .32s cubic-bezier(0.16, 1, 0.3, 1),
+    text-shadow .26s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.footer-v2 .footer-col ul li a::after,
+.footer-v2 .footer-col ul li button.footer-link-btn::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -3px;
+  height: 1.5px;
+  background: currentColor;
+  opacity: .9;
+  transform: scaleX(0);
+  transform-origin: left center;
+  transition:
+    transform .42s cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow .32s cubic-bezier(0.16, 1, 0.3, 1);
+  pointer-events: none;
+  border-radius: 1px;
+}
+
+.footer-v2 .footer-col ul li a:hover,
+.footer-v2 .footer-col ul li button.footer-link-btn:hover,
+.footer-v2 .footer-col ul li a:focus-visible,
+.footer-v2 .footer-col ul li button.footer-link-btn:focus-visible {
+  color: var(--col-hue);
+  letter-spacing: .03em;
+  transform: translateX(2px);
+  text-shadow: 0 0 10px currentColor, 0 0 20px currentColor;
+}
+
+.footer-v2 .footer-col ul li a:hover::after,
+.footer-v2 .footer-col ul li button.footer-link-btn:hover::after,
+.footer-v2 .footer-col ul li a:focus-visible::after,
+.footer-v2 .footer-col ul li button.footer-link-btn:focus-visible::after {
+  transform: scaleX(1);
+  box-shadow: 0 0 8px currentColor, 0 0 18px currentColor;
+}
+
+/* Column heading also breathes the hue when the column is hovered. */
+.footer-v2 .footer-col-heading {
+  transition: color .3s cubic-bezier(0.16, 1, 0.3, 1),
+              text-shadow .3s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.footer-v2 .footer-col:hover .footer-col-heading,
+.footer-v2 .footer-col:focus-within .footer-col-heading {
+  color: var(--col-hue);
+  text-shadow: 0 0 12px currentColor;
+}
+
 /* Honor attribution — contributor handle only */
 .footer-v2 .footer-link-honor {
   color: var(--honor-red) !important;
@@ -5681,6 +6045,53 @@ footer.footer-v2::before {
 
 .footer-v2 .footer-link-honor:hover {
   color: var(--text) !important;
+}
+
+/* Honor handle keeps red end-to-end, but still gets the glow treatment
+   from currentColor — the column-hue rule above shouldn't override it. */
+.footer-v2 .footer-col ul li a.footer-link-honor:hover,
+.footer-v2 .footer-col ul li a.footer-link-honor:focus-visible {
+  color: var(--honor-red) !important;
+  text-shadow: 0 0 10px var(--honor-red), 0 0 22px var(--honor-red);
+}
+
+/* Docs page-footer (en/*.html): same color motion, scaled down. */
+.page-footer a {
+  position: relative;
+  display: inline-block;
+  letter-spacing: .005em;
+  transition:
+    color .26s cubic-bezier(0.16, 1, 0.3, 1),
+    letter-spacing .32s cubic-bezier(0.16, 1, 0.3, 1),
+    text-shadow .26s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.page-footer a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -2px;
+  height: 1.5px;
+  background: currentColor;
+  opacity: .9;
+  transform: scaleX(0);
+  transform-origin: left center;
+  transition:
+    transform .42s cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow .32s cubic-bezier(0.16, 1, 0.3, 1);
+  pointer-events: none;
+  border-radius: 1px;
+}
+.page-footer a:hover,
+.page-footer a:focus-visible {
+  color: var(--tier-basic, #38bdf8) !important;
+  letter-spacing: .03em;
+  text-shadow: 0 0 10px currentColor, 0 0 20px currentColor;
+}
+.page-footer a:hover::after,
+.page-footer a:focus-visible::after {
+  transform: scaleX(1);
+  box-shadow: 0 0 8px currentColor, 0 0 18px currentColor;
 }
 
 /* External link indicator */

--- a/docs/index.html
+++ b/docs/index.html
@@ -152,36 +152,8 @@
 <body class="home-page">
 
   <!-- ─── NAV ─── -->
-  <nav>
-    <a href="/" class="nav-logo" aria-label="Gaia home">
-      <svg class="ico nav-seal" aria-hidden="true" focusable="false"><use href="assets/icons.svg#seal-diamond"/></svg>
-      <span class="nav-wordmark">Gaia</span>
-    </a>
-    <button type="button" class="nav-search-btn-mobile" id="navSearchBtnMobile" aria-label="Search named" hidden><svg class="ico" width="18" height="18" aria-hidden="true"><use href="assets/icons.svg#search"/></svg></button>
-    <button class="nav-menu-toggle" type="button" aria-label="Open navigation" aria-expanded="false">
-      <span></span>
-      <span></span>
-      <span></span>
-    </button>
-    <ul class="nav-primary">
-      <li style="--nav-i:0"><a href="/" style="color: var(--text);" aria-current="page">Home</a></li>
-      <li style="--nav-i:1"><a href="about.html" style="color: var(--apex-gold);">About</a></li>
-      <li style="--nav-i:2"><a href="badges/" style="color: var(--tier-unique);"><svg class="ico" width="13" height="13" aria-hidden="true" style="vertical-align: -2px; margin-right: .35em;"><use href="assets/icons.svg#github"/></svg>GitHub Badges</a></li>
-      <li style="--nav-i:3"><a href="named/" style="color: var(--honor-red);">Skills</a></li>
-      <li style="--nav-i:4"><a href="en/" style="color: var(--tier-basic);">Docs</a></li>
-      <li class="nav-more-dropdown" style="--nav-i:5">
-        <button class="nav-more-toggle" aria-label="More options" aria-expanded="false">More</button>
-        <ul class="nav-more-menu">
-          <li><button type="button" class="nav-tree" id="treeNavBtn" style="color: #34d399;">Skill Tree</button></li>
-          <li><button type="button" class="nav-graph-trigger" data-graph-trigger style="color: #38bdf8;">Skill Graph</button></li>
-          <li><a href="codex.html" style="color: var(--tier-basic);">The Codex</a></li>
-          <li><a href="starless.html" style="color: var(--muted);">Starless</a></li>
-          <li><a href="u/" style="color: var(--honor-red);">Named Contributors</a></li>
-          <li><a href="meta.html" class="nav-meta" id="metaNavBtn">Meta Reports</a></li>
-        </ul>
-      </li>
-    </ul>
-  </nav>
+  <nav id="site-nav"></nav>
+  <script src="js/site-nav.js?v=4.7.5"></script>
 
   <!-- ─── HERO ─── -->
   <section id="hero">
@@ -593,82 +565,9 @@
 
   <div class="section-divider"></div>
 
-  <!-- ─── FOOTER v2 ─── -->
-  <footer class="footer-v2">
-    <div class="footer-inner">
-
-      <!-- Brand column -->
-      <div class="footer-brand-col">
-        <div class="footer-brand-mark">
-          <svg class="ico footer-seal" aria-hidden="true" focusable="false">
-            <use href="assets/icons.svg#seal-diamond"/>
-          </svg>
-          <span class="footer-wordmark">Gaia</span>
-        </div>
-        <p class="footer-tagline">An evidence-backed atlas<br>of agent capabilities.</p>
-      </div>
-
-      <!-- Link columns -->
-      <nav class="footer-cols" aria-label="Site navigation">
-
-        <div class="footer-col">
-          <span class="footer-col-heading">Registry</span>
-          <ul>
-            <li><a href="index.html">Home</a></li>
-            <li><a href="index.html">Skill Tree</a></li>
-            <li><a href="index.html?field=1">Skill Graph</a></li>
-            <li><a href="starless.html">Starless</a></li>
-            <li><a href="meta.html">Meta Reports</a></li>
-          </ul>
-        </div>
-
-        <div class="footer-col">
-          <span class="footer-col-heading">Discover</span>
-          <ul>
-            <li><a href="codex.html">The Codex</a></li>
-            <li><a href="named/">Named Skills</a></li>
-            <li><a href="index.html#hall-of-heroes">Hall of Heroes</a></li>
-            <li><a href="u/">Named Contributors</a></li>
-            <li><a href="badges/">GitHub Badges</a></li>
-            <li><a href="samples/index.html">Samples</a></li>
-          </ul>
-        </div>
-
-        <div class="footer-col">
-          <span class="footer-col-heading">Contribute</span>
-          <ul>
-            <li><a href="index.html#paths">Push a skill</a></li>
-            <li><a href="https://github.com/mbtiongson1/gaia-skill-tree" target="_blank" rel="noopener" class="footer-ext">GitHub</a></li>
-            <li><a href="https://github.com/mbtiongson1/gaia-skill-tree/issues" target="_blank" rel="noopener" class="footer-ext">Open Issues</a></li>
-          </ul>
-        </div>
-
-        <div class="footer-col">
-          <span class="footer-col-heading">About</span>
-          <ul>
-            <li><a href="about.html">About Gaia</a></li>
-            <li><a href="u/mbtiongson1/" class="footer-link-honor">@mbtiongson1</a></li>
-            <li><a href="privacy.html">Privacy</a></li>
-            <li>
-              <button id="copyAgentFooterBtn" type="button" class="footer-link-btn" aria-label="Copy page context for agents">
-                Copy Page
-              </button>
-            </li>
-          </ul>
-        </div>
-
-      </nav>
-    </div>
-
-    <!-- Bottom strip -->
-    <div class="footer-bottom">
-      <span>MIT License</span>
-      <span class="footer-bottom-sep" aria-hidden="true">·</span>
-      <span id="footerVersion">v4.1.2</span>
-      <span class="footer-bottom-sep" aria-hidden="true">·</span>
-      <span>© 2026 Gaia</span>
-    </div>
-  </footer>
+  <!-- ─── FOOTER ─── -->
+  <div id="site-footer-mount"></div>
+  <script src="js/site-footer.js?v=4.7.5"></script>
 
   <!-- ─── SKILL EXPLORER OVERLAY ─── -->
   <div id="skillExplorer" class="skill-explorer" role="dialog" aria-modal="true" aria-label="Skill Explorer" tabindex="-1">

--- a/docs/index.html
+++ b/docs/index.html
@@ -164,11 +164,11 @@
       <span></span>
     </button>
     <ul class="nav-primary">
-      <li><a href="/" style="color: var(--text);" aria-current="page">Home</a></li>
-      <li><a href="about.html" style="color: var(--apex-gold);">About</a></li>
-      <li><a href="badges/" style="color: var(--tier-unique);"><svg class="ico" width="13" height="13" aria-hidden="true" style="vertical-align: -2px; margin-right: .35em;"><use href="assets/icons.svg#github"/></svg>GitHub Badges</a></li>
-      <li><a href="named/" style="color: var(--honor-red);">Skills</a></li>
-      <li class="nav-more-dropdown">
+      <li style="--nav-i:0"><a href="/" style="color: var(--text);" aria-current="page">Home</a></li>
+      <li style="--nav-i:1"><a href="about.html" style="color: var(--apex-gold);">About</a></li>
+      <li style="--nav-i:2"><a href="badges/" style="color: var(--tier-unique);"><svg class="ico" width="13" height="13" aria-hidden="true" style="vertical-align: -2px; margin-right: .35em;"><use href="assets/icons.svg#github"/></svg>GitHub Badges</a></li>
+      <li style="--nav-i:3"><a href="named/" style="color: var(--honor-red);">Skills</a></li>
+      <li class="nav-more-dropdown" style="--nav-i:4">
         <button class="nav-more-toggle" aria-label="More options" aria-expanded="false">More</button>
         <ul class="nav-more-menu">
           <li><button type="button" class="nav-tree" id="treeNavBtn" style="color: #34d399;">Skill Tree</button></li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -168,7 +168,8 @@
       <li style="--nav-i:1"><a href="about.html" style="color: var(--apex-gold);">About</a></li>
       <li style="--nav-i:2"><a href="badges/" style="color: var(--tier-unique);"><svg class="ico" width="13" height="13" aria-hidden="true" style="vertical-align: -2px; margin-right: .35em;"><use href="assets/icons.svg#github"/></svg>GitHub Badges</a></li>
       <li style="--nav-i:3"><a href="named/" style="color: var(--honor-red);">Skills</a></li>
-      <li class="nav-more-dropdown" style="--nav-i:4">
+      <li style="--nav-i:4"><a href="en/" style="color: var(--tier-basic);">Docs</a></li>
+      <li class="nav-more-dropdown" style="--nav-i:5">
         <button class="nav-more-toggle" aria-label="More options" aria-expanded="false">More</button>
         <ul class="nav-more-menu">
           <li><button type="button" class="nav-tree" id="treeNavBtn" style="color: #34d399;">Skill Tree</button></li>

--- a/docs/js/site-footer.js
+++ b/docs/js/site-footer.js
@@ -74,7 +74,7 @@
             <span class="footer-col-heading">About</span>
             <ul>
               <li><a href="${r}about.html">About Gaia</a></li>
-              <li><a href="${r}u/mbtiongson1/" class="footer-link-honor">@mbtiongson1</a></li>
+              <li><a href="https://github.com/mbtiongson1" target="_blank" rel="noopener" class="footer-link-honor">@mbtiongson1</a></li>
               <li><a href="${r}privacy.html">Privacy</a></li>
               <li>
                 <button id="copyAgentFooterBtn" type="button" class="footer-link-btn" aria-label="Copy page context for agents">

--- a/docs/js/site-footer.js
+++ b/docs/js/site-footer.js
@@ -1,0 +1,103 @@
+/**
+ * site-footer.js — single source of truth for the main site footer.
+ * Renders into <div id="site-footer-mount"> on every page.
+ * Auto-detects root path depth from window.location.
+ */
+(function () {
+  const el = document.getElementById('site-footer-mount');
+  if (!el) return;
+
+  const parts = window.location.pathname.replace(/\/$/, '').split('/');
+  const filename = parts[parts.length - 1];
+  const isFile = filename.includes('.');
+  const dirParts = isFile ? parts.slice(0, -1) : parts;
+  const docsDirIndex = dirParts.findIndex(p => p === 'docs');
+  const depth = docsDirIndex >= 0 ? dirParts.length - docsDirIndex - 1 : 0;
+  const r = depth === 0 ? '' : '../'.repeat(depth);
+
+  el.innerHTML = `
+    <footer class="footer-v2">
+      <div class="footer-inner">
+        <div class="footer-brand-col">
+          <div class="footer-brand-mark">
+            <svg class="ico footer-seal" aria-hidden="true" focusable="false">
+              <use href="${r}assets/icons.svg#seal-diamond"/>
+            </svg>
+            <span class="footer-wordmark">Gaia</span>
+          </div>
+          <p class="footer-tagline">An evidence-backed atlas<br>of agent capabilities.</p>
+        </div>
+
+        <nav class="footer-cols" aria-label="Site navigation">
+
+          <div class="footer-col">
+            <span class="footer-col-heading">Registry</span>
+            <ul>
+              <li><a href="${r}index.html">Home</a></li>
+              <li><a href="${r}index.html">Skill Tree</a></li>
+              <li><a href="${r}index.html?field=1">Skill Graph</a></li>
+              <li><a href="${r}starless.html">Starless</a></li>
+              <li><a href="${r}meta.html">Meta Reports</a></li>
+            </ul>
+          </div>
+
+          <div class="footer-col">
+            <span class="footer-col-heading">Discover</span>
+            <ul>
+              <li><a href="${r}codex.html">The Codex</a></li>
+              <li><a href="${r}named/">Named Skills</a></li>
+              <li><a href="${r}index.html#hall-of-heroes">Hall of Heroes</a></li>
+              <li><a href="${r}u/">Named Contributors</a></li>
+              <li><a href="${r}badges/">GitHub Badges</a></li>
+            </ul>
+          </div>
+
+          <div class="footer-col">
+            <span class="footer-col-heading">Docs</span>
+            <ul>
+              <li><a href="${r}en/">Docs Home</a></li>
+              <li><a href="${r}en/getting-started.html">Getting Started</a></li>
+              <li><a href="${r}en/cli-reference.html">CLI Reference</a></li>
+            </ul>
+          </div>
+
+          <div class="footer-col">
+            <span class="footer-col-heading">Contribute</span>
+            <ul>
+              <li><a href="${r}index.html#paths">Push a skill</a></li>
+              <li><a href="https://github.com/mbtiongson1/gaia-skill-tree" target="_blank" rel="noopener" class="footer-ext">GitHub</a></li>
+              <li><a href="https://github.com/mbtiongson1/gaia-skill-tree/issues" target="_blank" rel="noopener" class="footer-ext">Open Issues</a></li>
+            </ul>
+          </div>
+
+          <div class="footer-col">
+            <span class="footer-col-heading">About</span>
+            <ul>
+              <li><a href="${r}about.html">About Gaia</a></li>
+              <li><a href="${r}u/mbtiongson1/" class="footer-link-honor">@mbtiongson1</a></li>
+              <li><a href="${r}privacy.html">Privacy</a></li>
+              <li>
+                <button id="copyAgentFooterBtn" type="button" class="footer-link-btn" aria-label="Copy page context for agents">
+                  Copy Page
+                </button>
+              </li>
+            </ul>
+          </div>
+
+        </nav>
+      </div>
+
+      <div class="footer-bottom">
+        <svg class="ico footer-seal" width="16" height="16" aria-hidden="true">
+          <use href="${r}assets/icons.svg#seal-diamond"/>
+        </svg>
+        <span class="footer-bottom-sep">—</span>
+        <span>Gaia Registry</span>
+        <span class="footer-bottom-sep">·</span>
+        <a href="https://github.com/mbtiongson1/gaia-skill-tree" target="_blank" rel="noopener">GitHub</a>
+        <span class="footer-bottom-sep">·</span>
+        <a href="${r}privacy.html">Privacy</a>
+      </div>
+    </footer>
+  `;
+})();

--- a/docs/js/site-nav.js
+++ b/docs/js/site-nav.js
@@ -7,9 +7,8 @@
   const el = document.getElementById('site-nav');
   if (!el) return;
 
-  // Compute depth the same way icons.js does: count segments after any known
-  // nested mount point. Works on both localhost (/docs/named/) and GH Pages
-  // (gaia.tiongson.co/named/) because we look for the mount name, not 'docs'.
+  // Compute depth via known mount names — works on both localhost (/docs/named/)
+  // and GH Pages (gaia.tiongson.co/named/) where 'docs' never appears in the URL.
   //
   //   /                          → depth 0  → root = ''
   //   /named/                    → depth 1  → root = '../'
@@ -20,11 +19,9 @@
   //
   const MOUNTS = ['named', 'en', 'badges', 'u', 'samples', 'graph'];
   const segs = window.location.pathname.replace(/\/+$/, '').split('/').filter(Boolean);
-  // Trim trailing filename
   const dir = /\.html?$/i.test(segs[segs.length - 1]) ? segs.slice(0, -1) : segs;
 
   let depth = 0;
-  // Find the first known mount and measure depth from there
   for (let i = 0; i < dir.length; i++) {
     if (MOUNTS.includes(dir[i])) {
       depth = dir.length - i;
@@ -39,14 +36,9 @@
     return root + 'assets/icons.svg';
   }
 
-  // Diamond Seal inlined — avoids any <use href> sprite-loading race or
-  // cross-origin block. Matches the seal-diamond symbol exactly.
-  const SEAL_SVG = `<svg class="ico nav-seal" viewBox="0 0 64 64" aria-hidden="true" focusable="false">
-    <path d="M 32 4 L 60 32 L 32 60 L 4 32 Z" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linejoin="miter"/>
-    <text x="32" y="34" font-family="EB Garamond, Georgia, serif" font-weight="600" font-size="28" fill="currentColor" text-anchor="middle" dominant-baseline="central">G</text>
-  </svg>`;
+  // Diamond Seal inlined — avoids <use href> sprite-load race and cross-origin blocks.
+  const SEAL_SVG = `<svg class="ico nav-seal" viewBox="0 0 64 64" aria-hidden="true" focusable="false"><path d="M 32 4 L 60 32 L 32 60 L 4 32 Z" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linejoin="miter"/><text x="32" y="34" font-family="EB Garamond, Georgia, serif" font-weight="600" font-size="28" fill="currentColor" text-anchor="middle" dominant-baseline="central">G</text></svg>`;
 
-  // Determine current page for aria-current
   const currentPath = window.location.pathname;
   function isActive(href) {
     const resolved = new URL(href, window.location.href).pathname.replace(/\/$/, '') || '/';
@@ -55,17 +47,17 @@
   }
 
   const links = [
-    { href: root + 'index.html',   label: 'Home',          color: 'var(--text)',        i: 0 },
-    { href: root + 'about.html',   label: 'About',         color: 'var(--apex-gold)',   i: 1 },
+    { href: root + 'index.html', label: 'Home',          color: 'var(--text)',       i: 0 },
+    { href: root + 'about.html', label: 'About',         color: 'var(--apex-gold)',  i: 1 },
     {
       href: root + 'badges/',
       label: 'GitHub Badges',
       color: 'var(--tier-unique)',
-      icon: () => `<svg class="ico" width="13" height="13" aria-hidden="true" style="vertical-align:-2px;margin-right:.35em"><use href="${iconBase()}#github"/></svg>`,
+      icon: function() { return '<svg class="ico" width="13" height="13" aria-hidden="true" style="vertical-align:-2px;margin-right:.35em"><use href="' + iconBase() + '#github"/></svg>'; },
       i: 2
     },
-    { href: root + 'named/',  label: 'Skills', color: 'var(--honor-red)',  i: 3 },
-    { href: root + 'en/',     label: 'Docs',   color: 'var(--tier-basic)', i: 4 },
+    { href: root + 'named/', label: 'Skills', color: 'var(--honor-red)',  i: 3 },
+    { href: root + 'en/',    label: 'Docs',   color: 'var(--tier-basic)', i: 4 },
   ];
 
   const dropdown = [
@@ -79,116 +71,41 @@
 
   function li(item) {
     const active = isActive(item.href) ? ' aria-current="page"' : '';
-    const icon = typeof item.icon === 'function' ? item.icon() : (item.icon || '');
-    return `<li style="--nav-i:${item.i}"><a href="${item.href}" style="color:${item.color}"${active}>${icon}${item.label}</a></li>`;
+    const icon = typeof item.icon === 'function' ? item.icon() : '';
+    return '<li style="--nav-i:' + item.i + '"><a href="' + item.href + '" style="color:' + item.color + '"' + active + '>' + icon + item.label + '</a></li>';
   }
 
   function dropdownItem(d) {
     if (d.type === 'btn') {
-      const extra = d.attr ? ` ${d.attr}` : '';
-      const cls = d.cls ? ` class="${d.cls}"` : '';
-      const id = d.id ? ` id="${d.id}"` : '';
-      return `<li><button type="button"${cls}${id} style="color:${d.color}"${extra}>${d.label}</button></li>`;
+      const extra = d.attr ? ' ' + d.attr : '';
+      const cls = d.cls ? ' class="' + d.cls + '"' : '';
+      const id = d.id ? ' id="' + d.id + '"' : '';
+      return '<li><button type="button"' + cls + id + ' style="color:' + d.color + '"' + extra + '>' + d.label + '</button></li>';
     }
     const active = isActive(d.href) ? ' aria-current="page"' : '';
-    const cls = d.cls ? ` class="${d.cls}"` : '';
-    const id = d.id ? ` id="${d.id}"` : '';
-    return `<li><a href="${d.href}"${cls}${id} style="color:${d.color || ''}"${active}>${d.label}</a></li>`;
+    const cls = d.cls ? ' class="' + d.cls + '"' : '';
+    const id = d.id ? ' id="' + d.id + '"' : '';
+    return '<li><a href="' + d.href + '"' + cls + id + ' style="color:' + (d.color || '') + '"' + active + '>' + d.label + '</a></li>';
   }
 
-  el.innerHTML = `
-    <a href="${root}index.html" class="nav-logo" aria-label="Gaia home">
-      ${SEAL_SVG}
-      <span class="nav-wordmark">Gaia</span>
-    </a>
-    <button type="button" class="nav-search-btn-mobile" id="navSearchBtnMobile" aria-label="Search named" hidden>
-      <svg class="ico" width="18" height="18" aria-hidden="true"><use href="${root}assets/icons.svg#search"/></svg>
-    </button>
-    <button class="nav-menu-toggle" type="button" aria-label="Open navigation" aria-expanded="false">
-      <span></span><span></span><span></span>
-    </button>
-    <ul class="nav-primary">
-      ${links.map(li).join('\n      ')}
-      <li class="nav-more-dropdown" style="--nav-i:5">
-        <button class="nav-more-toggle" aria-label="More options" aria-expanded="false">More</button>
-        <ul class="nav-more-menu">
-          ${dropdown.map(dropdownItem).join('\n          ')}
-        </ul>
-      </li>
-    </ul>
-  `;
-})();
-
-
-  // Determine current page for aria-current
-  const currentPath = window.location.pathname;
-  function isActive(href) {
-    const resolved = new URL(href, window.location.href).pathname.replace(/\/$/, '') || '/';
-    const cur = currentPath.replace(/\/$/, '') || '/';
-    return resolved === cur || (href === 'index.html' && (cur.endsWith('/docs') || cur.endsWith('/docs/')));
-  }
-
-  const links = [
-    { href: root + 'index.html',   label: 'Home',          color: 'var(--text)',        i: 0 },
-    { href: root + 'about.html',   label: 'About',         color: 'var(--apex-gold)',   i: 1 },
-    {
-      href: root + 'badges/',
-      label: 'GitHub Badges',
-      color: 'var(--tier-unique)',
-      icon: () => `<svg class="ico" width="13" height="13" aria-hidden="true" style="vertical-align:-2px;margin-right:.35em"><use href="${iconBase()}#github"/></svg>`,
-      i: 2
-    },
-    { href: root + 'named/',  label: 'Skills', color: 'var(--honor-red)',  i: 3 },
-    { href: root + 'en/',     label: 'Docs',   color: 'var(--tier-basic)', i: 4 },
-  ];
-
-  const dropdown = [
-    { type: 'btn',  id: 'treeNavBtn',  label: 'Skill Tree',          color: '#34d399', cls: 'nav-tree' },
-    { type: 'btn',  id: 'navGraphBtn', label: 'Skill Graph',          color: '#38bdf8', cls: 'nav-graph-trigger', attr: 'data-graph-trigger' },
-    { type: 'link', href: root + 'codex.html',    label: 'The Codex',          color: 'var(--tier-basic)' },
-    { type: 'link', href: root + 'starless.html', label: 'Starless',           color: 'var(--muted)' },
-    { type: 'link', href: root + 'u/',            label: 'Named Contributors', color: 'var(--honor-red)' },
-    { type: 'link', href: root + 'meta.html',     label: 'Meta Reports',       cls: 'nav-meta', id: 'metaNavBtn' },
-  ];
-
-  function li(item) {
-    const active = isActive(item.href) ? ' aria-current="page"' : '';
-    const icon = typeof item.icon === 'function' ? item.icon() : (item.icon || '');
-    return `<li style="--nav-i:${item.i}"><a href="${item.href}" style="color:${item.color}"${active}>${icon}${item.label}</a></li>`;
-  }
-
-  function dropdownItem(d) {
-    if (d.type === 'btn') {
-      const extra = d.attr ? ` ${d.attr}` : '';
-      const cls = d.cls ? ` class="${d.cls}"` : '';
-      const id = d.id ? ` id="${d.id}"` : '';
-      return `<li><button type="button"${cls}${id} style="color:${d.color}"${extra}>${d.label}</button></li>`;
-    }
-    const active = isActive(d.href) ? ' aria-current="page"' : '';
-    const cls = d.cls ? ` class="${d.cls}"` : '';
-    const id = d.id ? ` id="${d.id}"` : '';
-    return `<li><a href="${d.href}"${cls}${id} style="color:${d.color || ''}"${active}>${d.label}</a></li>`;
-  }
-
-  el.innerHTML = `
-    <a href="${root}index.html" class="nav-logo" aria-label="Gaia home">
-      ${SEAL_SVG}
-      <span class="nav-wordmark">Gaia</span>
-    </a>
-    <button type="button" class="nav-search-btn-mobile" id="navSearchBtnMobile" aria-label="Search named" hidden>
-      <svg class="ico" width="18" height="18" aria-hidden="true"><use href="${root}assets/icons.svg#search"/></svg>
-    </button>
-    <button class="nav-menu-toggle" type="button" aria-label="Open navigation" aria-expanded="false">
-      <span></span><span></span><span></span>
-    </button>
-    <ul class="nav-primary">
-      ${links.map(li).join('\n      ')}
-      <li class="nav-more-dropdown" style="--nav-i:5">
-        <button class="nav-more-toggle" aria-label="More options" aria-expanded="false">More</button>
-        <ul class="nav-more-menu">
-          ${dropdown.map(dropdownItem).join('\n          ')}
-        </ul>
-      </li>
-    </ul>
-  `;
+  el.innerHTML =
+    '<a href="' + root + 'index.html" class="nav-logo" aria-label="Gaia home">' +
+      SEAL_SVG +
+      '<span class="nav-wordmark">Gaia</span>' +
+    '</a>' +
+    '<button type="button" class="nav-search-btn-mobile" id="navSearchBtnMobile" aria-label="Search named" hidden>' +
+      '<svg class="ico" width="18" height="18" aria-hidden="true"><use href="' + root + 'assets/icons.svg#search"/></svg>' +
+    '</button>' +
+    '<button class="nav-menu-toggle" type="button" aria-label="Open navigation" aria-expanded="false">' +
+      '<span></span><span></span><span></span>' +
+    '</button>' +
+    '<ul class="nav-primary">' +
+      links.map(li).join('') +
+      '<li class="nav-more-dropdown" style="--nav-i:5">' +
+        '<button class="nav-more-toggle" aria-label="More options" aria-expanded="false">More</button>' +
+        '<ul class="nav-more-menu">' +
+          dropdown.map(dropdownItem).join('') +
+        '</ul>' +
+      '</li>' +
+    '</ul>';
 })();

--- a/docs/js/site-nav.js
+++ b/docs/js/site-nav.js
@@ -1,0 +1,96 @@
+/**
+ * site-nav.js — single source of truth for the main site nav.
+ * Renders into <nav id="site-nav"> on every page.
+ * Auto-detects root path depth and active page from window.location.
+ */
+(function () {
+  const el = document.getElementById('site-nav');
+  if (!el) return;
+
+  // Detect how many levels deep we are from /docs/
+  // depth 0 = docs/*.html, depth 1 = docs/en/*.html or docs/named/*.html, etc.
+  const parts = window.location.pathname.replace(/\/$/, '').split('/');
+  // Strip trailing filename
+  const filename = parts[parts.length - 1];
+  const isFile = filename.includes('.');
+  const dirParts = isFile ? parts.slice(0, -1) : parts;
+
+  // Find the docs root by looking for known subdirs
+  // Works for: /docs/, /docs/en/, /docs/named/, /docs/u/username/, etc.
+  // We need to figure out the relative prefix to reach docs root.
+  const docsDirIndex = dirParts.findIndex(p => p === 'docs');
+  const depth = docsDirIndex >= 0 ? dirParts.length - docsDirIndex - 1 : 0;
+  const root = depth === 0 ? '' : '../'.repeat(depth);
+
+  // Determine current page for aria-current
+  const currentPath = window.location.pathname;
+  function isActive(href) {
+    const resolved = new URL(href, window.location.href).pathname.replace(/\/$/, '') || '/';
+    const cur = currentPath.replace(/\/$/, '') || '/';
+    return resolved === cur || (href === 'index.html' && (cur.endsWith('/docs') || cur.endsWith('/docs/')));
+  }
+
+  const links = [
+    { href: root + 'index.html',   label: 'Home',          color: 'var(--text)',        i: 0 },
+    { href: root + 'about.html',   label: 'About',         color: 'var(--apex-gold)',   i: 1 },
+    {
+      href: root + 'badges/',
+      label: 'GitHub Badges',
+      color: 'var(--tier-unique)',
+      icon: `<svg class="ico" width="13" height="13" aria-hidden="true" style="vertical-align:-2px;margin-right:.35em"><use href="${root}assets/icons.svg#github"/></svg>`,
+      i: 2
+    },
+    { href: root + 'named/',       label: 'Skills',        color: 'var(--honor-red)',   i: 3 },
+    { href: root + 'en/',          label: 'Docs',          color: 'var(--tier-basic)',  i: 4 },
+  ];
+
+  const dropdown = [
+    { type: 'btn',  id: 'treeNavBtn',    label: 'Skill Tree',         color: '#34d399',              cls: 'nav-tree' },
+    { type: 'btn',  id: 'navGraphBtn',   label: 'Skill Graph',        color: '#38bdf8',              cls: 'nav-graph-trigger', attr: 'data-graph-trigger' },
+    { type: 'link', href: root + 'codex.html',   label: 'The Codex',         color: 'var(--tier-basic)' },
+    { type: 'link', href: root + 'starless.html', label: 'Starless',          color: 'var(--muted)' },
+    { type: 'link', href: root + 'u/',            label: 'Named Contributors',color: 'var(--honor-red)' },
+    { type: 'link', href: root + 'meta.html',     label: 'Meta Reports',      cls: 'nav-meta', id: 'metaNavBtn' },
+  ];
+
+  function li(item) {
+    const active = isActive(item.href) ? ' aria-current="page"' : '';
+    const icon = item.icon || '';
+    return `<li style="--nav-i:${item.i}"><a href="${item.href}" style="color:${item.color}"${active}>${icon}${item.label}</a></li>`;
+  }
+
+  function dropdownItem(d) {
+    if (d.type === 'btn') {
+      const extra = d.attr ? ` ${d.attr}` : '';
+      const cls = d.cls ? ` class="${d.cls}"` : '';
+      const id = d.id ? ` id="${d.id}"` : '';
+      return `<li><button type="button"${cls}${id} style="color:${d.color}"${extra}>${d.label}</button></li>`;
+    }
+    const active = isActive(d.href) ? ' aria-current="page"' : '';
+    const cls = d.cls ? ` class="${d.cls}"` : '';
+    const id = d.id ? ` id="${d.id}"` : '';
+    return `<li><a href="${d.href}"${cls}${id} style="color:${d.color || ''}"${active}>${d.label}</a></li>`;
+  }
+
+  el.innerHTML = `
+    <a href="${root}index.html" class="nav-logo" aria-label="Gaia home">
+      <svg class="ico nav-seal" aria-hidden="true" focusable="false"><use href="${root}assets/icons.svg#seal-diamond"/></svg>
+      <span class="nav-wordmark">Gaia</span>
+    </a>
+    <button type="button" class="nav-search-btn-mobile" id="navSearchBtnMobile" aria-label="Search named" hidden>
+      <svg class="ico" width="18" height="18" aria-hidden="true"><use href="${root}assets/icons.svg#search"/></svg>
+    </button>
+    <button class="nav-menu-toggle" type="button" aria-label="Open navigation" aria-expanded="false">
+      <span></span><span></span><span></span>
+    </button>
+    <ul class="nav-primary">
+      ${links.map(li).join('\n      ')}
+      <li class="nav-more-dropdown" style="--nav-i:5">
+        <button class="nav-more-toggle" aria-label="More options" aria-expanded="false">More</button>
+        <ul class="nav-more-menu">
+          ${dropdown.map(dropdownItem).join('\n          ')}
+        </ul>
+      </li>
+    </ul>
+  `;
+})();

--- a/docs/js/site-nav.js
+++ b/docs/js/site-nav.js
@@ -7,27 +7,51 @@
   const el = document.getElementById('site-nav');
   if (!el) return;
 
-  // Detect how many levels deep we are from /docs/
-  // depth 0 = docs/*.html, depth 1 = docs/en/*.html or docs/named/*.html, etc.
-  const parts = window.location.pathname.replace(/\/$/, '').split('/');
-  // Strip trailing filename
-  const filename = parts[parts.length - 1];
-  const isFile = filename.includes('.');
-  const dirParts = isFile ? parts.slice(0, -1) : parts;
+  // Compute depth the same way icons.js does: count segments after any known
+  // nested mount point. Works on both localhost (/docs/named/) and GH Pages
+  // (gaia.tiongson.co/named/) because we look for the mount name, not 'docs'.
+  //
+  //   /                          → depth 0  → root = ''
+  //   /named/                    → depth 1  → root = '../'
+  //   /en/getting-started.html   → depth 1  → root = '../'
+  //   /badges/                   → depth 1  → root = '../'
+  //   /u/                        → depth 1  → root = '../'
+  //   /u/mbtiongson1/            → depth 2  → root = '../../'
+  //
+  const MOUNTS = ['named', 'en', 'badges', 'u', 'samples', 'graph'];
+  const segs = window.location.pathname.replace(/\/+$/, '').split('/').filter(Boolean);
+  // Trim trailing filename
+  const dir = /\.html?$/i.test(segs[segs.length - 1]) ? segs.slice(0, -1) : segs;
 
-  // Find the docs root by looking for known subdirs
-  // Works for: /docs/, /docs/en/, /docs/named/, /docs/u/username/, etc.
-  // We need to figure out the relative prefix to reach docs root.
-  const docsDirIndex = dirParts.findIndex(p => p === 'docs');
-  const depth = docsDirIndex >= 0 ? dirParts.length - docsDirIndex - 1 : 0;
+  let depth = 0;
+  // Find the first known mount and measure depth from there
+  for (let i = 0; i < dir.length; i++) {
+    if (MOUNTS.includes(dir[i])) {
+      depth = dir.length - i;
+      break;
+    }
+  }
   const root = depth === 0 ? '' : '../'.repeat(depth);
+
+  // Resolve icon sprite — prefer icons.js's gaiaIconBase() if already loaded.
+  function iconBase() {
+    if (typeof window.gaiaIconBase === 'function') return window.gaiaIconBase();
+    return root + 'assets/icons.svg';
+  }
+
+  // Diamond Seal inlined — avoids any <use href> sprite-loading race or
+  // cross-origin block. Matches the seal-diamond symbol exactly.
+  const SEAL_SVG = `<svg class="ico nav-seal" viewBox="0 0 64 64" aria-hidden="true" focusable="false">
+    <path d="M 32 4 L 60 32 L 32 60 L 4 32 Z" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linejoin="miter"/>
+    <text x="32" y="34" font-family="EB Garamond, Georgia, serif" font-weight="600" font-size="28" fill="currentColor" text-anchor="middle" dominant-baseline="central">G</text>
+  </svg>`;
 
   // Determine current page for aria-current
   const currentPath = window.location.pathname;
   function isActive(href) {
     const resolved = new URL(href, window.location.href).pathname.replace(/\/$/, '') || '/';
     const cur = currentPath.replace(/\/$/, '') || '/';
-    return resolved === cur || (href === 'index.html' && (cur.endsWith('/docs') || cur.endsWith('/docs/')));
+    return resolved === cur;
   }
 
   const links = [
@@ -37,25 +61,25 @@
       href: root + 'badges/',
       label: 'GitHub Badges',
       color: 'var(--tier-unique)',
-      icon: `<svg class="ico" width="13" height="13" aria-hidden="true" style="vertical-align:-2px;margin-right:.35em"><use href="${root}assets/icons.svg#github"/></svg>`,
+      icon: () => `<svg class="ico" width="13" height="13" aria-hidden="true" style="vertical-align:-2px;margin-right:.35em"><use href="${iconBase()}#github"/></svg>`,
       i: 2
     },
-    { href: root + 'named/',       label: 'Skills',        color: 'var(--honor-red)',   i: 3 },
-    { href: root + 'en/',          label: 'Docs',          color: 'var(--tier-basic)',  i: 4 },
+    { href: root + 'named/',  label: 'Skills', color: 'var(--honor-red)',  i: 3 },
+    { href: root + 'en/',     label: 'Docs',   color: 'var(--tier-basic)', i: 4 },
   ];
 
   const dropdown = [
-    { type: 'btn',  id: 'treeNavBtn',    label: 'Skill Tree',         color: '#34d399',              cls: 'nav-tree' },
-    { type: 'btn',  id: 'navGraphBtn',   label: 'Skill Graph',        color: '#38bdf8',              cls: 'nav-graph-trigger', attr: 'data-graph-trigger' },
-    { type: 'link', href: root + 'codex.html',   label: 'The Codex',         color: 'var(--tier-basic)' },
-    { type: 'link', href: root + 'starless.html', label: 'Starless',          color: 'var(--muted)' },
-    { type: 'link', href: root + 'u/',            label: 'Named Contributors',color: 'var(--honor-red)' },
-    { type: 'link', href: root + 'meta.html',     label: 'Meta Reports',      cls: 'nav-meta', id: 'metaNavBtn' },
+    { type: 'btn',  id: 'treeNavBtn',  label: 'Skill Tree',          color: '#34d399', cls: 'nav-tree' },
+    { type: 'btn',  id: 'navGraphBtn', label: 'Skill Graph',          color: '#38bdf8', cls: 'nav-graph-trigger', attr: 'data-graph-trigger' },
+    { type: 'link', href: root + 'codex.html',    label: 'The Codex',          color: 'var(--tier-basic)' },
+    { type: 'link', href: root + 'starless.html', label: 'Starless',           color: 'var(--muted)' },
+    { type: 'link', href: root + 'u/',            label: 'Named Contributors', color: 'var(--honor-red)' },
+    { type: 'link', href: root + 'meta.html',     label: 'Meta Reports',       cls: 'nav-meta', id: 'metaNavBtn' },
   ];
 
   function li(item) {
     const active = isActive(item.href) ? ' aria-current="page"' : '';
-    const icon = item.icon || '';
+    const icon = typeof item.icon === 'function' ? item.icon() : (item.icon || '');
     return `<li style="--nav-i:${item.i}"><a href="${item.href}" style="color:${item.color}"${active}>${icon}${item.label}</a></li>`;
   }
 
@@ -74,7 +98,81 @@
 
   el.innerHTML = `
     <a href="${root}index.html" class="nav-logo" aria-label="Gaia home">
-      <svg class="ico nav-seal" aria-hidden="true" focusable="false"><use href="${root}assets/icons.svg#seal-diamond"/></svg>
+      ${SEAL_SVG}
+      <span class="nav-wordmark">Gaia</span>
+    </a>
+    <button type="button" class="nav-search-btn-mobile" id="navSearchBtnMobile" aria-label="Search named" hidden>
+      <svg class="ico" width="18" height="18" aria-hidden="true"><use href="${root}assets/icons.svg#search"/></svg>
+    </button>
+    <button class="nav-menu-toggle" type="button" aria-label="Open navigation" aria-expanded="false">
+      <span></span><span></span><span></span>
+    </button>
+    <ul class="nav-primary">
+      ${links.map(li).join('\n      ')}
+      <li class="nav-more-dropdown" style="--nav-i:5">
+        <button class="nav-more-toggle" aria-label="More options" aria-expanded="false">More</button>
+        <ul class="nav-more-menu">
+          ${dropdown.map(dropdownItem).join('\n          ')}
+        </ul>
+      </li>
+    </ul>
+  `;
+})();
+
+
+  // Determine current page for aria-current
+  const currentPath = window.location.pathname;
+  function isActive(href) {
+    const resolved = new URL(href, window.location.href).pathname.replace(/\/$/, '') || '/';
+    const cur = currentPath.replace(/\/$/, '') || '/';
+    return resolved === cur || (href === 'index.html' && (cur.endsWith('/docs') || cur.endsWith('/docs/')));
+  }
+
+  const links = [
+    { href: root + 'index.html',   label: 'Home',          color: 'var(--text)',        i: 0 },
+    { href: root + 'about.html',   label: 'About',         color: 'var(--apex-gold)',   i: 1 },
+    {
+      href: root + 'badges/',
+      label: 'GitHub Badges',
+      color: 'var(--tier-unique)',
+      icon: () => `<svg class="ico" width="13" height="13" aria-hidden="true" style="vertical-align:-2px;margin-right:.35em"><use href="${iconBase()}#github"/></svg>`,
+      i: 2
+    },
+    { href: root + 'named/',  label: 'Skills', color: 'var(--honor-red)',  i: 3 },
+    { href: root + 'en/',     label: 'Docs',   color: 'var(--tier-basic)', i: 4 },
+  ];
+
+  const dropdown = [
+    { type: 'btn',  id: 'treeNavBtn',  label: 'Skill Tree',          color: '#34d399', cls: 'nav-tree' },
+    { type: 'btn',  id: 'navGraphBtn', label: 'Skill Graph',          color: '#38bdf8', cls: 'nav-graph-trigger', attr: 'data-graph-trigger' },
+    { type: 'link', href: root + 'codex.html',    label: 'The Codex',          color: 'var(--tier-basic)' },
+    { type: 'link', href: root + 'starless.html', label: 'Starless',           color: 'var(--muted)' },
+    { type: 'link', href: root + 'u/',            label: 'Named Contributors', color: 'var(--honor-red)' },
+    { type: 'link', href: root + 'meta.html',     label: 'Meta Reports',       cls: 'nav-meta', id: 'metaNavBtn' },
+  ];
+
+  function li(item) {
+    const active = isActive(item.href) ? ' aria-current="page"' : '';
+    const icon = typeof item.icon === 'function' ? item.icon() : (item.icon || '');
+    return `<li style="--nav-i:${item.i}"><a href="${item.href}" style="color:${item.color}"${active}>${icon}${item.label}</a></li>`;
+  }
+
+  function dropdownItem(d) {
+    if (d.type === 'btn') {
+      const extra = d.attr ? ` ${d.attr}` : '';
+      const cls = d.cls ? ` class="${d.cls}"` : '';
+      const id = d.id ? ` id="${d.id}"` : '';
+      return `<li><button type="button"${cls}${id} style="color:${d.color}"${extra}>${d.label}</button></li>`;
+    }
+    const active = isActive(d.href) ? ' aria-current="page"' : '';
+    const cls = d.cls ? ` class="${d.cls}"` : '';
+    const id = d.id ? ` id="${d.id}"` : '';
+    return `<li><a href="${d.href}"${cls}${id} style="color:${d.color || ''}"${active}>${d.label}</a></li>`;
+  }
+
+  el.innerHTML = `
+    <a href="${root}index.html" class="nav-logo" aria-label="Gaia home">
+      ${SEAL_SVG}
       <span class="nav-wordmark">Gaia</span>
     </a>
     <button type="button" class="nav-search-btn-mobile" id="navSearchBtnMobile" aria-label="Search named" hidden>

--- a/docs/js/site-nav.js
+++ b/docs/js/site-nav.js
@@ -108,4 +108,13 @@
         '</ul>' +
       '</li>' +
     '</ul>';
+
+  // Skill Graph button: on the home page skill-graph.js owns [data-graph-trigger].
+  // On any other page, navigate to home with ?field=1 which hud-toggle.js picks up.
+  var graphBtn = el.querySelector('[data-graph-trigger]');
+  if (graphBtn && root !== '') {
+    graphBtn.addEventListener('click', function () {
+      window.location.href = root + 'index.html?field=1';
+    });
+  }
 })();

--- a/docs/meta.html
+++ b/docs/meta.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script>window.GAIA_VERSION = "3.25.2";</script>
+  <script>window.GAIA_VERSION = "4.7.5";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -12,13 +12,13 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-<link rel="stylesheet" href="css/styles.css?v=3.25.2">
+<link rel="stylesheet" href="css/styles.css?v=4.7.5">
 <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-<script src="js/icons.js?v=3.25.2"></script>
+<script src="js/icons.js?v=4.7.5"></script>
 <!-- Stage 2 — shared rank-badge primitive. -->
-<script src="js/rank-badge.js?v=3.25.2"></script>
+<script src="js/rank-badge.js?v=4.7.5"></script>
 <!-- Stage 3 — plaque component family. -->
-<script src="js/plaque.js?v=3.25.2"></script>
+<script src="js/plaque.js?v=4.7.5"></script>
 <style>
   .meta-report-grid {
     display: grid;
@@ -95,38 +95,12 @@
     border-color: #34d399;
   }
 </style>
+  <link rel="stylesheet" href="css/plaque.css?v=4.7.5">
 </head>
 <body class="process-page">
 
-<nav>
-    <a href="index.html" class="nav-logo" aria-label="Gaia home">
-      <svg class="ico nav-seal" aria-hidden="true" focusable="false"><use href="assets/icons.svg#seal-diamond"/></svg>
-      <span class="nav-wordmark">Gaia</span>
-    </a>
-    <button type="button" class="nav-search-btn-mobile" id="navSearchBtnMobile" aria-label="Search named" hidden><svg class="ico" width="18" height="18" aria-hidden="true"><use href="assets/icons.svg#search"/></svg></button>
-    <button class="nav-menu-toggle" type="button" aria-label="Open navigation" aria-expanded="false">
-      <span></span>
-      <span></span>
-      <span></span>
-    </button>
-    <ul class="nav-primary">
-      <li><a href="index.html" style="color: var(--text);">Home</a></li>
-      <li><a href="about.html" style="color: var(--apex-gold);">About</a></li>
-      <li><a href="badges/" style="color: var(--tier-unique);"><svg class="ico" width="13" height="13" aria-hidden="true" style="vertical-align: -2px; margin-right: .35em;"><use href="assets/icons.svg#github"/></svg>GitHub Badges</a></li>
-      <li><a href="named/" style="color: var(--honor-red);">Skills</a></li>
-      <li class="nav-more-dropdown">
-        <button class="nav-more-toggle" aria-label="More options" aria-expanded="false">More</button>
-        <ul class="nav-more-menu">
-          <li><button type="button" class="nav-tree" id="treeNavBtn" style="color: #34d399;">Skill Tree</button></li>
-          <li><a href="index.html?field=1" class="nav-graph-trigger" style="color: #38bdf8;">Skill Graph</a></li>
-          <li><a href="codex.html" style="color: var(--tier-basic);">The Codex</a></li>
-          <li><a href="starless.html" style="color: var(--muted);">Starless</a></li>
-          <li><a href="u/" style="color: var(--honor-red);">Named Contributors</a></li>
-          <li><a href="meta.html" class="nav-meta" id="metaNavBtn" aria-current="page">Meta Reports</a></li>
-        </ul>
-      </li>
-    </ul>
-  </nav>
+  <nav id="site-nav"></nav>
+  <script src="js/site-nav.js?v=4.7.5"></script>
 
 <main>
   <!-- ─── BACK ─── -->
@@ -214,81 +188,8 @@
 </main>
 
 <!-- ─── FOOTER v2 ─── -->
-  <footer class="footer-v2">
-    <div class="footer-inner">
-
-      <!-- Brand column -->
-      <div class="footer-brand-col">
-        <div class="footer-brand-mark">
-          <svg class="ico footer-seal" aria-hidden="true" focusable="false">
-            <use href="assets/icons.svg#seal-diamond"/>
-          </svg>
-          <span class="footer-wordmark">Gaia</span>
-        </div>
-        <p class="footer-tagline">An evidence-backed atlas<br>of agent capabilities.</p>
-      </div>
-
-      <!-- Link columns -->
-      <nav class="footer-cols" aria-label="Site navigation">
-
-        <div class="footer-col">
-          <span class="footer-col-heading">Registry</span>
-          <ul>
-            <li><a href="index.html">Home</a></li>
-            <li><a href="index.html">Skill Tree</a></li>
-            <li><a href="index.html?field=1">Skill Graph</a></li>
-            <li><a href="starless.html">Starless</a></li>
-            <li><a href="meta.html">Meta Reports</a></li>
-          </ul>
-        </div>
-
-        <div class="footer-col">
-          <span class="footer-col-heading">Discover</span>
-          <ul>
-            <li><a href="codex.html">The Codex</a></li>
-            <li><a href="named/">Named Skills</a></li>
-            <li><a href="index.html#hall-of-heroes">Hall of Heroes</a></li>
-            <li><a href="u/">Named Contributors</a></li>
-            <li><a href="badges/">GitHub Badges</a></li>
-            <li><a href="samples/index.html">Samples</a></li>
-          </ul>
-        </div>
-
-        <div class="footer-col">
-          <span class="footer-col-heading">Contribute</span>
-          <ul>
-            <li><a href="index.html#paths">Push a skill</a></li>
-            <li><a href="https://github.com/mbtiongson1/gaia-skill-tree" target="_blank" rel="noopener" class="footer-ext">GitHub</a></li>
-            <li><a href="https://github.com/mbtiongson1/gaia-skill-tree/issues" target="_blank" rel="noopener" class="footer-ext">Open Issues</a></li>
-          </ul>
-        </div>
-
-        <div class="footer-col">
-          <span class="footer-col-heading">About</span>
-          <ul>
-            <li><a href="about.html">About Gaia</a></li>
-            <li><a href="u/mbtiongson1/" class="footer-link-honor">@mbtiongson1</a></li>
-            <li><a href="privacy.html">Privacy</a></li>
-            <li>
-              <button id="copyAgentFooterBtn" type="button" class="footer-link-btn" aria-label="Copy page context for agents">
-                Copy Page
-              </button>
-            </li>
-          </ul>
-        </div>
-
-      </nav>
-    </div>
-
-    <!-- Bottom strip -->
-    <div class="footer-bottom">
-      <span>MIT License</span>
-      <span class="footer-bottom-sep" aria-hidden="true">·</span>
-      <span id="footerVersion">v4.1.2</span>
-      <span class="footer-bottom-sep" aria-hidden="true">·</span>
-      <span>© 2026 Gaia</span>
-    </div>
-  </footer>
+  <div id="site-footer-mount"></div>
+  <script src="js/site-footer.js?v=4.7.5"></script>
 
   <!-- ─── TREE DIALOG ─── -->
   <a id="tree" tabindex="-1" aria-hidden="true"></a>
@@ -313,10 +214,10 @@
   </button>
 
   <!-- ─── SCRIPTS ─── -->
-  <script src="js/atlas-helpers.js?v=3.25.2"></script>
-  <script src="js/skill-explorer.js?v=3.25.2"></script>
-  <script src="js/ui.js?v=3.25.2"></script>
-  <script src="js/page-ia.js?v=3.25.2"></script>
+  <script src="js/atlas-helpers.js?v=4.7.5"></script>
+  <script src="js/skill-explorer.js?v=4.7.5"></script>
+  <script src="js/ui.js?v=4.7.5"></script>
+  <script src="js/page-ia.js?v=4.7.5"></script>
   <script>
   function metaReportShare(btn) {
     const rel = btn.dataset.reportUrl;

--- a/docs/named/index.html
+++ b/docs/named/index.html
@@ -2,7 +2,7 @@
 <html lang="en" data-icon-base="../assets/icons.svg">
 
 <head>
-  <script>window.GAIA_VERSION = "4.3.7";</script>
+  <script>window.GAIA_VERSION = "4.7.5";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -21,52 +21,26 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
   <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
-  <link rel="stylesheet" href="../css/styles.css?v=4.3.7">
-  <link rel="stylesheet" href="../css/plaque.css?v=4.3.7">
+  <link rel="stylesheet" href="../css/styles.css?v=4.7.5">
+  <link rel="stylesheet" href="../css/plaque.css?v=4.7.5">
   <!-- AlphaRail temporarily disabled — keep the stylesheet reference here so
        re-enabling is one uncomment away. The page-wide rail script + integration
        are commented out near the bottom of <body>. -->
-  <!-- <link rel="stylesheet" href="../css/alpha-rail.css?v=4.3.7"> -->
+  <!-- <link rel="stylesheet" href="../css/alpha-rail.css?v=4.7.5"> -->
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../js/icons.js?v=4.3.7"></script>
-  <script src="../js/atlas-helpers.js?v=4.3.7"></script>
+  <script src="../js/icons.js?v=4.7.5"></script>
+  <script src="../js/atlas-helpers.js?v=4.7.5"></script>
   <!-- Stage 2 — shared rank-badge primitive, loaded after icons. -->
-  <script src="../js/rank-badge.js?v=4.3.7"></script>
+  <script src="../js/rank-badge.js?v=4.7.5"></script>
   <!-- Stage 3 — plaque component family, loaded after rank-badge. -->
-  <script src="../js/plaque.js?v=4.3.7"></script>
+  <script src="../js/plaque.js?v=4.7.5"></script>
 </head>
 
 <body class="named-explorer-page">
 
   <!-- ─── NAV ─── -->
-  <nav>
-    <a href="../" class="nav-logo" aria-label="Gaia home">
-      <svg class="ico nav-seal" aria-hidden="true" focusable="false"><use href="../assets/icons.svg#seal-diamond"/></svg>
-      <span class="nav-wordmark">Gaia</span>
-    </a>
-    <button class="nav-menu-toggle" type="button" aria-label="Open navigation" aria-expanded="false">
-      <span></span>
-      <span></span>
-      <span></span>
-    </button>
-    <ul class="nav-primary">
-      <li><a href="../" style="color: var(--text);">Home</a></li>
-      <li><a href="../about.html" style="color: var(--apex-gold);">About</a></li>
-      <li><a href="../badges/" style="color: var(--tier-unique);"><svg class="ico" width="13" height="13" aria-hidden="true" style="vertical-align: -2px; margin-right: .35em;"><use href="../assets/icons.svg#github"/></svg>GitHub Badges</a></li>
-      <li><a href="./" style="color: var(--honor-red);" aria-current="page">Skills</a></li>
-      <li class="nav-more-dropdown">
-        <button class="nav-more-toggle" aria-label="More options" aria-expanded="false">More</button>
-        <ul class="nav-more-menu">
-          <li><button type="button" class="nav-tree" id="treeNavBtn" style="color: #34d399;">Skill Tree</button></li>
-          <li><a href="../index.html?field=1" class="nav-graph-trigger" style="color: #38bdf8;">Skill Graph</a></li>
-          <li><a href="../codex.html" style="color: var(--tier-basic);">The Codex</a></li>
-          <li><a href="../starless.html" style="color: var(--muted);">Starless</a></li>
-          <li><a href="../u/" style="color: var(--honor-red);">Named Contributors</a></li>
-          <li><a href="../meta.html" class="nav-meta" id="metaNavBtn">Meta Reports</a></li>
-        </ul>
-      </li>
-    </ul>
-  </nav>
+  <nav id="site-nav"></nav>
+  <script src="../js/site-nav.js?v=4.7.5"></script>
 
   <!-- ─── BACK ─── -->
   <div class="profile-back-row">
@@ -152,81 +126,8 @@
   </section>
 
   <!-- ─── FOOTER v2 ─── -->
-  <footer class="footer-v2">
-    <div class="footer-inner">
-
-      <!-- Brand column -->
-      <div class="footer-brand-col">
-        <div class="footer-brand-mark">
-          <svg class="ico footer-seal" aria-hidden="true" focusable="false">
-            <use href="../assets/icons.svg#seal-diamond"/>
-          </svg>
-          <span class="footer-wordmark">Gaia</span>
-        </div>
-        <p class="footer-tagline">An evidence-backed atlas<br>of agent capabilities.</p>
-      </div>
-
-      <!-- Link columns -->
-      <nav class="footer-cols" aria-label="Site navigation">
-
-        <div class="footer-col">
-          <span class="footer-col-heading">Registry</span>
-          <ul>
-            <li><a href="../index.html">Home</a></li>
-            <li><a href="../index.html">Skill Tree</a></li>
-            <li><a href="../index.html?field=1">Skill Graph</a></li>
-            <li><a href="../starless.html">Starless</a></li>
-            <li><a href="../meta.html">Meta Reports</a></li>
-          </ul>
-        </div>
-
-        <div class="footer-col">
-          <span class="footer-col-heading">Discover</span>
-          <ul>
-            <li><a href="../codex.html">The Codex</a></li>
-            <li><a href="./" aria-current="page">Named Skills</a></li>
-            <li><a href="../index.html#hall-of-heroes">Hall of Heroes</a></li>
-            <li><a href="../u/">Named Contributors</a></li>
-            <li><a href="../badges/">GitHub Badges</a></li>
-            <li><a href="../samples/index.html">Samples</a></li>
-          </ul>
-        </div>
-
-        <div class="footer-col">
-          <span class="footer-col-heading">Contribute</span>
-          <ul>
-            <li><a href="../index.html#paths">Push a skill</a></li>
-            <li><a href="https://github.com/mbtiongson1/gaia-skill-tree" target="_blank" rel="noopener" class="footer-ext">GitHub</a></li>
-            <li><a href="https://github.com/mbtiongson1/gaia-skill-tree/issues" target="_blank" rel="noopener" class="footer-ext">Open Issues</a></li>
-          </ul>
-        </div>
-
-        <div class="footer-col">
-          <span class="footer-col-heading">About</span>
-          <ul>
-            <li><a href="../about.html">About Gaia</a></li>
-            <li><a href="../u/mbtiongson1/" class="footer-link-honor">@mbtiongson1</a></li>
-            <li><a href="../privacy.html">Privacy</a></li>
-            <li>
-              <button id="copyAgentFooterBtn" type="button" class="footer-link-btn" aria-label="Copy page context for agents">
-                Copy Page
-              </button>
-            </li>
-          </ul>
-        </div>
-
-      </nav>
-    </div>
-
-    <!-- Bottom strip -->
-    <div class="footer-bottom">
-      <span>MIT License</span>
-      <span class="footer-bottom-sep" aria-hidden="true">·</span>
-      <span id="footerVersion">v4.1.3</span>
-      <span class="footer-bottom-sep" aria-hidden="true">·</span>
-      <span>© 2026 Gaia</span>
-    </div>
-  </footer>
+  <div id="site-footer-mount"></div>
+  <script src="../js/site-footer.js?v=4.7.5"></script>
 
   <!-- ─── SKILL EXPLORER OVERLAY ─── -->
   <div id="skillExplorer" class="skill-explorer" role="dialog" aria-modal="true" aria-label="Skill Explorer" tabindex="-1">
@@ -297,16 +198,16 @@
 
   <!-- ─── SCRIPTS ─── -->
   <!-- icons.js already loaded in <head> so gaiaIcon() is available before any of these. -->
-  <script src="../js/atlas-helpers.js?v=4.3.7"></script>
-  <script src="../js/scroll-reveal.js?v=4.3.7"></script>
-  <script src="../js/named-skills.js?v=4.3.7"></script>
+  <script src="../js/atlas-helpers.js?v=4.7.5"></script>
+  <script src="../js/scroll-reveal.js?v=4.7.5"></script>
+  <script src="../js/named-skills.js?v=4.7.5"></script>
   <!-- AlphaRail temporarily disabled. Uncomment both <script> tags to re-enable
        the section + dynamic letter/tier markers inside the explorer. -->
-  <!-- <script src="../js/alpha-rail.js?v=4.3.7"></script> -->
-  <!-- <script src="../js/index-rail.js?v=4.3.7"></script> -->
-  <script src="../js/skill-explorer.js?v=4.3.7"></script>
-  <script src="../js/ui.js?v=4.3.7"></script>
-  <script src="../js/plaque-reveal.js?v=4.3.7" defer></script>
+  <!-- <script src="../js/alpha-rail.js?v=4.7.5"></script> -->
+  <!-- <script src="../js/index-rail.js?v=4.7.5"></script> -->
+  <script src="../js/skill-explorer.js?v=4.7.5"></script>
+  <script src="../js/ui.js?v=4.7.5"></script>
+  <script src="../js/plaque-reveal.js?v=4.7.5" defer></script>
 
   <!-- ─── HALL OF HEROES FULLSCREEN OG VIEW ─── -->
   <div id="hohFullscreenModal" class="hoh-fs-modal" aria-hidden="true" tabindex="-1">
@@ -402,7 +303,7 @@
   </button>
 </div>
 
-  <script src="../js/hoh-modal.js?v=4.3.7"></script>
+  <script src="../js/hoh-modal.js?v=4.7.5"></script>
 
 </body>
 

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script>window.GAIA_VERSION = "3.23.9";</script>
+  <script>window.GAIA_VERSION = "4.7.5";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -14,11 +14,11 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
   <link rel="icon" type="image/svg+xml" href="assets/marks/diamond-seal.svg">
-  <link rel="stylesheet" href="css/styles.css?v=3.23.9">
+  <link rel="stylesheet" href="css/styles.css?v=4.7.5">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="js/icons.js?v=3.23.9"></script>
+  <script src="js/icons.js?v=4.7.5"></script>
   <!-- Stage 2 — shared rank-badge primitive. -->
-  <script src="js/rank-badge.js?v=3.23.9"></script>
+  <script src="js/rank-badge.js?v=4.7.5"></script>
   <style>
     /* ── Privacy page local overrides ── */
     .privacy-hero {
@@ -129,39 +129,13 @@
     }
     .privacy-footer-note a { color: var(--color-accent, #c084fc); }
   </style>
+  <link rel="stylesheet" href="css/plaque.css?v=4.7.5">
 </head>
 
 <body>
 
-  <nav>
-    <a href="index.html" class="nav-logo" aria-label="Gaia home">
-      <svg class="ico nav-seal" aria-hidden="true" focusable="false"><use href="assets/icons.svg#seal-diamond"/></svg>
-      <span class="nav-wordmark">Gaia</span>
-    </a>
-    <button type="button" class="nav-search-btn-mobile" id="navSearchBtnMobile" aria-label="Search named" hidden><svg class="ico" width="18" height="18" aria-hidden="true"><use href="assets/icons.svg#search"/></svg></button>
-    <button class="nav-menu-toggle" type="button" aria-label="Open navigation" aria-expanded="false">
-      <span></span>
-      <span></span>
-      <span></span>
-    </button>
-    <ul class="nav-primary">
-      <li><a href="index.html" style="color: var(--text);">Home</a></li>
-      <li><a href="about.html" style="color: var(--apex-gold);">About</a></li>
-      <li><a href="badges/" style="color: var(--tier-unique);"><svg class="ico" width="13" height="13" aria-hidden="true" style="vertical-align: -2px; margin-right: .35em;"><use href="assets/icons.svg#github"/></svg>GitHub Badges</a></li>
-      <li><a href="named/" style="color: var(--honor-red);">Skills</a></li>
-      <li class="nav-more-dropdown">
-        <button class="nav-more-toggle" aria-label="More options" aria-expanded="false">More</button>
-        <ul class="nav-more-menu">
-          <li><button type="button" class="nav-tree" id="treeNavBtn" style="color: #34d399;">Skill Tree</button></li>
-          <li><a href="index.html?field=1" class="nav-graph-trigger" style="color: #38bdf8;">Skill Graph</a></li>
-          <li><a href="codex.html" style="color: var(--tier-basic);">The Codex</a></li>
-          <li><a href="starless.html" style="color: var(--muted);">Starless</a></li>
-          <li><a href="u/" style="color: var(--honor-red);">Named Contributors</a></li>
-          <li><a href="meta.html" class="nav-meta" id="metaNavBtn">Meta Reports</a></li>
-        </ul>
-      </li>
-    </ul>
-  </nav>
+  <nav id="site-nav"></nav>
+  <script src="js/site-nav.js?v=4.7.5"></script>
 
   <!-- ─── BACK ─── -->
   <div class="profile-back-row">
@@ -285,81 +259,8 @@
   </main>
 
   <!-- ─── FOOTER v2 ─── -->
-  <footer class="footer-v2">
-    <div class="footer-inner">
-
-      <!-- Brand column -->
-      <div class="footer-brand-col">
-        <div class="footer-brand-mark">
-          <svg class="ico footer-seal" aria-hidden="true" focusable="false">
-            <use href="assets/icons.svg#seal-diamond"/>
-          </svg>
-          <span class="footer-wordmark">Gaia</span>
-        </div>
-        <p class="footer-tagline">An evidence-backed atlas<br>of agent capabilities.</p>
-      </div>
-
-      <!-- Link columns -->
-      <nav class="footer-cols" aria-label="Site navigation">
-
-        <div class="footer-col">
-          <span class="footer-col-heading">Registry</span>
-          <ul>
-            <li><a href="index.html">Home</a></li>
-            <li><a href="index.html">Skill Tree</a></li>
-            <li><a href="index.html?field=1">Skill Graph</a></li>
-            <li><a href="starless.html">Starless</a></li>
-            <li><a href="meta.html">Meta Reports</a></li>
-          </ul>
-        </div>
-
-        <div class="footer-col">
-          <span class="footer-col-heading">Discover</span>
-          <ul>
-            <li><a href="codex.html">The Codex</a></li>
-            <li><a href="named/">Named Skills</a></li>
-            <li><a href="index.html#hall-of-heroes">Hall of Heroes</a></li>
-            <li><a href="u/">Named Contributors</a></li>
-            <li><a href="badges/">GitHub Badges</a></li>
-            <li><a href="samples/index.html">Samples</a></li>
-          </ul>
-        </div>
-
-        <div class="footer-col">
-          <span class="footer-col-heading">Contribute</span>
-          <ul>
-            <li><a href="index.html#paths">Push a skill</a></li>
-            <li><a href="https://github.com/mbtiongson1/gaia-skill-tree" target="_blank" rel="noopener" class="footer-ext">GitHub</a></li>
-            <li><a href="https://github.com/mbtiongson1/gaia-skill-tree/issues" target="_blank" rel="noopener" class="footer-ext">Open Issues</a></li>
-          </ul>
-        </div>
-
-        <div class="footer-col">
-          <span class="footer-col-heading">About</span>
-          <ul>
-            <li><a href="about.html">About Gaia</a></li>
-            <li><a href="u/mbtiongson1/" class="footer-link-honor">@mbtiongson1</a></li>
-            <li><a href="privacy.html" aria-current="page">Privacy</a></li>
-            <li>
-              <button id="copyAgentFooterBtn" type="button" class="footer-link-btn" aria-label="Copy page context for agents">
-                Copy Page
-              </button>
-            </li>
-          </ul>
-        </div>
-
-      </nav>
-    </div>
-
-    <!-- Bottom strip -->
-    <div class="footer-bottom">
-      <span>MIT License</span>
-      <span class="footer-bottom-sep" aria-hidden="true">·</span>
-      <span id="footerVersion">v4.1.2</span>
-      <span class="footer-bottom-sep" aria-hidden="true">·</span>
-      <span>© 2026 Gaia</span>
-    </div>
-  </footer>
+  <div id="site-footer-mount"></div>
+  <script src="js/site-footer.js?v=4.7.5"></script>
 
   <!-- ─── TREE DIALOG ─── -->
   <a id="tree" tabindex="-1" aria-hidden="true"></a>
@@ -380,10 +281,10 @@
   </dialog>
 
   <!-- ─── SCRIPTS ─── -->
-  <script src="js/atlas-helpers.js?v=3.23.9"></script>
-  <script src="js/skill-explorer.js?v=3.23.9"></script>
-  <script src="js/ui.js?v=3.23.9"></script>
-  <script src="js/page-ia.js?v=3.23.9"></script>
+  <script src="js/atlas-helpers.js?v=4.7.5"></script>
+  <script src="js/skill-explorer.js?v=4.7.5"></script>
+  <script src="js/ui.js?v=4.7.5"></script>
+  <script src="js/page-ia.js?v=4.7.5"></script>
 
 </body>
 </html>

--- a/docs/starless.html
+++ b/docs/starless.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script>window.GAIA_VERSION = "3.27.0";</script>
+  <script>window.GAIA_VERSION = "4.7.5";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -12,18 +12,18 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-<link rel="stylesheet" href="css/styles.css?v=3.27.0">
-<link rel="stylesheet" href="css/alpha-rail.css?v=3.27.0">
+<link rel="stylesheet" href="css/styles.css?v=4.7.5">
+<link rel="stylesheet" href="css/alpha-rail.css?v=4.7.5">
 <!-- plaque.css supplies the slate .plaque__redacted-handle styling for ≤1★ chips. -->
-<link rel="stylesheet" href="css/plaque.css?v=3.27.0">
+<link rel="stylesheet" href="css/plaque.css?v=4.7.5">
 <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-<script src="js/icons.js?v=3.27.0"></script>
+<script src="js/icons.js?v=4.7.5"></script>
 <!-- Stage 2 — shared rank-badge primitive. -->
-<script src="js/rank-badge.js?v=3.27.0"></script>
+<script src="js/rank-badge.js?v=4.7.5"></script>
 <!-- Stage 3 — plaque component family. -->
-<script src="js/plaque.js?v=3.27.0"></script>
+<script src="js/plaque.js?v=4.7.5"></script>
 <!-- Universal alphabetical scrubber component. -->
-<script src="js/alpha-rail.js?v=3.27.0"></script>
+<script src="js/alpha-rail.js?v=4.7.5"></script>
 <style>
   /* ───────────────────────────────────────────────────────────────────
      Starless taxonomy — a single-page ledger.
@@ -127,35 +127,8 @@
 </head>
 <body class="process-page">
 
-<nav>
-    <a href="index.html" class="nav-logo" aria-label="Gaia home">
-      <svg class="ico nav-seal" aria-hidden="true" focusable="false"><use href="assets/icons.svg#seal-diamond"/></svg>
-      <span class="nav-wordmark">Gaia</span>
-    </a>
-    <button type="button" class="nav-search-btn-mobile" id="navSearchBtnMobile" aria-label="Search named" hidden><svg class="ico" width="18" height="18" aria-hidden="true"><use href="assets/icons.svg#search"/></svg></button>
-    <button class="nav-menu-toggle" type="button" aria-label="Open navigation" aria-expanded="false">
-      <span></span>
-      <span></span>
-      <span></span>
-    </button>
-    <ul class="nav-primary">
-      <li><a href="index.html" style="color: var(--text);">Home</a></li>
-      <li><a href="about.html" style="color: var(--apex-gold);">About</a></li>
-      <li><a href="badges/" style="color: var(--tier-unique);"><svg class="ico" width="13" height="13" aria-hidden="true" style="vertical-align: -2px; margin-right: .35em;"><use href="assets/icons.svg#github"/></svg>GitHub Badges</a></li>
-      <li><a href="named/" style="color: var(--honor-red);">Skills</a></li>
-      <li class="nav-more-dropdown">
-        <button class="nav-more-toggle" aria-label="More options" aria-expanded="false">More</button>
-        <ul class="nav-more-menu">
-          <li><button type="button" class="nav-tree" id="treeNavBtn" style="color: #34d399;">Skill Tree</button></li>
-          <li><a href="index.html?field=1" class="nav-graph-trigger" style="color: #38bdf8;">Skill Graph</a></li>
-          <li><a href="codex.html" style="color: var(--tier-basic);">The Codex</a></li>
-          <li><a href="starless.html" style="color: var(--muted);" aria-current="page">Starless</a></li>
-          <li><a href="u/" style="color: var(--honor-red);">Named Contributors</a></li>
-          <li><a href="meta.html" class="nav-meta" id="metaNavBtn">Meta Reports</a></li>
-        </ul>
-      </li>
-    </ul>
-  </nav>
+  <nav id="site-nav"></nav>
+  <script src="js/site-nav.js?v=4.7.5"></script>
 
 <main>
   <!-- ─── BACK ─── -->
@@ -197,81 +170,8 @@
 </main>
 
 <!-- ─── FOOTER v2 ─── -->
-  <footer class="footer-v2">
-    <div class="footer-inner">
-
-      <!-- Brand column -->
-      <div class="footer-brand-col">
-        <div class="footer-brand-mark">
-          <svg class="ico footer-seal" aria-hidden="true" focusable="false">
-            <use href="assets/icons.svg#seal-diamond"/>
-          </svg>
-          <span class="footer-wordmark">Gaia</span>
-        </div>
-        <p class="footer-tagline">An evidence-backed atlas<br>of agent capabilities.</p>
-      </div>
-
-      <!-- Link columns -->
-      <nav class="footer-cols" aria-label="Site navigation">
-
-        <div class="footer-col">
-          <span class="footer-col-heading">Registry</span>
-          <ul>
-            <li><a href="index.html">Home</a></li>
-            <li><a href="index.html">Skill Tree</a></li>
-            <li><a href="index.html?field=1">Skill Graph</a></li>
-            <li><a href="starless.html">Starless</a></li>
-            <li><a href="meta.html">Meta Reports</a></li>
-          </ul>
-        </div>
-
-        <div class="footer-col">
-          <span class="footer-col-heading">Discover</span>
-          <ul>
-            <li><a href="codex.html">The Codex</a></li>
-            <li><a href="named/">Named Skills</a></li>
-            <li><a href="index.html#hall-of-heroes">Hall of Heroes</a></li>
-            <li><a href="u/">Named Contributors</a></li>
-            <li><a href="badges/">GitHub Badges</a></li>
-            <li><a href="samples/index.html">Samples</a></li>
-          </ul>
-        </div>
-
-        <div class="footer-col">
-          <span class="footer-col-heading">Contribute</span>
-          <ul>
-            <li><a href="index.html#paths">Push a skill</a></li>
-            <li><a href="https://github.com/mbtiongson1/gaia-skill-tree" target="_blank" rel="noopener" class="footer-ext">GitHub</a></li>
-            <li><a href="https://github.com/mbtiongson1/gaia-skill-tree/issues" target="_blank" rel="noopener" class="footer-ext">Open Issues</a></li>
-          </ul>
-        </div>
-
-        <div class="footer-col">
-          <span class="footer-col-heading">About</span>
-          <ul>
-            <li><a href="about.html">About Gaia</a></li>
-            <li><a href="u/mbtiongson1/" class="footer-link-honor">@mbtiongson1</a></li>
-            <li><a href="privacy.html">Privacy</a></li>
-            <li>
-              <button id="copyAgentFooterBtn" type="button" class="footer-link-btn" aria-label="Copy page context for agents">
-                Copy Page
-              </button>
-            </li>
-          </ul>
-        </div>
-
-      </nav>
-    </div>
-
-    <!-- Bottom strip -->
-    <div class="footer-bottom">
-      <span>MIT License</span>
-      <span class="footer-bottom-sep" aria-hidden="true">·</span>
-      <span id="footerVersion">v4.1.2</span>
-      <span class="footer-bottom-sep" aria-hidden="true">·</span>
-      <span>© 2026 Gaia</span>
-    </div>
-  </footer>
+  <div id="site-footer-mount"></div>
+  <script src="js/site-footer.js?v=4.7.5"></script>
 
   <!-- ─── TREE DIALOG ─── -->
   <a id="tree" tabindex="-1" aria-hidden="true"></a>
@@ -540,10 +440,10 @@
   </script>
 
   <!-- ─── SCRIPTS ─── -->
-  <script src="js/atlas-helpers.js?v=3.27.0"></script>
-  <script src="js/skill-explorer.js?v=3.27.0"></script>
-  <script src="js/ui.js?v=3.27.0"></script>
-  <script src="js/page-ia.js?v=3.27.0"></script>
+  <script src="js/atlas-helpers.js?v=4.7.5"></script>
+  <script src="js/skill-explorer.js?v=4.7.5"></script>
+  <script src="js/ui.js?v=4.7.5"></script>
+  <script src="js/page-ia.js?v=4.7.5"></script>
 
 </body>
 </html>

--- a/docs/u/index.html
+++ b/docs/u/index.html
@@ -26,35 +26,8 @@
 </head>
 <body class="profile-directory-page">
 
-  <nav>
-  <a href="../" class="nav-logo" aria-label="Gaia home">
-    <svg class="ico nav-seal" aria-hidden="true" focusable="false"><use href="../assets/icons.svg#seal-diamond"/></svg>
-    <span class="nav-wordmark">Gaia</span>
-  </a>
-  <button type="button" class="nav-search-btn-mobile" id="navSearchBtnMobile" aria-label="Search named" hidden><svg class="ico" width="18" height="18" aria-hidden="true"><use href="../assets/icons.svg#search"/></svg></button>
-  <button class="nav-menu-toggle" type="button" aria-label="Open navigation" aria-expanded="false">
-    <span></span>
-    <span></span>
-    <span></span>
-  </button>
-  <ul class="nav-primary">
-    <li><a href="../" style="color: var(--text);">Home</a></li>
-    <li><a href="../about.html" style="color: var(--apex-gold);">About</a></li>
-    <li><a href="../badges/" style="color: var(--tier-unique);"><svg class="ico" width="13" height="13" aria-hidden="true" style="vertical-align: -2px; margin-right: .35em;"><use href="../assets/icons.svg#github"/></svg>GitHub Badges</a></li>
-    <li><a href="../named/" style="color: var(--honor-red);">Skills</a></li>
-    <li class="nav-more-dropdown">
-      <button class="nav-more-toggle" aria-label="More options" aria-expanded="false">More</button>
-      <ul class="nav-more-menu">
-        <li><button type="button" class="nav-tree" id="treeNavBtn" style="color: #34d399;">Skill Tree</button></li>
-        <li><a href="../index.html?field=1" class="nav-graph-trigger" style="color: #38bdf8;">Skill Graph</a></li>
-        <li><a href="../codex.html" style="color: var(--tier-basic);">The Codex</a></li>
-        <li><a href="../starless.html" style="color: var(--muted);">Starless</a></li>
-        <li><a href="./" style="color: var(--honor-red);" aria-current="page">Named Contributors</a></li>
-        <li><a href="../meta.html" class="nav-meta" id="metaNavBtn">Meta Reports</a></li>
-      </ul>
-    </li>
-  </ul>
-</nav>
+  <nav id="site-nav"></nav>
+  <script src="../js/site-nav.js?v=4.7.5"></script>
 
   <!-- ─── PROFILE BACK ─── -->
   <div class="profile-back-row">
@@ -1321,81 +1294,8 @@
   </section>
 
   <!-- ─── FOOTER v2 ─── -->
-<footer class="footer-v2">
-  <div class="footer-inner">
-
-    <!-- Brand column -->
-    <div class="footer-brand-col">
-      <div class="footer-brand-mark">
-        <svg class="ico footer-seal" aria-hidden="true" focusable="false">
-          <use href="../assets/icons.svg#seal-diamond"/>
-        </svg>
-        <span class="footer-wordmark">Gaia</span>
-      </div>
-      <p class="footer-tagline">An evidence-backed atlas<br>of agent capabilities.</p>
-    </div>
-
-    <!-- Link columns -->
-    <nav class="footer-cols" aria-label="Site navigation">
-
-      <div class="footer-col">
-        <span class="footer-col-heading">Registry</span>
-        <ul>
-          <li><a href="../">Home</a></li>
-          <li><a href="../">Skill Tree</a></li>
-          <li><a href="../index.html?field=1">Skill Graph</a></li>
-          <li><a href="../starless.html">Starless</a></li>
-          <li><a href="../meta.html">Meta Reports</a></li>
-        </ul>
-      </div>
-
-      <div class="footer-col">
-        <span class="footer-col-heading">Discover</span>
-        <ul>
-          <li><a href="../codex.html">The Codex</a></li>
-          <li><a href="../named/">Named Skills</a></li>
-          <li><a href="../index.html#hall-of-heroes">Hall of Heroes</a></li>
-          <li><a href="./">Named Contributors</a></li>
-          <li><a href="../badges/">GitHub Badges</a></li>
-          <li><a href="../samples/index.html">Samples</a></li>
-        </ul>
-      </div>
-
-      <div class="footer-col">
-        <span class="footer-col-heading">Contribute</span>
-        <ul>
-          <li><a href="../index.html#paths">Push a skill</a></li>
-          <li><a href="https://github.com/mbtiongson1/gaia-skill-tree" target="_blank" rel="noopener" class="footer-ext">GitHub</a></li>
-          <li><a href="https://github.com/mbtiongson1/gaia-skill-tree/issues" target="_blank" rel="noopener" class="footer-ext">Open Issues</a></li>
-        </ul>
-      </div>
-
-      <div class="footer-col">
-        <span class="footer-col-heading">About</span>
-        <ul>
-          <li><a href="../about.html">About Gaia</a></li>
-          <li><a href="./mbtiongson1/" class="footer-link-honor">@mbtiongson1</a></li>
-          <li><a href="../privacy.html">Privacy</a></li>
-          <li>
-            <button id="copyAgentFooterBtn" type="button" class="footer-link-btn" aria-label="Copy page context for agents">
-              Copy Page
-            </button>
-          </li>
-        </ul>
-      </div>
-
-    </nav>
-  </div>
-
-  <!-- Bottom strip -->
-  <div class="footer-bottom">
-    <span>MIT License</span>
-    <span class="footer-bottom-sep" aria-hidden="true">·</span>
-    <span id="footerVersion">v4.1.2</span>
-    <span class="footer-bottom-sep" aria-hidden="true">·</span>
-    <span>© 2026 Gaia</span>
-  </div>
-</footer>
+<div id="site-footer-mount"></div>
+  <script src="../js/site-footer.js?v=4.7.5"></script>
 
   <script>
     document.addEventListener('DOMContentLoaded', () => {

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -305,7 +305,17 @@ def _apply_cache_busting(text: str, version: str) -> str:
 def build_html_cache_busting(check: bool) -> bool:
     version = _read_version()
     changed = False
-    for filename in ("index.html", "codex.html", "badges/index.html"):
+    for filename in (
+        "index.html",
+        "about.html",
+        "codex.html",
+        "meta.html",
+        "privacy.html",
+        "starless.html",
+        "badges/index.html",
+        "named/index.html",
+        "u/index.html",
+    ):
         path = ROOT / "docs" / filename
         if not path.exists():
             continue

--- a/scripts/generateProfilePages.py
+++ b/scripts/generateProfilePages.py
@@ -613,112 +613,12 @@ def build_ascension_log(skills: list) -> str:
     return ""
 
 
-NAV_HTML = f"""<nav>
-  <a href="../../" class="nav-logo" aria-label="Gaia home">
-    <svg class="ico nav-seal" aria-hidden="true" focusable="false"><use href="{ICON_SPRITE_REL}#seal-diamond"/></svg>
-    <span class="nav-wordmark">Gaia</span>
-  </a>
-  <button type="button" class="nav-search-btn-mobile" id="navSearchBtnMobile" aria-label="Search named" hidden><svg class="ico" width="18" height="18" aria-hidden="true"><use href="{ICON_SPRITE_REL}#search"/></svg></button>
-  <button class="nav-menu-toggle" type="button" aria-label="Open navigation" aria-expanded="false">
-    <span></span>
-    <span></span>
-    <span></span>
-  </button>
-  <ul class="nav-primary">
-    <li><a href="../../" style="color: var(--text);">Home</a></li>
-    <li><a href="../../about.html" style="color: var(--apex-gold);">About</a></li>
-    <li><a href="../../badges/" style="color: var(--tier-unique);"><svg class="ico" width="13" height="13" aria-hidden="true" style="vertical-align: -2px; margin-right: .35em;"><use href="{ICON_SPRITE_REL}#github"/></svg>GitHub Badges</a></li>
-    <li><a href="../../named/" style="color: var(--honor-red);">Skills</a></li>
-    <li class="nav-more-dropdown">
-      <button class="nav-more-toggle" aria-label="More options" aria-expanded="false">More</button>
-      <ul class="nav-more-menu">
-        <li><button type="button" class="nav-tree" id="treeNavBtn" style="color: #34d399;">Skill Tree</button></li>
-        <li><a href="../../index.html?field=1" class="nav-graph-trigger" style="color: #38bdf8;">Skill Graph</a></li>
-        <li><a href="../../codex.html" style="color: var(--tier-basic);">The Codex</a></li>
-        <li><a href="../../starless.html" style="color: var(--muted);">Starless</a></li>
-        <li><a href="../" style="color: var(--honor-red);">Named Contributors</a></li>
-        <li><a href="../../meta.html" class="nav-meta" id="metaNavBtn">Meta Reports</a></li>
-      </ul>
-    </li>
-  </ul>
-</nav>"""
+NAV_HTML = """<nav id="site-nav"></nav>
+<script src="../../js/site-nav.js"></script>"""
 
-FOOTER_HTML = f"""<!-- ─── FOOTER v2 ─── -->
-<footer class="footer-v2">
-  <div class="footer-inner">
-
-    <!-- Brand column -->
-    <div class="footer-brand-col">
-      <div class="footer-brand-mark">
-        <svg class="ico footer-seal" aria-hidden="true" focusable="false">
-          <use href="{ICON_SPRITE_REL}#seal-diamond"/>
-        </svg>
-        <span class="footer-wordmark">Gaia</span>
-      </div>
-      <p class="footer-tagline">An evidence-backed atlas<br>of agent capabilities.</p>
-    </div>
-
-    <!-- Link columns -->
-    <nav class="footer-cols" aria-label="Site navigation">
-
-      <div class="footer-col">
-        <span class="footer-col-heading">Registry</span>
-        <ul>
-          <li><a href="../../">Home</a></li>
-          <li><a href="../../">Skill Tree</a></li>
-          <li><a href="../../index.html?field=1">Skill Graph</a></li>
-          <li><a href="../../starless.html">Starless</a></li>
-          <li><a href="../../meta.html">Meta Reports</a></li>
-        </ul>
-      </div>
-
-      <div class="footer-col">
-        <span class="footer-col-heading">Discover</span>
-        <ul>
-          <li><a href="../../codex.html">The Codex</a></li>
-          <li><a href="../../named/">Named Skills</a></li>
-          <li><a href="../../index.html#hall-of-heroes">Hall of Heroes</a></li>
-          <li><a href="../">Named Contributors</a></li>
-          <li><a href="../../badges/">GitHub Badges</a></li>
-          <li><a href="../../samples/index.html">Samples</a></li>
-        </ul>
-      </div>
-
-      <div class="footer-col">
-        <span class="footer-col-heading">Contribute</span>
-        <ul>
-          <li><a href="../../index.html#paths">Push a skill</a></li>
-          <li><a href="https://github.com/mbtiongson1/gaia-skill-tree" target="_blank" rel="noopener" class="footer-ext">GitHub</a></li>
-          <li><a href="https://github.com/mbtiongson1/gaia-skill-tree/issues" target="_blank" rel="noopener" class="footer-ext">Open Issues</a></li>
-        </ul>
-      </div>
-
-      <div class="footer-col">
-        <span class="footer-col-heading">About</span>
-        <ul>
-          <li><a href="../../about.html">About Gaia</a></li>
-          <li><a href="../mbtiongson1/" class="footer-link-honor">@mbtiongson1</a></li>
-          <li><a href="../../privacy.html">Privacy</a></li>
-          <li>
-            <button id="copyAgentFooterBtn" type="button" class="footer-link-btn" aria-label="Copy page context for agents">
-              Copy Page
-            </button>
-          </li>
-        </ul>
-      </div>
-
-    </nav>
-  </div>
-
-  <!-- Bottom strip -->
-  <div class="footer-bottom">
-    <span>MIT License</span>
-    <span class="footer-bottom-sep" aria-hidden="true">·</span>
-    <span id="footerVersion">v4.1.2</span>
-    <span class="footer-bottom-sep" aria-hidden="true">·</span>
-    <span>© 2026 Gaia</span>
-  </div>
-</footer>"""
+FOOTER_HTML = """<!-- ─── FOOTER ─── -->
+<div id="site-footer-mount"></div>
+<script src="../../js/site-footer.js"></script>"""
 
 
 SIDEBAR_HTML = """<aside class="profile-sidebar" id="profileSidebar" aria-label="Filters">
@@ -1285,112 +1185,12 @@ def build_directory_page(by_contributor: dict) -> str:
 
     contributors_cards_html = "\n".join(tier_sections)
 
-    NAV_DIR_HTML = f"""<nav>
-  <a href="../" class="nav-logo" aria-label="Gaia home">
-    <svg class="ico nav-seal" aria-hidden="true" focusable="false"><use href="../assets/icons.svg#seal-diamond"/></svg>
-    <span class="nav-wordmark">Gaia</span>
-  </a>
-  <button type="button" class="nav-search-btn-mobile" id="navSearchBtnMobile" aria-label="Search named" hidden><svg class="ico" width="18" height="18" aria-hidden="true"><use href="../assets/icons.svg#search"/></svg></button>
-  <button class="nav-menu-toggle" type="button" aria-label="Open navigation" aria-expanded="false">
-    <span></span>
-    <span></span>
-    <span></span>
-  </button>
-  <ul class="nav-primary">
-    <li><a href="../" style="color: var(--text);">Home</a></li>
-    <li><a href="../about.html" style="color: var(--apex-gold);">About</a></li>
-    <li><a href="../badges/" style="color: var(--tier-unique);"><svg class="ico" width="13" height="13" aria-hidden="true" style="vertical-align: -2px; margin-right: .35em;"><use href="../assets/icons.svg#github"/></svg>GitHub Badges</a></li>
-    <li><a href="../named/" style="color: var(--honor-red);">Skills</a></li>
-    <li class="nav-more-dropdown">
-      <button class="nav-more-toggle" aria-label="More options" aria-expanded="false">More</button>
-      <ul class="nav-more-menu">
-        <li><button type="button" class="nav-tree" id="treeNavBtn" style="color: #34d399;">Skill Tree</button></li>
-        <li><a href="../index.html?field=1" class="nav-graph-trigger" style="color: #38bdf8;">Skill Graph</a></li>
-        <li><a href="../codex.html" style="color: var(--tier-basic);">The Codex</a></li>
-        <li><a href="../starless.html" style="color: var(--muted);">Starless</a></li>
-        <li><a href="./" style="color: var(--honor-red);" aria-current="page">Named Contributors</a></li>
-        <li><a href="../meta.html" class="nav-meta" id="metaNavBtn">Meta Reports</a></li>
-      </ul>
-    </li>
-  </ul>
-</nav>"""
+    NAV_DIR_HTML = """<nav id="site-nav"></nav>
+<script src="../js/site-nav.js"></script>"""
 
-    FOOTER_DIR_HTML = f"""<!-- ─── FOOTER v2 ─── -->
-<footer class="footer-v2">
-  <div class="footer-inner">
-
-    <!-- Brand column -->
-    <div class="footer-brand-col">
-      <div class="footer-brand-mark">
-        <svg class="ico footer-seal" aria-hidden="true" focusable="false">
-          <use href="../assets/icons.svg#seal-diamond"/>
-        </svg>
-        <span class="footer-wordmark">Gaia</span>
-      </div>
-      <p class="footer-tagline">An evidence-backed atlas<br>of agent capabilities.</p>
-    </div>
-
-    <!-- Link columns -->
-    <nav class="footer-cols" aria-label="Site navigation">
-
-      <div class="footer-col">
-        <span class="footer-col-heading">Registry</span>
-        <ul>
-          <li><a href="../">Home</a></li>
-          <li><a href="../">Skill Tree</a></li>
-          <li><a href="../index.html?field=1">Skill Graph</a></li>
-          <li><a href="../starless.html">Starless</a></li>
-          <li><a href="../meta.html">Meta Reports</a></li>
-        </ul>
-      </div>
-
-      <div class="footer-col">
-        <span class="footer-col-heading">Discover</span>
-        <ul>
-          <li><a href="../codex.html">The Codex</a></li>
-          <li><a href="../named/">Named Skills</a></li>
-          <li><a href="../index.html#hall-of-heroes">Hall of Heroes</a></li>
-          <li><a href="./">Named Contributors</a></li>
-          <li><a href="../badges/">GitHub Badges</a></li>
-          <li><a href="../samples/index.html">Samples</a></li>
-        </ul>
-      </div>
-
-      <div class="footer-col">
-        <span class="footer-col-heading">Contribute</span>
-        <ul>
-          <li><a href="../index.html#paths">Push a skill</a></li>
-          <li><a href="https://github.com/mbtiongson1/gaia-skill-tree" target="_blank" rel="noopener" class="footer-ext">GitHub</a></li>
-          <li><a href="https://github.com/mbtiongson1/gaia-skill-tree/issues" target="_blank" rel="noopener" class="footer-ext">Open Issues</a></li>
-        </ul>
-      </div>
-
-      <div class="footer-col">
-        <span class="footer-col-heading">About</span>
-        <ul>
-          <li><a href="../about.html">About Gaia</a></li>
-          <li><a href="./mbtiongson1/" class="footer-link-honor">@mbtiongson1</a></li>
-          <li><a href="../privacy.html">Privacy</a></li>
-          <li>
-            <button id="copyAgentFooterBtn" type="button" class="footer-link-btn" aria-label="Copy page context for agents">
-              Copy Page
-            </button>
-          </li>
-        </ul>
-      </div>
-
-    </nav>
-  </div>
-
-  <!-- Bottom strip -->
-  <div class="footer-bottom">
-    <span>MIT License</span>
-    <span class="footer-bottom-sep" aria-hidden="true">·</span>
-    <span id="footerVersion">v4.1.2</span>
-    <span class="footer-bottom-sep" aria-hidden="true">·</span>
-    <span>© 2026 Gaia</span>
-  </div>
-</footer>"""
+    FOOTER_DIR_HTML = """<!-- ─── FOOTER ─── -->
+<div id="site-footer-mount"></div>
+<script src="../js/site-footer.js"></script>"""
 
     page_title = "Contributors Directory — Gaia Skill Registry"
     og_description = (

--- a/scripts/patch_nav_footer.py
+++ b/scripts/patch_nav_footer.py
@@ -1,0 +1,129 @@
+"""
+One-shot script to:
+1. Replace inline <nav> blocks with <nav id="site-nav"></nav> + site-nav.js
+2. Replace inline footer HTML with <div id="site-footer-mount"></div> + site-footer.js
+3. Fix all stale ?v= version strings to 4.7.5
+4. Fix missing plaque.css / alpha-rail.css stylesheet refs where needed
+
+Target pages (docs root depth=0):
+  about.html, codex.html, meta.html, privacy.html, starless.html
+
+Target pages (depth=1):
+  named/index.html, badges/index.html
+
+Already correct: index.html (we'll only fix version string there)
+
+NOT touched: docs/u/* (generated), docs/en/* (different nav type)
+"""
+
+import re, pathlib
+
+DOCS = pathlib.Path("docs")
+TARGET_VERSION = "4.7.5"
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+def fix_versions(html: str) -> str:
+    """Replace all ?v=X.Y.Z with the current version."""
+    return re.sub(r'\?v=[\d.]+', f'?v={TARGET_VERSION}', html)
+
+def replace_nav(html: str, depth: int) -> str:
+    """Replace the hand-coded <nav> block (not footer-cols) with the mount point."""
+    # Match <nav> ... </nav> that is NOT a footer nav and NOT docs-nav
+    # We look for <nav> (no class, or class without footer/docs)
+    pattern = re.compile(
+        r'([ \t]*)<!--\s*[─\-]*\s*NAV\s*[─\-]*\s*-->\s*\n'  # optional comment
+        r'([ \t]*)<nav>.*?</nav>',
+        re.DOTALL
+    )
+    root = '' if depth == 0 else '../' * depth
+    replacement = (
+        f'  <!-- ─── NAV ─── -->\n'
+        f'  <nav id="site-nav"></nav>\n'
+        f'  <script src="{root}js/site-nav.js?v={TARGET_VERSION}"></script>'
+    )
+    result, n = pattern.subn(replacement, html)
+    if n:
+        return result
+    # Fallback: match bare <nav> block without comment
+    pattern2 = re.compile(r'([ \t]*)<nav>\s*\n.*?</nav>', re.DOTALL)
+    result, n = pattern2.subn(
+        f'  <nav id="site-nav"></nav>\n'
+        f'  <script src="{root}js/site-nav.js?v={TARGET_VERSION}"></script>',
+        html
+    )
+    return result
+
+def replace_footer(html: str, depth: int) -> str:
+    """Replace the hand-coded <footer class="footer-v2"> block with the mount point."""
+    root = '' if depth == 0 else '../' * depth
+    pattern = re.compile(r'<footer class="footer-v2">.*?</footer>', re.DOTALL)
+    replacement = (
+        f'<div id="site-footer-mount"></div>\n'
+        f'  <script src="{root}js/site-footer.js?v={TARGET_VERSION}"></script>'
+    )
+    result, n = pattern.subn(replacement, html)
+    return result
+
+def ensure_styles(html: str, depth: int) -> str:
+    """Make sure styles.css, plaque.css, alpha-rail.css are present and up to date."""
+    root = '' if depth == 0 else '../' * depth
+    prefix = root + 'css/'
+
+    def has(name):
+        return name in html
+
+    inserts = []
+    # styles.css is always required; fix version handled by fix_versions above
+    if not has('styles.css'):
+        inserts.append(f'  <link rel="stylesheet" href="{prefix}styles.css?v={TARGET_VERSION}">')
+    if not has('plaque.css'):
+        inserts.append(f'  <link rel="stylesheet" href="{prefix}plaque.css?v={TARGET_VERSION}">')
+
+    if inserts:
+        html = html.replace('</head>', '\n'.join(inserts) + '\n</head>', 1)
+    return html
+
+# ── Pages to patch ─────────────────────────────────────────────────────────
+
+PAGES = [
+    # (relative path, depth)
+    ("index.html",         0),
+    ("about.html",         0),
+    ("codex.html",         0),
+    ("meta.html",          0),
+    ("privacy.html",       0),
+    ("starless.html",      0),
+    ("named/index.html",   1),
+    ("badges/index.html",  1),
+    ("u/index.html",       1),
+]
+
+for rel, depth in PAGES:
+    path = DOCS / rel
+    if not path.exists():
+        print(f"SKIP (not found): {rel}")
+        continue
+
+    original = path.read_text(encoding='utf-8')
+    html = original
+
+    # 1. Fix version strings everywhere
+    html = fix_versions(html)
+
+    # Skip nav/footer replacement for index.html (already has site-nav.js)
+    # and for u/index.html (generated, different structure)
+    if rel not in ('index.html',):
+        html = replace_nav(html, depth)
+        html = replace_footer(html, depth)
+
+    # 2. Ensure stylesheet refs exist
+    html = ensure_styles(html, depth)
+
+    if html != original:
+        path.write_text(html, encoding='utf-8')
+        print(f"PATCHED: {rel}")
+    else:
+        print(f"NO CHANGE: {rel}")
+
+print("Done.")


### PR DESCRIPTION
## Summary

- **Diamond Seal** breathes with Apex-Gold glow at idle; one-shot 360° spin + scale on hover. Wordmark sweeps to gold with letter-spacing expansion.
- **Top-level nav links** — center-out 2px underline wipe with currentColor halo, plate-dot marker, 2px lift, tracking widen, double-stop text-shadow. Active route underline pulses on a 2.6s loop. Stagger entrance on paint (`--nav-i` CSS custom property per `<li>`).
- **Universal** — single selector block in `styles.css` covers both `.nav-primary` (main site) and `.docs-nav .nav-crumb` (all `/en/*` docs pages via shared stylesheet).
- **Dropdown (More menu)** — left-edge color bar wipes vertically, labels slide right, glow in each item's inline tier hue. Removed `color: var(--text) !important` that was killing the color signal.
- **Footer** — per-column hue tokens (Registry=basic, Discover=extra, Contribute=apex-gold, About=honor-red). Left-wipe underline + glow. Column heading lights up on hover. Honor handle stays red end-to-end. `.page-footer` in docs pages gets matching `--tier-basic` motion.
- All animations respect the existing `prefers-reduced-motion` Phase 5 block in `styles.css`.

## Files changed

- `docs/css/styles.css` — all motion CSS
- `docs/index.html` — `--nav-i` stagger indices on `<li>` items

## Test plan

- [ ] Open `docs/index.html` at localhost:8000 — hover each nav link, check underline wipe + glow in the link's tier color
- [ ] Hover the Diamond Seal logo — confirm spin + wordmark gold sweep
- [ ] Open More dropdown — confirm each item glows in its own hue
- [ ] Scroll to footer — hover links across all 5 columns, confirm per-column hue
- [ ] Open `docs/en/contributing.html` — confirm breadcrumb animation (hover shows tier-basic glow, `.current` crumb is gold)
- [ ] Toggle OS reduced-motion — confirm all animations suppress cleanly