### PR TITLE
fix: CLI shows repo owner instead of current user as username

### DIFF
--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -293,25 +293,11 @@ _SKILL_CANDIDATES = [
 
 
 def _detect_github_username():
-    """Detect GitHub username from git remote URL, email, or display name."""
+    """Detect GitHub username from git email or display name."""
     import subprocess
     import re
 
-    # Most reliable: parse github.com/USERNAME from origin remote URL
-    try:
-        r = subprocess.run(
-            ["git", "remote", "get-url", "origin"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        if r.returncode == 0:
-            m = re.search(r"github\.com[:/]([^/]+?)(?:\.git)?(?:/|$)", r.stdout.strip())
-            if m:
-                return m.group(1)
-    except Exception:
-        pass
-    # Fallback: noreply GitHub email (e.g. 12345+username@users.noreply.github.com)
+    # Most reliable: noreply GitHub email (e.g. 12345+username@users.noreply.github.com)
     try:
         r = subprocess.run(
             ["git", "config", "user.email"], capture_output=True, text=True, timeout=5


### PR DESCRIPTION
## Summary

- `_detect_github_username()` was parsing the git remote origin URL (`github.com/mbtiongson1/gaia-skill-tree`) and returning the **repo owner** (`mbtiongson1`) as the detected username during `gaia init`
- This caused `gaia whoami`, scan output, and any display of the configured `gaiaUser` to show `mbtiongson1` for every user who cloned/forked the repo without explicitly passing `--user`
- Fix removes the remote URL detection step; username auto-detection now falls back to the user's own git email (noreply GitHub format) then `git user.name` slug

## Test plan

- [ ] `gaia init` without `--user` on a clone no longer sets username to the repo owner
- [ ] `gaia whoami` shows the correct user (from git email / user.name, or prompts if unknown)
- [ ] 54 tests in `test_cli_core.py` and `test_dx.py` pass (covering `_detect_github_username` usages)

https://claude.ai/code/session_0183nUTYAfztd1CiiZSBKzgf

---
_Generated by [Claude Code](https://claude.ai/code/session_0183nUTYAfztd1CiiZSBKzgf)_