### PR TITLE
feat(cli): grading pipeline — trust numbers, evidence types, Overall Trust Grade

### DIFF
--- a/docs/graph/named/index.json
+++ b/docs/graph/named/index.json
@@ -2332,7 +2332,11 @@
         ],
         "type": "ultimate",
         "installBody": "**Requirements:** [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Git](https://git-scm.com/), [Bun](https://bun.sh/) v1.0+, [Node.js](https://nodejs.org/) (Windows only)\n\n### Step 1: Install on your machine\n\nOpen Claude Code and paste this. Claude does the rest.\n\n> Install gstack: run **`git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup`** then add a \"gstack\" section to CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\\_\\_claude-in-chrome\\_\\_\\* tools, and lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /design-shotgun, /design-html, /review, /ship, /land-and-deploy, /canary, /benchmark, /browse, /connect-chrome, /qa, /qa-only, /design-review, /setup-browser-cookies, /setup-deploy, /setup-gbrain, /retro, /investigate, /document-release, /document-generate, /codex, /cso, /autoplan, /plan-devex-review, /devex-review, /careful, /freeze, /guard, /unfreeze, /gstack-upgrade, /learn. Then ask the user if they also want to add gstack to the current project so teammates get it.\n\n### Step 2: Team mode — auto-update for shared repos (recommended)\n\nFrom inside your repo, paste this. Switches you to team mode, bootstraps the repo so teammates get gstack automatically, and commits the change:\n\n```bash\n(cd ~/.claude/skills/gstack && ./setup --team) && ~/.claude/skills/gstack/bin/gstack-team-init required && git add .claude/ CLAUDE.md && git commit -m \"require gstack for AI-assisted work\"\n```bash\nNo vendored files in your repo, no version drift, no manual upgrades. Every Claude Code session starts with a fast auto-update check (throttled to once/hour, network-failure-safe, completely silent).\n\nSwap `required` for `optional` if you'd rather nudge teammates than block them.\n\n### OpenClaw\n\nOpenClaw spawns Claude Code sessions via ACP, so every gstack skill just works\nwhen Claude Code has gstack installed. Paste this to your OpenClaw agent:\n\n> Install gstack: run `git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup` to install gstack for Claude Code. Then add a \"Coding Tasks\" section to AGENTS.md that says: when spawning Claude Code sessions for coding work, tell the session to use gstack skills. Include these examples — security audit: \"Load gstack. Run /cso\", code review: \"Load gstack. Run /review\", QA test a URL: \"Load gstack. Run /qa https://...\", build a feature end-to-end: \"Load gstack. Run /autoplan, implement the plan, then run /ship\", plan before building: \"Load gstack. Run /office-hours then /autoplan. Save the plan, don't implement.\"\n\n**After setup, just talk to your OpenClaw agent naturally:**\n\n| You say | What happens |\n|---------|-------------|\n| \"Fix the typo in README\" | Simple — Claude Code session, no gstack needed |\n| \"Run a security audit on this repo\" | Spawns Claude Code with `Run /cso` |\n| \"Build me a notifications feature\" | Spawns Claude Code with /autoplan → implement → /ship |\n| \"Help me plan the v2 API redesign\" | Spawns Claude Code with /office-hours → /autoplan, saves plan |\n\nSee [docs/OPENCLAW.md](docs/OPENCLAW.md) for advanced dispatch routing and\nthe gstack-lite/gstack-full prompt templates.\n\n### Native OpenClaw Skills (via ClawHub)\n\nFour methodology skills that work directly in your OpenClaw agent, no Claude Code\nsession needed. Install from ClawHub:\n\n```\nclawhub install gstack-openclaw-office-hours gstack-openclaw-ceo-review gstack-openclaw-investigate gstack-openclaw-retro\n```bash\n| Skill | What it does |\n|-------|-------------|\n| `gstack-openclaw-office-hours` | Product interrogation with 6 forcing questions |\n| `gstack-openclaw-ceo-review` | Strategic challenge with 4 scope modes |\n| `gstack-openclaw-investigate` | Root cause debugging methodology |\n| `gstack-openclaw-retro` | Weekly engineering retrospective |\n\nThese are conversational skills. Your OpenClaw agent runs them directly via chat.\n\n### Other AI Agents\n\ngstack works on 10 AI coding agents, not just Claude. Setup auto-detects which\nagents you have installed:\n\n```bash\ngit clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/gstack\ncd ~/gstack && ./setup\n```\n\nOr target a specific agent with `./setup --host <name>`:\n\n| Agent | Flag | Skills install to |\n|-------|------|-------------------|\n| OpenAI Codex CLI | `--host codex` | `~/.codex/skills/gstack-*/` |\n| OpenCode | `--host opencode` | `~/.config/opencode/skills/gstack-*/` |\n| Cursor | `--host cursor` | `~/.cursor/skills/gstack-*/` |\n| Factory Droid | `--host factory` | `~/.factory/skills/gstack-*/` |\n| Slate | `--host slate` | `~/.slate/skills/gstack-*/` |\n| Kiro | `--host kiro` | `~/.kiro/skills/gstack-*/` |\n| Hermes | `--host hermes` | `~/.hermes/skills/gstack-*/` |\n| GBrain (mod) | `--host gbrain` | `~/.gbrain/skills/gstack-*/` |\n\n**Want to add support for another agent?** See [docs/ADDING_A_HOST.md](docs/ADDING_A_HOST.md).\nIt's one TypeScript config file, zero code changes.",
-        "role": "origin"
+        "role": "origin",
+        "ultimateGateStatus": {
+          "passes": false,
+          "reason": "only 0/3 components carry graded evidence"
+        }
       }
     ],
     "systematic-debugging": [
@@ -4209,7 +4213,11 @@
         ],
         "type": "ultimate",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
-        "role": "origin"
+        "role": "origin",
+        "ultimateGateStatus": {
+          "passes": false,
+          "reason": "only 0/3 components carry graded evidence"
+        }
       }
     ],
     "grill-me": [
@@ -4534,7 +4542,11 @@
         ],
         "type": "ultimate",
         "installBody": "Install the full Matt Pocock skills suite with:\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required.",
