### PR TITLE
cli(promotion): read evidence[].grade with fallback to evidence[].class (#699)

### DIFF
--- a/src/gaia_cli/promotion.py
+++ b/src/gaia_cli/promotion.py
@@ -12,6 +12,9 @@ from .treeManager import load_tree, save_tree
 from .registry import promotion_candidates_path, registry_graph_path
 from .leveling import level_index, effective_level
 
+# Grade ordering for evidence rows: S > A > B > C (index 0 = strongest).
+_GRADE_ORDER = ["S", "A", "B", "C"]
+
 
 def _load_meta():
     """Load registry/schema/meta.json from repo root or bundled fallback."""
@@ -60,14 +63,48 @@ def _get_skill_from_tree(tree_data: dict, skill_id: str) -> dict | None:
     return None
 
 
+def _effective_grade(ev: dict) -> str | None:
+    """Return the effective grade for a single evidence row.
+
+    Reads ``grade`` first (S/A/B/C, per G7 Trust Taxonomy RFC).  Falls back to
+    ``class`` (A/B/C legacy) when ``grade`` is absent.  Returns None for rows
+    that carry neither a recognised grade nor a recognised class (ungraded).
+    """
+    grade = ev.get("grade")
+    if grade in _GRADE_ORDER:
+        return grade
+    cls = ev.get("class")
+    if cls in _GRADE_ORDER:
+        return cls
+    return None
+
+
 def _meets_evidence_floor(graph_skill: dict, target_level: str) -> bool:
-    """Check whether the graph skill has evidence meeting the floor for target_level."""
+    """Check whether the graph skill has evidence meeting the floor for target_level.
+
+    The floor list (e.g. ["B", "A"]) means "at least one evidence row whose
+    effective grade is >= the weakest letter in the list".  Grade ordering is
+    S > A > B > C so S satisfies any floor including ["A"].
+
+    Evidence rows are evaluated via :func:`_effective_grade`, which reads the
+    ``grade`` field first (new) and falls back to ``class`` (legacy).  Rows
+    with neither field are ignored.
+    """
     required_classes = EVIDENCE_FLOOR.get(target_level)
     if required_classes is None:
         return True
+    # The floor list encodes "at least one row at grade >= min(floor)".
+    # Determine the weakest acceptable grade index (highest index in _GRADE_ORDER).
+    floor_index = max(
+        (_GRADE_ORDER.index(f) for f in required_classes if f in _GRADE_ORDER),
+        default=len(_GRADE_ORDER),
+    )
     evidence_list = graph_skill.get("evidence", [])
     for ev in evidence_list:
-        if ev.get("class") in required_classes:
+        grade = _effective_grade(ev)
+        if grade is None:
+            continue
+        if _GRADE_ORDER.index(grade) <= floor_index:
             return True
     return False
 

--- a/tests/test_promotion.py
+++ b/tests/test_promotion.py
@@ -13,6 +13,8 @@ from gaia_cli.promotion import (
     check_promotion_eligibility,
     promote_skill,
     promotion_state,
+    _effective_grade,
+    _meets_evidence_floor,
 )
 
 
@@ -327,3 +329,94 @@ class TestConstants:
 
     def test_level_names_apex(self):
         assert LEVEL_NAMES["6★"] == "Apex"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _effective_grade and _meets_evidence_floor (grade/class translation)
+# ---------------------------------------------------------------------------
+
+
+class TestGradeTranslation:
+    """Tests for evidence grade/class fallback logic in _meets_evidence_floor.
+
+    Per G7 Trust Taxonomy RFC: evidence[].grade (S/A/B/C) supersedes the
+    legacy evidence[].class (A/B/C).  Floor lists encode "at least one row at
+    grade >= the weakest letter in the list".  Grade ordering: S > A > B > C.
+    """
+
+    # 1. Legacy: class-only row passes a ["B","A"] floor.
+    def test_legacy_class_only_passes_floor(self):
+        """A row with only class="B" (no grade field) satisfies a ["B","A"] floor."""
+        skill = _make_skill(
+            "legacy-skill",
+            evidence=[{"class": "B", "source": "http://x.com", "evaluator": "x",
+                        "date": "2026-01-01", "notes": ""}],
+        )
+        assert _meets_evidence_floor(skill, "3★") is True
+
+    # 2. New: grade-only row passes a ["B","A"] floor.
+    def test_new_grade_only_passes_floor(self):
+        """A row with only grade="B" (no class field) satisfies a ["B","A"] floor."""
+        skill = _make_skill(
+            "graded-skill",
+            evidence=[{"grade": "B", "source": "http://x.com", "evaluator": "x",
+                        "date": "2026-01-01", "notes": ""}],
+        )
+        assert _meets_evidence_floor(skill, "3★") is True
+
+    # 3. Mixed list: one class-only + one grade-only together pass a ["B","A"] floor.
+    def test_mixed_class_and_grade_rows_pass_floor(self):
+        """A list with one class-only (C) and one grade-only (B) entry passes ["B","A"]."""
+        skill = _make_skill(
+            "mixed-skill",
+            evidence=[
+                {"class": "C", "source": "http://c.com", "evaluator": "x",
+                 "date": "2026-01-01", "notes": "class-only"},
+                {"grade": "B", "source": "http://b.com", "evaluator": "x",
+                 "date": "2026-01-01", "notes": "grade-only"},
+            ],
+        )
+        assert _meets_evidence_floor(skill, "3★") is True
+
+    # 4. Boundary: grade="C" only FAILS a ["B","A"] floor.
+    def test_grade_c_fails_b_floor(self):
+        """A row with only grade="C" does NOT satisfy a ["B","A"] floor."""
+        skill = _make_skill(
+            "weak-skill",
+            evidence=[{"grade": "C", "source": "http://x.com", "evaluator": "x",
+                        "date": "2026-01-01", "notes": ""}],
+        )
+        assert _meets_evidence_floor(skill, "3★") is False
+
+    # 5. Bonus: S satisfies an A floor (["A"]).
+    def test_grade_s_satisfies_a_floor(self):
+        """A row with grade="S" satisfies a ["A"] floor (6★ gate). S > A."""
+        skill = _make_skill(
+            "apex-skill",
+            evidence=[{"grade": "S", "source": "http://x.com", "evaluator": "x",
+                        "date": "2026-01-01", "notes": ""}],
+        )
+        assert _meets_evidence_floor(skill, "6★") is True
+
+    # 6. Ungraded entry (no class, no grade) is ignored.
+    def test_ungraded_entry_ignored(self):
+        """An entry with neither class nor grade does not satisfy any floor."""
+        skill = _make_skill(
+            "ungraded-skill",
+            evidence=[{"source": "http://x.com", "evaluator": "x",
+                        "date": "2026-01-01", "notes": "no grade or class"}],
+        )
+        assert _meets_evidence_floor(skill, "2★") is False
+
+    # Integration: grade-only evidence propagates through check_promotion_eligibility.
+    def test_grade_only_evidence_enables_eligibility(self):
+        """A skill with grade-only evidence is included in promotion candidates."""
+        ev = [{"grade": "B", "source": "http://x.com", "evaluator": "x",
+               "date": "2026-01-01", "notes": ""}]
+        graph = _make_graph(_make_skill("graded-skill", evidence=ev))
+        tree = _make_tree("alice", [_make_unlocked("graded-skill", "2★")])
+        eligible = check_promotion_eligibility(graph, tree)
+        assert len(eligible) == 1
+        assert eligible[0]["skillId"] == "graded-skill"
+        assert eligible[0]["nextLevel"] == "3★"
+


### PR DESCRIPTION
## Summary

Per the G7 Trust Taxonomy RFC (`founder/handovers/G7_TRUST_TAXONOMY_RFC.md`, ratified 2026-06-16), evidence rows now carry **`grade`** (S/A/B/C, S strongest) alongside the deprecated **`class`** (A/B/C). `_meets_evidence_floor()` now reads `grade` first and falls back to `class` so existing rows still gate correctly during the migration window.

## Behavior

- Floor list `["B","A"]` semantically means "at least one row at grade ≥ B".
- **S satisfies any A floor** (S > A in the new ordering).
- Ungraded rows (no `grade`, no `class`) are ignored when computing the floor.

## New helper

`_effective_grade(ev)` — reads `grade` first, falls back to `class`, returns `None` for ungraded rows.

## Tests

7 new tests in `TestGradeTranslation` class added to `tests/test_promotion.py`:
- Legacy: only `class:"B"` passes `["B","A"]`.
- New: only `grade:"B"` passes `["B","A"]`.
- Mixed: list with one class-only + one grade-only entry passes.
- Boundary: only `grade:"C"` FAILS `["B","A"]`.
- S>A: `grade:"S"` passes `["A"]`.
- Ungraded entry ignored.
- Integration: grade-only row in `check_promotion_eligibility`.

Existing 32 promotion tests still pass; all 39 in `tests/test_promotion.py` pass. macOS local pass green.

## Closes

#699. G2 of Phase 1 closeout.

---

Token spend: `2026-06-16 Sonnet 4.6: ~35k in, ~5k out. ~$0.15`
