### PR TITLE
fix(badges): add namedSkills to renderRows() destructuring — badges not generating

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,14 @@ Available gstack skills:
 
 ## Agent-Managed Files (Hermes Ownership)
 
+## Known Badges Issues (Core Implementation)
+
+`docs/badges/index.html` is a **core** page — badge generation is user-facing and must work at all times. Key invariants to maintain:
+
+**`renderRows()` currentState destructuring** (fixed in PR #675, issue #674): `renderRows()` (line ~1378) reads several fields from `currentState` via destructuring. Any new field used inside `renderRows()` **must** be added to that destructuring — or defined with `const <field> = currentState.<field> || <default>` — before use. Silent `ReferenceError`s from missing variables blank the entire badge output with no visible error. Pattern to follow: every other function (`updatePickerActions`, `buildSkillOptions`, `addSkillRow`, button handlers) defines `const namedSkills = currentState.namedSkills || []` at the top. Match this pattern whenever extending `renderRows()`.
+
+**Rule:** after any edit to `docs/badges/index.html`, manually verify `https://gaia.tiongson.co/badges/?u=mattpocock&s=grill-me` renders badge markdown before merging.
+
 ## Known Graph Issues
 
 **`docs/js/skill-graph.js` bootstrap guard** (fixed in PR #365 `9fa66b8`): Any `querySelector(...).addEventListener(...)` call at module bootstrap level will silently abort the entire IIFE if the selector returns null, causing the canvas to fall back to the embedded `FALLBACK_SKILLS` (~18 legacy nodes) instead of fetching `docs/graph/gaia.json`. Always null-check overlay button selectors before wiring events. Grep for `_graphCloseOverlay.querySelector` if the 3D graph regresses to fallback mode.

--- a/docs/badges/index.html
+++ b/docs/badges/index.html
@@ -1375,7 +1375,7 @@
 
     // ── Per-badge rows renderer ───────────────────────────────────────────────
     function renderRows() {
-      const { handle, selectedRepo, hasRank, hasSkills, hasHandle, linkTarget, pickedFiles } = currentState;
+      const { handle, selectedRepo, hasRank, hasSkills, hasHandle, linkTarget, pickedFiles, namedSkills } = currentState;
       rowsEl.innerHTML = "";
       badges.innerHTML = "";
 


### PR DESCRIPTION
## Problem Statement

The badge generator page (`/badges/?u=<handle>&s=<skill>`) has been completely non-functional for all users since v4.3.8. When `renderRows()` runs, it references `namedSkills` — a variable never defined in its scope — causing a `ReferenceError` that silently kills the badge output. The page loads and the skill picker populates, but no badge markdown is ever rendered.

Closes #674

## Plan

1. `docs/badges/index.html` — add `namedSkills` to the `currentState` destructuring in `renderRows()` (line 1378), fixing the `ReferenceError: namedSkills is not defined` that prevents all badge output from rendering.

## Root Cause

Added in v3.28.0→v4.3.8: the feature that links skill badges to their `#explorer/<id>` page instead of the generic contributor profile required `namedSkills.find()` inside `renderRows()`. Every other function that uses `namedSkills` correctly pulls it from `currentState`; `renderRows()` was the sole exception.

---
_Generated by [Claude Code](https://claude.ai/code/session_019eq8zQzkRnJtvvrewcU9Ey)_