-        "role": "origin"
+        "role": "origin",
+        "ultimateGateStatus": {
+          "passes": false,
+          "reason": "only 0/3 components carry graded evidence"
+        }
       }
     ],
     "prd-generation": [
@@ -5582,7 +5594,11 @@
         ],
         "type": "ultimate",
         "installBody": "Installation differs by harness. If you use more than one, install Superpowers separately for each one.\n\n### Claude Code\n\nSuperpowers is available via the [official Claude plugin marketplace](https://claude.com/plugins/superpowers)\n\n#### Official Marketplace\n\n- Install the plugin from Anthropic's official marketplace:\n\n  ```bash\n  /plugin install superpowers@claude-plugins-official\n  ```\n\n#### Superpowers Marketplace\n\nThe Superpowers marketplace provides Superpowers and some other related plugins for Claude Code.\n\n- Register the marketplace:\n\n  ```bash\n  /plugin marketplace add obra/superpowers-marketplace\n  ```\n\n- Install the plugin from this marketplace:\n\n  ```bash\n  /plugin install superpowers@superpowers-marketplace\n  ```\n\n### Codex CLI\n\nSuperpowers is available via the [official Codex plugin marketplace](https://github.com/openai/plugins).\n\n- Open the plugin search interface:\n\n  ```bash\n  /plugins\n  ```\n\n- Search for Superpowers:\n\n  ```bash\n  superpowers\n  ```\n\n- Select `Install Plugin`.\n\n### Codex App\n\nSuperpowers is available via the [official Codex plugin marketplace](https://github.com/openai/plugins).\n\n- In the Codex app, click on Plugins in the sidebar.\n- You should see `Superpowers` in the Coding section.\n- Click the `+` next to Superpowers and follow the prompts.\n\n### Factory Droid\n\n- Register the marketplace:\n\n  ```bash\n  droid plugin marketplace add https://github.com/obra/superpowers\n  ```\n\n- Install the plugin:\n\n  ```bash\n  droid plugin install superpowers@superpowers\n  ```\n\n### Gemini CLI\n\n- Install the extension:\n\n  ```bash\n  gemini extensions install https://github.com/obra/superpowers\n  ```\n\n- Update later:\n\n  ```bash\n  gemini extensions update superpowers\n  ```\n\n### OpenCode\n\nOpenCode uses its own plugin install; install Superpowers separately even if you\nalready use it in another harness.\n\n- Tell OpenCode:\n\n  ```\n  Fetch and follow instructions from https://raw.githubusercontent.com/obra/superpowers/refs/heads/main/.opencode/INSTALL.md\n  ```\n\n- Detailed docs: [docs/README.opencode.md](docs/README.opencode.md)\n\n### Cursor\n\n- In Cursor Agent chat, install from marketplace:\n\n  ```bash\n  /add-plugin superpowers\n  ```\n\n- Or search for \"superpowers\" in the plugin marketplace.\n\n### GitHub Copilot CLI\n\n- Register the marketplace:\n\n  ```bash\n  copilot plugin marketplace add obra/superpowers-marketplace\n  ```\n\n- Install the plugin:\n\n  ```bash\n  copilot plugin install superpowers@superpowers-marketplace\n  ```",
-        "role": "origin"
+        "role": "origin",
+        "ultimateGateStatus": {
+          "passes": false,
+          "reason": "only 0/3 components carry graded evidence"
+        }
       }
     ],
     "using-git-worktrees": [
@@ -6061,7 +6077,11 @@
         ],
         "type": "ultimate",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
-        "role": "origin"
+        "role": "origin",
+        "ultimateGateStatus": {
+          "passes": false,
+          "reason": "only 0/3 components carry graded evidence"
+        }
       }
     ],
     "git-diff-risk-analysis": [
@@ -6901,7 +6921,11 @@
         ],
         "type": "ultimate",
         "installBody": "The quickest path to Ruflo:\n\n```bash\nnpx ruflo@latest init\n```\n\nThis launches an interactive wizard that detects your platform and configures\nthe full Ruflo loop (98 agents, 60+ commands, MCP server, hooks, and daemon).\nFor Claude Code plugin installs, Windows specifics, or the complete options\nreference, see the [full installation guide on GitHub](https://github.com/ruvnet/ruflo#installation).",
-        "role": "origin"
+        "role": "origin",
+        "ultimateGateStatus": {
+          "passes": false,
+          "reason": "only 0/3 components carry graded evidence"
+        }
       }
     ],
     "agentic-workflow-design": [

--- a/registry/named-skills.json
+++ b/registry/named-skills.json
@@ -2332,7 +2332,11 @@
         ],
         "type": "ultimate",
         "installBody": "**Requirements:** [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Git](https://git-scm.com/), [Bun](https://bun.sh/) v1.0+, [Node.js](https://nodejs.org/) (Windows only)\n\n### Step 1: Install on your machine\n\nOpen Claude Code and paste this. Claude does the rest.\n\n> Install gstack: run **`git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup`** then add a \"gstack\" section to CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\\_\\_claude-in-chrome\\_\\_\\* tools, and lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /design-shotgun, /design-html, /review, /ship, /land-and-deploy, /canary, /benchmark, /browse, /connect-chrome, /qa, /qa-only, /design-review, /setup-browser-cookies, /setup-deploy, /setup-gbrain, /retro, /investigate, /document-release, /document-generate, /codex, /cso, /autoplan, /plan-devex-review, /devex-review, /careful, /freeze, /guard, /unfreeze, /gstack-upgrade, /learn. Then ask the user if they also want to add gstack to the current project so teammates get it.\n\n### Step 2: Team mode — auto-update for shared repos (recommended)\n\nFrom inside your repo, paste this. Switches you to team mode, bootstraps the repo so teammates get gstack automatically, and commits the change:\n\n```bash\n(cd ~/.claude/skills/gstack && ./setup --team) && ~/.claude/skills/gstack/bin/gstack-team-init required && git add .claude/ CLAUDE.md && git commit -m \"require gstack for AI-assisted work\"\n```bash\nNo vendored files in your repo, no version drift, no manual upgrades. Every Claude Code session starts with a fast auto-update check (throttled to once/hour, network-failure-safe, completely silent).\n\nSwap `required` for `optional` if you'd rather nudge teammates than block them.\n\n### OpenClaw\n\nOpenClaw spawns Claude Code sessions via ACP, so every gstack skill just works\nwhen Claude Code has gstack installed. Paste this to your OpenClaw agent:\n\n> Install gstack: run `git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup` to install gstack for Claude Code. Then add a \"Coding Tasks\" section to AGENTS.md that says: when spawning Claude Code sessions for coding work, tell the session to use gstack skills. Include these examples — security audit: \"Load gstack. Run /cso\", code review: \"Load gstack. Run /review\", QA test a URL: \"Load gstack. Run /qa https://...\", build a feature end-to-end: \"Load gstack. Run /autoplan, implement the plan, then run /ship\", plan before building: \"Load gstack. Run /office-hours then /autoplan. Save the plan, don't implement.\"\n\n**After setup, just talk to your OpenClaw agent naturally:**\n\n| You say | What happens |\n|---------|-------------|\n| \"Fix the typo in README\" | Simple — Claude Code session, no gstack needed |\n| \"Run a security audit on this repo\" | Spawns Claude Code with `Run /cso` |\n| \"Build me a notifications feature\" | Spawns Claude Code with /autoplan → implement → /ship |\n| \"Help me plan the v2 API redesign\" | Spawns Claude Code with /office-hours → /autoplan, saves plan |\n\nSee [docs/OPENCLAW.md](docs/OPENCLAW.md) for advanced dispatch routing and\nthe gstack-lite/gstack-full prompt templates.\n\n### Native OpenClaw Skills (via ClawHub)\n\nFour methodology skills that work directly in your OpenClaw agent, no Claude Code\nsession needed. Install from ClawHub:\n\n```\nclawhub install gstack-openclaw-office-hours gstack-openclaw-ceo-review gstack-openclaw-investigate gstack-openclaw-retro\n```bash\n| Skill | What it does |\n|-------|-------------|\n| `gstack-openclaw-office-hours` | Product interrogation with 6 forcing questions |\n| `gstack-openclaw-ceo-review` | Strategic challenge with 4 scope modes |\n| `gstack-openclaw-investigate` | Root cause debugging methodology |\n| `gstack-openclaw-retro` | Weekly engineering retrospective |\n\nThese are conversational skills. Your OpenClaw agent runs them directly via chat.\n\n### Other AI Agents\n\ngstack works on 10 AI coding agents, not just Claude. Setup auto-detects which\nagents you have installed:\n\n```bash\ngit clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/gstack\ncd ~/gstack && ./setup\n```\n\nOr target a specific agent with `./setup --host <name>`:\n\n| Agent | Flag | Skills install to |\n|-------|------|-------------------|\n| OpenAI Codex CLI | `--host codex` | `~/.codex/skills/gstack-*/` |\n| OpenCode | `--host opencode` | `~/.config/opencode/skills/gstack-*/` |\n| Cursor | `--host cursor` | `~/.cursor/skills/gstack-*/` |\n| Factory Droid | `--host factory` | `~/.factory/skills/gstack-*/` |\n| Slate | `--host slate` | `~/.slate/skills/gstack-*/` |\n| Kiro | `--host kiro` | `~/.kiro/skills/gstack-*/` |\n| Hermes | `--host hermes` | `~/.hermes/skills/gstack-*/` |\n| GBrain (mod) | `--host gbrain` | `~/.gbrain/skills/gstack-*/` |\n\n**Want to add support for another agent?** See [docs/ADDING_A_HOST.md](docs/ADDING_A_HOST.md).\nIt's one TypeScript config file, zero code changes.",
