### PR TITLE
fix(tree): show configured username instead of tree's stale userId

### DIFF
--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -293,25 +293,11 @@ _SKILL_CANDIDATES = [
 
 
 def _detect_github_username():
-    """Detect GitHub username from git remote URL, email, or display name."""
+    """Detect GitHub username from git email or display name."""
     import subprocess
     import re
 
-    # Most reliable: parse github.com/USERNAME from origin remote URL
-    try:
-        r = subprocess.run(
-            ["git", "remote", "get-url", "origin"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        if r.returncode == 0:
-            m = re.search(r"github\.com[:/]([^/]+?)(?:\.git)?(?:/|$)", r.stdout.strip())
-            if m:
-                return m.group(1)
-    except Exception:
-        pass
-    # Fallback: noreply GitHub email (e.g. 12345+username@users.noreply.github.com)
+    # Most reliable: noreply GitHub email (e.g. 12345+username@users.noreply.github.com)
     try:
         r = subprocess.run(
             ["git", "config", "user.email"], capture_output=True, text=True, timeout=5
@@ -1005,6 +991,7 @@ def render_user_tree_outputs(
             registry_path=registry_path,
             mode=mode,
             custom=custom,
+            username=username,
         )
     text = buf.getvalue()
 
@@ -1609,6 +1596,7 @@ def tree_command(args):
         canon=canon,
         custom=custom,
         known_only=known_only,
+        username=config.get("gaiaUser"),
     )
     try:
         detect_source_repo(config)

--- a/src/gaia_cli/treeManager.py
+++ b/src/gaia_cli/treeManager.py
@@ -436,13 +436,13 @@ def _render_subtree(skill_id, skill_map, display_ids, named_by_ref, local_by_ref
 
 # ─── public entry point ───────────────────────────────────────────────────────
 
-def show_tree(tree_data, graph_data=None, registry_path=".", mode="default", canon=False, custom=False, known_only=True):
+def show_tree(tree_data, graph_data=None, registry_path=".", mode="default", canon=False, custom=False, known_only=True, username=None):
     if not tree_data:
         print("No skill tree found.")
         return
 
     unlocked = tree_data.get("unlockedSkills", [])
-    username = tree_data.get("userId", "unknown")
+    username = username or tree_data.get("userId", "unknown")
 
     skill_map = {}
     if graph_data:


### PR DESCRIPTION
## Summary

Fixes the bug where `gaia tree` showed `mbtiongson1` instead of the collaborator's own username.

**Root causes (two, fixed together):**

- `show_tree()` read the username from `tree_data["userId"]` — the value frozen at init time. If a collaborator's tree was initialized with the wrong userId, `gaia tree` would always display that wrong name regardless of what's in config.
- `_detect_github_username()` parsed the git remote origin URL and returned the *repo owner* (`mbtiongson1`) as the username. Any collaborator who cloned the repo and ran `gaia init` without `--user` would get `mbtiongson1` stored as their `gaiaUser`.

**Changes:**

1. **`treeManager.py`** — `show_tree()` now accepts an explicit `username` parameter. When provided it takes precedence over `tree_data.get("userId")`, so the display always reflects the live config value.

2. **`main.py`** — Both `tree_command` and `render_user_tree_outputs` now pass `username=config.get("gaiaUser")` into `show_tree()`, ensuring the config is the source of truth for display.

3. **`main.py`** — Removed the git remote origin URL step from `_detect_github_username()`. The remote URL identifies the repo owner, not the current user. Detection now falls back to the user's own GitHub noreply email then `git user.name` slug.

## Test plan

- [ ] Collaborator clones repo, runs `gaia init` without `--user` → no longer initialized as `mbtiongson1`
- [ ] `gaia tree` shows the value from config (`gaiaUser`), even if the skill-tree.json has a stale/wrong `userId`
- [ ] 687 tests pass (excluding pre-existing env-broken packaging/TUI/path-command tests)

https://claude.ai/code/session_0183nUTYAfztd1CiiZSBKzgf

---
_Generated by [Claude Code](https://claude.ai/code/session_0183nUTYAfztd1CiiZSBKzgf)_