### PR TITLE
fix: gaia logout — honest revoke for the secret-less MVP

### DIFF
--- a/src/gaia_cli/auth.py
+++ b/src/gaia_cli/auth.py
@@ -294,23 +294,6 @@ def verify_repo_ownership(token: str, owner: str, repo: str) -> bool:
     return bool(perms.get("admin"))
 
 
-def revoke_token(client_id: str, token: str) -> bool:
-    """Best-effort revoke of an OAuth token (``DELETE /applications/.../token``).
-
-    Returns True on success, False if the call could not confirm revocation.
-    Never raises — logout should always clear local state even if revoke fails.
-    """
-    if not is_configured(client_id) or not token:
-        return False
-    try:
-        status, _ = http_request(
-            "DELETE",
-            f"{API_ROOT}/applications/{client_id}/token",
-            data={"access_token": token},
-        )
-        return status in (204, 200)
-    except Exception:
-        return False
 
 
 # ---------------------------------------------------------------------------

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -174,7 +174,7 @@ Share:
 Utilities:
   {_fg(*C2)}gaia whoami{_reset()}
   {_fg(*COLOR_LOCAL_USER)}gaia login{_reset()}                    Sign in with GitHub (device flow)
-  {_fg(*COLOR_GREY)}gaia logout{_reset()}                   Sign out and revoke the token
+  {_fg(*COLOR_GREY)}gaia logout{_reset()}                   Sign out of GitHub (clears the local token)
   {_fg(*C1)}gaia version{_reset()}
   {_fg(*C3)}gaia update{_reset()}
   {_fg(*HARNESS_COLORS["claude"])}gaia mcp{_reset()}
@@ -463,7 +463,13 @@ def login_command(args):
 
 
 def logout_command(args):
-    """Delete the stored GitHub token and best-effort revoke it (PRD #155)."""
+    """Sign out of GitHub by clearing the locally stored token (PRD #155).
+
+    The MVP stores no client secret, and GitHub's revocation endpoint
+    (DELETE /applications/{client_id}/token) requires client_id:client_secret
+    Basic auth — so a server-side revoke isn't possible here. We clear the
+    local token and point the user at GitHub's UI to fully revoke if they want.
+    """
     from gaia_cli import auth
 
     store = auth.TokenStore()
@@ -472,19 +478,20 @@ def logout_command(args):
         print("Not signed in — nothing to do.")
         return
 
-    revoked = False
-    if not getattr(args, "no_revoke", False) and creds.source != "env":
-        config = load_config() or {}
-        client_id = auth.resolve_client_id(config)
-        revoked = auth.revoke_token(client_id, creds.token)
-
     if creds.source == "env":
         print("Signed in via an environment token — unset it to fully sign out.")
 
     store.delete()
     handle = f" ({creds.login})" if creds.login else ""
-    revoke_note = "revoked + " if revoked else ""
-    print(f"✓ Signed out{handle}. Token {revoke_note}cleared locally.")
+    print(f"✓ Signed out{handle}. Local token cleared.")
+
+    config = load_config() or {}
+    client_id = auth.resolve_client_id(config)
+    if auth.is_configured(client_id):
+        print("  To fully revoke this authorization, visit:")
+        print(f"  https://github.com/settings/connections/applications/{client_id}")
+    else:
+        print("  To fully revoke: GitHub → Settings → Applications → Authorized OAuth Apps.")
 
 
 def reset_command(args):
@@ -3040,13 +3047,9 @@ def get_parser():
         action="store_true",
         help="Authenticate for this session only; do not persist the token",
     )
