### PR TITLE
Update LICENSE badge and section to Apache 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ### How does ranking work? Read [META.md](META.md) for a comprehensive list
 
 [![Validate](https://github.com/mbtiongson1/gaia-skill-tree/actions/workflows/validate.yml/badge.svg)](https://github.com/mbtiongson1/gaia-skill-tree/actions/workflows/validate.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-c084fc.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Website](https://img.shields.io/badge/Website-gaia.tiongson.co-f59e0b)](https://gaia.tiongson.co/)
 
 # Name a skill, get a badge.
@@ -393,7 +393,7 @@ Full details: [PRIVACY.md](PRIVACY.md) · [gaia.tiongson.co/privacy.html](https:
 
 ## License
 
-MIT: see [LICENSE](LICENSE).
+Apache 2.0: see [LICENSE](LICENSE).
 
 ---
 


### PR DESCRIPTION
## Summary
- Updated license badge from MIT to Apache 2.0
- Changed license section documentation to reflect Apache 2.0

## Test plan
- [x] Badge displays correctly with Apache 2.0 label
- [x] License link still points to LICENSE file

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbABrFynwwcJnjN1ZVAPAb)_