-        "role": "origin"
+        "role": "origin",
+        "ultimateGateStatus": {
+          "passes": false,
+          "reason": "only 0/3 components carry graded evidence"
+        }
       }
     ],
     "systematic-debugging": [
@@ -4209,7 +4213,11 @@
         ],
         "type": "ultimate",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
-        "role": "origin"
+        "role": "origin",
+        "ultimateGateStatus": {
+          "passes": false,
+          "reason": "only 0/3 components carry graded evidence"
+        }
       }
     ],
     "grill-me": [
@@ -4534,7 +4542,11 @@
         ],
         "type": "ultimate",
         "installBody": "Install the full Matt Pocock skills suite with:\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required.",
-        "role": "origin"
+        "role": "origin",
+        "ultimateGateStatus": {
+          "passes": false,
+          "reason": "only 0/3 components carry graded evidence"
+        }
       }
     ],
     "prd-generation": [
@@ -5582,7 +5594,11 @@
         ],
         "type": "ultimate",
         "installBody": "Installation differs by harness. If you use more than one, install Superpowers separately for each one.\n\n### Claude Code\n\nSuperpowers is available via the [official Claude plugin marketplace](https://claude.com/plugins/superpowers)\n\n#### Official Marketplace\n\n- Install the plugin from Anthropic's official marketplace:\n\n  ```bash\n  /plugin install superpowers@claude-plugins-official\n  ```\n\n#### Superpowers Marketplace\n\nThe Superpowers marketplace provides Superpowers and some other related plugins for Claude Code.\n\n- Register the marketplace:\n\n  ```bash\n  /plugin marketplace add obra/superpowers-marketplace\n  ```\n\n- Install the plugin from this marketplace:\n\n  ```bash\n  /plugin install superpowers@superpowers-marketplace\n  ```\n\n### Codex CLI\n\nSuperpowers is available via the [official Codex plugin marketplace](https://github.com/openai/plugins).\n\n- Open the plugin search interface:\n\n  ```bash\n  /plugins\n  ```\n\n- Search for Superpowers:\n\n  ```bash\n  superpowers\n  ```\n\n- Select `Install Plugin`.\n\n### Codex App\n\nSuperpowers is available via the [official Codex plugin marketplace](https://github.com/openai/plugins).\n\n- In the Codex app, click on Plugins in the sidebar.\n- You should see `Superpowers` in the Coding section.\n- Click the `+` next to Superpowers and follow the prompts.\n\n### Factory Droid\n\n- Register the marketplace:\n\n  ```bash\n  droid plugin marketplace add https://github.com/obra/superpowers\n  ```\n\n- Install the plugin:\n\n  ```bash\n  droid plugin install superpowers@superpowers\n  ```\n\n### Gemini CLI\n\n- Install the extension:\n\n  ```bash\n  gemini extensions install https://github.com/obra/superpowers\n  ```\n\n- Update later:\n\n  ```bash\n  gemini extensions update superpowers\n  ```\n\n### OpenCode\n\nOpenCode uses its own plugin install; install Superpowers separately even if you\nalready use it in another harness.\n\n- Tell OpenCode:\n\n  ```\n  Fetch and follow instructions from https://raw.githubusercontent.com/obra/superpowers/refs/heads/main/.opencode/INSTALL.md\n  ```\n\n- Detailed docs: [docs/README.opencode.md](docs/README.opencode.md)\n\n### Cursor\n\n- In Cursor Agent chat, install from marketplace:\n\n  ```bash\n  /add-plugin superpowers\n  ```\n\n- Or search for \"superpowers\" in the plugin marketplace.\n\n### GitHub Copilot CLI\n\n- Register the marketplace:\n\n  ```bash\n  copilot plugin marketplace add obra/superpowers-marketplace\n  ```\n\n- Install the plugin:\n\n  ```bash\n  copilot plugin install superpowers@superpowers-marketplace\n  ```",
-        "role": "origin"
+        "role": "origin",
+        "ultimateGateStatus": {
+          "passes": false,
+          "reason": "only 0/3 components carry graded evidence"
+        }
       }
     ],
     "using-git-worktrees": [
@@ -6061,7 +6077,11 @@
         ],
         "type": "ultimate",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
-        "role": "origin"
+        "role": "origin",
+        "ultimateGateStatus": {
+          "passes": false,
+          "reason": "only 0/3 components carry graded evidence"
+        }
       }
     ],
     "git-diff-risk-analysis": [
@@ -6901,7 +6921,11 @@
         ],
         "type": "ultimate",
         "installBody": "The quickest path to Ruflo:\n\n```bash\nnpx ruflo@latest init\n```\n\nThis launches an interactive wizard that detects your platform and configures\nthe full Ruflo loop (98 agents, 60+ commands, MCP server, hooks, and daemon).\nFor Claude Code plugin installs, Windows specifics, or the complete options\nreference, see the [full installation guide on GitHub](https://github.com/ruvnet/ruflo#installation).",
