### PR TITLE
feat(cli): in-place evidence re-grade (--index) + evidence_graded enum [PR-2.5]

### DIFF
--- a/docs/graph/named/index.json
+++ b/docs/graph/named/index.json
@@ -2332,7 +2332,11 @@
         ],
         "type": "ultimate",
         "installBody": "**Requirements:** [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Git](https://git-scm.com/), [Bun](https://bun.sh/) v1.0+, [Node.js](https://nodejs.org/) (Windows only)\n\n### Step 1: Install on your machine\n\nOpen Claude Code and paste this. Claude does the rest.\n\n> Install gstack: run **`git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup`** then add a \"gstack\" section to CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\\_\\_claude-in-chrome\\_\\_\\* tools, and lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /design-shotgun, /design-html, /review, /ship, /land-and-deploy, /canary, /benchmark, /browse, /connect-chrome, /qa, /qa-only, /design-review, /setup-browser-cookies, /setup-deploy, /setup-gbrain, /retro, /investigate, /document-release, /document-generate, /codex, /cso, /autoplan, /plan-devex-review, /devex-review, /careful, /freeze, /guard, /unfreeze, /gstack-upgrade, /learn. Then ask the user if they also want to add gstack to the current project so teammates get it.\n\n### Step 2: Team mode — auto-update for shared repos (recommended)\n\nFrom inside your repo, paste this. Switches you to team mode, bootstraps the repo so teammates get gstack automatically, and commits the change:\n\n```bash\n(cd ~/.claude/skills/gstack && ./setup --team) && ~/.claude/skills/gstack/bin/gstack-team-init required && git add .claude/ CLAUDE.md && git commit -m \"require gstack for AI-assisted work\"\n```bash\nNo vendored files in your repo, no version drift, no manual upgrades. Every Claude Code session starts with a fast auto-update check (throttled to once/hour, network-failure-safe, completely silent).\n\nSwap `required` for `optional` if you'd rather nudge teammates than block them.\n\n### OpenClaw\n\nOpenClaw spawns Claude Code sessions via ACP, so every gstack skill just works\nwhen Claude Code has gstack installed. Paste this to your OpenClaw agent:\n\n> Install gstack: run `git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup` to install gstack for Claude Code. Then add a \"Coding Tasks\" section to AGENTS.md that says: when spawning Claude Code sessions for coding work, tell the session to use gstack skills. Include these examples — security audit: \"Load gstack. Run /cso\", code review: \"Load gstack. Run /review\", QA test a URL: \"Load gstack. Run /qa https://...\", build a feature end-to-end: \"Load gstack. Run /autoplan, implement the plan, then run /ship\", plan before building: \"Load gstack. Run /office-hours then /autoplan. Save the plan, don't implement.\"\n\n**After setup, just talk to your OpenClaw agent naturally:**\n\n| You say | What happens |\n|---------|-------------|\n| \"Fix the typo in README\" | Simple — Claude Code session, no gstack needed |\n| \"Run a security audit on this repo\" | Spawns Claude Code with `Run /cso` |\n| \"Build me a notifications feature\" | Spawns Claude Code with /autoplan → implement → /ship |\n| \"Help me plan the v2 API redesign\" | Spawns Claude Code with /office-hours → /autoplan, saves plan |\n\nSee [docs/OPENCLAW.md](docs/OPENCLAW.md) for advanced dispatch routing and\nthe gstack-lite/gstack-full prompt templates.\n\n### Native OpenClaw Skills (via ClawHub)\n\nFour methodology skills that work directly in your OpenClaw agent, no Claude Code\nsession needed. Install from ClawHub:\n\n```\nclawhub install gstack-openclaw-office-hours gstack-openclaw-ceo-review gstack-openclaw-investigate gstack-openclaw-retro\n```bash\n| Skill | What it does |\n|-------|-------------|\n| `gstack-openclaw-office-hours` | Product interrogation with 6 forcing questions |\n| `gstack-openclaw-ceo-review` | Strategic challenge with 4 scope modes |\n| `gstack-openclaw-investigate` | Root cause debugging methodology |\n| `gstack-openclaw-retro` | Weekly engineering retrospective |\n\nThese are conversational skills. Your OpenClaw agent runs them directly via chat.\n\n### Other AI Agents\n\ngstack works on 10 AI coding agents, not just Claude. Setup auto-detects which\nagents you have installed:\n\n```bash\ngit clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/gstack\ncd ~/gstack && ./setup\n```\n\nOr target a specific agent with `./setup --host <name>`:\n\n| Agent | Flag | Skills install to |\n|-------|------|-------------------|\n| OpenAI Codex CLI | `--host codex` | `~/.codex/skills/gstack-*/` |\n| OpenCode | `--host opencode` | `~/.config/opencode/skills/gstack-*/` |\n| Cursor | `--host cursor` | `~/.cursor/skills/gstack-*/` |\n| Factory Droid | `--host factory` | `~/.factory/skills/gstack-*/` |\n| Slate | `--host slate` | `~/.slate/skills/gstack-*/` |\n| Kiro | `--host kiro` | `~/.kiro/skills/gstack-*/` |\n| Hermes | `--host hermes` | `~/.hermes/skills/gstack-*/` |\n| GBrain (mod) | `--host gbrain` | `~/.gbrain/skills/gstack-*/` |\n\n**Want to add support for another agent?** See [docs/ADDING_A_HOST.md](docs/ADDING_A_HOST.md).\nIt's one TypeScript config file, zero code changes.",
