### PR TITLE
infra(ci): include registry/** in path filter so data-only PRs trigger tests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -10,6 +10,8 @@ on:
       - 'src/**'
       - 'packages/cli-npm/cli/**'
       - 'tests/**'
+      - 'registry/**'
+      - 'registry/schema/**'
       - '.github/workflows/python-package.yml'
   pull_request:
     paths:
@@ -18,6 +20,8 @@ on:
       - 'src/**'
       - 'packages/cli-npm/cli/**'
       - 'tests/**'
+      - 'registry/**'
+      - 'registry/schema/**'
       - '.github/workflows/**'
   workflow_dispatch: {}
 


### PR DESCRIPTION
## Summary

`.github/workflows/python-package.yml` triggered on `push` and `pull_request` with path filters covering `src/**`, `tests/**`, `pyproject.toml`, `packages/cli-npm/cli/**`, and the workflow YAML — but **not** `registry/**`. Result: PRs that touched only `registry/` (e.g., named-skill backfills, schema fixture updates) silently skipped CI.

Original symptom: PR #690 — a 316-file data-only head SHA that landed without any test run.

## Change

4 lines added: `registry/**` and `registry/schema/**` to both `push.paths` and `pull_request.paths`.

## Verification

YAML parses cleanly. macOS local pass green across the 7-PR Phase-1 batch.

## Closes

G1 of Phase 1 closeout (`founder/handovers/PHASE1_MASTER.md`).

---

Token spend: `2026-06-16 Haiku 4.5: 28k in, 12k out. ~$0.18`
