### PR TITLE
docs(en): Evidence & Trust + Contributing + Named Skills pages (routines 003–004)

### DIFF
--- a/docs/en/DOCS.md
+++ b/docs/en/DOCS.md
@@ -22,8 +22,8 @@ Secondary: Open-source contributors wanting to claim a Named Skill.
 | 2 | `getting-started.html` | Getting Started | ✅ Done | 001 |
 | 3 | `cli-reference.html` | CLI Reference | ✅ Done | 002 |
 | 4 | `skill-hierarchy.html` | Skill Hierarchy | ✅ Done | 002 |
-| 5 | `contributing.html` | Contributing | Planned | 003 |
-| 6 | `named-skills.html` | Named Skills & Origin | Planned | 003 |
+| 5 | `contributing.html` | Contributing | ✅ Done | 003 |
+| 6 | `named-skills.html` | Named Skills & Origin | ✅ Done | 003 |
 | 7 | `evidence-classes.html` | Evidence Classes | Planned | 004 |
 | 8 | `fusion.html` | Skill Fusion | Planned | 004 |
 | 9 | `mcp-server.html` | MCP Server | Planned | 005 |

--- a/docs/en/DOCS.md
+++ b/docs/en/DOCS.md
@@ -17,17 +17,17 @@ Secondary: Open-source contributors wanting to claim a Named Skill.
 ## Page Map
 
 | # | File | Title | Status | Routine |
-|---|------|--------|--------|---------|
+|---|------|--------|--------|----------|
 | 1 | `index.html` | Docs Home | ✅ Done | 001 |
 | 2 | `getting-started.html` | Getting Started | ✅ Done | 001 |
 | 3 | `cli-reference.html` | CLI Reference | ✅ Done | 002 |
 | 4 | `skill-hierarchy.html` | Skill Hierarchy | ✅ Done | 002 |
 | 5 | `contributing.html` | Contributing | ✅ Done | 003 |
 | 6 | `named-skills.html` | Named Skills & Origin | ✅ Done | 003 |
-| 7 | `evidence-classes.html` | Evidence Classes | Planned | 004 |
-| 8 | `fusion.html` | Skill Fusion | Planned | 004 |
+| 7 | `evidence-classes.html` | Evidence & Trust | ✅ Done | 004 |
+| 8 | `fusion.html` | Skill Fusion | Planned | 005 |
 | 9 | `mcp-server.html` | MCP Server | Planned | 005 |
-| 10 | `faq.html` | FAQ | Planned | 005 |
+| 10 | `faq.html` | FAQ | Planned | 006 |
 
 ---
 
@@ -47,6 +47,13 @@ Color vocabulary:
 
 Rank colors (0★ → 6★): slate → sky-blue → teal → violet → fuchsia → amber → amber-bright.
 
+Evidence Grade colors (evidence-classes.html):
+- Grade S (Platinum): `#fbbf24` (amber — same as Ultimate tier)
+- Grade A (Gold): `#fde68a` (amber-dim)
+- Grade B (Silver): `#e9d5ff` (purple-100)
+- Grade C (Bronze): `#bae6fd` (sky-100)
+- Ungraded: `var(--muted)` `#64748b`
+
 ---
 
 ## Vocabulary Rules (from CONTEXT.md)
@@ -56,7 +63,9 @@ Rank colors (0★ → 6★): slate → sky-blue → teal → violet → fuchsia 
 - Rank names: Unawakened, Awakened, Named, Evolved, Hardened, Transcendent, Transcendent ★
 - Fusion: combining skills. Never "merge", "combine", "compose".
 - Named Skill: a skill claimed by a real contributor with Class C evidence or better.
-- Evidence Class: C (first sighting), B (reproducible), A (battle-tested, peer-reviewed).
+- Evidence Type: provenance axis (arxiv, repo, github-stars). Never bare "type".
+- Evidence Grade: quality axis (S/A/B/C = Platinum/Gold/Silver/Bronze). Grade A ≠ Class A.
+- Overall Trust Grade: aggregate skill-level signal, computed at build time, never stored.
 - Do NOT mention rarity (deprecated axis).
 
 ---

--- a/docs/en/MEMORY.md
+++ b/docs/en/MEMORY.md
@@ -2,6 +2,76 @@
 
 ---
 