-        "role": "origin"
+        "role": "origin",
+        "ultimateGateStatus": {
+          "passes": false,
+          "reason": "only 0/3 components carry graded evidence"
+        }
       }
     ],
     "systematic-debugging": [
@@ -4209,7 +4213,11 @@
         ],
         "type": "ultimate",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
-        "role": "origin"
+        "role": "origin",
+        "ultimateGateStatus": {
+          "passes": false,
+          "reason": "only 0/3 components carry graded evidence"
+        }
       }
     ],
     "grill-me": [
@@ -4534,7 +4542,11 @@
         ],
         "type": "ultimate",
         "installBody": "Install the full Matt Pocock skills suite with:\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required.",
-        "role": "origin"
+        "role": "origin",
+        "ultimateGateStatus": {
+          "passes": false,
+          "reason": "only 0/3 components carry graded evidence"
+        }
       }
     ],
     "prd-generation": [
@@ -5582,7 +5594,11 @@
         ],
         "type": "ultimate",
         "installBody": "Installation differs by harness. If you use more than one, install Superpowers separately for each one.\n\n### Claude Code\n\nSuperpowers is available via the [official Claude plugin marketplace](https://claude.com/plugins/superpowers)\n\n#### Official Marketplace\n\n- Install the plugin from Anthropic's official marketplace:\n\n  ```bash\n  /plugin install superpowers@claude-plugins-official\n  ```\n\n#### Superpowers Marketplace\n\nThe Superpowers marketplace provides Superpowers and some other related plugins for Claude Code.\n\n- Register the marketplace:\n\n  ```bash\n  /plugin marketplace add obra/superpowers-marketplace\n  ```\n\n- Install the plugin from this marketplace:\n\n  ```bash\n  /plugin install superpowers@superpowers-marketplace\n  ```\n\n### Codex CLI\n\nSuperpowers is available via the [official Codex plugin marketplace](https://github.com/openai/plugins).\n\n- Open the plugin search interface:\n\n  ```bash\n  /plugins\n  ```\n\n- Search for Superpowers:\n\n  ```bash\n  superpowers\n  ```\n\n- Select `Install Plugin`.\n\n### Codex App\n\nSuperpowers is available via the [official Codex plugin marketplace](https://github.com/openai/plugins).\n\n- In the Codex app, click on Plugins in the sidebar.\n- You should see `Superpowers` in the Coding section.\n- Click the `+` next to Superpowers and follow the prompts.\n\n### Factory Droid\n\n- Register the marketplace:\n\n  ```bash\n  droid plugin marketplace add https://github.com/obra/superpowers\n  ```\n\n- Install the plugin:\n\n  ```bash\n  droid plugin install superpowers@superpowers\n  ```\n\n### Gemini CLI\n\n- Install the extension:\n\n  ```bash\n  gemini extensions install https://github.com/obra/superpowers\n  ```\n\n- Update later:\n\n  ```bash\n  gemini extensions update superpowers\n  ```\n\n### OpenCode\n\nOpenCode uses its own plugin install; install Superpowers separately even if you\nalready use it in another harness.\n\n- Tell OpenCode:\n\n  ```\n  Fetch and follow instructions from https://raw.githubusercontent.com/obra/superpowers/refs/heads/main/.opencode/INSTALL.md\n  ```\n\n- Detailed docs: [docs/README.opencode.md](docs/README.opencode.md)\n\n### Cursor\n\n- In Cursor Agent chat, install from marketplace:\n\n  ```bash\n  /add-plugin superpowers\n  ```\n\n- Or search for \"superpowers\" in the plugin marketplace.\n\n### GitHub Copilot CLI\n\n- Register the marketplace:\n\n  ```bash\n  copilot plugin marketplace add obra/superpowers-marketplace\n  ```\n\n- Install the plugin:\n\n  ```bash\n  copilot plugin install superpowers@superpowers-marketplace\n  ```",