-    logout_parser = subparsers.add_parser(
-        "logout", help="Sign out of GitHub and revoke the stored token"
-    )
-    logout_parser.add_argument(
-        "--no-revoke",
-        action="store_true",
-        help="Delete the local token without calling GitHub to revoke it",
+    subparsers.add_parser(
+        "logout",
+        help="Sign out of GitHub (clears the local token; revoke in GitHub settings)",
     )
     reset_parser = subparsers.add_parser(
         "reset", help="Clear your skill tree and local state for a fresh start"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -6,12 +6,12 @@ command surface in `main.py`, with zero network and zero real sleeping:
   * client_id resolution + the "not configured" guard
   * `http_request` parsing (fake urlopen, incl. the HTTPError/4xx path)
   * the device flow: request_device_code, poll_for_token (pending/slow_down/
-    expired/denied/timeout/max_attempts), fetch_user, verify_repo_ownership,
-    revoke_token
+    expired/denied/timeout/max_attempts), fetch_user, verify_repo_ownership
   * TokenStore: file roundtrip + chmod, env override precedence, keyring backend
     (fake), delete semantics
   * command integration: login happy-path / unconfigured / denied / timed-out /
-    --no-store / --repo, logout (+revoke), and the whoami GitHub status line
+    --no-store / --repo, logout (clears locally, points to GitHub UI for revoke),
+    and the whoami GitHub status line
 
 Network is injected via `gaia_cli.auth.http_request`; tests monkeypatch it.
 Sleeping is injected into `poll_for_token`. Nothing here opens a socket.
@@ -39,6 +39,8 @@ from gaia_cli.auth import (
     Credentials,
     DeviceCode,
     TokenStore,
+    resolve_client_id,
+    is_configured,
 )
 
 
@@ -322,22 +324,6 @@ class TestIdentity:
         assert auth.verify_repo_ownership("tok", "x", "y") is False
 
 
-class TestRevoke:
-    def test_revoke_success(self, http):
-        http.route("DELETE", "/applications/", 204, {})
-        assert auth.revoke_token("real-id", "tok") is True
-
-    def test_revoke_unconfigured_noop(self, http):
-        assert auth.revoke_token(auth.PLACEHOLDER_CLIENT_ID, "tok") is False
-        assert http.calls == []
-
-    def test_revoke_swallows_errors(self, monkeypatch):
-        def boom(*a, **k):
-            raise RuntimeError("network down")
-        monkeypatch.setattr(auth, "http_request", boom)
-        assert auth.revoke_token("real-id", "tok") is False
-
-
 # ===========================================================================
 # TokenStore
 # ===========================================================================
@@ -524,35 +510,32 @@ class TestLoginCommand:
 class TestLogoutCommand:
     def test_not_signed_in(self, capsys):
         from gaia_cli.main import logout_command
-        logout_command(SimpleNamespace(no_revoke=False))
+        logout_command(SimpleNamespace())
         out, _ = _capture(capsys)
         assert "Not signed in" in out
 
-    def test_logout_revokes_and_clears(self, monkeypatch, capsys):
+    def test_logout_clears_and_points_to_revoke_url(self, monkeypatch, capsys):
         TokenStore().save(Credentials(token="T", login="marco"))
-        monkeypatch.setenv(auth.CLIENT_ID_ENV, "real-id")
-        revoked = {}
-        monkeypatch.setattr(auth, "revoke_token",
-                            lambda cid, tok: revoked.setdefault("hit", True) or True)
+        monkeypatch.setenv(auth.CLIENT_ID_ENV, "Ov23litFvQBfMkwbIxfg")
         from gaia_cli.main import logout_command
-        logout_command(SimpleNamespace(no_revoke=False))
+        logout_command(SimpleNamespace())
         out, _ = _capture(capsys)
         assert "Signed out (marco)" in out
-        assert "revoked" in out
-        assert revoked.get("hit") is True
+        assert "settings/connections/applications/Ov23litFvQBfMkwbIxfg" in out
+        assert "revoked" not in out.lower()
         assert TokenStore().load() is None
 
-    def test_logout_no_revoke(self, monkeypatch, capsys):
+    def test_logout_env_token_message(self, monkeypatch, capsys):
         TokenStore().save(Credentials(token="T", login="marco"))
-        called = {}
-        monkeypatch.setattr(auth, "revoke_token",
-                            lambda *a: called.setdefault("hit", True))
+        monkeypatch.setenv("GAIA_AUTH_TOKEN", "env-token")
+        monkeypatch.setenv(auth.CLIENT_ID_ENV, "Ov23litFvQBfMkwbIxfg")
         from gaia_cli.main import logout_command
-        logout_command(SimpleNamespace(no_revoke=True))
+        logout_command(SimpleNamespace())
         out, _ = _capture(capsys)
-        assert "Signed out" in out
-        assert "hit" not in called  # revoke skipped
-        assert TokenStore().load() is None
+        assert "environment token" in out
+        # Local file is cleared, but env token persists.
+        file_creds = TokenStore().load()
+        assert file_creds.source == "env"
 
 
 class TestWhoamiGitHubLine:
@@ -592,5 +575,5 @@ class TestParserWiring:
         parser, _ = get_parser()
         ns = parser.parse_args(["login", "--repo", "a/b", "--no-store"])
         assert ns.command == "login" and ns.repo == "a/b" and ns.no_store is True
-        ns2 = parser.parse_args(["logout", "--no-revoke"])
-        assert ns2.command == "logout" and ns2.no_revoke is True
+        ns2 = parser.parse_args(["logout"])
+        assert ns2.command == "logout"


### PR DESCRIPTION
## Summary

Make logout honest about server-side revocation limitations. The MVP stores no client secret, so GitHub's revocation endpoint (which requires `client_id:client_secret` Basic auth) is unreachable. Instead, we now:

- Clear the local token
- Point users to GitHub's UI for full revocation
- Remove the non-functional `revoke_token()` function
- Drop the misleading `--no-revoke` flag and "revokes via the API" claim
- Fix test suite false confidence (was asserting 204 from mocked endpoint)

## Changes

- **`src/gaia_cli/auth.py`**: Remove `revoke_token()` function (dead code against live API)
- **`src/gaia_cli/main.py`**: Rewrite `logout_command` to clear locally and point to GitHub UI; drop `--no-revoke` flag
- **`tests/test_auth.py`**: Remove `TestRevoke` tests; replace logout tests with honest assertions

## Acceptance Criteria

- ✅ All tests pass (809 total)
- ✅ `gaia logout` clears local token and prints GitHub revoke URL
- ✅ Help text no longer claims server-side revoke; `--no-revoke` flag removed
- ✅ No reference to `revoke_token` remains

Fixes #155

---
_Generated by [Claude Code](https://claude.ai/code/session_01KuGcsTxNzQmZyN9xfUBCnu)_