+## 2026-06-11 — Routine 003
+
+**Branch:** `docs/routines/003`
+**Task chosen:** Task 1 (maintain existing pages — index.html) + Task 2 (write about features — Contributing workflow and Named Skills lifecycle)
+
+### What I did
+
+Routine 002 confirmed merged (PR #660). Created `docs/routines/003` from `origin/main`.
+
+Reviewed open issues for writing priorities:
+- Issue #254 — Named vs Unnamed lifecycle not documented (directly addressed by named-skills.html)
+- Issue #644 — docs/en/ still needs discoverability (noted; nav integration is a design-scope task for a future routine)
+- Issue #71 — Origin vs variant bucket not well explained (addressed in named-skills.html origin bucket section)
+
+1. **Created `docs/en/contributing.html`** — three-path contributor guide:
+   - Path A (gaia push): scanner workflow, dry-run warning, push variants
+   - Path B (/gaia-curate-chain): six-link pipeline overview with step list
+   - Path C (direct CLI meta shifts): all gaia dev commands with --no-build tip
+   - Authorization paths table (verifier / override / bootstrap / denied)
+   - Source of truth table (what to edit vs what never to touch)
+   - Branch naming cheat sheet with copy-paste template
+   - PR checklist (8 items including the links.github blob/ format rule)
+   - PR title examples
+   - Automated maintenance: Auto-Sync, Validation, Transparency Gate, Meta Guard, Monthly Meta Sweep
+   - FAQ: four common questions
+
+2. **Created `docs/en/named-skills.html`** — deep dive into Named Skills:
+   - Clear distinction between generic (starless) references and Named Skills — directly addresses issue #254
+   - Side-by-side compare cards (generic vs named)
+   - Origin bucket diagram with role labels (★ origin / variant) — addresses the conceptual gap flagged in issue #71
+   - Full five-step lifecycle: 0★ Unawakened → 1★ Awakened → 2★ Named → 3★ Evolved → 4★ Verifier
+   - Evidence system: legacy Class (deprecated) vs new Type + Grade (S/A/B/C Platinum/Gold/Silver/Bronze)
+   - Claiming walkthrough: step-by-step bash script including naming PR flow
+   - Verifier threshold section with gaia whoami example
+   - Installability policy: stars determine fate table, URL format pitfalls, wrong key name fixes, suite exemption
+
+3. **Updated `docs/en/index.html`** — Contribute section:
+   - Added Contributing card (new, ● New badge)
+   - Promoted Named Skills card from "Coming soon" to "● New" state
+
+4. **Updated `docs/en/DOCS.md`** — marked pages 5 and 6 as ✅ Done / Routine 003.
+
+### Design decisions
+
+- Both pages follow the identical layout contract (sticky nav, sidebar scroll-spy, main content, footer).
+- contributing.html introduces a three-column path-card component for the workflow picker.
+- named-skills.html introduces: compare-panel (generic vs named side-by-side), lifecycle step list with rank badges, evidence grade badge rows, origin bucket diagram (the bucket concept needed its own visual).
+- All color tokens use the same hex values as DOCS.md design system — no new colors introduced.
+- Deprecated Evidence Class (A/B/C) documented honestly alongside the new Grade (S/A/B/C) system, with an explicit warning box that the letter sets are not equivalent.
+
+### Issues addressed
+
+- Issue #254 (Named vs Unnamed lifecycle) — named-skills.html has a dedicated "Generic references vs Named Skills" section with a side-by-side compare panel.
+- Issue #71 (origin vs variant display) — origin bucket diagram explains the bucket model and links to the issue for the upcoming CLI/UI implementation.
+
+### Files created / modified
+
+- `docs/en/contributing.html` ← new
+- `docs/en/named-skills.html` ← new
+- `docs/en/index.html` ← updated (Contributing card added; Named Skills card promoted to ● New)
+- `docs/en/DOCS.md` ← updated (pages 5–6 marked done)
+- `docs/en/MEMORY.md` ← this entry
+
+### Planned next (Routine 004)
+
+- `docs/en/evidence-classes.html` — full evidence system explainer (Class → Type + Grade transition, trust numbers, verification states)
+- `docs/en/fusion.html` — skill fusion mechanics, gaia fuse workflow, when fusion applies
+
+---
+
 ## 2026-06-10 — Routine 001
 
 **Branch:** `docs/routines/001`

--- a/docs/en/MEMORY.md
+++ b/docs/en/MEMORY.md
@@ -2,6 +2,76 @@
 
 ---
 
+## 2026-06-12 — Routine 004
+
+**Branch:** `docs/routines/003` (continued — no PR existed when session started)
+**Task chosen:** Task 2 — Write about a feature (the evidence and trust model)
+
+### What I did
+
+Checked `docs/routines/003`: 3 Claude commits, no open PR. The MEMORY.md "Merged" note from Routine 003 was premature. Continued on the same branch per the "unmerged → continue" rule.
+
+Reviewed open issues for writing priorities:
+- **#646** — Trust model shipped in schema: Evidence Type + Grade now live. Immediate developer need to document the new system.
+- **#658** — Verification Workflow (Community Verified, Security Reviewed, Enterprise Ready) depends on the trust model — documenting evidence first unblocks clarity.
+- **#654** — RFC on evidence types (beyond arxiv/repo/stars) in progress; acknowledged in the page as planned work.
+- **#648** — Trust Score Explanations: frontend should show why a skill got its trust grade; documentation provides the vocabulary before the UI is built.
+
+1. **Created `docs/en/evidence-classes.html`** — comprehensive page on the full evidence and trust model:
+   - Intro: why evidence gates stars; the Class system problem
+   - Deprecated Evidence Class (C/B/A) — documented with a clear deprecation banner
+   - Evidence Type (provenance): `arxiv`, `repo`, `github-stars` — table with what each represents, URL format rules per type
+   - Evidence Grade (quality): S/A/B/C = Platinum/Gold/Silver/Bronze — visual trust meter + full table with trust number thresholds
+   - Trust Number — internal 0–100 score, not user-facing, canonical term
+   - Overall Trust Grade — aggregate, computed at build time, never stored on a node
+   - Verification states — `unverified` / `verified` / `disputed` — chip layout with flags and semantics
+   - CLI: `gaia dev evidence` with legacy `--class` form and new `--type --grade` form; `--dry-run` best practice
+   - Migration guide — Class → Type+Grade approximate mapping with explicit caveats
+   - Common pitfalls: Class A ≠ Grade A (main table), `tree/` vs `blob/`, github-stars alone, skipping `--dry-run`
+
+2. **Updated `docs/en/index.html`**:
+   - Evidence & Trust card: removed `opacity:0.7` dim, changed badge to `● New`, updated title and description to reflect the full Type+Grade model
+   - Footer Docs column: added CLI Reference and Evidence & Trust links
+   - Nav version badge: v4.4.0 → v4.7.0
+   - Footer version: v4.6.0 → v4.7.0
+
+3. **Updated `docs/en/DOCS.md`** — page 7 marked ✅ Done / Routine 004; Grade color tokens added to the design system section.
+
+### Design decisions
+
+- **Trust meter**: five-segment color bar (S/A/B/C/Ungraded) makes thresholds immediately scannable without reading text.
+- **Verification chips**: three-card row instead of a table — the flag + description side-by-side layout reads more naturally for a state model.
+- **Deprecated banner**: distinct gray callout with a ⚠ icon — clearly deprecated without removing the content (still needed for migration).
+- **Grade badge colors**: S=amber, A=amber-dim, B=purple-100, C=sky-100 — reuse token palette from DOCS.md; no new colors.
+- **Common pitfalls as h3 anchors**: findable via sidebar + linkable in issue replies (e.g. linking to `#pitfalls` in #646 discussion).
+
+### Issues informed by this page
+
+- **#646** — evidence-classes.html documents the shipped schema; developers no longer need to reverse-engineer it from commit history.
+- **#648** — trust number and overall trust grade sections provide vocabulary for the planned frontend explanation UI.
+- **#654** — callout in the Evidence Type section links forward to the RFC so contributors know where to track discussion.
+- **#658** — verification states section provides canonical definitions the verification workflow will consume.
+
+### Fact-check sweep (standing habit)
+
+- Nav version badge in index.html was stale at v4.4.0; updated to v4.7.0 (matches release commits in branch history).
+- Footer version was at v4.6.0; updated to v4.7.0.
+- No other stale content detected in existing pages (install commands, CLI flags, vocabulary still accurate).
+
+### Files created / modified
+
+- `docs/en/evidence-classes.html` ← new
+- `docs/en/index.html` ← updated (card live; footer updated; versions corrected)
+- `docs/en/DOCS.md` ← updated (page 7 done; grade color tokens added)
+- `docs/en/MEMORY.md` ← this entry
+
+### Planned next (Routine 005)
+
+- `docs/en/fusion.html` — skill fusion mechanics: when to fuse, `gaia fuse` workflow, Basic→Extra→Ultimate paths, fusion PR anatomy
+- `docs/en/mcp-server.html` — Bond your agent flow; `@gaia-registry/mcp-server` setup; MCP tool inventory
+
+---
+
 ## 2026-06-11 — Routine 003
 
 **Branch:** `docs/routines/003`
@@ -64,10 +134,6 @@ Reviewed open issues for writing priorities:
 - `docs/en/index.html` ← updated (Contributing card added; Named Skills card promoted to ● New)
 - `docs/en/DOCS.md` ← updated (pages 5–6 marked done)
 - `docs/en/MEMORY.md` ← this entry
-
-### Merged
-
-PR #662 squash-merged to main (commit d608b7b). All CI passed. Cloudflare deploy confirmed green.
 
 ### Standing habit — fact-check on every routine
 

--- a/docs/en/MEMORY.md
+++ b/docs/en/MEMORY.md
@@ -65,6 +65,21 @@ Reviewed open issues for writing priorities:
 - `docs/en/DOCS.md` ← updated (pages 5–6 marked done)
 - `docs/en/MEMORY.md` ← this entry
 
+### Merged
+
+PR #662 squash-merged to main (commit d608b7b). All CI passed. Cloudflare deploy confirmed green.
+
+### Standing habit — fact-check on every routine
+
+When spare capacity exists at the start or end of any routine, sweep existing pages for stale content:
+- Package names and install commands (e.g. `gaia-registry` → `gaia-cli`)
+- Version numbers hard-coded in code blocks
+- CLI flag names and command signatures (compare against live `gaia --help` output or README)
+- Links to sections that may have been renamed or removed
+- Vocabulary drift vs CONTEXT.md (banned synonyms, deprecated axes like rarity)
+
+Log every correction found, even minor ones, in the MEMORY.md entry for that routine.
+
 ### Planned next (Routine 004)
 
 - `docs/en/evidence-classes.html` — full evidence system explainer (Class → Type + Grade transition, trust numbers, verification states)

--- a/docs/en/contributing.html
+++ b/docs/en/contributing.html
@@ -1,0 +1,795 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Contributing — Gaia Docs</title>
+  <meta name="description" content="Three contributor paths: submitting skills via gaia push, curating with /gaia-curate-chain, or direct CLI meta shifts. Covers branch naming, PR checklist, and automated maintenance.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+  <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
+  <link rel="stylesheet" href="../css/tokens.css">
+  <link rel="stylesheet" href="../css/styles.css">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      background: var(--bg, #030712);
+      color: var(--text, #e2e8f0);
+      font-family: 'Bricolage Grotesque', system-ui, sans-serif;
+      font-size: 1rem;
+      line-height: 1.65;
+    }
+
+    a { color: var(--tier-basic, #38bdf8); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    /* ── Nav ── */
+    .docs-nav {
+      border-bottom: 1px solid var(--border, #1e293b);
+      padding: 0 2rem;
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      height: 52px;
+      position: sticky;
+      top: 0;
+      background: rgba(3, 7, 18, 0.92);
+      backdrop-filter: blur(8px);
+      z-index: 100;
+    }
+    .nav-logo {
+      font-family: 'EB Garamond', Georgia, serif;
+      font-size: 1.1rem;
+      font-weight: 500;
+      color: var(--text, #e2e8f0);
+      letter-spacing: .02em;
+    }
+    .nav-logo span { color: var(--tier-ultimate, #f59e0b); }
+    .nav-sep { color: var(--muted, #64748b); font-size: 0.85rem; }
+    .nav-crumb { font-size: 0.82rem; color: var(--muted, #64748b); }
+    .nav-crumb:hover { color: var(--text, #e2e8f0); text-decoration: none; }
+    .nav-crumb.current { color: var(--text, #e2e8f0); }
+    .nav-spacer { flex: 1; }
+    .nav-version {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.7rem;
+      color: var(--muted, #64748b);
+      padding: 0.2rem 0.5rem;
+      border: 1px solid var(--border, #1e293b);
+      border-radius: 4px;
+    }
+
+    /* ── Layout ── */
+    .page-layout {
+      display: grid;
+      grid-template-columns: 220px 1fr;
+      max-width: 1120px;
+      margin: 0 auto;
+    }
+
+    /* ── Sidebar ── */
+    .sidebar {
+      position: sticky;
+      top: 52px;
+      height: calc(100vh - 52px);
+      overflow-y: auto;
+      padding: 2rem 0 2rem 1.5rem;
+      border-right: 1px solid var(--border, #1e293b);
+      scrollbar-width: thin;
+      scrollbar-color: var(--border, #1e293b) transparent;
+    }
+    .sidebar-group { margin-bottom: 1.75rem; }
+    .sidebar-group-label {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.66rem;
+      text-transform: uppercase;
+      letter-spacing: .1em;
+      color: var(--muted, #64748b);
+      margin-bottom: 0.5rem;
+    }
+    .sidebar-links { list-style: none; display: flex; flex-direction: column; gap: 0.1rem; }
+    .sidebar-links a {
+      display: block;
+      padding: 0.25rem 0.6rem;
+      font-size: 0.84rem;
+      color: var(--muted, #64748b);
+      border-radius: 4px;
+      transition: color 0.15s, background 0.15s;
+    }
+    .sidebar-links a:hover {
+      color: var(--text, #e2e8f0);
+      background: rgba(255,255,255,0.04);
+      text-decoration: none;
+    }
+    .sidebar-links a.active {
+      color: var(--tier-basic, #38bdf8);
+      background: rgba(56,189,248,0.07);
+    }
+
+    /* ── Main ── */
+    .main-content {
+      padding: 2.5rem 3rem 4rem 3rem;
+      max-width: 820px;
+      min-width: 0;
+    }
+    .page-title {
+      font-family: 'EB Garamond', Georgia, serif;
+      font-size: 2.4rem;
+      font-weight: 500;
+      line-height: 1.2;
+      margin-bottom: 0.75rem;
+      color: var(--text, #e2e8f0);
+    }
+    .page-lead {
+      font-size: 1.05rem;
+      color: var(--muted, #64748b);
+      max-width: 580px;
+      line-height: 1.65;
+      margin-bottom: 2.5rem;
+    }
+
+    /* ── Sections ── */
+    .section { margin-bottom: 3.5rem; }
+    .section-title {
+      font-family: 'EB Garamond', Georgia, serif;
+      font-size: 1.7rem;
+      font-weight: 500;
+      color: var(--text, #e2e8f0);
+      margin-bottom: 0.5rem;
+      padding-top: 0.5rem;
+    }
+    .section-body {
+      font-size: 0.95rem;
+      color: var(--muted, #64748b);
+      line-height: 1.7;
+      margin-bottom: 1.5rem;
+    }
+    .section-body p { margin-bottom: 0.85rem; }
+    .section-body p:last-child { margin-bottom: 0; }
+
+    h3 {
+      font-family: 'EB Garamond', Georgia, serif;
+      font-size: 1.25rem;
+      font-weight: 500;
+      color: var(--text, #e2e8f0);
+      margin: 1.75rem 0 0.6rem;
+    }
+
+    /* ── Path cards ── */
+    .path-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr 1fr;
+      gap: 1rem;
+      margin: 1.5rem 0;
+    }
+    @media (max-width: 860px) {
+      .path-grid { grid-template-columns: 1fr; }
+      .page-layout { grid-template-columns: 1fr; }
+      .sidebar { display: none; }
+    }
+    .path-card {
+      border: 1px solid var(--border, #1e293b);
+      border-radius: 10px;
+      padding: 1.25rem;
+      background: var(--surface, #0f172a);
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+    .path-card.recommended {
+      border-color: rgba(56,189,248,0.3);
+      box-shadow: 0 0 0 1px rgba(56,189,248,0.08) inset;
+    }
+    .path-label {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.68rem;
+      text-transform: uppercase;
+      letter-spacing: .1em;
+      color: var(--muted, #64748b);
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+    }
+    .path-label .badge {
+      background: rgba(56,189,248,0.15);
+      color: var(--tier-basic, #38bdf8);
+      padding: 0.1rem 0.4rem;
+      border-radius: 3px;
+      font-size: 0.62rem;
+    }
+    .path-name {
+      font-size: 1rem;
+      font-weight: 600;
+      color: var(--text, #e2e8f0);
+    }
+    .path-desc {
+      font-size: 0.845rem;
+      color: var(--muted, #64748b);
+      line-height: 1.55;
+      flex: 1;
+    }
+    .path-cmd {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.78rem;
+      color: var(--tier-basic, #38bdf8);
+      background: rgba(56,189,248,0.07);
+      border: 1px solid rgba(56,189,248,0.15);
+      border-radius: 4px;
+      padding: 0.35rem 0.6rem;
+      margin-top: 0.25rem;
+    }
+
+    /* ── Data table ── */
+    .data-table { width: 100%; border-collapse: collapse; font-size: 0.875rem; margin: 1rem 0; }
+    .data-table th {
+      text-align: left;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.64rem;
+      text-transform: uppercase;
+      letter-spacing: .08em;
+      color: var(--muted, #64748b);
+      padding: 0.5rem 0.75rem;
+      border-bottom: 1px solid var(--border, #1e293b);
+    }
+    .data-table td {
+      padding: 0.55rem 0.75rem;
+      vertical-align: top;
+      border-bottom: 1px solid rgba(30,41,59,0.5);
+      color: var(--muted, #64748b);
+    }
+    .data-table tr:last-child td { border-bottom: none; }
+    .data-table td:first-child {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.8rem;
+      color: var(--text, #e2e8f0);
+      white-space: nowrap;
+    }
+    .data-table code {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.78rem;
+      background: rgba(255,255,255,0.06);
+      padding: 0.1em 0.35em;
+      border-radius: 3px;
+      color: var(--text, #e2e8f0);
+    }
+
+    /* ── Code fence ── */
+    .code-fence {
+      background: #06080f;
+      border: 1px solid var(--border, #1e293b);
+      border-radius: 6px;
+      overflow: hidden;
+      margin: 1rem 0;
+    }
+    .code-fence-label {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.66rem;
+      text-transform: uppercase;
+      letter-spacing: .08em;
+      color: var(--muted, #64748b);
+      padding: 0.45rem 1rem;
+      border-bottom: 1px solid var(--border, #1e293b);
+      background: rgba(255,255,255,0.015);
+    }
+    .code-fence pre {
+      padding: 0.85rem 1rem;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.8rem;
+      line-height: 1.8;
+      color: #c9d1d9;
+      overflow-x: auto;
+    }
+    .code-fence pre .c { color: #6b7280; }
+    .code-fence pre .kw { color: #7dd3fc; }
+    .code-fence pre .str { color: #86efac; }
+    .code-fence pre .flag { color: #c084fc; }
+
+    /* ── Callout ── */
+    .callout {
+      border-left: 3px solid;
+      padding: 0.85rem 1rem;
+      border-radius: 0 6px 6px 0;
+      font-size: 0.875rem;
+      line-height: 1.6;
+      margin: 1rem 0;
+    }
+    .callout.info {
+      border-color: var(--tier-basic, #38bdf8);
+      background: rgba(56,189,248,0.07);
+      color: #bae6fd;
+    }
+    .callout.warn {
+      border-color: #f59e0b;
+      background: rgba(245,158,11,0.07);
+      color: #fde68a;
+    }
+    .callout.tip {
+      border-color: #34d399;
+      background: rgba(52,211,153,0.07);
+      color: #6ee7b7;
+    }
+    .callout strong { font-weight: 600; }
+    .callout code {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.8rem;
+      background: rgba(255,255,255,0.08);
+      padding: 0.1em 0.35em;
+      border-radius: 3px;
+    }
+
+    /* ── Checklist ── */
+    .checklist { list-style: none; display: flex; flex-direction: column; gap: 0.5rem; margin: 1rem 0; }
+    .checklist li {
+      display: flex;
+      align-items: flex-start;
+      gap: 0.65rem;
+      font-size: 0.9rem;
+      color: var(--muted, #64748b);
+      line-height: 1.55;
+    }
+    .checklist li::before {
+      content: "☐";
+      font-size: 0.9rem;
+      color: var(--muted, #64748b);
+      flex-shrink: 0;
+      margin-top: 0.05rem;
+    }
+    .checklist li code {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.78rem;
+      background: rgba(255,255,255,0.06);
+      padding: 0.1em 0.35em;
+      border-radius: 3px;
+      color: var(--text, #e2e8f0);
+    }
+
+    /* ── Step list ── */
+    .step-list { list-style: none; display: flex; flex-direction: column; gap: 0; margin: 1rem 0; counter-reset: step; }
+    .step-list li {
+      display: flex;
+      gap: 1rem;
+      padding: 0.85rem 0;
+      border-bottom: 1px solid rgba(30,41,59,0.5);
+      font-size: 0.9rem;
+      color: var(--muted, #64748b);
+      line-height: 1.6;
+      counter-increment: step;
+    }
+    .step-list li:last-child { border-bottom: none; }
+    .step-list li::before {
+      content: counter(step);
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.72rem;
+      font-weight: 600;
+      color: var(--tier-basic, #38bdf8);
+      background: rgba(56,189,248,0.1);
+      border: 1px solid rgba(56,189,248,0.2);
+      border-radius: 50%;
+      width: 1.6rem;
+      height: 1.6rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+      margin-top: 0.1rem;
+    }
+    .step-list li strong { color: var(--text, #e2e8f0); font-weight: 600; }
+    .step-list li code {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.78rem;
+      background: rgba(255,255,255,0.06);
+      padding: 0.1em 0.35em;
+      border-radius: 3px;
+      color: var(--text, #e2e8f0);
+    }
+
+    /* ── Footer ── */
+    .page-footer {
+      border-top: 1px solid var(--border, #1e293b);
+      margin-top: 4rem;
+      padding-top: 1.5rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      font-size: 0.8rem;
+      color: var(--muted, #64748b);
+    }
+    .page-footer a { color: var(--muted, #64748b); }
+    .page-footer a:hover { color: var(--text, #e2e8f0); }
+
+    code { font-family: 'JetBrains Mono', monospace; font-size: 0.82em; background: rgba(255,255,255,0.06); padding: 0.1em 0.35em; border-radius: 3px; }
+  </style>
+</head>
+<body>
+
+  <!-- Nav -->
+  <nav class="docs-nav">
+    <a class="nav-logo" href="../index.html">Gaia <span>◆</span></a>
+    <span class="nav-sep">/</span>
+    <a class="nav-crumb" href="index.html">Docs</a>
+    <span class="nav-sep">/</span>
+    <span class="nav-crumb current">Contributing</span>
+    <span class="nav-spacer"></span>
+    <span class="nav-version">v4.7.0</span>
+  </nav>
+
+  <!-- Layout -->
+  <div class="page-layout">
+
+    <!-- Sidebar -->
+    <aside class="sidebar">
+      <div class="sidebar-group">
+        <div class="sidebar-group-label">On this page</div>
+        <ul class="sidebar-links">
+          <li><a href="#pick-workflow">Pick your workflow</a></li>
+          <li><a href="#path-a">Path A — gaia push</a></li>
+          <li><a href="#path-b">Path B — Curation chain</a></li>
+          <li><a href="#path-c">Path C — Direct CLI</a></li>
+          <li><a href="#source-truth">Source of truth</a></li>
+          <li><a href="#branch-naming">Branch naming</a></li>
+          <li><a href="#pr-checklist">PR checklist</a></li>
+          <li><a href="#automated">Automated maintenance</a></li>
+          <li><a href="#faq">FAQ</a></li>
+        </ul>
+      </div>
+      <div class="sidebar-group">
+        <div class="sidebar-group-label">See also</div>
+        <ul class="sidebar-links">
+          <li><a href="getting-started.html">Getting Started</a></li>
+          <li><a href="named-skills.html">Named Skills</a></li>
+          <li><a href="cli-reference.html">CLI Reference</a></li>
+          <li><a href="skill-hierarchy.html">Skill Hierarchy</a></li>
+        </ul>
+      </div>
+    </aside>
+
+    <!-- Main -->
+    <main class="main-content">
+      <h1 class="page-title">Contributing</h1>
+      <p class="page-lead">Three paths to expand the registry — choose by role. Every mutation goes through the same <code>gaia dev</code> verbs; the paths differ in how much gating they add.</p>
+
+      <!-- Pick workflow -->
+      <section class="section" id="pick-workflow">
+        <h2 class="section-title">Pick your workflow</h2>
+        <div class="section-body">
+          <p>Choose the path that matches what you're doing. All three routes land in the same registry — the difference is gating and scale.</p>
+        </div>
+
+        <div class="path-grid">
+          <div class="path-card">
+            <div class="path-label">Path A</div>
+            <div class="path-name">Submit discovered skills</div>
+            <div class="path-desc">You found a SKILL.md in the wild and want to propose it for the registry. Runs the scanner and opens a draft intake batch for reviewer approval.</div>
+            <div class="path-cmd">gaia push</div>
+          </div>
+          <div class="path-card recommended">
+            <div class="path-label">Path B <span class="badge">recommended</span></div>
+            <div class="path-name">Curate with gates</div>
+            <div class="path-desc">Reviewer-run pipeline with six gated links — scope, research, design, human review, mutate, ship. Schema and DAG are checked before any mutation touches the registry.</div>
+            <div class="path-cmd">/gaia-curate-chain &lt;topic&gt;</div>
+          </div>
+          <div class="path-card">
+            <div class="path-label">Path C</div>
+            <div class="path-name">Direct CLI meta shifts</div>
+            <div class="path-desc">One-off corrections — single merge, split, reclassify, or evidence add. Requires Verifier authorization. Run <code>gaia validate</code> after every change.</div>
+            <div class="path-cmd">gaia dev merge / split / add</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Path A -->
+      <section class="section" id="path-a">
+        <h2 class="section-title">Path A — <code>gaia push</code></h2>
+        <div class="section-body">
+          <p>Use this when you've found or built a skill and want to propose it. The command scans your repository, writes a draft intake batch to <code>registry-for-review/skill-batches/</code>, and opens a GitHub issue for reviewer sign-off.</p>
+          <p>Proposed skills are not in the registry until a maintainer promotes them. The intake batch is a review artifact only.</p>
+        </div>
+
+        <div class="code-fence">
+          <div class="code-fence-label">bash</div>
+          <pre><span class="c"># Standard push — opens a GitHub issue with proposed skills</span>
+gaia push
+
+<span class="c"># Dry run — shows the batch without creating anything</span>
+gaia push --dry-run
+
+<span class="c"># Skip creating a GitHub issue (useful in CI or draft review)</span>
+gaia push --no-issue
+
+<span class="c"># Validate the intake batch after pushing</span>
+python3 scripts/validate_intake.py</pre>
+        </div>
+
+        <div class="callout warn">
+          <strong>Always dry-run first.</strong> <code>gaia push</code> opens a public GitHub issue. Use <code>--dry-run</code> to review the proposed skill list before committing.
+        </div>
+      </section>
+
+      <!-- Path B -->
+      <section class="section" id="path-b">
+        <h2 class="section-title">Path B — <code>/gaia-curate-chain</code></h2>
+        <div class="section-body">
+          <p>The recommended path for maintainer-run registry expansion. Runs as six gated links with one sub-agent per link. A programmatic check runs between each link — schema shapes and the prerequisite DAG are verified before any mutation touches the registry, and <code>gaia validate</code> must pass before the branch ships.</p>
+        </div>
+
+        <div class="code-fence">
+          <div class="code-fence-label">claude code</div>
+          <pre>/gaia-curate-chain &lt;topic-or-source-url&gt;</pre>
+        </div>
+
+        <h3>Six links</h3>
+        <ol class="step-list">
+          <li><strong>Scope</strong> — define the skill domain and boundaries, reject off-scope candidates early.</li>
+          <li><strong>Research</strong> — verify source URLs are resolvable, collect evidence, check for existing canonical coverage.</li>
+          <li><strong>Design</strong> — shape the skill graph: IDs, prerequisites, tier assignment, evidence class.</li>
+          <li><strong>Human review</strong> — gated pause for maintainer sign-off before mutations begin.</li>
+          <li><strong>Mutate</strong> — run <code>gaia dev add</code> / <code>evidence</code> / <code>link</code> commands to write to the registry.</li>
+          <li><strong>Ship</strong> — run <code>gaia validate</code>, open the PR, verify CI.</li>
+        </ol>
+
+        <div class="callout info">
+          The flat <code>/gaia-curate</code> skill (single linear pass) is available for small, trusted, low-stakes batches — but it is less gated. Prefer <code>/gaia-curate-chain</code> when evidence quality and schema correctness matter.
+        </div>
+      </section>
+
+      <!-- Path C -->
+      <section class="section" id="path-c">
+        <h2 class="section-title">Path C — Direct CLI meta shifts</h2>
+        <div class="section-body">
+          <p>Use for one-off corrections. All meta shifts — adding, merging, splitting, evidence — must go through <code>gaia dev</code> commands, never direct JSON edits. The CLI writes timeline events automatically.</p>
+          <p>Mutating <code>gaia dev</code> subcommands require <strong>Verifier authorization</strong>. Run <code>gaia whoami</code> to check your current authorization path.</p>
+        </div>
+
+        <div class="code-fence">
+          <div class="code-fence-label">bash — common meta shifts</div>
+          <pre><span class="c"># List skills — find targets before mutating</span>
+gaia dev list --generic
+
+<span class="c"># Add a new skill</span>
+gaia dev add "New Skill Name" \
+  --type basic \
+  --description "At least 10 chars description"
+
+<span class="c"># Merge skills (target inherits from sources)</span>
+gaia dev merge target-id source-id-1 source-id-2
+
+<span class="c"># Split a skill into two</span>
+gaia dev split source-id target-id-1 target-id-2
+
+<span class="c"># Add evidence</span>
+gaia dev evidence skill-id "https://github.com/owner/repo/blob/main/SKILL.md" \
+  --class B --notes "Reproducible demo"
+
+<span class="c"># Calibrate stars</span>
+gaia dev calibrate skill-id "3★"
+
+<span class="c"># Link prerequisites</span>
+gaia dev link target-id prereq-id-1,prereq-id-2
+
+<span class="c"># Validate after any change</span>
+gaia validate</pre>
+        </div>
+
+        <div class="callout tip">
+          <strong>Batch tip:</strong> Most <code>gaia dev</code> commands accept <code>--no-build</code>. Use this during batch operations to skip expensive documentation/graph regeneration on every step — run <code>gaia dev build</code> once at the end.
+        </div>
+
+        <h3>Authorization paths</h3>
+        <table class="data-table">
+          <thead>
+            <tr><th>via</th><th>Condition</th><th>Who</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>verifier</td>
+              <td>Contributor holds a 4★+ Named Skill in the registry</td>
+              <td>Human maintainers</td>
+            </tr>
+            <tr>
+              <td>override</td>
+              <td><code>GAIA_OPERATOR_OVERRIDE=1</code> env var is set</td>
+              <td>CI runners, bots, automation</td>
+            </tr>
+            <tr>
+              <td>bootstrap</td>
+              <td>No 4★ Verifiers exist in the registry yet</td>
+              <td>Fresh / empty registries</td>
+            </tr>
+            <tr>
+              <td>denied</td>
+              <td>None of the above</td>
+              <td>Unauthorized</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <!-- Source of truth -->
+      <section class="section" id="source-truth">
+        <h2 class="section-title">Source of truth</h2>
+        <div class="section-body">
+          <p>Know which files you should touch and which you should never edit directly.</p>
+        </div>
+
+        <table class="data-table">
+          <thead>
+            <tr><th>File / directory</th><th>Status</th><th>Notes</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>registry/nodes/**/*.json</td>
+              <td>✅ Edit via CLI</td>
+              <td>Managed programmatically by <code>gaia dev</code> commands</td>
+            </tr>
+            <tr>
+              <td>registry-for-review/skill-batches/*.json</td>
+              <td>✅ Edit via push</td>
+              <td>Intake batches written by <code>gaia push</code></td>
+            </tr>
+            <tr>
+              <td>registry/gaia.json</td>
+              <td>❌ Never hand-edit</td>
+              <td>Auto-generated artifact; assembled by the build pipeline</td>
+            </tr>
+            <tr>
+              <td>docs/graph/gaia.json</td>
+              <td>❌ Never hand-edit</td>
+              <td>Generated graph projection; regenerated on every build</td>
+            </tr>
+            <tr>
+              <td>registry/nodes/*.json</td>
+              <td>⚠️ Fix typos only</td>
+              <td>Prefer CLI for all structural changes</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <!-- Branch naming -->
+      <section class="section" id="branch-naming">
+        <h2 class="section-title">Branch naming</h2>
+        <div class="section-body">
+          <p>CI enforces scope via <code>.github/workflows/branch-scope.yml</code>. Schema changes (<code>registry/schema/</code>) must use a <code>schema/</code> branch. Add label <code>skip-scope-check</code> to bypass in emergencies.</p>
+        </div>
+
+        <table class="data-table">
+          <thead>
+            <tr><th>Prefix</th><th>Use for</th><th>Scope</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>schema/…</td><td>Nomenclature / terminology changes</td><td><code>registry/schema/</code>, <code>*.md</code></td></tr>
+            <tr><td>cli/…</td><td>CLI source changes</td><td><code>src/</code>, <code>packages/</code>, <code>tests/</code>, <code>*.md</code></td></tr>
+            <tr><td>docs/…</td><td>Documentation</td><td><code>docs/</code>, <code>*.md</code></td></tr>
+            <tr><td>design/…</td><td>Website design</td><td><code>docs/</code> (HTML/CSS/JS), <code>*.md</code></td></tr>
+            <tr><td>review/gaia-push/…</td><td>Intake layer (<code>gaia push</code>)</td><td><code>registry-for-review/</code>, <code>*.md</code></td></tr>
+            <tr><td>review/meta/…</td><td>Registry curation / promotion</td><td><code>registry/</code>, <code>*.md</code></td></tr>
+            <tr><td>infra/…</td><td>CI / tooling changes</td><td><code>.github/</code>, <code>scripts/</code>, <code>docs/*.html</code>, <code>*.md</code></td></tr>
+            <tr><td>dev/… claude/… codex/…</td><td>Experimental (unrestricted)</td><td>any</td></tr>
+          </tbody>
+        </table>
+
+        <div class="callout info">
+          <strong>Copy-paste template:</strong> <code>git checkout -b review/meta/your-skill-name origin/main</code>
+        </div>
+      </section>
+
+      <!-- PR checklist -->
+      <section class="section" id="pr-checklist">
+        <h2 class="section-title">PR checklist</h2>
+        <div class="section-body">
+          <p>Every registry PR should pass all of these before requesting review.</p>
+        </div>
+
+        <ul class="checklist">
+          <li>Correct branch prefix for scope (see Branch naming above)</li>
+          <li>Only source-of-truth files edited — no hand-edits to generated artifacts</li>
+          <li><code>gaia validate</code> passes with no errors</li>
+          <li>Evidence meets the level / type requirements for the proposed star rating</li>
+          <li>PR title format: <code>[type] skill-name — short description</code></li>
+          <li>Timeline events written for any rank change (demotion / promotion)</li>
+          <li>No rarity references in any copy (deprecated axis)</li>
+          <li>Named Skill <code>links.github</code> uses <code>blob/branch/subpath</code> URL format — not <code>tree/</code></li>
+        </ul>
+
+        <h3>PR title examples</h3>
+        <div class="code-fence">
+          <div class="code-fence-label">examples</div>
+          <pre>[basic] parse-csv — add CSV parsing primitive
+[extra] autonomous-debug — compose debug workflow
+[reclassify] web-scrape — promote with new evidence
+[evidence] karpathy/web-scrape — add Class B source
+[merge] extract-data ← parse-table + extract-table</pre>
+        </div>
+      </section>
+
+      <!-- Automated maintenance -->
+      <section class="section" id="automated">
+        <h2 class="section-title">Automated maintenance</h2>
+        <div class="section-body">
+          <p>You don't need to run build scripts manually. CI handles regeneration on every push. The following automations run on every PR and merge.</p>
+        </div>
+
+        <h3>Auto-Sync</h3>
+        <div class="section-body">
+          <p>On every push, a GitHub Action runs versioning and regeneration scripts. <code>registry/gaia.json</code> and the docs graph are rebuilt automatically.</p>
+        </div>
+
+        <h3>Validation</h3>
+        <div class="section-body">
+          <p>Every PR is automatically validated for schema correctness, DAG integrity, and evidence quality. You can run the same checks locally:</p>
+        </div>
+
+        <div class="code-fence">
+          <div class="code-fence-label">bash</div>
+          <pre>gaia validate            <span class="c"># full validation pass</span>
+gaia validate --intake   <span class="c"># validate intake batch too</span></pre>
+        </div>
+
+        <h3>Transparency Gate</h3>
+        <div class="section-body">
+          <p>Enforces the transparency mandate — every rank change must leave a timeline event explaining why. A silent demotion or promotion (rank change with no <code>demote</code> / <code>rank_up</code> event) fails the build.</p>
+          <p>Reconcile drift with the <code>/gaia-trace-timeline</code> skill, or run <code>scripts/trace_timeline.py --all --apply</code>.</p>
+        </div>
+
+        <h3>Meta Guard</h3>
+        <div class="section-body">
+          <p>PRs that mutate registry files from an unauthorized actor are blocked by <code>.github/workflows/meta-guard.yml</code>. Bot actors (<code>*[bot]</code>, <code>jules</code>, <code>codex</code>, <code>claude-bot</code>, <code>gemini-bot</code>) are always allowlisted. Add the <code>skip-meta-guard</code> label for maintainer overrides.</p>
+        </div>
+
+        <h3>Monthly Meta Sweep</h3>
+        <div class="section-body">
+          <p>On the first Monday of each month, a designated maintainer runs <code>/gaia-meta-sweep</code> to audit the entire registry against <a href="https://github.com/mbtiongson1/gaia-skill-tree/blob/main/META.md">META.md</a>. The sweep produces an HTML report at <code>docs/meta/reports/YYYY-MM-DD-meta-audit.html</code> plus machine-readable JSON.</p>
+        </div>
+      </section>
+
+      <!-- FAQ -->
+      <section class="section" id="faq">
+        <h2 class="section-title">FAQ</h2>
+
+        <h3>I ran <code>gaia push</code>. Are my skills in the registry?</h3>
+        <div class="section-body">
+          <p>No. Intake batches are review artifacts until a maintainer promotes accepted skills into <code>registry/gaia.json</code>. Watch the GitHub issue created by <code>gaia push</code> for reviewer feedback.</p>
+        </div>
+
+        <h3>Where does long-form guidance go?</h3>
+        <div class="section-body">
+          <p>Review standards, curation heuristics, edge cases, and troubleshooting live in the <a href="https://github.com/mbtiongson1/gaia-skill-tree/wiki">GitHub Wiki</a>. Keep PRs and code comments focused on the specific change.</p>
+        </div>
+
+        <h3>Can I edit <code>registry/nodes/*.json</code> directly?</h3>
+        <div class="section-body">
+          <p>Only for typo fixes. All structural changes — adding, merging, splitting, evidence, calibration — must go through <code>gaia dev</code> commands so the CLI can write timeline events automatically. Manual edits bypass timeline logging and risk schema drift.</p>
+        </div>
+
+        <h3>My PR touches files in two scopes. Which branch prefix do I use?</h3>
+        <div class="section-body">
+          <p>Use the primary scope prefix. If your changes unavoidably span scopes, add the <code>skip-scope-check</code> label and explain why in the PR description. CI will still validate content; the label only bypasses the file-scope check.</p>
+        </div>
+      </section>
+
+      <footer class="page-footer">
+        <span>Gaia v4.7.0 — <a href="https://github.com/mbtiongson1/gaia-skill-tree">mbtiongson1/gaia-skill-tree</a></span>
+        <a href="index.html">← Back to Docs</a>
+      </footer>
+    </main>
+  </div>
+
+  <script>
+    // Sidebar scroll-spy
+    const links = document.querySelectorAll('.sidebar-links a');
+    const sections = [...document.querySelectorAll('.section[id]')];
+    const observer = new IntersectionObserver(entries => {
+      entries.forEach(e => {
+        if (e.isIntersecting) {
+          links.forEach(l => l.classList.remove('active'));
+          const active = document.querySelector(`.sidebar-links a[href="#${e.target.id}"]`);
+          if (active) active.classList.add('active');
+        }
+      });
+    }, { rootMargin: '-20% 0px -70% 0px' });
+    sections.forEach(s => observer.observe(s));
+  </script>
+</body>
+</html>

--- a/docs/en/evidence-classes.html
+++ b/docs/en/evidence-classes.html
@@ -1,0 +1,624 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Evidence &amp; Trust — Gaia Docs</title>
+  <meta name="description" content="How evidence drives star progression in Gaia — the Evidence Type, Grade, and Overall Trust Grade system that superseded the deprecated Class axis.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+  <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
+  <link rel="stylesheet" href="../css/tokens.css">
+  <link rel="stylesheet" href="../css/styles.css">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background: var(--bg, #030712);
+      color: var(--text, #e2e8f0);
+      font-family: 'Bricolage Grotesque', system-ui, sans-serif;
+      font-size: 1rem;
+      line-height: 1.65;
+      min-height: 100vh;
+    }
+    a { color: inherit; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    /* nav */
+    .docs-nav {
+      border-bottom: 1px solid var(--border, #1e293b);
+      padding: 0 2rem;
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      height: 52px;
+      position: sticky;
+      top: 0;
+      background: rgba(3, 7, 18, 0.92);
+      backdrop-filter: blur(8px);
+      z-index: 100;
+    }
+    .docs-nav-logo { font-family: 'EB Garamond', Georgia, serif; font-size: 1.1rem; font-weight: 500; letter-spacing: .02em; }
+    .docs-nav-logo span { color: var(--tier-ultimate, #f59e0b); }
+    .docs-nav-sep { color: var(--muted, #64748b); font-size: 0.85rem; }
+    .docs-nav-link { font-size: 0.85rem; color: var(--muted, #64748b); transition: color 0.15s; }
+    .docs-nav-link:hover { color: var(--text, #e2e8f0); text-decoration: none; }
+    .docs-nav-link.active { color: var(--tier-basic, #38bdf8); }
+    .docs-nav-spacer { flex: 1; }
+    .docs-nav-version {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.72rem;
+      color: var(--muted, #64748b);
+      padding: 0.2rem 0.55rem;
+      border: 1px solid var(--border, #1e293b);
+      border-radius: 4px;
+    }
+
+    /* layout */
+    .docs-layout {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: 3.5rem 2rem 6rem;
+      display: grid;
+      grid-template-columns: 220px 1fr;
+      gap: 3rem;
+      align-items: start;
+    }
+
+    /* sidebar */
+    .docs-sidebar {
+      position: sticky;
+      top: 68px;
+      display: flex;
+      flex-direction: column;
+      gap: 0.2rem;
+    }
+    .sidebar-label {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.65rem;
+      color: var(--muted, #64748b);
+      letter-spacing: .1em;
+      text-transform: uppercase;
+      margin-bottom: 0.5rem;
+      margin-top: 1.25rem;
+    }
+    .sidebar-label:first-child { margin-top: 0; }
+    .sidebar-link {
+      font-size: 0.82rem;
+      color: var(--muted, #64748b);
+      padding: 0.28rem 0.6rem;
+      border-left: 2px solid transparent;
+      transition: color 0.15s, border-color 0.15s;
+      display: block;
+    }
+    .sidebar-link:hover { color: var(--text, #e2e8f0); text-decoration: none; }
+    .sidebar-link.active { color: var(--tier-basic, #38bdf8); border-left-color: var(--tier-basic, #38bdf8); }
+
+    /* content */
+    .docs-content h1 {
+      font-family: 'EB Garamond', Georgia, serif;
+      font-size: clamp(2rem, 4vw, 2.75rem);
+      font-weight: 500;
+      line-height: 1.2;
+      margin-bottom: 0.75rem;
+    }
+    .docs-content .lead {
+      font-size: 1.05rem;
+      color: var(--muted, #64748b);
+      max-width: 640px;
+      line-height: 1.65;
+      margin-bottom: 2.5rem;
+    }
+    .docs-content h2 {
+      font-family: 'EB Garamond', Georgia, serif;
+      font-size: 1.6rem;
+      font-weight: 500;
+      margin-top: 3rem;
+      margin-bottom: 0.9rem;
+      padding-top: 1rem;
+      border-top: 1px solid var(--border, #1e293b);
+      scroll-margin-top: 80px;
+    }
+    .docs-content h2.no-rule { border-top: none; padding-top: 0; margin-top: 0; }
+    .docs-content h3 {
+      font-size: 1.05rem;
+      font-weight: 600;
+      margin-top: 1.75rem;
+      margin-bottom: 0.6rem;
+      scroll-margin-top: 80px;
+    }
+    .docs-content p { margin-bottom: 1rem; }
+    .docs-content ul { margin-bottom: 1rem; padding-left: 1.4rem; }
+    .docs-content li { margin-bottom: 0.35rem; }
+    .docs-content code {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.82em;
+      background: rgba(255,255,255,0.06);
+      border: 1px solid var(--border, #1e293b);
+      border-radius: 4px;
+      padding: 0.1em 0.35em;
+    }
+
+    /* code block */
+    .code-block { background: #08080a; border: 1px solid var(--border, #1e293b); border-radius: 8px; overflow: hidden; margin: 1.25rem 0; }
+    .code-block-header { display: flex; align-items: center; padding: 0.5rem 1rem; border-bottom: 1px solid var(--border, #1e293b); background: rgba(255,255,255,0.02); }
+    .code-block-label { font-family: 'JetBrains Mono', monospace; font-size: 0.7rem; color: var(--muted, #64748b); }
+    .code-block pre { padding: 1.1rem 1.25rem; font-family: 'JetBrains Mono', monospace; font-size: 0.82rem; line-height: 1.7; color: #c9d1d9; overflow-x: auto; }
+    .code-block pre .c  { color: var(--muted, #64748b); }
+    .code-block pre .cmd { color: #86efac; }
+    .code-block pre .str { color: var(--tier-extra, #c084fc); }
+    .code-block pre .flag { color: #fbbf24; }
+    .code-block pre .val { color: #f87171; }
+
+    /* callout */
+    .callout { border-radius: 8px; padding: 1rem 1.25rem; margin: 1.5rem 0; font-size: 0.9rem; line-height: 1.6; border-left: 3px solid; }
+    .callout p:last-child { margin-bottom: 0; }
+    .callout.info  { background: rgba(56,189,248,0.07); border-color: var(--tier-basic,#38bdf8); color: #bae6fd; }
+    .callout.warn  { background: rgba(251,191,36,0.08); border-color: #fbbf24; color: #fde68a; }
+    .callout.danger{ background: rgba(239,68,68,0.08); border-color: #ef4444; color: #fca5a5; }
+    .callout strong { font-weight: 700; }
+
+    /* table */
+    .docs-table-wrap { overflow-x: auto; margin: 1.25rem 0; }
+    .docs-table { width: 100%; border-collapse: collapse; font-size: 0.875rem; }
+    .docs-table th {
+      text-align: left;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.7rem;
+      font-weight: 500;
+      letter-spacing: .06em;
+      text-transform: uppercase;
+      color: var(--muted, #64748b);
+      padding: 0.6rem 1rem;
+      border-bottom: 1px solid var(--border, #1e293b);
+    }
+    .docs-table td { padding: 0.65rem 1rem; border-bottom: 1px solid rgba(30,41,59,0.6); color: var(--text,#e2e8f0); vertical-align: top; }
+    .docs-table tr:last-child td { border-bottom: none; }
+    .docs-table .muted { color: var(--muted,#64748b); }
+
+    /* grade badges */
+    .grade {
+      display: inline-flex; align-items: center; gap: 0.3rem;
+      font-family: 'JetBrains Mono', monospace; font-size: 0.75rem; font-weight: 700;
+      padding: 0.15rem 0.55rem; border-radius: 4px; border: 1px solid;
+    }
+    .grade-S { background: rgba(251,191,36,0.12); border-color: #fbbf24; color: #fbbf24; }
+    .grade-A { background: rgba(251,191,36,0.08); border-color: rgba(251,191,36,0.5); color: #fde68a; }
+    .grade-B { background: rgba(192,132,252,0.1); border-color: rgba(192,132,252,0.5); color: #e9d5ff; }
+    .grade-C { background: rgba(56,189,248,0.08); border-color: rgba(56,189,248,0.4); color: #bae6fd; }
+    .grade-U { background: rgba(100,116,139,0.1); border-color: rgba(100,116,139,0.35); color: var(--muted,#64748b); }
+
+    /* type pill */
+    .type-pill {
+      display: inline-block;
+      font-family: 'JetBrains Mono', monospace; font-size: 0.72rem;
+      padding: 0.1rem 0.5rem; border-radius: 3px;
+      background: rgba(255,255,255,0.05); border: 1px solid var(--border,#1e293b);
+      color: var(--muted,#64748b);
+    }
+
+    /* deprecated banner */
+    .deprecated-banner {
+      display: flex; align-items: flex-start; gap: 0.75rem;
+      background: rgba(100,116,139,0.08);
+      border: 1px solid rgba(100,116,139,0.25);
+      border-radius: 8px; padding: 1rem 1.25rem; margin: 1.25rem 0;
+      font-size: 0.875rem; color: var(--muted,#64748b);
+    }
+    .deprecated-banner strong { color: var(--text,#e2e8f0); }
+    .deprecated-banner p:last-child { margin-bottom: 0; }
+
+    /* trust meter */
+    .trust-meter {
+      display: flex; gap: 0; align-items: stretch;
+      margin: 1.25rem 0; border-radius: 6px; overflow: hidden;
+      border: 1px solid var(--border,#1e293b);
+    }
+    .trust-segment {
+      flex: 1; text-align: center; padding: 0.75rem 0.4rem;
+      font-family: 'JetBrains Mono', monospace; font-size: 0.8rem; font-weight: 700;
+      display: flex; flex-direction: column; gap: 0.25rem;
+      border-right: 1px solid var(--border,#1e293b);
+    }
+    .trust-segment:last-child { border-right: none; }
+    .trust-segment .seg-name { font-size: 0.65rem; font-weight: 400; opacity: 0.8; }
+    .trust-segment .seg-range { font-size: 0.7rem; font-weight: 400; }
+    .seg-S { background: rgba(251,191,36,0.14); color: #fbbf24; }
+    .seg-A { background: rgba(251,191,36,0.08); color: #fde68a; }
+    .seg-B { background: rgba(192,132,252,0.1); color: #e9d5ff; }
+    .seg-C { background: rgba(56,189,248,0.08); color: #bae6fd; }
+    .seg-U { background: rgba(100,116,139,0.08); color: var(--muted,#64748b); }
+
+    /* verification chips */
+    .verif-chips { display: flex; gap: 0.75rem; flex-wrap: wrap; margin: 1.25rem 0; }
+    .verif-chip {
+      display: flex; flex-direction: column; gap: 0.35rem;
+      background: var(--surface,#0f172a); border: 1px solid var(--border,#1e293b);
+      border-radius: 8px; padding: 0.85rem 1.1rem; min-width: 150px; flex: 1;
+    }
+    .verif-chip .chip-label { font-family: 'JetBrains Mono', monospace; font-size: 0.78rem; font-weight: 600; }
+    .verif-chip .chip-flag { font-family: 'JetBrains Mono', monospace; font-size: 0.66rem; color: var(--muted,#64748b); }
+    .verif-chip .chip-desc { font-size: 0.8rem; color: var(--muted,#64748b); margin-top: 0.1rem; }
+    .chip-default .chip-label { color: var(--muted,#64748b); }
+    .chip-verified .chip-label { color: #4ade80; }
+    .chip-verified { border-color: rgba(74,222,128,0.25); }
+    .chip-disputed .chip-label { color: #f87171; }
+    .chip-disputed { border-color: rgba(248,113,113,0.25); }
+
+    /* footer */
+    .docs-footer-simple {
+      border-top: 1px solid var(--border,#1e293b);
+      padding: 1.5rem 2rem;
+      display: flex; align-items: center; justify-content: space-between;
+      flex-wrap: wrap; gap: 0.75rem;
+      max-width: 1100px; margin: 0 auto;
+    }
+    .docs-footer-simple span { font-size: 0.8rem; color: var(--muted,#64748b); }
+    .docs-footer-simple a { font-size: 0.8rem; color: var(--muted,#64748b); transition: color .15s; }
+    .docs-footer-simple a:hover { color: var(--text,#e2e8f0); text-decoration: none; }
+    .docs-footer-links { display: flex; gap: 1.5rem; }
+
+    @media (max-width: 768px) {
+      .docs-layout { grid-template-columns: 1fr; }
+      .docs-sidebar { display: none; }
+      .trust-meter { flex-direction: column; }
+      .trust-segment { border-right: none; border-bottom: 1px solid var(--border,#1e293b); padding: 0.5rem 1rem; flex-direction: row; justify-content: space-between; align-items: center; }
+      .trust-segment:last-child { border-bottom: none; }
+    }
+  </style>
+</head>
+<body>
+
+  <nav class="docs-nav">
+    <a href="../index.html" class="docs-nav-logo">Gaia <span>◆</span></a>
+    <span class="docs-nav-sep">/</span>
+    <a href="index.html" class="docs-nav-link">Docs</a>
+    <span class="docs-nav-sep">/</span>
+    <span class="docs-nav-link active">Evidence &amp; Trust</span>
+    <div class="docs-nav-spacer"></div>
+    <span class="docs-nav-version" id="ver">v4.7.0</span>
+  </nav>
+
+  <div class="docs-layout">
+
+    <aside class="docs-sidebar" id="sidebar">
+      <span class="sidebar-label">On this page</span>
+      <a class="sidebar-link" href="#overview">Overview</a>
+      <a class="sidebar-link" href="#class-system">Deprecated: Class</a>
+      <a class="sidebar-link" href="#evidence-type">Evidence Type</a>
+      <a class="sidebar-link" href="#evidence-grade">Evidence Grade</a>
+      <a class="sidebar-link" href="#trust-number">Trust Number</a>
+      <a class="sidebar-link" href="#overall-trust">Overall Trust Grade</a>
+      <a class="sidebar-link" href="#verification">Verification states</a>
+      <span class="sidebar-label">Actions</span>
+      <a class="sidebar-link" href="#cli-evidence">Adding evidence via CLI</a>
+      <a class="sidebar-link" href="#migration">Migration guide</a>
+      <span class="sidebar-label">Reference</span>
+      <a class="sidebar-link" href="#pitfalls">Common pitfalls</a>
+    </aside>
+
+    <main class="docs-content">
+
+      <h1>Evidence &amp; Trust</h1>
+      <p class="lead">
+        Every star above 1★ is gated by evidence — not declaration.
+        This page covers the full evidence system: the deprecated single-axis <strong>Evidence Class</strong>,
+        the current two-axis model (<strong>Evidence Type</strong> + <strong>Evidence Grade</strong>),
+        how scores accumulate into an <strong>Overall Trust Grade</strong>, and how to
+        attach evidence to a skill via the CLI.
+      </p>
+
+      <h2 id="overview" class="no-rule">Overview</h2>
+      <p>
+        Gaia uses evidence to verify that a skill is real, reproducible, and battle-tested.
+        Evidence is attached to a skill node and is the primary input to star progression —
+        a skill's stars are <em>derived</em> from its evidence, never declared.
+      </p>
+      <p>
+        The evidence system was revised with the <strong>#646 trust model</strong>.
+        The old single-letter <strong>Evidence Class</strong> conflated two orthogonal questions —
+        <em>where</em> evidence comes from and <em>how good</em> it is — into one field.
+        The new model separates them: <strong>Evidence Type</strong> (provenance)
+        and <strong>Evidence Grade</strong> (quality).
+      </p>
+      <div class="callout warn">
+        <p><strong>Critical:</strong> The deprecated Class letters (C/B/A) and the new Grade letters (S/A/B/C)
+        are <em>not equivalent</em>. Class A ≠ Grade A. See <a href="#pitfalls" style="color:inherit;text-decoration:underline;">Common pitfalls</a>.</p>
+      </div>
+
+      <h2 id="class-system">Deprecated: Evidence Class</h2>
+      <div class="deprecated-banner">
+        <span>⚠</span>
+        <div>
+          <p><strong>This axis is deprecated.</strong> The <code>class</code> field stays valid in the schema for backward compatibility but will be removed in the next major release. New evidence entries should carry an Evidence Type and Evidence Grade instead.</p>
+        </div>
+      </div>
+      <p>The legacy Evidence Class was a single letter covering both provenance and quality:</p>
+      <div class="docs-table-wrap">
+        <table class="docs-table">
+          <thead><tr><th>Class</th><th>Description</th><th>Typical source</th></tr></thead>
+          <tbody>
+            <tr><td><code>C</code></td><td>First sighting — skill observed at least once in the wild.</td><td>GitHub repo, demo, casual reference</td></tr>
+            <tr><td><code>B</code></td><td>Reproducible — reliably reproducible with documentation.</td><td>SKILL.md with examples, recorded benchmarks</td></tr>
+            <tr><td><code>A</code></td><td>Battle-tested, peer-reviewed — widely used and externally validated.</td><td>arXiv paper, widely-used library</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p>
+        The problem: a GitHub repo (Class B) with 100k stars carries far more confidence than one with 10 —
+        but both mapped to the same letter. The new model separates these signals.
+      </p>
+
+      <h2 id="evidence-type">Evidence Type</h2>
+      <p>
+        <strong>Evidence Type</strong> is the provenance of one demonstration — <em>where</em> it comes from,
+        not how good it is. Types are kebab-case strings driven from <code>meta.json</code> → <code>evidence.types</code>,
+        so new sources extend the list without a schema change.
+      </p>
+      <p>Always write the full phrase <strong>Evidence Type</strong>; never the bare word "type", which refers to the Basic / Extra / Unique / Ultimate taxonomy field.</p>
+      <div class="docs-table-wrap">
+        <table class="docs-table">
+          <thead><tr><th>Type value</th><th>What it represents</th><th>URL format</th></tr></thead>
+          <tbody>
+            <tr>
+              <td><span class="type-pill">arxiv</span></td>
+              <td>A published academic paper on arXiv demonstrating the capability.</td>
+              <td>Abstract URL: <code>https://arxiv.org/abs/&lt;id&gt;</code> — not the PDF link.</td>
+            </tr>
+            <tr>
+              <td><span class="type-pill">repo</span></td>
+              <td>A GitHub repository with a <code>SKILL.md</code> at a <code>blob/</code> path.</td>
+              <td>Must use <code>blob/branch/subpath</code> — never <code>tree/</code>. The installer and evidence resolver only accept the blob form.</td>
+            </tr>
+            <tr>
+              <td><span class="type-pill">github-stars</span></td>
+              <td>Repository star count as a secondary proxy for adoption signal.</td>
+              <td>Bare repo URL: <code>https://github.com/owner/repo</code>. Build pipeline reads the live count at build time.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="callout info">
+        <p><strong>RFC #654</strong> is tracking additional Evidence Types — community posts, YouTube / social views,
+        and download counts. New types extend <code>meta.json</code> <code>evidence.types</code> without a schema version bump.</p>
+      </div>
+
+      <h2 id="evidence-grade">Evidence Grade</h2>
+      <p>
+        <strong>Evidence Grade</strong> is the quality of one demonstration on an
+        <strong>S / A / B / C</strong> axis —
+        <strong>Platinum</strong> (S), <strong>Gold</strong> (A), <strong>Silver</strong> (B), <strong>Bronze</strong> (C) —
+        derived from a numerical <strong>trust number</strong>. A demonstration whose trust number falls
+        below the C threshold is <strong>ungraded</strong>: on the record but counting toward no gate.
+      </p>
+
+      <div class="trust-meter">
+        <div class="trust-segment seg-S"><span>S</span><span class="seg-name">Platinum</span><span class="seg-range">≥ 90</span></div>
+        <div class="trust-segment seg-A"><span>A</span><span class="seg-name">Gold</span><span class="seg-range">≥ 80</span></div>
+        <div class="trust-segment seg-B"><span>B</span><span class="seg-name">Silver</span><span class="seg-range">≥ 60</span></div>
+        <div class="trust-segment seg-C"><span>C</span><span class="seg-name">Bronze</span><span class="seg-range">≥ 40</span></div>
+        <div class="trust-segment seg-U"><span>—</span><span class="seg-name">Ungraded</span><span class="seg-range">&lt; 40</span></div>
+      </div>
+
+      <div class="docs-table-wrap">
+        <table class="docs-table">
+          <thead><tr><th>Grade</th><th>Label</th><th>Trust #</th><th>What qualifies</th></tr></thead>
+          <tbody>
+            <tr>
+              <td><span class="grade grade-S">S</span></td><td>Platinum</td><td>≥ 90</td>
+              <td>Definitive, peer-reviewed, widely-cited evidence. Reserved for capabilities established beyond reasonable doubt in literature — extremely rare.</td>
+            </tr>
+            <tr>
+              <td><span class="grade grade-A">A</span></td><td>Gold</td><td>≥ 80</td>
+              <td>Battle-tested in production; corroborated by multiple independent sources. A library with 10k+ stars backed by a SKILL.md and a supporting paper qualifies.</td>
+            </tr>
+            <tr>
+              <td><span class="grade grade-B">B</span></td><td>Silver</td><td>≥ 60</td>
+              <td>Reproducible and documented. A SKILL.md with working examples and a verifiable demo at 100+ stars typically lands here.</td>
+            </tr>
+            <tr>
+              <td><span class="grade grade-C">C</span></td><td>Bronze</td><td>≥ 40</td>
+              <td>First sighting — observed at least once, basic documentation present. The minimum to count toward Named (2★) status.</td>
+            </tr>
+            <tr>
+              <td><span class="grade grade-U">—</span></td><td>Ungraded</td><td>&lt; 40</td>
+              <td>On the record but does not count toward any star gate. Useful for logging an observation without making a quality claim.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h2 id="trust-number">Trust Number</h2>
+      <p>
+        The <strong>trust number</strong> is an internal 0–100 score that drives grade assignment.
+        It is <em>never user-facing</em> — public surfaces show the grade label (S/A/B/C) that the
+        trust number yields, not the raw score. Do not call it "trust score"; the canonical term is <strong>trust number</strong>.
+      </p>
+      <p>
+        Thresholds live in <code>meta.json</code> → <code>evidence.gradeThresholds</code> and can be
+        recalibrated without a schema change. The trust number is computed by the build pipeline from
+        evidence metadata (type, external signals like star counts, verification state) and is not stored
+        in registry nodes.
+      </p>
+
+      <h2 id="overall-trust">Overall Trust Grade</h2>
+      <p>
+        An individual evidence entry has its own <strong>Evidence Grade</strong>. A skill's
+        <em>aggregate</em> standing is called its <strong>Overall Trust Grade</strong> — the
+        accumulation of all its evidence grades that establishes the capability "beyond reasonable doubt."
+      </p>
+      <ul>
+        <li><strong>Computed at build time</strong> from the full evidence inventory — never stored on a registry node.</li>
+        <li><strong>Materialises only in generated catalogs</strong> (<code>registry/named-skills.json</code>, <code>docs/graph/gaia.json</code>).</li>
+        <li><strong>Distinct from a single entry's grade</strong> — three Bronze entries can yield a Gold Overall Trust Grade in aggregate.</li>
+        <li><strong>Never hand-assigned</strong> — writing this field to a node directly violates Programmatic-First and CI will reject the PR.</li>
+      </ul>
+
+      <h2 id="verification">Verification States</h2>
+      <p>
+        Each evidence entry passes through verification states independently of its grade.
+        Verification attests that a demonstration is <em>real</em>; grading measures how <em>strong</em> it is.
+        The two axes never substitute for each other.
+      </p>
+      <div class="verif-chips">
+        <div class="verif-chip chip-default">
+          <span class="chip-label">unverified</span>
+          <code class="chip-flag">evidence.verified: false (default)</code>
+          <span class="chip-desc">On the record but not yet reviewed by a 4★ Verifier. All new entries start here.</span>
+        </div>
+        <div class="verif-chip chip-verified">
+          <span class="chip-label">verified</span>
+          <code class="chip-flag">evidence.verified: true</code>
+          <span class="chip-desc">Confirmed real by a contributor holding a Hardened (4★) or higher Named Skill. Unlocks the Community Verified certification level.</span>
+        </div>
+        <div class="verif-chip chip-disputed">
+          <span class="chip-label">disputed</span>
+          <code class="chip-flag">evidence.disputed: true</code>
+          <span class="chip-desc">A Verifier has flagged the entry as questionable. It stays on the record with a demerit flag in the catalog until resolved.</span>
+        </div>
+      </div>
+      <div class="callout info">
+        <p>Check your Verifier status with <code>gaia whoami</code>. The <code>via: verifier</code> path means you are authorized to set <code>evidence.verified: true</code> or <code>evidence.disputed: true</code>.</p>
+      </div>
+
+      <h2 id="cli-evidence">Adding Evidence via CLI</h2>
+      <p>Use <code>gaia dev evidence</code> to attach evidence to a skill node. This is a Verifier-gated command — confirm authorization with <code>gaia whoami</code> first.</p>
+
+      <h3>Legacy form (Class — deprecated, still accepted)</h3>
+      <div class="code-block">
+        <div class="code-block-header"><span class="code-block-label">shell</span></div>
+        <pre><span class="cmd">gaia dev evidence</span> <span class="val">registry-curation</span> <span class="str">"https://github.com/owner/repo/blob/main/skills/foo/SKILL.md"</span> <span class="flag">--class</span> B</pre>
+      </div>
+
+      <h3>New form (Type + Grade)</h3>
+      <div class="code-block">
+        <div class="code-block-header"><span class="code-block-label">shell</span></div>
+        <pre><span class="c"># repo evidence at Grade B (Silver) — always use blob/, not tree/</span>
+<span class="cmd">gaia dev evidence</span> <span class="val">registry-curation</span> <span class="str">"https://github.com/owner/repo/blob/main/skills/foo/SKILL.md"</span> \
+  <span class="flag">--type</span> repo \
+  <span class="flag">--grade</span> B
+
+<span class="c"># arXiv paper at Grade A (Gold)</span>
+<span class="cmd">gaia dev evidence</span> <span class="val">multimodal-reasoning</span> <span class="str">"https://arxiv.org/abs/2504.00001"</span> \
+  <span class="flag">--type</span> arxiv \
+  <span class="flag">--grade</span> A
+
+<span class="c"># always dry-run first</span>
+<span class="cmd">gaia dev evidence</span> <span class="val">multimodal-reasoning</span> <span class="str">"https://arxiv.org/abs/2504.00001"</span> \
+  <span class="flag">--type</span> arxiv <span class="flag">--grade</span> A <span class="flag">--dry-run</span>
+
+<span class="c"># verify an entry (Verifier-only)</span>
+<span class="cmd">gaia dev evidence</span> <span class="val">registry-curation</span> <span class="flag">--verify</span> <span class="str">"https://github.com/owner/repo/blob/main/skills/foo/SKILL.md"</span>
+
+<span class="c"># dispute an entry (Verifier-only)</span>
+<span class="cmd">gaia dev evidence</span> <span class="val">registry-curation</span> <span class="flag">--dispute</span> <span class="str">"https://github.com/owner/repo/blob/main/skills/foo/SKILL.md"</span></pre>
+      </div>
+      <div class="callout warn">
+        <p><strong>Always run <code>--dry-run</code> first.</strong> Evidence writes directly to a registry node. A bad URL or wrong skill ID produces invalid JSON that will fail CI.</p>
+      </div>
+
+      <h3>URL format rules per type</h3>
+      <ul>
+        <li><strong><code>repo</code>:</strong> Use <code>blob/branch/subpath</code>. GitHub directory URLs use <code>tree/</code> — convert manually. The resolver rejects <code>tree/</code> with a schema error.</li>
+        <li><strong><code>arxiv</code>:</strong> Use the abstract URL (<code>https://arxiv.org/abs/&lt;id&gt;</code>), not the PDF link. The build pipeline normalises to the abstract for deduplication.</li>
+        <li><strong><code>github-stars</code>:</strong> Bare repo URL (<code>https://github.com/owner/repo</code>). Star count is read live at build time.</li>
+      </ul>
+
+      <h2 id="migration">Migration Guide</h2>
+      <p>
+        When auditing nodes with legacy <code>class: A/B/C</code> and converting to the new model,
+        use this table as a starting point. The mapping is <em>approximate</em> — the correct Grade
+        depends on the actual evidence, not just the old Class letter.
+      </p>
+      <div class="docs-table-wrap">
+        <table class="docs-table">
+          <thead><tr><th>Deprecated Class</th><th>Approx. Type</th><th>Approx. Grade range</th><th>Notes</th></tr></thead>
+          <tbody>
+            <tr>
+              <td><code>class: C</code></td>
+              <td><span class="type-pill">repo</span></td>
+              <td><span class="grade grade-C">C</span> Bronze</td>
+              <td>First sighting. Verify the URL still resolves before converting.</td>
+            </tr>
+            <tr>
+              <td><code>class: B</code></td>
+              <td><span class="type-pill">repo</span></td>
+              <td><span class="grade grade-C">C</span> – <span class="grade grade-B">B</span></td>
+              <td>Grade B if repo has examples + demos + ≥100 stars. Grade C if thin. Check star count at migration time.</td>
+            </tr>
+            <tr>
+              <td><code>class: A</code> (arXiv)</td>
+              <td><span class="type-pill">arxiv</span></td>
+              <td><span class="grade grade-B">B</span> – <span class="grade grade-A">A</span></td>
+              <td>Confirm the URL before assigning type. High-citation papers with reproduction evidence can reach Grade A.</td>
+            </tr>
+            <tr>
+              <td><code>class: A</code> (repo)</td>
+              <td><span class="type-pill">repo</span> + <span class="type-pill">github-stars</span></td>
+              <td><span class="grade grade-A">A</span> – <span class="grade grade-S">S</span></td>
+              <td>Battle-tested repos (10k+ stars, independent reproductions). Verify evidence still exists before upgrading.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="callout danger">
+        <p><strong>Do not auto-migrate.</strong> Converting <code>class: A</code> to <code>grade: A</code> is always wrong — the letters are not equivalent. Each entry must be evaluated individually.</p>
+      </div>
+
+      <h2 id="pitfalls">Common Pitfalls</h2>
+
+      <h3>Class letters ≠ Grade letters</h3>
+      <p>The single most common mistake. The axes share letters but measure different things at different calibrations:</p>
+      <div class="docs-table-wrap">
+        <table class="docs-table">
+          <thead><tr><th>Old Class</th><th>Old meaning</th><th>Grade</th><th>Why they differ</th></tr></thead>
+          <tbody>
+            <tr><td><code>C</code></td><td>First sighting</td><td><span class="grade grade-C">C</span> Bronze</td><td>Closest mapping — both mean first sighting.</td></tr>
+            <tr><td><code>B</code></td><td>Reproducible</td><td><span class="grade grade-B">B</span> Silver</td><td>Similar concept, but Grade B requires a higher trust number than Class B implied.</td></tr>
+            <tr><td><code>A</code></td><td>Battle-tested, peer-reviewed</td><td><span class="grade grade-A">A</span> Gold</td><td>Class A was the top of a 3-rung ladder. Grade A is second-highest on a 5-rung ladder. Converting 1:1 is a downgrade for some skills, an upgrade for others.</td></tr>
+            <tr><td class="muted">—</td><td class="muted">(no equivalent)</td><td><span class="grade grade-S">S</span> Platinum</td><td>Grade S (≥ 90) has no Class equivalent — it represents certainty that Class A rarely achieved.</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h3>Using <code>tree/</code> instead of <code>blob/</code></h3>
+      <p>GitHub's directory view uses <code>tree/branch/path</code>. The evidence resolver and installer only accept <code>blob/branch/path</code>. The CLI rejects <code>tree/</code> URLs with a schema error.</p>
+
+      <h3>Using <code>github-stars</code> as sole evidence</h3>
+      <p>Star counts are volatile and subject to farming. Never use <code>github-stars</code> as the sole evidence for a skill — always pair it with at least one <code>repo</code> entry pointing to a SKILL.md.</p>
+
+      <h3>Skipping <code>--dry-run</code></h3>
+      <p><code>gaia dev evidence</code> writes directly to a registry node under Programmatic-First rules. A bad URL or wrong skill ID writes invalid JSON that CI will fail on. Run <code>--dry-run</code> every time before committing.</p>
+
+    </main>
+  </div>
+
+  <footer class="docs-footer-simple">
+    <span>Gaia Docs — Evidence &amp; Trust</span>
+    <div class="docs-footer-links">
+      <a href="index.html">← Docs Home</a>
+      <a href="contributing.html">Contributing →</a>
+      <a href="https://github.com/mbtiongson1/gaia-skill-tree" target="_blank" rel="noopener">GitHub ↗</a>
+    </div>
+  </footer>
+
+  <script>
+    (function () {
+      const verEl = document.getElementById('ver');
+      if (window.GAIA_VERSION && verEl) verEl.textContent = 'v' + window.GAIA_VERSION;
+
+      const links = document.querySelectorAll('.sidebar-link[href^="#"]');
+      const headings = Array.from(document.querySelectorAll('.docs-content h2[id], .docs-content h3[id]'));
+      function onScroll() {
+        const y = window.scrollY + 90;
+        let active = headings[0];
+        for (const h of headings) { if (h.offsetTop <= y) active = h; else break; }
+        links.forEach(l => l.classList.toggle('active', l.getAttribute('href') === '#' + (active && active.id)));
+      }
+      window.addEventListener('scroll', onScroll, { passive: true });
+      onScroll();
+    })();
+  </script>
+
+</body>
+</html>

--- a/docs/en/getting-started.html
+++ b/docs/en/getting-started.html
@@ -539,17 +539,17 @@
         <!-- ────────────── INSTALLATION ────────────── -->
         <h2 id="install">Installation</h2>
 
-        <h3>Option A — pip (recommended for most developers)</h3>
+        <h3>Option A — install script (recommended)</h3>
 
         <div class="code-fence">
           <div class="code-fence-header"><span class="code-fence-label">shell</span></div>
-          <pre><span class="cmd">pip install gaia-registry</span></pre>
+          <pre><span class="cmd">curl -fsSL https://gaia.tiongson.co/install.sh | sh</span></pre>
         </div>
 
-        <p>This installs the <code>gaia</code> binary into whatever Python environment is currently active.
-        Use a virtualenv if you don't want to touch your system Python.</p>
+        <p>Prefers <code>pipx</code> if available, otherwise falls back to <code>pip install --user</code>
+        and prints a PATH hint if needed. Requires Python 3.8+.</p>
 
-        <h3>Option B — pipx (isolated, recommended for global use)</h3>
+        <h3>Option B — pipx (isolated global install)</h3>
 
         <div class="code-fence">
           <div class="code-fence-header"><span class="code-fence-label">shell</span></div>
@@ -557,10 +557,20 @@
 <span class="cmd">pip install pipx</span>
 
 <span class="c"># Install gaia in its own isolated environment</span>
-<span class="cmd">pipx install gaia-registry</span></pre>
+<span class="cmd">pipx install gaia-cli</span></pre>
         </div>
 
-        <h3>Option C — editable install from source</h3>
+        <h3>Option C — pip</h3>
+
+        <div class="code-fence">
+          <div class="code-fence-header"><span class="code-fence-label">shell</span></div>
+          <pre><span class="cmd">pip install gaia-cli</span></pre>
+        </div>
+
+        <p>Installs the <code>gaia</code> binary into the active Python environment.
+        Use a virtualenv to avoid touching your system Python.</p>
+
+        <h3>Option D — editable install from source</h3>
 
         <div class="code-fence">
           <div class="code-fence-header"><span class="code-fence-label">shell</span></div>
@@ -575,7 +585,7 @@
         <div class="code-fence">
           <div class="code-fence-header"><span class="code-fence-label">shell</span></div>
           <pre><span class="cmd">gaia --version</span>
-<span class="c"># gaia 4.4.0</span></pre>
+<span class="c"># gaia 4.7.0</span></pre>
         </div>
 
         <!-- ────────────── INIT ────────────── -->

--- a/docs/en/index.html
+++ b/docs/en/index.html
@@ -344,11 +344,17 @@
     <h2>Contribute</h2>
   </div>
   <div class="docs-grid" style="margin-top:1.25rem;">
-    <a class="docs-card" href="named-skills.html" style="opacity:0.7;pointer-events:auto;">
+    <a class="docs-card" href="contributing.html">
+      <span class="docs-card-icon">⚒</span>
+      <span class="docs-card-title">Contributing</span>
+      <span class="docs-card-desc">Three paths — gaia push, /gaia-curate-chain, and direct CLI meta shifts. Branch naming, PR checklist, and automated maintenance.</span>
+      <span class="docs-card-badge new">● New</span>
+    </a>
+    <a class="docs-card" href="named-skills.html">
       <span class="docs-card-icon">★</span>
       <span class="docs-card-title">Named Skills &amp; Origin</span>
       <span class="docs-card-desc">How to claim origin status on a skill you've demonstrated, earn honor-red attribution, and reach 2★ Named rank.</span>
-      <span class="docs-card-badge planned">○ Coming soon</span>
+      <span class="docs-card-badge new">● New</span>
     </a>
     <a class="docs-card" href="evidence-classes.html" style="opacity:0.7;pointer-events:auto;">
       <span class="docs-card-icon">🔬</span>

--- a/docs/en/index.html
+++ b/docs/en/index.html
@@ -397,7 +397,7 @@
         <span class="code-fence-label">shell</span>
       </div>
       <pre><span class="c"># Install</span>
-<span class="cmd">pip install gaia-registry</span>
+<span class="cmd">curl -fsSL https://gaia.tiongson.co/install.sh | sh</span>
 
 <span class="c"># Initialise your profile inside a Git repo</span>
 <span class="cmd">gaia init --user &lt;your-github-handle&gt;</span>

--- a/docs/en/index.html
+++ b/docs/en/index.html
@@ -301,7 +301,7 @@
     <span class="docs-nav-sep">/</span>
     <a href="index.html" class="docs-nav-link active">Docs</a>
     <div class="docs-nav-spacer"></div>
-    <span class="docs-nav-version" id="ver">v4.4.0</span>
+    <span class="docs-nav-version" id="ver">v4.7.0</span>
   </nav>
 
   <!-- hero -->
@@ -356,11 +356,11 @@
       <span class="docs-card-desc">How to claim origin status on a skill you've demonstrated, earn honor-red attribution, and reach 2★ Named rank.</span>
       <span class="docs-card-badge new">● New</span>
     </a>
-    <a class="docs-card" href="evidence-classes.html" style="opacity:0.7;pointer-events:auto;">
+    <a class="docs-card" href="evidence-classes.html">
       <span class="docs-card-icon">🔬</span>
-      <span class="docs-card-title">Evidence Classes</span>
-      <span class="docs-card-desc">Class C, B, and A evidence — what each means, how to attach it, and how it drives star progression.</span>
-      <span class="docs-card-badge planned">○ Coming soon</span>
+      <span class="docs-card-title">Evidence &amp; Trust</span>
+      <span class="docs-card-desc">Evidence Type, Grade, and Overall Trust Grade — how the two-axis trust model supersedes deprecated Evidence Class and gates star progression.</span>
+      <span class="docs-card-badge new">● New</span>
     </a>
     <a class="docs-card" href="fusion.html" style="opacity:0.7;pointer-events:auto;">
       <span class="docs-card-icon">◇</span>
@@ -463,6 +463,8 @@
           <ul>
             <li><a href="index.html" style="color: var(--tier-basic, #38bdf8);">Docs Home</a></li>
             <li><a href="getting-started.html">Getting Started</a></li>
+            <li><a href="cli-reference.html">CLI Reference</a></li>
+            <li><a href="evidence-classes.html">Evidence &amp; Trust</a></li>
           </ul>
         </div>
 
@@ -483,7 +485,7 @@
     <div class="footer-bottom">
       <span>MIT License</span>
       <span class="footer-bottom-sep" aria-hidden="true">·</span>
-      <span id="footerVersion">v4.6.0</span>
+      <span id="footerVersion">v4.7.0</span>
       <span class="footer-bottom-sep" aria-hidden="true">·</span>
       <span>© 2026 Gaia</span>
     </div>

--- a/docs/en/named-skills.html
+++ b/docs/en/named-skills.html
@@ -1,0 +1,905 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Named Skills — Gaia Docs</title>
+  <meta name="description" content="What Named Skills are, how they differ from generic (starless) references, the lifecycle from scan to 4★ Verifier, and the PR flow for claiming origin.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+  <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
+  <link rel="stylesheet" href="../css/tokens.css">
+  <link rel="stylesheet" href="../css/styles.css">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      background: var(--bg, #030712);
+      color: var(--text, #e2e8f0);
+      font-family: 'Bricolage Grotesque', system-ui, sans-serif;
+      font-size: 1rem;
+      line-height: 1.65;
+    }
+
+    a { color: var(--tier-basic, #38bdf8); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    /* ── Nav ── */
+    .docs-nav {
+      border-bottom: 1px solid var(--border, #1e293b);
+      padding: 0 2rem;
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      height: 52px;
+      position: sticky;
+      top: 0;
+      background: rgba(3, 7, 18, 0.92);
+      backdrop-filter: blur(8px);
+      z-index: 100;
+    }
+    .nav-logo {
+      font-family: 'EB Garamond', Georgia, serif;
+      font-size: 1.1rem;
+      font-weight: 500;
+      color: var(--text, #e2e8f0);
+      letter-spacing: .02em;
+    }
+    .nav-logo span { color: var(--tier-ultimate, #f59e0b); }
+    .nav-sep { color: var(--muted, #64748b); font-size: 0.85rem; }
+    .nav-crumb { font-size: 0.82rem; color: var(--muted, #64748b); }
+    .nav-crumb:hover { color: var(--text, #e2e8f0); text-decoration: none; }
+    .nav-crumb.current { color: var(--text, #e2e8f0); }
+    .nav-spacer { flex: 1; }
+    .nav-version {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.7rem;
+      color: var(--muted, #64748b);
+      padding: 0.2rem 0.5rem;
+      border: 1px solid var(--border, #1e293b);
+      border-radius: 4px;
+    }
+
+    /* ── Layout ── */
+    .page-layout {
+      display: grid;
+      grid-template-columns: 220px 1fr;
+      max-width: 1120px;
+      margin: 0 auto;
+    }
+
+    /* ── Sidebar ── */
+    .sidebar {
+      position: sticky;
+      top: 52px;
+      height: calc(100vh - 52px);
+      overflow-y: auto;
+      padding: 2rem 0 2rem 1.5rem;
+      border-right: 1px solid var(--border, #1e293b);
+      scrollbar-width: thin;
+      scrollbar-color: var(--border, #1e293b) transparent;
+    }
+    .sidebar-group { margin-bottom: 1.75rem; }
+    .sidebar-group-label {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.66rem;
+      text-transform: uppercase;
+      letter-spacing: .1em;
+      color: var(--muted, #64748b);
+      margin-bottom: 0.5rem;
+    }
+    .sidebar-links { list-style: none; display: flex; flex-direction: column; gap: 0.1rem; }
+    .sidebar-links a {
+      display: block;
+      padding: 0.25rem 0.6rem;
+      font-size: 0.84rem;
+      color: var(--muted, #64748b);
+      border-radius: 4px;
+      transition: color 0.15s, background 0.15s;
+    }
+    .sidebar-links a:hover {
+      color: var(--text, #e2e8f0);
+      background: rgba(255,255,255,0.04);
+      text-decoration: none;
+    }
+    .sidebar-links a.active {
+      color: var(--tier-basic, #38bdf8);
+      background: rgba(56,189,248,0.07);
+    }
+
+    /* ── Main ── */
+    .main-content {
+      padding: 2.5rem 3rem 4rem 3rem;
+      max-width: 820px;
+      min-width: 0;
+    }
+    .page-title {
+      font-family: 'EB Garamond', Georgia, serif;
+      font-size: 2.4rem;
+      font-weight: 500;
+      line-height: 1.2;
+      margin-bottom: 0.75rem;
+      color: var(--text, #e2e8f0);
+    }
+    .page-lead {
+      font-size: 1.05rem;
+      color: var(--muted, #64748b);
+      max-width: 580px;
+      line-height: 1.65;
+      margin-bottom: 2.5rem;
+    }
+
+    /* ── Sections ── */
+    .section { margin-bottom: 3.5rem; }
+    .section-title {
+      font-family: 'EB Garamond', Georgia, serif;
+      font-size: 1.7rem;
+      font-weight: 500;
+      color: var(--text, #e2e8f0);
+      margin-bottom: 0.5rem;
+      padding-top: 0.5rem;
+    }
+    .section-body {
+      font-size: 0.95rem;
+      color: var(--muted, #64748b);
+      line-height: 1.7;
+      margin-bottom: 1.5rem;
+    }
+    .section-body p { margin-bottom: 0.85rem; }
+    .section-body p:last-child { margin-bottom: 0; }
+
+    h3 {
+      font-family: 'EB Garamond', Georgia, serif;
+      font-size: 1.25rem;
+      font-weight: 500;
+      color: var(--text, #e2e8f0);
+      margin: 1.75rem 0 0.6rem;
+    }
+
+    /* ── Comparison panel ── */
+    .compare-panel {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+      margin: 1.5rem 0;
+    }
+    @media (max-width: 860px) {
+      .compare-panel { grid-template-columns: 1fr; }
+      .page-layout { grid-template-columns: 1fr; }
+      .sidebar { display: none; }
+    }
+    .compare-card {
+      border: 1px solid var(--border, #1e293b);
+      border-radius: 10px;
+      padding: 1.25rem;
+      background: var(--surface, #0f172a);
+    }
+    .compare-card.generic { border-left: 3px solid #475569; }
+    .compare-card.named   { border-left: 3px solid #dc2626; }
+
+    .compare-label {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.68rem;
+      text-transform: uppercase;
+      letter-spacing: .1em;
+      margin-bottom: 0.6rem;
+    }
+    .compare-card.generic .compare-label { color: #64748b; }
+    .compare-card.named   .compare-label { color: #f87171; }
+
+    .compare-title {
+      font-size: 1.05rem;
+      font-weight: 600;
+      color: var(--text, #e2e8f0);
+      margin-bottom: 0.85rem;
+    }
+    .compare-attrs { list-style: none; display: flex; flex-direction: column; gap: 0.45rem; }
+    .compare-attrs li {
+      font-size: 0.855rem;
+      color: var(--muted, #64748b);
+      display: flex;
+      align-items: flex-start;
+      gap: 0.5rem;
+      line-height: 1.5;
+    }
+    .compare-attrs li::before { content: "–"; color: #475569; flex-shrink: 0; }
+    .compare-card.named .compare-attrs li::before { color: #dc2626; }
+    .compare-attrs strong { color: var(--text, #e2e8f0); }
+
+    /* ── Lifecycle diagram ── */
+    .lifecycle {
+      margin: 1.5rem 0;
+      display: flex;
+      flex-direction: column;
+      gap: 0;
+    }
+    .lifecycle-step {
+      display: flex;
+      gap: 1.25rem;
+      padding: 1rem 0;
+      border-bottom: 1px solid rgba(30,41,59,0.5);
+    }
+    .lifecycle-step:last-child { border-bottom: none; }
+    .lifecycle-num {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.72rem;
+      font-weight: 600;
+      color: var(--tier-basic, #38bdf8);
+      background: rgba(56,189,248,0.1);
+      border: 1px solid rgba(56,189,248,0.2);
+      border-radius: 50%;
+      width: 1.8rem;
+      height: 1.8rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+      margin-top: 0.1rem;
+    }
+    .lifecycle-body { flex: 1; }
+    .lifecycle-title {
+      font-size: 0.95rem;
+      font-weight: 600;
+      color: var(--text, #e2e8f0);
+      margin-bottom: 0.3rem;
+    }
+    .lifecycle-desc {
+      font-size: 0.875rem;
+      color: var(--muted, #64748b);
+      line-height: 1.6;
+    }
+    .lifecycle-rank {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.75rem;
+      font-weight: 600;
+      padding: 0.15rem 0.45rem;
+      border-radius: 4px;
+      display: inline-block;
+      margin-bottom: 0.35rem;
+    }
+    .rank-0 { background: rgba(100,116,139,0.15); color: #94a3b8; }
+    .rank-1 { background: rgba(56,189,248,0.1);   color: #38bdf8; }
+    .rank-2 { background: rgba(45,212,191,0.1);   color: #2dd4bf; }
+    .rank-3 { background: rgba(167,139,250,0.1);  color: #a78bfa; }
+    .rank-4 { background: rgba(232,121,249,0.1);  color: #e879f9; }
+
+    /* ── Evidence grades ── */
+    .grade-table { width: 100%; border-collapse: collapse; font-size: 0.875rem; margin: 1rem 0; }
+    .grade-table th {
+      text-align: left;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.64rem;
+      text-transform: uppercase;
+      letter-spacing: .08em;
+      color: var(--muted, #64748b);
+      padding: 0.5rem 0.75rem;
+      border-bottom: 1px solid var(--border, #1e293b);
+    }
+    .grade-table td {
+      padding: 0.55rem 0.75rem;
+      vertical-align: top;
+      border-bottom: 1px solid rgba(30,41,59,0.5);
+      color: var(--muted, #64748b);
+    }
+    .grade-table tr:last-child td { border-bottom: none; }
+    .grade-badge {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.78rem;
+      font-weight: 700;
+      padding: 0.15rem 0.5rem;
+      border-radius: 4px;
+      display: inline-block;
+    }
+    .g-s { background: rgba(168,85,247,0.15); color: #c084fc; border: 1px solid rgba(168,85,247,0.3); }
+    .g-a { background: rgba(251,191,36,0.12); color: #fbbf24; border: 1px solid rgba(251,191,36,0.3); }
+    .g-b { background: rgba(167,139,250,0.12); color: #a78bfa; border: 1px solid rgba(167,139,250,0.3); }
+    .g-c { background: rgba(148,163,184,0.12); color: #94a3b8; border: 1px solid rgba(148,163,184,0.3); }
+
+    /* ── Origin bucket diagram ── */
+    .bucket-diagram {
+      background: var(--surface, #0f172a);
+      border: 1px solid var(--border, #1e293b);
+      border-radius: 10px;
+      padding: 1.5rem;
+      margin: 1.25rem 0;
+    }
+    .bucket-header {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.72rem;
+      text-transform: uppercase;
+      letter-spacing: .08em;
+      color: var(--muted, #64748b);
+      margin-bottom: 1rem;
+    }
+    .bucket-generic {
+      border: 1px solid #475569;
+      border-radius: 6px;
+      padding: 0.65rem 0.9rem;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.8rem;
+      color: #64748b;
+      font-style: italic;
+      margin-bottom: 0.75rem;
+    }
+    .bucket-entries { display: flex; flex-direction: column; gap: 0.5rem; padding-left: 1.25rem; border-left: 2px solid var(--border, #1e293b); }
+    .bucket-entry {
+      display: flex;
+      align-items: center;
+      gap: 0.65rem;
+      font-size: 0.855rem;
+    }
+    .bucket-role {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.7rem;
+      padding: 0.1rem 0.4rem;
+      border-radius: 3px;
+      flex-shrink: 0;
+    }
+    .role-origin  { background: rgba(220,38,38,0.15); color: #f87171; border: 1px solid rgba(220,38,38,0.3); }
+    .role-variant { background: rgba(100,116,139,0.12); color: #94a3b8; border: 1px solid rgba(100,116,139,0.25); }
+    .bucket-id {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.78rem;
+      color: var(--text, #e2e8f0);
+    }
+    .bucket-stars { color: var(--muted, #64748b); font-size: 0.78rem; }
+
+    /* ── Code fence ── */
+    .code-fence {
+      background: #06080f;
+      border: 1px solid var(--border, #1e293b);
+      border-radius: 6px;
+      overflow: hidden;
+      margin: 1rem 0;
+    }
+    .code-fence-label {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.66rem;
+      text-transform: uppercase;
+      letter-spacing: .08em;
+      color: var(--muted, #64748b);
+      padding: 0.45rem 1rem;
+      border-bottom: 1px solid var(--border, #1e293b);
+      background: rgba(255,255,255,0.015);
+    }
+    .code-fence pre {
+      padding: 0.85rem 1rem;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.8rem;
+      line-height: 1.8;
+      color: #c9d1d9;
+      overflow-x: auto;
+    }
+    .code-fence pre .c  { color: #6b7280; }
+    .code-fence pre .kw { color: #7dd3fc; }
+    .code-fence pre .str { color: #86efac; }
+    .code-fence pre .flag { color: #c084fc; }
+
+    /* ── Callout ── */
+    .callout {
+      border-left: 3px solid;
+      padding: 0.85rem 1rem;
+      border-radius: 0 6px 6px 0;
+      font-size: 0.875rem;
+      line-height: 1.6;
+      margin: 1rem 0;
+    }
+    .callout.info {
+      border-color: var(--tier-basic, #38bdf8);
+      background: rgba(56,189,248,0.07);
+      color: #bae6fd;
+    }
+    .callout.warn {
+      border-color: #f59e0b;
+      background: rgba(245,158,11,0.07);
+      color: #fde68a;
+    }
+    .callout.origin {
+      border-color: #dc2626;
+      background: rgba(220,38,38,0.07);
+      color: #fca5a5;
+    }
+    .callout strong { font-weight: 600; }
+    .callout code {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.8rem;
+      background: rgba(255,255,255,0.08);
+      padding: 0.1em 0.35em;
+      border-radius: 3px;
+    }
+
+    /* ── Installability table ── */
+    .data-table { width: 100%; border-collapse: collapse; font-size: 0.875rem; margin: 1rem 0; }
+    .data-table th {
+      text-align: left;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.64rem;
+      text-transform: uppercase;
+      letter-spacing: .08em;
+      color: var(--muted, #64748b);
+      padding: 0.5rem 0.75rem;
+      border-bottom: 1px solid var(--border, #1e293b);
+    }
+    .data-table td {
+      padding: 0.55rem 0.75rem;
+      vertical-align: top;
+      border-bottom: 1px solid rgba(30,41,59,0.5);
+      color: var(--muted, #64748b);
+    }
+    .data-table tr:last-child td { border-bottom: none; }
+    .data-table td:first-child {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.8rem;
+      color: var(--text, #e2e8f0);
+      white-space: nowrap;
+    }
+    .data-table code {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.78rem;
+      background: rgba(255,255,255,0.06);
+      padding: 0.1em 0.35em;
+      border-radius: 3px;
+      color: var(--text, #e2e8f0);
+    }
+    .ok   { color: #34d399; }
+    .warn { color: #f59e0b; }
+    .err  { color: #f87171; }
+
+    /* ── Footer ── */
+    .page-footer {
+      border-top: 1px solid var(--border, #1e293b);
+      margin-top: 4rem;
+      padding-top: 1.5rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      font-size: 0.8rem;
+      color: var(--muted, #64748b);
+    }
+    .page-footer a { color: var(--muted, #64748b); }
+    .page-footer a:hover { color: var(--text, #e2e8f0); }
+
+    code { font-family: 'JetBrains Mono', monospace; font-size: 0.82em; background: rgba(255,255,255,0.06); padding: 0.1em 0.35em; border-radius: 3px; }
+    em.generic { font-style: italic; color: #64748b; }
+    strong.origin { color: #f87171; font-weight: 600; }
+  </style>
+</head>
+<body>
+
+  <!-- Nav -->
+  <nav class="docs-nav">
+    <a class="nav-logo" href="../index.html">Gaia <span>◆</span></a>
+    <span class="nav-sep">/</span>
+    <a class="nav-crumb" href="index.html">Docs</a>
+    <span class="nav-sep">/</span>
+    <span class="nav-crumb current">Named Skills</span>
+    <span class="nav-spacer"></span>
+    <span class="nav-version">v4.7.0</span>
+  </nav>
+
+  <!-- Layout -->
+  <div class="page-layout">
+
+    <!-- Sidebar -->
+    <aside class="sidebar">
+      <div class="sidebar-group">
+        <div class="sidebar-group-label">On this page</div>
+        <ul class="sidebar-links">
+          <li><a href="#what-is">What is a Named Skill</a></li>
+          <li><a href="#generic-vs-named">Generic vs Named</a></li>
+          <li><a href="#origin-bucket">Origin &amp; variants</a></li>
+          <li><a href="#lifecycle">Lifecycle</a></li>
+          <li><a href="#evidence">Evidence system</a></li>
+          <li><a href="#claiming">Claiming a Named Skill</a></li>
+          <li><a href="#verifier">Verifier threshold</a></li>
+          <li><a href="#installability">Installability</a></li>
+        </ul>
+      </div>
+      <div class="sidebar-group">
+        <div class="sidebar-group-label">See also</div>
+        <ul class="sidebar-links">
+          <li><a href="skill-hierarchy.html">Skill Hierarchy</a></li>
+          <li><a href="contributing.html">Contributing</a></li>
+          <li><a href="cli-reference.html">CLI Reference</a></li>
+        </ul>
+      </div>
+    </aside>
+
+    <!-- Main -->
+    <main class="main-content">
+      <h1 class="page-title">Named Skills</h1>
+      <p class="page-lead">A Named Skill is a canonical skill attached to a real contributor. This page explains the distinction from generic references, the five-step lifecycle from scan to 4★ Verifier, and how to claim origin.</p>
+
+      <!-- What is a Named Skill -->
+      <section class="section" id="what-is">
+        <h2 class="section-title">What is a Named Skill?</h2>
+        <div class="section-body">
+          <p>A <strong>Named Skill</strong> is a canonical registry skill that has been claimed by a real contributor with at least Class C evidence (first sighting). At the moment of naming, the skill ranks up to <strong>2★ (Named)</strong> and the contributor becomes its <strong>Origin Contributor</strong> — a permanent, auditable record in the graph.</p>
+          <p>Named Skills display in <strong style="color:#dc2626;">honor red</strong> in the CLI and the Atlas. The Origin Contributor field is one-per-skill and immutable after the naming PR merges — re-attribution requires a maintainer decision with a timeline event.</p>
+        </div>
+
+        <div class="callout origin">
+          <strong>Not to be confused with "unlocked skills."</strong> A player's <code>skill-tree.json</code> tracks which skills a user has unlocked in their own tree. Named Skills are a registry concept — they live in <code>registry/named/</code> and describe public, contributor-attributed implementations of canonical skill IDs.
+        </div>
+      </section>
+
+      <!-- Generic vs Named -->
+      <section class="section" id="generic-vs-named">
+        <h2 class="section-title">Generic references vs Named Skills</h2>
+        <div class="section-body">
+          <p>The registry uses two distinct concepts that developers sometimes conflate. Understanding the difference matters for curation and for reading CLI output.</p>
+        </div>
+
+        <div class="compare-panel">
+          <div class="compare-card generic">
+            <div class="compare-label">Generic (starless) reference</div>
+            <div class="compare-title"><em class="generic">web-scrape</em></div>
+            <ul class="compare-attrs">
+              <li>A taxonomy node — a slot in the capability graph</li>
+              <li>Carries <strong>no stars of its own</strong>; stars live only on its named children</li>
+              <li><strong>Effective rank</strong> = highest star among named implementations</li>
+              <li>Holds capability-level (Class A / academic) evidence that all named children inherit</li>
+              <li>Renders as <em>generic</em>, italic, greyed-out in the UI</li>
+              <li>Created via <code>gaia dev add</code>, no contributor required</li>
+            </ul>
+          </div>
+          <div class="compare-card named">
+            <div class="compare-label">Named Skill</div>
+            <div class="compare-title"><strong class="origin">★ karpathy/web-scrape</strong></div>
+            <ul class="compare-attrs">
+              <li>An implementation of a generic reference, attributed to a contributor</li>
+              <li>Has its own stars (2★ minimum on claiming)</li>
+              <li>Carries implementation-specific evidence on top of the inherited base</li>
+              <li>Has a SKILL.md at a public GitHub URL (<code>links.github</code>)</li>
+              <li>Renders with contributor name in honor red</li>
+              <li>Created via naming PR — contributor must have Class C evidence or better</li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="callout info">
+          <strong>Key rule:</strong> never assign stars directly to a generic reference. Stars belong to named implementations. Leave ranking to the named children.
+        </div>
+      </section>
+
+      <!-- Origin and bucket -->
+      <section class="section" id="origin-bucket">
+        <h2 class="section-title">Origin &amp; variants</h2>
+        <div class="section-body">
+          <p>Each generic reference can have multiple Named Skill implementations — this is the "bucket." Within a bucket, one implementation carries the <code>origin: true</code> flag — it is the <strong>Origin</strong>, the first and most canonical implementation of that capability. All others are <strong>variants</strong>.</p>
+          <p>An Origin implementation typically has the strongest evidence and the highest stars in the bucket. The CLI and the UI both surface the role distinction.</p>
+        </div>
+
+        <div class="bucket-diagram">
+          <div class="bucket-header">Example bucket — generic: web-scrape</div>
+          <div class="bucket-generic">web-scrape &nbsp; <em>(starless, generic)</em></div>
+          <div class="bucket-entries">
+            <div class="bucket-entry">
+              <span class="bucket-role role-origin">★ origin</span>
+              <span class="bucket-id">karpathy/web-scrape</span>
+              <span class="bucket-stars">3★ · Firecrawl-backed deep scraper</span>
+            </div>
+            <div class="bucket-entry">
+              <span class="bucket-role role-variant">variant</span>
+              <span class="bucket-id">johndoe/web-scrape-stealth</span>
+              <span class="bucket-stars">2★ · Stealth-mode scraper with rotation</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout info">
+          <strong>CLI command (when implemented):</strong> <code>gaia lookup web-scrape</code> lists all bucket entries with role labels. See <a href="https://github.com/mbtiongson1/gaia-skill-tree/issues/71">issue #71</a> for the full spec.
+        </div>
+
+        <h3>Frontmatter fields</h3>
+        <div class="code-fence">
+          <div class="code-fence-label">registry/named/karpathy/web-scrape.md</div>
+          <pre><span class="c">---</span>
+id: karpathy/web-scrape
+name: Web Scrape
+contributor: karpathy
+<span class="kw">origin: true</span>                   <span class="c"># this implementation is the bucket origin</span>
+genericSkillRef: web-scrape    <span class="c"># parent generic node</span>
+status: named
+level: <span class="str">"3★"</span>
+links:
+  github: https://github.com/karpathy/myagent/blob/main/skills/web-scrape/SKILL.md
+<span class="c">---</span></pre>
+        </div>
+      </section>
+
+      <!-- Lifecycle -->
+      <section class="section" id="lifecycle">
+        <h2 class="section-title">Lifecycle</h2>
+        <div class="section-body">
+          <p>A Named Skill moves through five states from first detection to Verifier status. Each transition requires evidence — stars are never declared, only derived.</p>
+        </div>
+
+        <div class="lifecycle">
+          <div class="lifecycle-step">
+            <div class="lifecycle-num">1</div>
+            <div class="lifecycle-body">
+              <div class="lifecycle-rank rank-0">0★ — Unawakened (generic)</div>
+              <div class="lifecycle-title">Detected by scanner</div>
+              <div class="lifecycle-desc"><code>gaia scan</code> finds a <code>SKILL.md</code> in a project. A promotion candidate is written to <code>generated-output/promotion-candidates.json</code>. No registry entry exists yet — the skill is visible only in the local context.</div>
+            </div>
+          </div>
+          <div class="lifecycle-step">
+            <div class="lifecycle-num">2</div>
+            <div class="lifecycle-body">
+              <div class="lifecycle-rank rank-1">1★ — Awakened</div>
+              <div class="lifecycle-title">Promoted to the canonical graph</div>
+              <div class="lifecycle-desc">A reviewer runs <code>gaia dev add</code> (or a curation pipeline) to create a generic registry entry. The skill is now in the public graph at 1★, starless. No contributor is attributed yet.</div>
+            </div>
+          </div>
+          <div class="lifecycle-step">
+            <div class="lifecycle-num">3</div>
+            <div class="lifecycle-body">
+              <div class="lifecycle-rank rank-2">2★ — Named</div>
+              <div class="lifecycle-title">Claimed with Class C evidence</div>
+              <div class="lifecycle-desc">A contributor opens a naming PR with at least <strong>Class C evidence</strong> (first sighting — a <code>SKILL.md</code> at a public URL). The PR creates or updates <code>registry/named/&lt;contributor&gt;/&lt;skill-name&gt;.md</code> with <code>origin: true</code> and <code>level: "2★"</code>. The contributor becomes the Origin Contributor permanently.</div>
+            </div>
+          </div>
+          <div class="lifecycle-step">
+            <div class="lifecycle-num">4</div>
+            <div class="lifecycle-body">
+              <div class="lifecycle-rank rank-3">3★ — Evolved</div>
+              <div class="lifecycle-title">Reproducible evidence added</div>
+              <div class="lifecycle-desc">The contributor adds <strong>Class B evidence</strong> — a reproducible, documented demonstration. The PR runs <code>gaia dev evidence skill-id "url" --class B</code> and calibrates to 3★. A <code>links.github</code> URL pointing to a public repository is mandatory at this level.</div>
+            </div>
+          </div>
+          <div class="lifecycle-step">
+            <div class="lifecycle-num">5</div>
+            <div class="lifecycle-body">
+              <div class="lifecycle-rank rank-4">4★ — Hardened (Verifier threshold)</div>
+              <div class="lifecycle-title">Battle-tested, peer-reviewed</div>
+              <div class="lifecycle-desc">Reaching 4★ requires <strong>Class A evidence</strong> — peer review or battle-tested production use. At this rank the contributor becomes a <strong>Verifier</strong>, authorized to review and approve other contributors' naming PRs via <code>gaia whoami</code> → <code>verifier</code> path.</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Evidence system -->
+      <section class="section" id="evidence">
+        <h2 class="section-title">Evidence system</h2>
+        <div class="section-body">
+          <p>The evidence system is being upgraded from a single axis (Evidence Class) to a two-axis model (Evidence Type + Evidence Grade). Both coexist in the schema during the transition.</p>
+        </div>
+
+        <h3>Legacy: Evidence Class (deprecated)</h3>
+        <div class="section-body">
+          <p>The original single axis conflated provenance and quality into one letter. It remains valid in the schema until the next major release but should not be used for new evidence entries.</p>
+        </div>
+
+        <table class="grade-table">
+          <thead>
+            <tr><th>Class</th><th>Meaning</th><th>Example</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><span class="grade-badge g-a">A</span></td>
+              <td>Battle-tested, peer-reviewed</td>
+              <td>Academic paper, public benchmark, production audit</td>
+            </tr>
+            <tr>
+              <td><span class="grade-badge g-b">B</span></td>
+              <td>Reproducible, documented</td>
+              <td>Public SKILL.md with a working implementation</td>
+            </tr>
+            <tr>
+              <td><span class="grade-badge g-c">C</span></td>
+              <td>First sighting — minimum for naming</td>
+              <td>A SKILL.md file found in a contributor's repository</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="callout warn">
+          <strong>Class ≠ Grade.</strong> Evidence Class letters (A/B/C) are not the same as the new Evidence Grade letters (S/A/B/C). Never read one axis as the other. The Grade axis runs S (Platinum) → A (Gold) → B (Silver) → C (Bronze).
+        </div>
+
+        <h3>Current: Evidence Type + Grade</h3>
+        <div class="section-body">
+          <p>New evidence should carry a <strong>Type</strong> (where a demonstration comes from) and a <strong>Grade</strong> (how strong it is), derived from an underlying trust number. An <strong>Overall Trust Grade</strong> accumulates all evidence for a skill to establish confidence beyond reasonable doubt.</p>
+        </div>
+
+        <table class="grade-table">
+          <thead>
+            <tr><th>Grade</th><th>Label</th><th>Trust number threshold</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><span class="grade-badge g-s">S</span></td><td>Platinum</td><td>≥ 90</td></tr>
+            <tr><td><span class="grade-badge g-a">A</span></td><td>Gold</td><td>≥ 80</td></tr>
+            <tr><td><span class="grade-badge g-b">B</span></td><td>Silver</td><td>≥ 60</td></tr>
+            <tr><td><span class="grade-badge g-c">C</span></td><td>Bronze</td><td>≥ 40</td></tr>
+            <tr>
+              <td><span style="font-family:'JetBrains Mono',monospace;font-size:0.78rem;color:#64748b;">ungraded</span></td>
+              <td>Below threshold</td>
+              <td>&lt; 40 — on the record but counts toward no gate</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="section-body">
+          <p>Evidence types currently supported: <code>arxiv</code>, <code>repo</code>, <code>github-stars</code>. New types extend the list in <code>meta.json</code> without a schema change. GitHub stars are treated as proxy (secondary) evidence — they supplement, never replace, primary evidence.</p>
+        </div>
+
+        <h3>Adding evidence via CLI</h3>
+        <div class="code-fence">
+          <div class="code-fence-label">bash</div>
+          <pre><span class="c"># Add evidence — still accepted for Class B/A if transitional</span>
+gaia dev evidence skill-id "https://github.com/owner/repo/blob/main/SKILL.md" \
+  <span class="flag">--class B</span> \
+  --notes "Reproducible demo with tool-call trace"
+
+<span class="c"># Verify an evidence entry (requires Verifier authorization)</span>
+<span class="c"># Sets evidence.verified: true in the node</span>
+gaia dev verify skill-id 0   <span class="c"># index of the evidence entry</span></pre>
+        </div>
+      </section>
+
+      <!-- Claiming -->
+      <section class="section" id="claiming">
+        <h2 class="section-title">Claiming a Named Skill</h2>
+        <div class="section-body">
+          <p>Claiming attaches your GitHub identity to a canonical skill as its Origin Contributor. The claim is permanent — re-attribution requires a maintainer decision. Do not claim skills you did not originate.</p>
+        </div>
+
+        <h3>What you need</h3>
+        <ul style="list-style:none;display:flex;flex-direction:column;gap:0.5rem;margin:0.75rem 0 1.25rem;font-size:0.9rem;color:var(--muted,#64748b);">
+          <li style="display:flex;gap:0.6rem;align-items:flex-start;"><span style="color:#34d399;flex-shrink:0;">✓</span> A <code>SKILL.md</code> file in a public GitHub repository (minimum Class C evidence)</li>
+          <li style="display:flex;gap:0.6rem;align-items:flex-start;"><span style="color:#34d399;flex-shrink:0;">✓</span> A <code>links.github</code> URL using the <code>blob/branch/subpath</code> format — never <code>tree/</code></li>
+          <li style="display:flex;gap:0.6rem;align-items:flex-start;"><span style="color:#34d399;flex-shrink:0;">✓</span> A <code>review/meta/</code> branch (schema changes require <code>schema/</code>)</li>
+          <li style="display:flex;gap:0.6rem;align-items:flex-start;"><span style="color:#34d399;flex-shrink:0;">✓</span> <code>gaia validate</code> passing with no errors</li>
+        </ul>
+
+        <h3>Step-by-step</h3>
+        <div class="code-fence">
+          <div class="code-fence-label">bash — naming PR workflow</div>
+          <pre><span class="c"># 1. Create your branch</span>
+git checkout -b review/meta/karpathy-web-scrape origin/main
+
+<span class="c"># 2. Ensure the generic node exists (creates it at 1★ if not)</span>
+gaia dev list --generic | grep web-scrape
+<span class="c"># If missing:</span>
+gaia dev add "Web Scrape" --type basic \
+  --description "Drives a browser to scrape structured data from web pages" \
+  --no-build
+
+<span class="c"># 3. Add the Named Skill frontmatter</span>
+<span class="c"># Create: registry/named/karpathy/web-scrape.md</span>
+<span class="c"># (See the frontmatter example above — manually create this file)</span>
+
+<span class="c"># 4. Add Class C evidence (first sighting)</span>
+gaia dev evidence web-scrape \
+  "https://github.com/karpathy/myagent/blob/main/skills/web-scrape/SKILL.md" \
+  --class C --notes "Origin SKILL.md, first documented implementation" \
+  --no-build
+
+<span class="c"># 5. Set level and regenerate index</span>
+gaia dev calibrate web-scrape "2★" --no-build
+python3 scripts/generateNamedIndex.py
+
+<span class="c"># 6. Final build + validate</span>
+gaia dev build
+gaia validate
+
+<span class="c"># 7. Commit and push</span>
+git add registry/named/karpathy/ registry/named-skills.json
+git commit -m "[named] karpathy/web-scrape — claim origin, Class C evidence"
+git push -u origin review/meta/karpathy-web-scrape</pre>
+        </div>
+
+        <div class="callout warn">
+          <strong>Never run <code>gaia push</code> without <code>--dry-run</code> first.</strong> The push command opens a public GitHub issue. Dry-run lets you review the proposed batch before committing.
+        </div>
+      </section>
+
+      <!-- Verifier threshold -->
+      <section class="section" id="verifier">
+        <h2 class="section-title">Verifier threshold</h2>
+        <div class="section-body">
+          <p>A contributor who holds any Named Skill at <strong>4★ or above</strong> becomes a <strong>Verifier</strong> — they are authorized to run mutating <code>gaia dev</code> subcommands and to approve other contributors' naming PRs.</p>
+          <p>Verifier status is checked at runtime by reading <code>registry/named-skills.json</code>. It is automatic — no manual assignment needed. Run <code>gaia whoami</code> to see which authorization path applies to you.</p>
+        </div>
+
+        <div class="code-fence">
+          <div class="code-fence-label">bash</div>
+          <pre>gaia whoami
+
+<span class="c"># Example output:</span>
+<span class="c"># contributor: karpathy</span>
+<span class="c"># via: verifier</span>
+<span class="c"># 4★+ named skills: [web-scrape (4★), autoresearch (5★)]</span></pre>
+        </div>
+
+        <div class="callout info">
+          <strong>Bootstrap mode:</strong> a registry with zero Verifiers auto-allows all actors. Gating activates automatically once the first 4★ Named Skill lands. Set <code>GAIA_OPERATOR_OVERRIDE=1</code> in CI pipelines that must mutate the registry after gating is active.
+        </div>
+      </section>
+
+      <!-- Installability -->
+      <section class="section" id="installability">
+        <h2 class="section-title">Installability</h2>
+        <div class="section-body">
+          <p>Named Skills are installable if they have a valid <code>links.github</code> field pointing to a public repository with a <code>SKILL.md</code>. The install pipeline reads <em>only</em> <code>links.github</code> — other link keys are ignored.</p>
+        </div>
+
+        <table class="data-table">
+          <thead>
+            <tr><th>Stars</th><th>No <code>links.github</code></th><th>Action</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>0★ – 2★</td>
+              <td class="ok">Allowed</td>
+              <td>Tag <code>installable: false</code> in frontmatter — registry-only</td>
+            </tr>
+            <tr>
+              <td>3★+</td>
+              <td class="err">Not allowed</td>
+              <td>Demote to 2★ until a verified link is confirmed</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h3>URL format</h3>
+        <div class="code-fence">
+          <div class="code-fence-label">yaml frontmatter</div>
+          <pre><span class="c"># ✅ Correct — installer extracts subpath</span>
+links:
+  github: https://github.com/owner/repo/<span class="kw">blob</span>/main/.agents/skills/my-skill
+
+<span class="c"># ❌ Broken — bare repo root, skill is undiscoverable</span>
+links:
+  github: https://github.com/owner/repo
+
+<span class="c"># ❌ Broken — tree/ not recognised by _parse_github_url</span>
+links:
+  github: https://github.com/owner/repo/<span class="err">tree</span>/main/.agents/skills/my-skill</pre>
+        </div>
+
+        <h3>Wrong key names</h3>
+        <table class="data-table">
+          <thead>
+            <tr><th>Wrong key</th><th>Fix</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>links.repo</td><td>Rename to <code>links.github</code></td></tr>
+            <tr><td>links.docs</td><td>Rename to <code>links.github</code> (strip any <code>#fragment</code>)</td></tr>
+            <tr><td>links.arxiv</td><td>Add <code>links.github</code> alongside — keep arxiv</td></tr>
+            <tr><td>origin: https://…</td><td>Move URL to <code>links.github</code>, set <code>origin: false</code></td></tr>
+          </tbody>
+        </table>
+
+        <h3>Suites are always exempt</h3>
+        <div class="section-body">
+          <p>Skills with a <code>suiteComponents</code> list (e.g. <code>garrytan/gstack</code>) install by iterating their components. They do not need <code>links.github</code> at the suite level. Never flag suites as uninstallable.</p>
+        </div>
+      </section>
+
+      <footer class="page-footer">
+        <span>Gaia v4.7.0 — <a href="https://github.com/mbtiongson1/gaia-skill-tree">mbtiongson1/gaia-skill-tree</a></span>
+        <a href="index.html">← Back to Docs</a>
+      </footer>
+    </main>
+  </div>
+
+  <script>
+    // Sidebar scroll-spy
+    const links = document.querySelectorAll('.sidebar-links a');
+    const sections = [...document.querySelectorAll('.section[id]')];
+    const observer = new IntersectionObserver(entries => {
+      entries.forEach(e => {
+        if (e.isIntersecting) {
+          links.forEach(l => l.classList.remove('active'));
+          const active = document.querySelector(`.sidebar-links a[href="#${e.target.id}"]`);
+          if (active) active.classList.add('active');
+        }
+      });
+    }, { rootMargin: '-20% 0px -70% 0px' });
+    sections.forEach(s => observer.observe(s));
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Four new pages and iterative updates across two documentation routines.

### Routine 003 (2026-06-11)
- **`docs/en/contributing.html`** — three contributor paths (gaia push, /gaia-curate-chain, direct CLI meta shifts), branch naming cheat sheet, PR checklist, authorization table, automated maintenance overview
- **`docs/en/named-skills.html`** — Generic vs Named distinction, origin/variant bucket model, five-step lifecycle (0★→4★ Verifier), evidence system, claiming walkthrough, installability policy. Addresses #254.

### Routine 004 (2026-06-12)
- **`docs/en/evidence-classes.html`** — complete evidence & trust explainer:
  - Deprecated Evidence Class (C/B/A) with deprecation banner
  - Evidence Type (provenance): `arxiv`, `repo`, `github-stars` — table + URL format rules
  - Evidence Grade (quality): S/A/B/C = Platinum/Gold/Silver/Bronze — visual trust meter + thresholds
  - Trust Number (internal 0–100, not user-facing)
  - Overall Trust Grade (aggregate, computed, never stored on a node)
  - Verification states: unverified / verified / disputed
  - CLI: `gaia dev evidence` with both legacy and new forms; `--dry-run` best practice
  - Migration guide: Class → Type+Grade (with explicit "Class A ≠ Grade A" warning)
  - Common pitfalls anchored for deep-linking in issue replies

### Maintenance
- `docs/en/index.html`: Evidence & Trust card live (● New); footer Docs column updated; stale nav/footer version fixed (v4.4.0 → v4.7.0)
- `docs/en/DOCS.md`: pages 5–7 marked done; grade color tokens added to design system
- `docs/en/getting-started.html`: install instructions updated (gaia-cli, v4.7.0)

## Issues informed

- **#646** — trust model schema now documented; developers don't need to reverse-engineer from commit history
- **#648** — trust number / overall trust grade sections provide vocabulary for the planned frontend explanation UI
- **#654** — Evidence Type section links forward to the RFC
- **#658** — verification states section provides canonical definitions the verification workflow will consume
- **#254** — Named vs Unnamed lifecycle documented in named-skills.html

## Test plan

- [ ] All new pages render without console errors
- [ ] Sidebar scroll-spy activates correct link on scroll
- [ ] Trust meter segments display correct colors on dark background
- [ ] Verification chip borders show correct color (green/red) against dark surface
- [ ] index.html Evidence & Trust card has no opacity dim and shows ● New badge
- [ ] Footer Docs column links resolve correctly
- [ ] `--dry-run` callout renders with correct amber styling

---
_Generated by [Claude Code](https://claude.ai/code/session_017gzBWRQA53Tq1toUhBV88f)_