-        "role": "origin"
+        "role": "origin",
+        "ultimateGateStatus": {
+          "passes": false,
+          "reason": "only 0/3 components carry graded evidence"
+        }
       }
     ],
     "using-git-worktrees": [
@@ -6061,7 +6077,11 @@
         ],
         "type": "ultimate",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
-        "role": "origin"
+        "role": "origin",
+        "ultimateGateStatus": {
+          "passes": false,
+          "reason": "only 0/3 components carry graded evidence"
+        }
       }
     ],
     "git-diff-risk-analysis": [
@@ -6901,7 +6921,11 @@
         ],
         "type": "ultimate",
         "installBody": "The quickest path to Ruflo:\n\n```bash\nnpx ruflo@latest init\n```\n\nThis launches an interactive wizard that detects your platform and configures\nthe full Ruflo loop (98 agents, 60+ commands, MCP server, hooks, and daemon).\nFor Claude Code plugin installs, Windows specifics, or the complete options\nreference, see the [full installation guide on GitHub](https://github.com/ruvnet/ruflo#installation).",
-        "role": "origin"
+        "role": "origin",
+        "ultimateGateStatus": {
+          "passes": false,
+          "reason": "only 0/3 components carry graded evidence"
+        }
       }
     ],
     "agentic-workflow-design": [

--- a/registry/named-skills.json
+++ b/registry/named-skills.json
@@ -2332,7 +2332,11 @@
         ],
         "type": "ultimate",
         "installBody": "**Requirements:** [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Git](https://git-scm.com/), [Bun](https://bun.sh/) v1.0+, [Node.js](https://nodejs.org/) (Windows only)\n\n### Step 1: Install on your machine\n\nOpen Claude Code and paste this. Claude does the rest.\n\n> Install gstack: run **`git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup`** then add a \"gstack\" section to CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\\_\\_claude-in-chrome\\_\\_\\* tools, and lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /design-shotgun, /design-html, /review, /ship, /land-and-deploy, /canary, /benchmark, /browse, /connect-chrome, /qa, /qa-only, /design-review, /setup-browser-cookies, /setup-deploy, /setup-gbrain, /retro, /investigate, /document-release, /document-generate, /codex, /cso, /autoplan, /plan-devex-review, /devex-review, /careful, /freeze, /guard, /unfreeze, /gstack-upgrade, /learn. Then ask the user if they also want to add gstack to the current project so teammates get it.\n\n### Step 2: Team mode — auto-update for shared repos (recommended)\n\nFrom inside your repo, paste this. Switches you to team mode, bootstraps the repo so teammates get gstack automatically, and commits the change:\n\n```bash\n(cd ~/.claude/skills/gstack && ./setup --team) && ~/.claude/skills/gstack/bin/gstack-team-init required && git add .claude/ CLAUDE.md && git commit -m \"require gstack for AI-assisted work\"\n```bash\nNo vendored files in your repo, no version drift, no manual upgrades. Every Claude Code session starts with a fast auto-update check (throttled to once/hour, network-failure-safe, completely silent).\n\nSwap `required` for `optional` if you'd rather nudge teammates than block them.\n\n### OpenClaw\n\nOpenClaw spawns Claude Code sessions via ACP, so every gstack skill just works\nwhen Claude Code has gstack installed. Paste this to your OpenClaw agent:\n\n> Install gstack: run `git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup` to install gstack for Claude Code. Then add a \"Coding Tasks\" section to AGENTS.md that says: when spawning Claude Code sessions for coding work, tell the session to use gstack skills. Include these examples — security audit: \"Load gstack. Run /cso\", code review: \"Load gstack. Run /review\", QA test a URL: \"Load gstack. Run /qa https://...\", build a feature end-to-end: \"Load gstack. Run /autoplan, implement the plan, then run /ship\", plan before building: \"Load gstack. Run /office-hours then /autoplan. Save the plan, don't implement.\"\n\n**After setup, just talk to your OpenClaw agent naturally:**\n\n| You say | What happens |\n|---------|-------------|\n| \"Fix the typo in README\" | Simple — Claude Code session, no gstack needed |\n| \"Run a security audit on this repo\" | Spawns Claude Code with `Run /cso` |\n| \"Build me a notifications feature\" | Spawns Claude Code with /autoplan → implement → /ship |\n| \"Help me plan the v2 API redesign\" | Spawns Claude Code with /office-hours → /autoplan, saves plan |\n\nSee [docs/OPENCLAW.md](docs/OPENCLAW.md) for advanced dispatch routing and\nthe gstack-lite/gstack-full prompt templates.\n\n### Native OpenClaw Skills (via ClawHub)\n\nFour methodology skills that work directly in your OpenClaw agent, no Claude Code\nsession needed. Install from ClawHub:\n\n```\nclawhub install gstack-openclaw-office-hours gstack-openclaw-ceo-review gstack-openclaw-investigate gstack-openclaw-retro\n```bash\n| Skill | What it does |\n|-------|-------------|\n| `gstack-openclaw-office-hours` | Product interrogation with 6 forcing questions |\n| `gstack-openclaw-ceo-review` | Strategic challenge with 4 scope modes |\n| `gstack-openclaw-investigate` | Root cause debugging methodology |\n| `gstack-openclaw-retro` | Weekly engineering retrospective |\n\nThese are conversational skills. Your OpenClaw agent runs them directly via chat.\n\n### Other AI Agents\n\ngstack works on 10 AI coding agents, not just Claude. Setup auto-detects which\nagents you have installed:\n\n```bash\ngit clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/gstack\ncd ~/gstack && ./setup\n```\n\nOr target a specific agent with `./setup --host <name>`:\n\n| Agent | Flag | Skills install to |\n|-------|------|-------------------|\n| OpenAI Codex CLI | `--host codex` | `~/.codex/skills/gstack-*/` |\n| OpenCode | `--host opencode` | `~/.config/opencode/skills/gstack-*/` |\n| Cursor | `--host cursor` | `~/.cursor/skills/gstack-*/` |\n| Factory Droid | `--host factory` | `~/.factory/skills/gstack-*/` |\n| Slate | `--host slate` | `~/.slate/skills/gstack-*/` |\n| Kiro | `--host kiro` | `~/.kiro/skills/gstack-*/` |\n| Hermes | `--host hermes` | `~/.hermes/skills/gstack-*/` |\n| GBrain (mod) | `--host gbrain` | `~/.gbrain/skills/gstack-*/` |\n\n**Want to add support for another agent?** See [docs/ADDING_A_HOST.md](docs/ADDING_A_HOST.md).\nIt's one TypeScript config file, zero code changes.",
