### PR TITLE
🎨 Palette: Add focus ring to share modal components

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -38,3 +38,7 @@
 ## 2026-06-13 - App-Wide Focus Ring for Navigation Toggles and Simulator Button
 **Learning:** Found that `.nav-more-toggle`, `.nav-menu-toggle`, and `.review-sim-btn` interactive elements were missing keyboard focus indicators. The codebase has an established focus ring pattern using `outline: 2px solid var(--tier-extra); outline-offset: 2px;`, which should be explicitly extended to all interactive generic buttons and controls. Furthermore, `.nav-menu-toggle:focus-visible` was explicitly removing outline `outline: none`, overriding accessibility.
 **Action:** Added these missing selectors to the app-wide focus ring block in `docs/css/styles.css` and removed `outline: none` from `.nav-menu-toggle:focus-visible` to maintain a consistent and accessible keyboard navigation experience.
+
+## 2026-06-25 - App-Wide Focus Ring for Share Modal Components
+**Learning:** Found that multiple interactive elements (`.share-action`, `.share-modal__close`) in the share modal were missing keyboard focus indicators. The codebase has an established focus ring pattern using `outline: 2px solid var(--tier-extra); outline-offset: 2px;`, which should be explicitly extended to all interactive generic buttons and controls, including new modal specific elements.
+**Action:** Added these missing selectors to the app-wide focus ring block in `docs/css/plaque.css` to maintain a consistent and accessible keyboard navigation experience.

--- a/docs/css/plaque.css
+++ b/docs/css/plaque.css
@@ -481,7 +481,9 @@ button.plaque__slug:focus-visible {
 .hoh-fs-overlay-restore:focus-visible,
 .hoh-fs-btn:focus-visible,
 .hoh-fs-btn--close:focus-visible,
-.hoh-fs-copy-btn:focus-visible {
+.hoh-fs-copy-btn:focus-visible,
+.share-action:focus-visible,
+.share-modal__close:focus-visible {
   outline: 2px solid var(--tier-extra);
   outline-offset: 2px;
 }


### PR DESCRIPTION
💡 **What:** Added keyboard focus rings to interactive elements within the share modal (`.share-action` buttons and `.share-modal__close`).
🎯 **Why:** These elements were previously unreachable or untrackable by users relying on keyboard navigation, as they lacked the standard visual focus indicator used throughout the app.
📸 **Before/After:** No visual change for mouse users. Keyboard users will now see the `var(--tier-extra)` purple outline when tabbing through the share modal.
♿ **Accessibility:** This ensures the share modal is fully keyboard accessible, making the UI more inclusive for all users.

---
*PR created automatically by Jules for task [12586395319561920208](https://jules.google.com/task/12586395319561920208) started by @mbtiongson1*

[skip-gen]