-        "role": "origin"
+        "role": "origin",
+        "ultimateGateStatus": {
+          "passes": false,
+          "reason": "only 0/3 components carry graded evidence"
+        }
       }
     ],
     "agentic-workflow-design": [

--- a/scripts/generateNamedIndex.py
+++ b/scripts/generateNamedIndex.py
@@ -397,8 +397,36 @@ def validate_and_group(named_skills, graph_data, skill_to_suite=None, suite_to_c
     return errors, buckets, awaiting_classification, by_contributor
 
 
-def write_index(buckets, awaiting_classification, by_contributor, output_path, today):
+def _inject_trust_grades(buckets, generic_skills_map, gate_config):
+    """Annotate each named-skill bucket entry with overallTrustGrade.
+
+    For ultimate-type entries, also compute ultimateGateStatus (based on their
+    suiteComponents if present, else their direct evidence).
+    Mutates entries in-place; no fields are stored in registry nodes.
+    """
+    from gaia_cli.grading import overall_trust_grade, check_ultimate_gate
+
+    for _ref, entries in buckets.items():
+        for entry in entries:
+            ev = entry.get("evidence") or []
+            grade = overall_trust_grade(ev)
+            if grade is not None:
+                entry["overallTrustGrade"] = grade
+
+            if entry.get("type") == "ultimate":
+                gate = check_ultimate_gate(entry, generic_skills_map, gate_config)
+                entry["ultimateGateStatus"] = {
+                    "passes": gate["passes"],
+                    "reason": gate["reason"],
+                }
+
+
+def write_index(buckets, awaiting_classification, by_contributor, output_path, today,
+                generic_skills_map=None, gate_config=None):
     """Write the named skill index JSON file."""
+    if generic_skills_map is not None:
+        _inject_trust_grades(buckets, generic_skills_map, gate_config or {})
+
     index = {
         "generatedAt": today,
         "buckets": buckets,
@@ -470,7 +498,19 @@ def main():
             print(f"  {i}. {err}")
         sys.exit(1)
 
-    write_index(buckets, awaiting_classification, by_contributor, output_path, today)
+    # Build generic skills map for trust grade injection
+    generic_skills_map = {s["id"]: s for s in graph_data.get("skills", [])}
+
+    # Load ultimate gate config from meta.json
+    try:
+        meta_path = os.path.join(repo_root, "registry", "schema", "meta.json")
+        with open(meta_path, "r", encoding="utf-8") as f:
+            gate_config = json.load(f).get("evidence", {}).get("ultimateGate", {})
+    except Exception:
+        gate_config = {}
+
+    write_index(buckets, awaiting_classification, by_contributor, output_path, today,
+                generic_skills_map=generic_skills_map, gate_config=gate_config)
     total_named = sum(len(v) for v in buckets.values())
     total_awaiting = len(awaiting_classification)
     print(f"\nWrote {output_path}")

--- a/scripts/syncDocsGraphAssets.py
+++ b/scripts/syncDocsGraphAssets.py
@@ -75,23 +75,50 @@ def sync_docs_graph_assets(root: Path = ROOT) -> None:
         if committed_src.exists():
             layout_nodes = json.loads(committed_src.read_text(encoding="utf-8")).get("nodes", {})
 
+    # Load ultimate gate config for trust grade injection
+    _gate_config: dict = {}
+    _meta_path = root / "registry" / "schema" / "meta.json"
+    if _meta_path.exists():
+        try:
+            _gate_config = json.loads(_meta_path.read_text(encoding="utf-8")).get("evidence", {}).get("ultimateGate", {})
+        except Exception:
+            pass
+
     for rel in required:
         src = root / rel
         dst = docs_graph / src.name
-        if src.name == "gaia.json" and layout_nodes:
+        if src.name == "gaia.json":
             # Enrich the docs copy with per-skill cluster/positions from the
             # generated layout artifact. registry/gaia.json stays schema-clean.
             gaia_data = json.loads(src.read_text(encoding="utf-8"))
             # Generic refs are rank-less — the web graph's rank legend reads the
             # top named-variant star (namedMaxLevel) instead of a generic level.
             named_max = _named_max_levels(root)
-            for skill in gaia_data.get("skills", []):
+            skills_list = gaia_data.get("skills", [])
+            generic_skills_map = {s.get("id"): s for s in skills_list}
+
+            # Import grading functions for Overall Trust Grade injection
+            sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+            from gaia_cli.grading import overall_trust_grade, check_ultimate_gate  # noqa: E402
+
+            for skill in skills_list:
                 sid = skill.get("id")
-                if sid in layout_nodes:
+                if layout_nodes and sid in layout_nodes:
                     skill["cluster"] = layout_nodes[sid]["cluster"]
                     skill["positions"] = layout_nodes[sid]["positions"]
                 if sid in named_max:
                     skill["namedMaxLevel"] = named_max[sid]
+                # Inject overall trust grade (computed, not stored in nodes)
+                grade = overall_trust_grade(skill.get("evidence") or [])
+                if grade is not None:
+                    skill["overallTrustGrade"] = grade
+                # Inject ultimate gate status for ultimate-type skills
+                if skill.get("type") == "ultimate":
+                    gate = check_ultimate_gate(skill, generic_skills_map, _gate_config)
+                    skill["ultimateGateStatus"] = {
+                        "passes": gate["passes"],
+                        "reason": gate["reason"],
+                    }
             dst.write_text(json.dumps(gaia_data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
             print(f"Synced+enriched {src.relative_to(root)} -> {dst.relative_to(root)}")
         else:

--- a/src/gaia_cli/commands/dev.py
+++ b/src/gaia_cli/commands/dev.py
@@ -1001,15 +1001,56 @@ def meta_evidence_command(args):
     evidence that every named implementation inherits. A ``contributor/skill``
     id targets that specific named implementation (e.g. its GitHub repo demo).
     """
+    from gaia_cli.grading import derive_grade, load_grade_thresholds, load_evidence_types
+
     registry_path = args.registry
     skill_id = args.skill_id.lstrip("/")
 
-    evidence = {
-        "class": getattr(args, "evidence_class", "C"),
+    # --class is deprecated; --trust + --type are the new interface.
+    evidence_class = getattr(args, "evidence_class", None)
+    trust_number = getattr(args, "trust", None)
+    evidence_type = getattr(args, "evidence_type", None)
+
+    if evidence_class is not None:
+        print(
+            "Warning: --class is deprecated and will be removed in the next major release. "
+            "Use --trust <0-100> to set a trust number (grade is auto-derived) "
+            "and --type <type> to specify the evidence type.",
+            file=sys.stderr,
+        )
+
+    # Validate --type against meta.json evidence.types
+    if evidence_type is not None:
+        valid_types = load_evidence_types(registry_path)
+        if evidence_type not in valid_types:
+            print(
+                f"Error: unknown evidence type '{evidence_type}'. "
+                f"Valid types: {', '.join(valid_types)}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    # Derive grade from trust number
+    derived_grade: str | None = None
+    if trust_number is not None:
+        thresholds = load_grade_thresholds(registry_path)
+        derived_grade = derive_grade(trust_number, thresholds)
+
+    evidence: dict = {
         "source": args.source,
         "evaluator": getattr(args, "evaluator", None) or _get_contributor(),
         "date": getattr(args, "date", None) or datetime.date.today().isoformat(),
     }
+    # Write new fields
+    if evidence_type is not None:
+        evidence["type"] = evidence_type
+    if trust_number is not None:
+        evidence["trustNumber"] = trust_number
+    if derived_grade is not None:
+        evidence["grade"] = derived_grade
+    # Legacy field: only written when explicitly passed
+    if evidence_class is not None:
+        evidence["class"] = evidence_class
     if getattr(args, "notes", None):
         evidence["notes"] = args.notes
 
@@ -1049,14 +1090,30 @@ def meta_evidence_command(args):
             json.dump(data, f, indent=2, ensure_ascii=False)
             f.write("\n")
 
-    print(f"Added evidence to skill: {skill_id}")
+    grade_label = derived_grade if derived_grade else "ungraded"
+    type_label = f" [{evidence_type}]" if evidence_type else ""
+    print(f"Added evidence to skill: {skill_id}{type_label} (grade: {grade_label})")
+
+    contributor = _get_contributor()
     append_skill_event(
         skill_id,
         "evidence_added",
-        _get_contributor(),
-        f"Added {evidence['class']} evidence from {evidence['source']}",
+        contributor,
+        f"Added evidence from {evidence['source']}"
+        + (f" (type: {evidence_type})" if evidence_type else ""),
         registry_path=registry_path,
     )
+
+    # Fire evidence_graded event whenever a grade was derived from a trust number
+    if derived_grade is not None:
+        append_skill_event(
+            skill_id,
+            "evidence_graded",
+            contributor,
+            f"Graded evidence from {evidence['source']} as {derived_grade} "
+            f"(trustNumber: {trust_number})",
+            registry_path=registry_path,
+        )
 
     if not getattr(args, "no_build", False):
         print("Regenerating registry and documentation...")

--- a/src/gaia_cli/formatting.py
+++ b/src/gaia_cli/formatting.py
@@ -143,6 +143,15 @@ TIER_COLORS, RANK_COLORS = _load_palette_from_registry()
 
 TYPE_SYMBOLS = {"basic": "○", "extra": "◇", "unique": "◉", "ultimate": "◆"}
 
+# Evidence Grade colors — single source of truth for grade design tokens.
+# Platinum (S) / Gold (A) / Silver (B) / Bronze (C)
+GRADE_COLORS: dict[str, tuple[int, int, int]] = {
+    "S": (226, 232, 240),   # Platinum — #e2e8f0
+    "A": (251, 191, 36),    # Gold     — #fbbf24
+    "B": (148, 163, 184),   # Silver   — #94a3b8
+    "C": (180, 83, 9),      # Bronze   — #b45309
+}
+
 COLOR_CONTRIBUTOR = (239, 68, 68)      # #ef4444 -- red for named contributors
 COLOR_LOCAL_USER  = (134, 239, 172)    # #86efac -- bright green for local/user skills
 COLOR_GREY        = (148, 163, 184)    # #94a3b8 -- slate grey for dev commands
@@ -294,3 +303,9 @@ def fusion_equation(prereqs: list[str], result: str, result_glyph: str = "◇") 
     """Plain text fusion equation: /a + /b -> /result glyph"""
     parts = " + ".join(f"/{p}" for p in prereqs)
     return f"{parts} → /{result} {result_glyph}"
+
+
+def format_grade_colored(grade: str) -> str:
+    """Return colored Evidence Grade badge: e.g. \033[...]S\033[0m."""
+    color = GRADE_COLORS.get(grade, COLOR_GREY)
+    return f"{_fg(*color)}{grade}{_reset()}"

--- a/src/gaia_cli/grading.py
+++ b/src/gaia_cli/grading.py
@@ -1,0 +1,199 @@
+"""Grade derivation and trust aggregation for the evidence grading pipeline.
+
+Implements the trust-number → letter-grade mapping defined in registry/schema/meta.json
+evidence.gradeThresholds, and the Overall Trust Grade aggregation / ultimate gate logic.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+_GRADE_ORDER = ["S", "A", "B", "C"]
+_DEFAULT_THRESHOLDS = {"S": 90, "A": 80, "B": 60, "C": 40}
+_DEFAULT_ULTIMATE_GATE = {
+    "minEvidencedComponents": 3,
+    "requiredComponentGrades": {"S": 1, "A": 2},
+    "componentFloor": "C",
+}
+
+
+def _load_meta_evidence(registry_path=".") -> dict:
+    meta_path = os.path.join(registry_path, "registry", "schema", "meta.json")
+    try:
+        with open(meta_path, "r", encoding="utf-8") as f:
+            return json.load(f).get("evidence", {})
+    except Exception:
+        return {}
+
+
+def load_grade_thresholds(registry_path=".") -> dict:
+    """Return grade thresholds from meta.json, falling back to defaults."""
+    return _load_meta_evidence(registry_path).get("gradeThresholds", _DEFAULT_THRESHOLDS)
+
+
+def load_ultimate_gate(registry_path=".") -> dict:
+    """Return ultimate gate config from meta.json, falling back to defaults."""
+    return _load_meta_evidence(registry_path).get("ultimateGate", _DEFAULT_ULTIMATE_GATE)
+
+
+def load_evidence_types(registry_path=".") -> list[str]:
+    """Return valid evidence types from meta.json."""
+    return _load_meta_evidence(registry_path).get("types", ["arxiv", "repo", "github-stars"])
+
+
+def derive_grade(trust_number: float | int, thresholds: dict | None = None) -> str | None:
+    """Map a trust number to a grade letter (S/A/B/C) or None (ungraded).
+
+    Thresholds are inclusive lower bounds:
+      S ≥ 90, A ≥ 80, B ≥ 60, C ≥ 40, < 40 → None (ungraded).
+    """
+    if thresholds is None:
+        thresholds = _DEFAULT_THRESHOLDS
+    t = float(trust_number)
+    for grade in _GRADE_ORDER:
+        if t >= thresholds.get(grade, _DEFAULT_THRESHOLDS[grade]):
+            return grade
+    return None
+
+
+def overall_trust_grade(evidence_list: list) -> str | None:
+    """Return the highest Evidence Grade across all graded entries.
+
+    Only entries with a ``grade`` field that is one of S/A/B/C count.
+    Ungraded entries (grade=None or missing) are ignored.
+    Returns None if no graded entries exist.
+    """
+    best: str | None = None
+    for entry in evidence_list or []:
+        g = entry.get("grade")
+        if g not in _GRADE_ORDER:
+            continue
+        if best is None or _GRADE_ORDER.index(g) < _GRADE_ORDER.index(best):
+            best = g
+    return best
+
+
+def _component_grade(skill: dict) -> str | None:
+    """Highest grade among a component skill's evidence entries."""
+    return overall_trust_grade(skill.get("evidence") or [])
+
+
+def check_ultimate_gate(
+    skill: dict,
+    generic_skills_map: dict,
+    gate_config: dict | None = None,
+) -> dict:
+    """Evaluate the ultimate gate for a skill.
+
+    For suite ultimates (has ``suiteComponents``): pillar rule from gate_config.
+    For non-suite ultimates: direct-evidence equivalent (≥3 sources, ≥1 S, ≥2 A).
+
+    Args:
+        skill: The skill dict (from gaia.json or a node file).
+        generic_skills_map: {skill_id: skill_dict} for looking up component evidence.
+        gate_config: From meta.json.evidence.ultimateGate; uses defaults if None.
+
+    Returns dict with keys: passes (bool), reason (str), details (dict).
+    """
+    if gate_config is None:
+        gate_config = _DEFAULT_ULTIMATE_GATE
+
+    floor = gate_config.get("componentFloor", "C")
+    floor_idx = _GRADE_ORDER.index(floor) if floor in _GRADE_ORDER else len(_GRADE_ORDER) - 1
+    min_evidenced = gate_config.get("minEvidencedComponents", 3)
+    required_grades: dict = gate_config.get("requiredComponentGrades", {"S": 1, "A": 2})
+
+    components = skill.get("suiteComponents") or []
+
+    if components:
+        # Suite ultimate: check component grades
+        evidenced_components = []
+        for cid in components:
+            comp = generic_skills_map.get(cid)
+            if comp is None:
+                continue
+            g = _component_grade(comp)
+            if g is not None:
+                evidenced_components.append((cid, g))
+
+        details: dict = {
+            "mode": "suite",
+            "evidencedComponents": len(evidenced_components),
+            "minEvidencedComponents": min_evidenced,
+            "gradeCounts": {},
+            "componentFloor": floor,
+        }
+
+        if len(evidenced_components) < min_evidenced:
+            return {
+                "passes": False,
+                "reason": f"only {len(evidenced_components)}/{min_evidenced} components carry graded evidence",
+                "details": details,
+            }
+
+        # Check floor — none may be below C
+        below_floor = [(cid, g) for cid, g in evidenced_components if _GRADE_ORDER.index(g) > floor_idx]
+        if below_floor:
+            details["belowFloor"] = [cid for cid, _ in below_floor]
+            return {
+                "passes": False,
+                "reason": f"component(s) below floor {floor}: {[cid for cid, _ in below_floor]}",
+                "details": details,
+            }
+
+        grade_counts: dict[str, int] = {}
+        for _, g in evidenced_components:
+            grade_counts[g] = grade_counts.get(g, 0) + 1
+        details["gradeCounts"] = grade_counts
+
+        for req_grade, req_count in required_grades.items():
+            actual = sum(
+                cnt for g, cnt in grade_counts.items()
+                if g in _GRADE_ORDER and _GRADE_ORDER.index(g) <= _GRADE_ORDER.index(req_grade)
+            )
+            if actual < req_count:
+                return {
+                    "passes": False,
+                    "reason": f"need ≥{req_count} component(s) graded {req_grade}+, have {actual}",
+                    "details": details,
+                }
+
+        return {"passes": True, "reason": "all pillars satisfied", "details": details}
+
+    else:
+        # Non-suite ultimate: direct evidence equivalent
+        evidence = skill.get("evidence") or []
+        graded = [e for e in evidence if e.get("grade") in _GRADE_ORDER]
+        details = {
+            "mode": "direct",
+            "gradedSources": len(graded),
+            "minSources": min_evidenced,
+        }
+
+        if len(graded) < min_evidenced:
+            return {
+                "passes": False,
+                "reason": f"only {len(graded)}/{min_evidenced} graded evidence sources",
+                "details": details,
+            }
+
+        grade_counts = {}
+        for e in graded:
+            g = e["grade"]
+            grade_counts[g] = grade_counts.get(g, 0) + 1
+        details["gradeCounts"] = grade_counts
+
+        for req_grade, req_count in required_grades.items():
+            actual = sum(
+                cnt for g, cnt in grade_counts.items()
+                if g in _GRADE_ORDER and _GRADE_ORDER.index(g) <= _GRADE_ORDER.index(req_grade)
+            )
+            if actual < req_count:
+                return {
+                    "passes": False,
+                    "reason": f"need ≥{req_count} graded source(s) at {req_grade}+, have {actual}",
+                    "details": details,
+                }
+
+        return {"passes": True, "reason": "direct evidence gate satisfied", "details": details}

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -3454,11 +3454,23 @@ def get_parser():
     dev_evidence.add_argument("skill_id", help="Skill ID to add evidence to")
     dev_evidence.add_argument("source", help="URL to the evidence source")
     dev_evidence.add_argument(
+        "--type",
+        dest="evidence_type",
+        metavar="TYPE",
+        help="Evidence type (e.g. arxiv, repo, github-stars). Validated against meta.json evidence.types.",
+    )
+    dev_evidence.add_argument(
+        "--trust",
+        type=float,
+        metavar="NUMBER",
+        help="Trust number 0-100. Grade is auto-derived: S≥90, A≥80, B≥60, C≥40; <40=ungraded.",
+    )
+    dev_evidence.add_argument(
         "--class",
         dest="evidence_class",
         choices=("A", "B", "C"),
-        default="C",
-        help="Evidence class (default: C)",
+        default=None,
+        help="[DEPRECATED] Use --trust instead. Evidence class (A/B/C).",
     )
     dev_evidence.add_argument("--evaluator", help="GitHub username of the evaluator")
     dev_evidence.add_argument("--date", help="Date of evaluation (ISO 8601)")

--- a/tests/test_grading.py
+++ b/tests/test_grading.py
@@ -1,0 +1,418 @@
+"""Tests for the grading pipeline — grade derivation, type validation, gate logic."""
+
+from __future__ import annotations
+
+import json
+import sys
+import pytest
+from pathlib import Path
+from gaia_cli.grading import (
+    derive_grade,
+    overall_trust_grade,
+    check_ultimate_gate,
+    load_evidence_types,
+    load_grade_thresholds,
+    load_ultimate_gate,
+)
+
+# ---------------------------------------------------------------------------
+# Grade derivation — boundary cases
+# ---------------------------------------------------------------------------
+
+class TestDeriveGrade:
+    def test_below_floor_is_ungraded(self):
+        assert derive_grade(39) is None
+
+    def test_c_floor(self):
+        assert derive_grade(40) == "C"
+
+    def test_c_interior(self):
+        assert derive_grade(59) == "C"
+
+    def test_b_floor(self):
+        assert derive_grade(60) == "B"
+
+    def test_b_interior(self):
+        assert derive_grade(79) == "B"
+
+    def test_a_floor(self):
+        assert derive_grade(80) == "A"
+
+    def test_a_interior(self):
+        assert derive_grade(89) == "A"
+
+    def test_s_floor(self):
+        assert derive_grade(90) == "S"
+
+    def test_s_above(self):
+        assert derive_grade(100) == "S"
+
+    def test_zero_is_ungraded(self):
+        assert derive_grade(0) is None
+
+    def test_float_trust(self):
+        assert derive_grade(80.0) == "A"
+        assert derive_grade(39.9) is None
+        assert derive_grade(40.0) == "C"
+
+    def test_custom_thresholds(self):
+        thresholds = {"S": 95, "A": 85, "B": 70, "C": 50}
+        assert derive_grade(94, thresholds) == "A"
+        assert derive_grade(95, thresholds) == "S"
+        assert derive_grade(49, thresholds) is None
+        assert derive_grade(50, thresholds) == "C"
+
+
+# ---------------------------------------------------------------------------
+# Overall Trust Grade aggregation
+# ---------------------------------------------------------------------------
+
+class TestOverallTrustGrade:
+    def test_empty_evidence(self):
+        assert overall_trust_grade([]) is None
+
+    def test_no_graded_entries(self):
+        ev = [{"class": "A", "source": "http://x"}, {"source": "http://y"}]
+        assert overall_trust_grade(ev) is None
+
+    def test_single_s_grade(self):
+        ev = [{"grade": "S", "source": "http://x"}]
+        assert overall_trust_grade(ev) == "S"
+
+    def test_highest_wins(self):
+        ev = [
+            {"grade": "C", "source": "http://x"},
+            {"grade": "A", "source": "http://y"},
+            {"grade": "B", "source": "http://z"},
+        ]
+        assert overall_trust_grade(ev) == "A"
+
+    def test_ungraded_entry_ignored(self):
+        ev = [
+            {"source": "http://x"},           # no grade key
+            {"grade": "B", "source": "http://y"},
+        ]
+        assert overall_trust_grade(ev) == "B"
+
+    def test_none_evidence_list(self):
+        assert overall_trust_grade(None) is None
+
+    def test_mixed_graded_ungraded(self):
+        ev = [
+            {"grade": "C", "source": "http://a"},
+            {"grade": None, "source": "http://b"},   # explicitly None
+            {"grade": "A", "source": "http://c"},
+        ]
+        assert overall_trust_grade(ev) == "A"
+
+
+# ---------------------------------------------------------------------------
+# Type validation — integration with meta.json
+# ---------------------------------------------------------------------------
+
+class TestEvidenceTypes:
+    def test_valid_types_from_meta(self):
+        # The real meta.json should have arxiv, repo, github-stars
+        types = load_evidence_types(".")
+        assert "arxiv" in types
+        assert "repo" in types
+        assert "github-stars" in types
+
+    def test_invalid_type_detection(self):
+        types = load_evidence_types(".")
+        assert "stars" not in types          # wrong alias
+        assert "GitHub-Stars" not in types   # wrong case
+
+
+# ---------------------------------------------------------------------------
+# Ungraded doesn't gate — ungraded entries must not satisfy the ultimate gate
+# ---------------------------------------------------------------------------
+
+class TestUngradedDoesNotGate:
+    def _skill_with_ungraded_evidence(self):
+        # trust < 40 → ungraded, so grade is absent/None
+        return {
+            "id": "my-ultimate",
+            "type": "ultimate",
+            "evidence": [
+                {"source": "http://a"},           # no grade
+                {"source": "http://b"},
+                {"source": "http://c"},
+            ],
+        }
+
+    def test_ungraded_evidence_fails_gate(self):
+        skill = self._skill_with_ungraded_evidence()
+        result = check_ultimate_gate(skill, {})
+        assert result["passes"] is False
+
+    def test_grade_none_ignored_in_gate(self):
+        skill = {
+            "id": "my-ultimate",
+            "type": "ultimate",
+            "evidence": [
+                {"grade": None, "source": "http://a"},
+                {"grade": None, "source": "http://b"},
+                {"grade": None, "source": "http://c"},
+            ],
+        }
+        result = check_ultimate_gate(skill, {})
+        assert result["passes"] is False
+
+
+# ---------------------------------------------------------------------------
+# Ultimate gate — pillar rule (suite) and direct-evidence path
+# ---------------------------------------------------------------------------
+
+def _make_component(skill_id, grade):
+    ev = [{"grade": grade, "source": f"http://{skill_id}"}] if grade else []
+    return {"id": skill_id, "type": "basic", "evidence": ev}
+
+
+GATE_CONFIG = {
+    "minEvidencedComponents": 3,
+    "requiredComponentGrades": {"S": 1, "A": 2},
+    "componentFloor": "C",
+}
+
+
+class TestUltimateGateSuite:
+    def _suite_skill(self, components):
+        return {
+            "id": "big-ultimate",
+            "type": "ultimate",
+            "suiteComponents": list(components.keys()),
+        }
+
+    def test_passes_with_s_and_two_a(self):
+        comps = {
+            "c1": _make_component("c1", "S"),
+            "c2": _make_component("c2", "A"),
+            "c3": _make_component("c3", "A"),
+        }
+        skill = self._suite_skill(comps)
+        result = check_ultimate_gate(skill, comps, GATE_CONFIG)
+        assert result["passes"] is True
+
+    def test_fails_not_enough_components(self):
+        comps = {
+            "c1": _make_component("c1", "S"),
+            "c2": _make_component("c2", "A"),
+        }
+        skill = self._suite_skill(comps)
+        result = check_ultimate_gate(skill, comps, GATE_CONFIG)
+        assert result["passes"] is False
+        assert "2/3" in result["reason"]
+
+    def test_fails_missing_s(self):
+        comps = {
+            "c1": _make_component("c1", "A"),
+            "c2": _make_component("c2", "A"),
+            "c3": _make_component("c3", "A"),
+        }
+        skill = self._suite_skill(comps)
+        result = check_ultimate_gate(skill, comps, GATE_CONFIG)
+        assert result["passes"] is False
+        assert "S" in result["reason"]
+
+    def test_fails_missing_second_a(self):
+        # S + B + B: only S counts as A+, so A+ count = 1 < 2. Fails A req.
+        comps = {
+            "c1": _make_component("c1", "S"),
+            "c2": _make_component("c2", "B"),
+            "c3": _make_component("c3", "B"),
+        }
+        skill = self._suite_skill(comps)
+        result = check_ultimate_gate(skill, comps, GATE_CONFIG)
+        assert result["passes"] is False
+        assert "A" in result["reason"]
+
+    def test_fails_component_below_floor(self):
+        # A component with trust < 40 → ungraded, not a "grade" at all
+        # But "below floor C" means a grade worse than C — since ungraded has no grade,
+        # it simply doesn't count as evidenced. A component graded below C would be
+        # below the floor. In our model, there's no grade below C (C is the lowest);
+        # ungraded means no grade at all (doesn't count toward evidenced).
+        # To test the floor: we'd need a synthetic config where B is the floor.
+        gate = {
+            "minEvidencedComponents": 2,
+            "requiredComponentGrades": {"S": 1, "A": 1},
+            "componentFloor": "A",  # very strict floor: all must be A or better
+        }
+        comps = {
+            "c1": _make_component("c1", "S"),
+            "c2": _make_component("c2", "B"),  # below A floor
+        }
+        skill = self._suite_skill(comps)
+        result = check_ultimate_gate(skill, comps, gate)
+        assert result["passes"] is False
+        assert "floor" in result["reason"]
+
+    def test_passes_s_counts_toward_a_requirement(self):
+        # S ≥ A, so 1S + 1A satisfies requiredComponentGrades {S:1, A:2}? No — A:2 means 2 A+,
+        # S counts as A+, so 1S + 1A = 2 A+. But we need S:1 (exactly 1+ S-grade) and A:2.
+        # With S=1, A=1: S(counts as A+) = 1, A(counts as A+) = 1, total A+ = 2. S requirement = 1. Should pass.
+        comps = {
+            "c1": _make_component("c1", "S"),
+            "c2": _make_component("c2", "A"),
+            "c3": _make_component("c3", "B"),  # B is above floor C but below A
+        }
+        skill = self._suite_skill(comps)
+        result = check_ultimate_gate(skill, comps, GATE_CONFIG)
+        # S req: need 1 S-grade+ component → S(1) ≥ 1. Pass.
+        # A req: need 2 A-grade+ components → S(1) + A(1) = 2. Pass.
+        # Floor C: B is above C floor. Pass.
+        assert result["passes"] is True
+
+
+class TestUltimateGateDirect:
+    def _direct_skill(self, evidence_grades):
+        return {
+            "id": "direct-ultimate",
+            "type": "ultimate",
+            "evidence": [
+                {"grade": g, "source": f"http://ev{i}"}
+                for i, g in enumerate(evidence_grades)
+            ],
+        }
+
+    def test_passes(self):
+        skill = self._direct_skill(["S", "A", "A"])
+        result = check_ultimate_gate(skill, {}, GATE_CONFIG)
+        assert result["passes"] is True
+
+    def test_fails_not_enough_sources(self):
+        skill = self._direct_skill(["S", "A"])
+        result = check_ultimate_gate(skill, {}, GATE_CONFIG)
+        assert result["passes"] is False
+
+    def test_fails_no_s_grade(self):
+        skill = self._direct_skill(["A", "A", "A"])
+        result = check_ultimate_gate(skill, {}, GATE_CONFIG)
+        assert result["passes"] is False
+
+    def test_fails_not_enough_a(self):
+        skill = self._direct_skill(["S", "A", "B"])
+        result = check_ultimate_gate(skill, {}, GATE_CONFIG)
+        # S req: 1 S+. Pass.
+        # A req: need 2 A+. S(1) + A(1) = 2. Pass.
+        # This should actually pass since S counts as A+.
+        assert result["passes"] is True
+
+    def test_fails_only_b_grades(self):
+        skill = self._direct_skill(["B", "B", "B"])
+        result = check_ultimate_gate(skill, {}, GATE_CONFIG)
+        assert result["passes"] is False
+
+
+# ---------------------------------------------------------------------------
+# CLI integration — --type validation and --trust → grade
+# ---------------------------------------------------------------------------
+
+class TestEvidenceCLI:
+    @pytest.fixture(autouse=True)
+    def no_docs_build(self, monkeypatch):
+        monkeypatch.setattr("gaia_cli.commands.dev._run_docs_build", lambda *a, **kw: None)
+
+    def write_fixture_skill(self, root: Path):
+        nodes = root / "registry" / "nodes" / "basic"
+        nodes.mkdir(parents=True)
+        (nodes / "test-skill.json").write_text(json.dumps({
+            "id": "test-skill",
+            "name": "Test Skill",
+            "type": "basic",
+            "description": "A test skill for grading tests",
+            "status": "provisional",
+            "prerequisites": [],
+            "derivatives": [],
+            "evidence": [],
+            "knownAgents": [],
+            "createdAt": "2026-06-14",
+            "updatedAt": "2026-06-14",
+            "version": "0.1.0",
+        }), encoding="utf-8")
+
+    def test_trust_derives_grade_a(self, tmp_path, monkeypatch, capsys):
+        self.write_fixture_skill(tmp_path)
+        monkeypatch.setattr(sys, "argv", [
+            "gaia", "--registry", str(tmp_path), "dev", "evidence",
+            "test-skill", "http://example.com/paper",
+            "--type", "arxiv", "--trust", "85", "--no-build",
+        ])
+        from gaia_cli.main import main
+        main()
+        node = json.loads((tmp_path / "registry" / "nodes" / "basic" / "test-skill.json").read_text())
+        ev = node["evidence"][-1]
+        assert ev["grade"] == "A"
+        assert ev["trustNumber"] == 85.0
+        assert ev["type"] == "arxiv"
+
+    def test_trust_below_40_is_ungraded(self, tmp_path, monkeypatch):
+        self.write_fixture_skill(tmp_path)
+        monkeypatch.setattr(sys, "argv", [
+            "gaia", "--registry", str(tmp_path), "dev", "evidence",
+            "test-skill", "http://example.com/x",
+            "--trust", "30", "--no-build",
+        ])
+        from gaia_cli.main import main
+        main()
+        node = json.loads((tmp_path / "registry" / "nodes" / "basic" / "test-skill.json").read_text())
+        ev = node["evidence"][-1]
+        assert "grade" not in ev
+        assert ev["trustNumber"] == 30.0
+
+    def test_invalid_type_rejected(self, tmp_path, monkeypatch):
+        self.write_fixture_skill(tmp_path)
+        monkeypatch.setattr(sys, "argv", [
+            "gaia", "--registry", str(tmp_path), "dev", "evidence",
+            "test-skill", "http://example.com/x",
+            "--type", "stars", "--trust", "80", "--no-build",
+        ])
+        from gaia_cli.main import main
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 1
+
+    def test_class_deprecated_warning(self, tmp_path, monkeypatch, capsys):
+        self.write_fixture_skill(tmp_path)
+        monkeypatch.setattr(sys, "argv", [
+            "gaia", "--registry", str(tmp_path), "dev", "evidence",
+            "test-skill", "http://example.com/x",
+            "--class", "B", "--no-build",
+        ])
+        from gaia_cli.main import main
+        main()
+        captured = capsys.readouterr()
+        assert "deprecated" in captured.err.lower()
+        # Class is still written to the entry
+        node = json.loads((tmp_path / "registry" / "nodes" / "basic" / "test-skill.json").read_text())
+        ev = node["evidence"][-1]
+        assert ev["class"] == "B"
+
+    def test_evidence_graded_timeline_event(self, tmp_path, monkeypatch):
+        self.write_fixture_skill(tmp_path)
+        monkeypatch.setattr(sys, "argv", [
+            "gaia", "--registry", str(tmp_path), "dev", "evidence",
+            "test-skill", "http://example.com/x",
+            "--type", "repo", "--trust", "92", "--no-build",
+        ])
+        from gaia_cli.main import main
+        main()
+        node = json.loads((tmp_path / "registry" / "nodes" / "basic" / "test-skill.json").read_text())
+        timeline = node.get("timeline", [])
+        actions = [e["action"] for e in timeline]
+        assert "evidence_added" in actions
+        assert "evidence_graded" in actions
+
+    def test_trust_s_boundary(self, tmp_path, monkeypatch):
+        self.write_fixture_skill(tmp_path)
+        monkeypatch.setattr(sys, "argv", [
+            "gaia", "--registry", str(tmp_path), "dev", "evidence",
+            "test-skill", "http://example.com/x",
+            "--trust", "90", "--no-build",
+        ])
+        from gaia_cli.main import main
+        main()
+        node = json.loads((tmp_path / "registry" / "nodes" / "basic" / "test-skill.json").read_text())
+        ev = node["evidence"][-1]
+        assert ev["grade"] == "S"


### PR DESCRIPTION
## Summary

Implements PR-2 of the evidence grading pipeline per `handovers/TRUST_IMPL_HANDOVER.md §PR-2` and TRUST_MODEL_RFC.md v2 (accepted 2026-06-10). Refs #646.

- **`gaia dev evidence --type <type>`** validated against `meta.json` `evidence.types` (list-driven — adding new types requires no schema PR). Unknown types are rejected with a helpful list of valid values.
- **`gaia dev evidence --trust <0-100>`** auto-derives a letter grade from `meta.json` `gradeThresholds` (S≥90 / A≥80 / B≥60 / C≥40 / <40 = ungraded) and writes `trustNumber`, `type`, and `grade` onto the evidence entry. Ungraded entries are stored and shown but do **not** count toward gates.
- **`--class` deprecated** — still accepted with a deprecation warning; not removed until next major.
- **`evidence_graded` timeline event** fired whenever a grade is derived, making grading auditable (CLI-only, never hand-edited).
- **`src/gaia_cli/grading.py`** (new) — pure grade derivation (`derive_grade`), `overall_trust_grade`, `check_ultimate_gate` (suite pillar rule + direct-evidence path). Single source for all grading logic.
- **`GRADE_COLORS`** dict in `formatting.py` — Platinum/Gold/Silver/Bronze (S/A/B/C) — alongside `RANK_COLORS` as the single source for grade design tokens. New `format_grade_colored` helper.
- **Overall Trust Grade** injected into generated catalogs at build time (`registry/named-skills.json` via `generateNamedIndex.py`, `docs/graph/gaia.json` via `syncDocsGraphAssets.py`). Not stored in registry nodes (Programmatic-First).
- **Ultimate gate status** (`ultimateGateStatus.passes/reason`) injected for ultimate-type skills in both catalogs. Suite ultimates use the pillar rule from `meta.json.evidence.ultimateGate`; non-suite ultimates use the direct-evidence equivalent.
- **40 unit tests** (`tests/test_grading.py`) covering: grade boundary cases (39/40/60/80/90), type validation (valid + rejected), ungraded-doesn't-gate rule, and pillar gate (pass + each failure mode).
- Verifier gate intact — all `gaia dev evidence` mutations remain gated.

## Test plan

- [ ] `gaia dev evidence <skill> "<url>" --type repo --trust 85 --no-build` → records an A-grade entry with `trustNumber: 85`, `type: repo`, `grade: A`, and an `evidence_graded` timeline event
- [ ] `gaia dev evidence <skill> "<url>" --type stars --trust 80 --no-build` → rejected with valid-types list
- [ ] `gaia dev evidence <skill> "<url>" --class B --no-build` → accepted with deprecation warning on stderr, `class: B` written to entry
- [ ] `gaia dev evidence <skill> "<url>" --trust 30 --no-build` → entry stored with `trustNumber: 30`, no `grade` field
- [ ] `gaia dev build` → `registry/named-skills.json` and `docs/graph/gaia.json` carry `overallTrustGrade` and `ultimateGateStatus` for applicable skills
- [ ] `pytest tests/test_grading.py` → 40 tests green
- [ ] Full suite: no new failures beyond pre-existing environment issues

## Post-ship obligation

Once this gate is live, the Orchestrator should open a recalibration RFC ~1 month out to revisit the pillar thresholds against real grade distributions.

https://claude.ai/code/session_01GziqkrSiATDwD8pvfGNSae

---
_Generated by [Claude Code](https://claude.ai/code/session_01GziqkrSiATDwD8pvfGNSae)_