-        "role": "origin"
+        "role": "origin",
+        "ultimateGateStatus": {
+          "passes": false,
+          "reason": "only 0/3 components carry graded evidence"
+        }
       }
     ],
     "systematic-debugging": [
@@ -4209,7 +4213,11 @@
         ],
         "type": "ultimate",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
-        "role": "origin"
+        "role": "origin",
+        "ultimateGateStatus": {
+          "passes": false,
+          "reason": "only 0/3 components carry graded evidence"
+        }
       }
     ],
     "grill-me": [
@@ -4534,7 +4542,11 @@
         ],
         "type": "ultimate",
         "installBody": "Install the full Matt Pocock skills suite with:\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required.",
-        "role": "origin"
+        "role": "origin",
+        "ultimateGateStatus": {
+          "passes": false,
+          "reason": "only 0/3 components carry graded evidence"
+        }
       }
     ],
     "prd-generation": [
@@ -5582,7 +5594,11 @@
         ],
         "type": "ultimate",
         "installBody": "Installation differs by harness. If you use more than one, install Superpowers separately for each one.\n\n### Claude Code\n\nSuperpowers is available via the [official Claude plugin marketplace](https://claude.com/plugins/superpowers)\n\n#### Official Marketplace\n\n- Install the plugin from Anthropic's official marketplace:\n\n  ```bash\n  /plugin install superpowers@claude-plugins-official\n  ```\n\n#### Superpowers Marketplace\n\nThe Superpowers marketplace provides Superpowers and some other related plugins for Claude Code.\n\n- Register the marketplace:\n\n  ```bash\n  /plugin marketplace add obra/superpowers-marketplace\n  ```\n\n- Install the plugin from this marketplace:\n\n  ```bash\n  /plugin install superpowers@superpowers-marketplace\n  ```\n\n### Codex CLI\n\nSuperpowers is available via the [official Codex plugin marketplace](https://github.com/openai/plugins).\n\n- Open the plugin search interface:\n\n  ```bash\n  /plugins\n  ```\n\n- Search for Superpowers:\n\n  ```bash\n  superpowers\n  ```\n\n- Select `Install Plugin`.\n\n### Codex App\n\nSuperpowers is available via the [official Codex plugin marketplace](https://github.com/openai/plugins).\n\n- In the Codex app, click on Plugins in the sidebar.\n- You should see `Superpowers` in the Coding section.\n- Click the `+` next to Superpowers and follow the prompts.\n\n### Factory Droid\n\n- Register the marketplace:\n\n  ```bash\n  droid plugin marketplace add https://github.com/obra/superpowers\n  ```\n\n- Install the plugin:\n\n  ```bash\n  droid plugin install superpowers@superpowers\n  ```\n\n### Gemini CLI\n\n- Install the extension:\n\n  ```bash\n  gemini extensions install https://github.com/obra/superpowers\n  ```\n\n- Update later:\n\n  ```bash\n  gemini extensions update superpowers\n  ```\n\n### OpenCode\n\nOpenCode uses its own plugin install; install Superpowers separately even if you\nalready use it in another harness.\n\n- Tell OpenCode:\n\n  ```\n  Fetch and follow instructions from https://raw.githubusercontent.com/obra/superpowers/refs/heads/main/.opencode/INSTALL.md\n  ```\n\n- Detailed docs: [docs/README.opencode.md](docs/README.opencode.md)\n\n### Cursor\n\n- In Cursor Agent chat, install from marketplace:\n\n  ```bash\n  /add-plugin superpowers\n  ```\n\n- Or search for \"superpowers\" in the plugin marketplace.\n\n### GitHub Copilot CLI\n\n- Register the marketplace:\n\n  ```bash\n  copilot plugin marketplace add obra/superpowers-marketplace\n  ```\n\n- Install the plugin:\n\n  ```bash\n  copilot plugin install superpowers@superpowers-marketplace\n  ```",
-        "role": "origin"
+        "role": "origin",
+        "ultimateGateStatus": {
+          "passes": false,
+          "reason": "only 0/3 components carry graded evidence"
+        }
       }
     ],
     "using-git-worktrees": [
@@ -6061,7 +6077,11 @@
         ],
         "type": "ultimate",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
-        "role": "origin"
+        "role": "origin",
+        "ultimateGateStatus": {
+          "passes": false,
+          "reason": "only 0/3 components carry graded evidence"
+        }
       }
     ],
     "git-diff-risk-analysis": [
@@ -6901,7 +6921,11 @@
         ],
         "type": "ultimate",
         "installBody": "The quickest path to Ruflo:\n\n```bash\nnpx ruflo@latest init\n```\n\nThis launches an interactive wizard that detects your platform and configures\nthe full Ruflo loop (98 agents, 60+ commands, MCP server, hooks, and daemon).\nFor Claude Code plugin installs, Windows specifics, or the complete options\nreference, see the [full installation guide on GitHub](https://github.com/ruvnet/ruflo#installation).",
-        "role": "origin"
+        "role": "origin",
+        "ultimateGateStatus": {
+          "passes": false,
+          "reason": "only 0/3 components carry graded evidence"
+        }
       }
     ],
     "agentic-workflow-design": [

--- a/registry/schema/namedSkill.schema.json
+++ b/registry/schema/namedSkill.schema.json
@@ -263,6 +263,7 @@
             "add",
             "evidence_added",
             "evidence_removed",
+            "evidence_graded",
             "type_change",
             "verified",
             "disputed"

--- a/registry/schema/skill.schema.json
+++ b/registry/schema/skill.schema.json
@@ -229,6 +229,7 @@
             "add",
             "evidence_added",
             "evidence_removed",
+            "evidence_graded",
             "type_change",
             "verified",
             "disputed"

--- a/src/gaia_cli/commands/dev.py
+++ b/src/gaia_cli/commands/dev.py
@@ -1036,6 +1036,20 @@ def meta_evidence_command(args):
         thresholds = load_grade_thresholds(registry_path)
         derived_grade = derive_grade(trust_number, thresholds)
 
+    # --index re-grades an existing entry in place (class→grade backfill);
+    # otherwise a new entry is appended.
+    index = getattr(args, "index", None)
+
+    if index is not None and trust_number is None and evidence_type is None and (
+        not getattr(args, "notes", None)
+    ):
+        print(
+            "Error: --index requires at least one of --trust, --type, or --notes "
+            "to update on the existing entry.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     evidence: dict = {
         "source": args.source,
         "evaluator": getattr(args, "evaluator", None) or _get_contributor(),
@@ -1054,6 +1068,43 @@ def meta_evidence_command(args):
     if getattr(args, "notes", None):
         evidence["notes"] = args.notes
 
+    def _apply(ev_list: list) -> dict:
+        """Append the new entry, or update the entry at ``index`` in place.
+
+        In-place mode only touches the fields explicitly supplied, preserving
+        the existing entry's other fields (notably the deprecated ``class``,
+        plus ``evaluator``/``date``/``source``). Returns the resulting entry.
+        """
+        if index is None:
+            ev_list.append(evidence)
+            return evidence
+        if index < 0 or index >= len(ev_list):
+            print(
+                f"Error: Evidence index {index} out of range "
+                f"(skill '{skill_id}' has {len(ev_list)} entries).",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        entry = ev_list[index]
+        if evidence_type is not None:
+            entry["type"] = evidence_type
+        if trust_number is not None:
+            entry["trustNumber"] = trust_number
+            # Re-derive grade from scratch; drop a stale grade if now ungraded.
+            if derived_grade is not None:
+                entry["grade"] = derived_grade
+            else:
+                entry.pop("grade", None)
+        if evidence_class is not None:
+            entry["class"] = evidence_class
+        if getattr(args, "notes", None):
+            entry["notes"] = args.notes
+        if getattr(args, "evaluator", None):
+            entry["evaluator"] = args.evaluator
+        if getattr(args, "date", None):
+            entry["date"] = args.date
+        return entry
+
     if "/" in skill_id:
         # Named implementation → write into the named .md frontmatter.
         named_dir = Path(named_skills_dir(registry_path))
@@ -1062,7 +1113,7 @@ def meta_evidence_command(args):
             print(f"Error: Named skill '{skill_id}' not found.")
             sys.exit(1)
         meta, body = _parse_md(named_file)
-        meta.setdefault("evidence", []).append(evidence)
+        result_entry = _apply(meta.setdefault("evidence", []))
         meta["updatedAt"] = datetime.date.today().isoformat()
         _write_md(named_file, meta, body)
     else:
@@ -1084,36 +1135,52 @@ def meta_evidence_command(args):
 
         with open(node_file, "r", encoding="utf-8") as f:
             data = json.load(f)
-        data.setdefault("evidence", []).append(evidence)
+        result_entry = _apply(data.setdefault("evidence", []))
         data["updatedAt"] = datetime.date.today().isoformat()
         with open(node_file, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2, ensure_ascii=False)
             f.write("\n")
 
-    grade_label = derived_grade if derived_grade else "ungraded"
-    type_label = f" [{evidence_type}]" if evidence_type else ""
-    print(f"Added evidence to skill: {skill_id}{type_label} (grade: {grade_label})")
+    grade_label = result_entry.get("grade") or "ungraded"
+    type_label = f" [{result_entry.get('type')}]" if result_entry.get("type") else ""
+    verb = "Re-graded evidence entry" if index is not None else "Added evidence to skill"
+    suffix = f" #{index}" if index is not None else ""
+    print(f"{verb}{suffix}: {skill_id}{type_label} (grade: {grade_label})")
 
     contributor = _get_contributor()
-    append_skill_event(
-        skill_id,
-        "evidence_added",
-        contributor,
-        f"Added evidence from {evidence['source']}"
-        + (f" (type: {evidence_type})" if evidence_type else ""),
-        registry_path=registry_path,
-    )
-
-    # Fire evidence_graded event whenever a grade was derived from a trust number
-    if derived_grade is not None:
+    src = result_entry.get("source")
+    if index is not None:
+        # In-place re-grade: a single evidence_graded event captures the change,
+        # fired whenever a trust number was supplied (graded or ungraded) so the
+        # backfill always leaves an audit trail.
+        if trust_number is not None:
+            append_skill_event(
+                skill_id,
+                "evidence_graded",
+                contributor,
+                f"Re-graded evidence from {src} as {grade_label} "
+                f"(trustNumber: {trust_number})",
+                registry_path=registry_path,
+            )
+    else:
         append_skill_event(
             skill_id,
-            "evidence_graded",
+            "evidence_added",
             contributor,
-            f"Graded evidence from {evidence['source']} as {derived_grade} "
-            f"(trustNumber: {trust_number})",
+            f"Added evidence from {src}"
+            + (f" (type: {evidence_type})" if evidence_type else ""),
             registry_path=registry_path,
         )
+        # Fire evidence_graded whenever a grade was derived from a trust number
+        if derived_grade is not None:
+            append_skill_event(
+                skill_id,
+                "evidence_graded",
+                contributor,
+                f"Graded evidence from {src} as {derived_grade} "
+                f"(trustNumber: {trust_number})",
+                registry_path=registry_path,
+            )
 
     if not getattr(args, "no_build", False):
         print("Regenerating registry and documentation...")

--- a/src/gaia_cli/data/registry/schema/namedSkill.schema.json
+++ b/src/gaia_cli/data/registry/schema/namedSkill.schema.json
@@ -263,6 +263,7 @@
             "add",
             "evidence_added",
             "evidence_removed",
+            "evidence_graded",
             "type_change",
             "verified",
             "disputed"

--- a/src/gaia_cli/data/registry/schema/skill.schema.json
+++ b/src/gaia_cli/data/registry/schema/skill.schema.json
@@ -229,6 +229,7 @@
             "add",
             "evidence_added",
             "evidence_removed",
+            "evidence_graded",
             "type_change",
             "verified",
             "disputed"

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -3454,6 +3454,17 @@ def get_parser():
     dev_evidence.add_argument("skill_id", help="Skill ID to add evidence to")
     dev_evidence.add_argument("source", help="URL to the evidence source")
     dev_evidence.add_argument(
+        "--index",
+        type=int,
+        metavar="N",
+        help=(
+            "Re-grade the existing evidence entry at this index in place "
+            "(0-based) instead of appending a new one. Sets --type/--trust/"
+            "--notes on that entry while preserving its other fields (e.g. "
+            "the deprecated class). Used by the class→grade backfill."
+        ),
+    )
+    dev_evidence.add_argument(
         "--type",
         dest="evidence_type",
         metavar="TYPE",

--- a/tests/test_evidence_regrade.py
+++ b/tests/test_evidence_regrade.py
@@ -1,0 +1,137 @@
+"""Tests for ``gaia dev evidence --index`` in-place re-grade mode.
+
+PR-2 shipped ``gaia dev evidence`` as append-only, which made the class→grade
+backfill (PR-3) impossible: re-running it over existing entries duplicated them
+and could not preserve the deprecated ``class``. ``--index`` re-grades the entry
+at a given position in place. These tests lock in that behaviour and the
+``evidence_graded`` audit event (which also had to be added to the schema enum).
+"""
+
+import json
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from gaia_cli.commands.dev import meta_evidence_command
+
+
+def _build_registry(tmp_path, evidence):
+    """Create a minimal registry with one node and a meta.json, return its root."""
+    nodes = tmp_path / "registry" / "nodes" / "extra"
+    nodes.mkdir(parents=True)
+    schema = tmp_path / "registry" / "schema"
+    schema.mkdir(parents=True)
+    (schema / "meta.json").write_text(
+        json.dumps(
+            {
+                "evidence": {
+                    "gradeThresholds": {"S": 90, "A": 80, "B": 60, "C": 40},
+                    "types": ["arxiv", "repo", "github-stars"],
+                }
+            }
+        )
+    )
+    node = {
+        "id": "demo-skill",
+        "name": "Demo Skill",
+        "type": "extra",
+        "description": "A demo skill for evidence re-grade tests.",
+        "evidence": evidence,
+        "timeline": [],
+    }
+    (nodes / "demo-skill.json").write_text(json.dumps(node, indent=2))
+    return str(tmp_path)
+
+
+def _load_node(registry_root):
+    path = os.path.join(
+        registry_root, "registry", "nodes", "extra", "demo-skill.json"
+    )
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _args(registry_root, **overrides):
+    base = dict(
+        registry=registry_root,
+        skill_id="demo-skill",
+        source="https://example.com/evidence",
+        index=None,
+        evidence_type=None,
+        trust=None,
+        evidence_class=None,
+        evaluator=None,
+        date=None,
+        notes=None,
+        no_build=True,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+@pytest.fixture(autouse=True)
+def _fixed_contributor(monkeypatch):
+    monkeypatch.setattr(
+        "gaia_cli.commands.dev._get_contributor", lambda: "tester"
+    )
+
+
+def test_append_mode_unchanged(tmp_path):
+    """Without --index a new entry is appended (legacy behaviour)."""
+    root = _build_registry(tmp_path, [{"source": "https://a", "class": "A"}])
+    meta_evidence_command(
+        _args(root, source="https://b", evidence_type="repo", trust=85)
+    )
+    ev = _load_node(root)["evidence"]
+    assert len(ev) == 2
+    assert ev[1]["type"] == "repo" and ev[1]["grade"] == "A"
+    assert ev[1]["trustNumber"] == 85
+
+
+def test_index_regrades_in_place_and_keeps_class(tmp_path):
+    """--index updates the existing entry; count is stable and class survives."""
+    root = _build_registry(
+        tmp_path,
+        [{"source": "https://a", "class": "A", "evaluator": "orig", "date": "2025-01-01"}],
+    )
+    meta_evidence_command(
+        _args(root, index=0, evidence_type="arxiv", trust=88)
+    )
+    node = _load_node(root)
+    ev = node["evidence"]
+    assert len(ev) == 1  # no duplicate
+    entry = ev[0]
+    assert entry["type"] == "arxiv"
+    assert entry["grade"] == "A"
+    assert entry["trustNumber"] == 88
+    assert entry["class"] == "A"  # deprecated field preserved
+    assert entry["evaluator"] == "orig"  # untouched fields preserved
+    assert entry["date"] == "2025-01-01"
+    # audit trail
+    assert node["timeline"][-1]["action"] == "evidence_graded"
+
+
+def test_index_ungraded_drops_grade(tmp_path):
+    """A trust number below the floor yields no grade but keeps trustNumber."""
+    root = _build_registry(
+        tmp_path, [{"source": "https://a", "class": "C", "grade": "B"}]
+    )
+    meta_evidence_command(_args(root, index=0, evidence_type="repo", trust=30))
+    entry = _load_node(root)["evidence"][0]
+    assert entry["trustNumber"] == 30
+    assert "grade" not in entry  # stale grade cleared
+    assert entry["class"] == "C"
+
+
+def test_index_out_of_range_exits(tmp_path):
+    root = _build_registry(tmp_path, [{"source": "https://a", "class": "A"}])
+    with pytest.raises(SystemExit):
+        meta_evidence_command(_args(root, index=5, trust=80))
+
+
+def test_index_requires_update_field(tmp_path):
+    """--index with nothing to set is rejected rather than a silent no-op."""
+    root = _build_registry(tmp_path, [{"source": "https://a", "class": "A"}])
+    with pytest.raises(SystemExit):
+        meta_evidence_command(_args(root, index=0))


### PR DESCRIPTION
## Summary

**Prerequisite fix for the evidence backfill (PR-3).** While preparing PR-3 (re-grade every existing evidence entry through the PR-2 CLI flow, per `TRUST_IMPL_HANDOVER.md §PR-3`), I hit two gaps in the merged PR-2 (#686) that make the backfill impossible as specified. This PR closes both so PR-3 can be a clean, 100%-CLI-driven data migration with zero hand-edits — per the repo's **"Close the Gap — fix the CLI first"** policy (`src/gaia_cli/CLAUDE.md`).

Refs #646.

### Gap 1 — `gaia dev evidence` was append-only
PR-3 needs to re-grade **existing** entries in place (add `type`/`grade`/`trustNumber`, keep the deprecated `class`). The PR-2 CLI only ever `.append(...)`ed, so re-running it over the 220 existing entries would **double** them (~440, duplicate sources) and drop `class`.

**Fix:** new `gaia dev evidence <skill> <source> --index N …` re-grades the entry at position `N` in place:
- Sets `type` / `trustNumber` (with `grade` **re-derived from scratch** from the trust number) and `notes`.
- **Preserves** the entry's other fields — notably the deprecated `class`, plus `evaluator` / `date` / `source`.
- A trust number `<40` clears any stale `grade` (entry becomes ungraded but keeps `trustNumber`).
- Guards: out-of-range index and empty-update (`--index` with no `--trust`/`--type`/`--notes`) both error instead of silently no-op'ing.
- Fires a single `evidence_graded` audit event whenever a trust number is supplied (graded **or** ungraded), so the backfill always leaves a trail.
- Append behaviour (no `--index`) is unchanged.

### Gap 2 — `evidence_graded` failed schema validation
PR-2 fires an `evidence_graded` timeline event when a grade is derived, but never added it to the timeline `action` enum — so `gaia validate` **failed** the moment any entry was graded (latent because nothing had been graded yet).

**Fix:** added `evidence_graded` to the `action` enum in `registry/schema/skill.schema.json` and `registry/schema/namedSkill.schema.json`.

## Test plan
- [x] `tests/test_evidence_regrade.py` (new, 5 tests): append unchanged · in-place re-grade keeps `class` + untouched fields · ungraded drops `grade` · out-of-range exits · empty-update exits
- [x] `pytest tests/test_grading.py` → 40 green
- [x] **Full suite: 854 passed** (the 7 `test_authz.py` failures only appear when `GAIA_OPERATOR_OVERRIDE=1` is exported into the shell — they pass clean without it; not a regression)
- [x] `gaia validate` green with a graded entry present (was failing before Gap 2 fix)

## Maintainer notes
- **Branch scope:** this touches both `src/` and `registry/schema/`. Schema changes normally require a `schema/` branch, but it's developed on `claude/*` (unrestricted scope) at the operator's direction so the two-line enum fix ships atomically with the CLI change it supports. Add `skip-scope-check` if branch-scope CI flags it.
- **Versioning:** no version bump included — left for a `gaia release minor` at merge time (adds a CLI feature).
- **Stacked:** **PR-3 (evidence backfill, `review/meta/evidence-backfill`) depends on this merging first.** Drafting PR-3 next, stacked on this branch so its diff stays data-only.

https://claude.ai/code/session_01Dh7jNctvK9Rmw6s4cUWA9y

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dh7jNctvK9Rmw6s4cUWA9y)_