### PR TITLE
cli(tree): add pathSubset narrowing to tree-render entrypoint (#642)

### DIFF
--- a/src/gaia_cli/treeManager.py
+++ b/src/gaia_cli/treeManager.py
@@ -331,7 +331,7 @@ def _plain_label(skill_id, skill_map, named_by_ref, local_by_ref, mode, canon=Fa
 
 # ─── recursive renderer ───────────────────────────────────────────────────────
 
-def _render_subtree(skill_id, skill_map, display_ids, named_by_ref, local_by_ref, mode, prefix, is_last, seen, unlocked_ids, custom_nodes, canon=False, current_user=None, fusion_nodes=None, origin_ids=None, known_only=False, reveal_unowned=False):
+def _render_subtree(skill_id, skill_map, display_ids, named_by_ref, local_by_ref, mode, prefix, is_last, seen, unlocked_ids, custom_nodes, canon=False, current_user=None, fusion_nodes=None, origin_ids=None, known_only=False, reveal_unowned=False, narrow=False):
     if fusion_nodes is None:
         fusion_nodes = set()
     if origin_ids is None:
@@ -382,6 +382,11 @@ def _render_subtree(skill_id, skill_map, display_ids, named_by_ref, local_by_ref
             prereqs = [p for p in prereqs if _is_named(p, named_by_ref, local_by_ref) or p in display_ids]
         else:
             prereqs = [p for p in prereqs if p in display_ids]
+    elif narrow:
+        # When narrowing to a path subset, only walk prereqs that survived the
+        # prune_to_subset filter (i.e. are in display_ids). This prevents
+        # sibling leaves of a subset node from appearing in the output.
+        prereqs = [p for p in prereqs if p in display_ids]
 
     owned_prereqs = []
     unowned_prereqs = []
@@ -421,7 +426,8 @@ def _render_subtree(skill_id, skill_map, display_ids, named_by_ref, local_by_ref
             _render_subtree(
                 child_id, skill_map, display_ids, named_by_ref, local_by_ref,
                 mode, child_prefix, child_is_last, seen, unlocked_ids, custom_nodes, canon=canon, current_user=current_user,
-                fusion_nodes=fusion_nodes, origin_ids=origin_ids, known_only=known_only, reveal_unowned=reveal_unowned
+                fusion_nodes=fusion_nodes, origin_ids=origin_ids, known_only=known_only, reveal_unowned=reveal_unowned,
+                narrow=narrow,
             )
         )
 
@@ -434,9 +440,54 @@ def _render_subtree(skill_id, skill_map, display_ids, named_by_ref, local_by_ref
     return lines
 
 
+# ─── path-subset narrowing ────────────────────────────────────────────────────
+
+
+def _collect_ancestors(node_id, skill_map, visited=None):
+    """Return the transitive closure of prerequisite IDs for *node_id* (inclusive)."""
+    if visited is None:
+        visited = set()
+    if node_id in visited:
+        return visited
+    visited.add(node_id)
+    for prereq in skill_map.get(node_id, {}).get("prerequisites", []):
+        _collect_ancestors(prereq, skill_map, visited)
+    return visited
+
+
+def prune_to_subset(node_ids, skill_map, path_subset):
+    """Return the subset of *node_ids* that are in the path slice for *path_subset*.
+
+    A node is kept when:
+
+    (a) its ID is directly in *path_subset*, OR
+    (b) at least one transitive prerequisite (i.e. a node further down the tree
+        that this node leads to) is in *path_subset*, making this node an ancestor
+        on the path to a subset member.
+
+    This preserves full ancestor paths so the rendered tree is structurally
+    intact even when sibling branches are dropped.
+
+    When *path_subset* is ``None`` the original *node_ids* collection is returned
+    unchanged — full-tree behaviour is preserved.
+    """
+    if path_subset is None:
+        return node_ids
+
+    kept = set()
+    for nid in node_ids:
+        if nid in path_subset:
+            kept.add(nid)
+            continue
+        closure = _collect_ancestors(nid, skill_map)
+        if closure & path_subset:
+            kept.add(nid)
+    return kept
+
+
 # ─── public entry point ───────────────────────────────────────────────────────
 
-def show_tree(tree_data, graph_data=None, registry_path=".", mode="default", canon=False, custom=False, known_only=True, username=None):
+def show_tree(tree_data, graph_data=None, registry_path=".", mode="default", canon=False, custom=False, known_only=True, username=None, path_subset=None):
     if not tree_data:
         print("No skill tree found.")
         return
@@ -589,6 +640,12 @@ def show_tree(tree_data, graph_data=None, registry_path=".", mode="default", can
     else:
         display_ids = unlocked_ids
 
+    # Narrow the display set when a path_subset is requested.
+    # prune_to_subset keeps only nodes that are in the subset OR are ancestors
+    # of a subset member (i.e. lie on the path to it). Returns display_ids
+    # unchanged when path_subset is None, preserving full-tree behavior.
+    display_ids = prune_to_subset(display_ids, skill_map, path_subset)
+
     # Allow roots to not be strictly filtered by `display_ids` if we are showing full prereqs
     # We still need to find roots based on unlocked skills.
     all_prereqs = set()
@@ -622,10 +679,11 @@ def show_tree(tree_data, graph_data=None, registry_path=".", mode="default", can
     username_colored = f"\033[38;2;{COLOR_CONTRIBUTOR[0]};{COLOR_CONTRIBUTOR[1]};{COLOR_CONTRIBUTOR[2]}m{username}\033[0m"
     print(username_colored)
     seen: set[str] = set()
+    narrowing = path_subset is not None
     for i, entry in enumerate(roots):
         sid = entry["skillId"]
         is_last = i == len(roots) - 1
-        for line in _render_subtree(sid, skill_map, display_ids, named_by_ref, local_by_ref, mode, "", is_last, seen, unlocked_ids, custom_nodes, canon=canon, current_user=username, fusion_nodes=fusion_nodes, origin_ids=origin_ids, known_only=known_only, reveal_unowned=reveal_unowned):
+        for line in _render_subtree(sid, skill_map, display_ids, named_by_ref, local_by_ref, mode, "", is_last, seen, unlocked_ids, custom_nodes, canon=canon, current_user=username, fusion_nodes=fusion_nodes, origin_ids=origin_ids, known_only=known_only, reveal_unowned=reveal_unowned, narrow=narrowing):
             print(line)
 
     if known_only:

--- a/tests/test_treeManager.py
+++ b/tests/test_treeManager.py
@@ -4,7 +4,7 @@ import json
 import os
 import pytest
 
-from gaia_cli.treeManager import load_tree, save_tree, show_tree
+from gaia_cli.treeManager import load_tree, save_tree, show_tree, prune_to_subset
 
 
 # ---------------------------------------------------------------------------
@@ -322,6 +322,193 @@ class TestTreeRenderFixes:
         monkeypatch.setenv("COLORTERM", "truecolor")
         show_tree(tree_data, graph_data=graph_data, registry_path=str(tmp_path))
         out = capsys.readouterr().out
-        
+
         # Owned named skills should show honor red handle (COLOR_CONTRIBUTOR = (239, 68, 68))
         assert "\033[38;2;239;68;68m" in out
+
+
+# ---------------------------------------------------------------------------
+# prune_to_subset — unit tests for the narrowing helper
+# ---------------------------------------------------------------------------
+
+# Graph layout used by subset tests:
+#
+#   ultimate-skill  (ultimate, has two extras as prerequisites)
+#       ├── extra-a  (extra, requires basic-a + basic-b)
+#       │       ├── basic-a  (basic)
+#       │       └── basic-b  (basic)
+#       └── extra-b  (extra, requires basic-c + basic-d)
+#               ├── basic-c  (basic)
+#               └── basic-d  (basic)
+#
+# Total 7 skills: 1 ultimate, 2 extras, 4 basics.
+
+_SUBSET_SKILL_MAP = {
+    "ultimate-skill": {"id": "ultimate-skill", "type": "ultimate", "level": "3★", "prerequisites": ["extra-a", "extra-b"]},
+    "extra-a":        {"id": "extra-a",        "type": "extra",    "level": "2★", "prerequisites": ["basic-a", "basic-b"]},
+    "extra-b":        {"id": "extra-b",        "type": "extra",    "level": "2★", "prerequisites": ["basic-c", "basic-d"]},
+    "basic-a":        {"id": "basic-a",        "type": "basic",    "level": "1★", "prerequisites": []},
+    "basic-b":        {"id": "basic-b",        "type": "basic",    "level": "1★", "prerequisites": []},
+    "basic-c":        {"id": "basic-c",        "type": "basic",    "level": "1★", "prerequisites": []},
+    "basic-d":        {"id": "basic-d",        "type": "basic",    "level": "1★", "prerequisites": []},
+}
+
+_ALL_SKILL_IDS = set(_SUBSET_SKILL_MAP.keys())
+
+
+class TestPruneToSubset:
+    """Unit tests for prune_to_subset — the path-narrowing helper."""
+
+    def test_none_subset_returns_full_set(self):
+        """When path_subset is None the full node_ids set comes back unchanged."""
+        result = prune_to_subset(_ALL_SKILL_IDS, _SUBSET_SKILL_MAP, None)
+        assert result == _ALL_SKILL_IDS
+
+    def test_basic_narrow_three_skill_path(self):
+        """Subset of {ultimate-skill, extra-a, basic-a} keeps them plus the
+        ancestor path from ultimate-skill down through extra-a to basic-a.
+        Sibling branch extra-b and its leaves basic-c / basic-d are absent."""
+        subset = {"ultimate-skill", "extra-a", "basic-a"}
+        result = prune_to_subset(_ALL_SKILL_IDS, _SUBSET_SKILL_MAP, subset)
+        # All three requested nodes must appear.
+        assert "ultimate-skill" in result
+        assert "extra-a" in result
+        assert "basic-a" in result
+        # basic-b is extra-a's sibling leaf — it is NOT in the subset and has no
+        # subset descendant, so it should be absent.
+        assert "basic-b" not in result
+        # entire extra-b branch must be absent
+        assert "extra-b" not in result
+        assert "basic-c" not in result
+        assert "basic-d" not in result
+
+    def test_empty_subset_returns_empty(self):
+        """An empty subset set means no node qualifies — result is empty."""
+        result = prune_to_subset(_ALL_SKILL_IDS, _SUBSET_SKILL_MAP, set())
+        assert result == set()
+
+    def test_full_coverage_subset_equals_full_tree(self):
+        """When the subset equals every node in the tree the result is the full set."""
+        result = prune_to_subset(_ALL_SKILL_IDS, _SUBSET_SKILL_MAP, _ALL_SKILL_IDS)
+        assert result == _ALL_SKILL_IDS
+
+    def test_unrelated_subset_ids_return_empty(self):
+        """IDs that do not appear anywhere in node_ids or skill_map yield nothing."""
+        result = prune_to_subset(_ALL_SKILL_IDS, _SUBSET_SKILL_MAP, {"ghost-skill", "phantom"})
+        assert result == set()
+
+    def test_leaf_only_subset_keeps_full_ancestor_chain(self):
+        """Selecting a single leaf keeps every ancestor node on the path to it."""
+        # basic-a is reachable via: ultimate-skill -> extra-a -> basic-a
+        result = prune_to_subset(_ALL_SKILL_IDS, _SUBSET_SKILL_MAP, {"basic-a"})
+        assert "basic-a" in result
+        assert "extra-a" in result
+        assert "ultimate-skill" in result
+        # sibling branch must be absent
+        assert "extra-b" not in result
+        assert "basic-b" not in result
+        assert "basic-c" not in result
+        assert "basic-d" not in result
+
+
+# ---------------------------------------------------------------------------
+# show_tree with path_subset — integration tests
+# ---------------------------------------------------------------------------
+
+# 3-level graph: root → mid → leaf + a sibling branch root → mid → sibling-leaf
+_NARROW_GRAPH = {
+    "skills": [
+        {"id": "ultimate-skill", "name": "Ultimate",     "type": "ultimate", "level": "3★",
+         "prerequisites": ["extra-a", "extra-b"]},
+        {"id": "extra-a",        "name": "Extra A",      "type": "extra",    "level": "2★",
+         "prerequisites": ["basic-a", "basic-b"]},
+        {"id": "extra-b",        "name": "Extra B",      "type": "extra",    "level": "2★",
+         "prerequisites": ["basic-c", "basic-d"]},
+        {"id": "basic-a",        "name": "Basic A",      "type": "basic",    "level": "1★",
+         "prerequisites": []},
+        {"id": "basic-b",        "name": "Basic B",      "type": "basic",    "level": "1★",
+         "prerequisites": []},
+        {"id": "basic-c",        "name": "Basic C",      "type": "basic",    "level": "1★",
+         "prerequisites": []},
+        {"id": "basic-d",        "name": "Basic D",      "type": "basic",    "level": "1★",
+         "prerequisites": []},
+    ]
+}
+
+_NARROW_TREE = {
+    "userId": "narrowuser",
+    "updatedAt": "2026-01-01",
+    "unlockedSkills": [
+        {"skillId": "ultimate-skill", "level": "3★"},
+        {"skillId": "extra-a",        "level": "2★"},
+        {"skillId": "extra-b",        "level": "2★"},
+        {"skillId": "basic-a",        "level": "1★"},
+        {"skillId": "basic-b",        "level": "1★"},
+        {"skillId": "basic-c",        "level": "1★"},
+        {"skillId": "basic-d",        "level": "1★"},
+    ],
+    "pendingCombinations": [],
+    "stats": {},
+}
+
+
+class TestShowTreePathSubset:
+    """Integration tests for show_tree's path_subset parameter."""
+
+    def test_backward_compat_no_subset(self, tmp_path, monkeypatch, capsys):
+        """Calling show_tree without path_subset renders the full tree (no regression)."""
+        monkeypatch.chdir(tmp_path)
+        show_tree(_NARROW_TREE, graph_data=_NARROW_GRAPH, registry_path=str(tmp_path))
+        out = capsys.readouterr().out
+        assert "/ultimate-skill" in out
+        assert "/extra-a" in out
+        assert "/extra-b" in out
+        assert "/basic-a" in out
+        assert "/basic-c" in out
+
+    def test_narrow_subset_shows_only_path_and_ancestors(self, tmp_path, monkeypatch, capsys):
+        """path_subset={ultimate-skill, extra-a, basic-a} keeps the path branch
+        and drops sibling branch extra-b, basic-b, basic-c, basic-d."""
+        monkeypatch.chdir(tmp_path)
+        subset = {"ultimate-skill", "extra-a", "basic-a"}
+        show_tree(_NARROW_TREE, graph_data=_NARROW_GRAPH, registry_path=str(tmp_path),
+                  path_subset=subset)
+        out = capsys.readouterr().out
+        assert "/ultimate-skill" in out
+        assert "/extra-a" in out
+        assert "/basic-a" in out
+        # sibling branch must be absent
+        assert "/extra-b" not in out
+        assert "/basic-b" not in out
+        assert "/basic-c" not in out
+        assert "/basic-d" not in out
+
+    def test_empty_subset_produces_no_skill_lines(self, tmp_path, monkeypatch, capsys):
+        """path_subset=set() → nothing passes the filter → no tree connectors."""
+        monkeypatch.chdir(tmp_path)
+        show_tree(_NARROW_TREE, graph_data=_NARROW_GRAPH, registry_path=str(tmp_path),
+                  path_subset=set())
+        out = capsys.readouterr().out
+        # No tree connectors means no skill lines were rendered.
+        assert "├" not in out and "└" not in out
+
+    def test_full_subset_equals_unnarrowed_render(self, tmp_path, monkeypatch, capsys):
+        """path_subset equal to all skill IDs produces the same output as no subset."""
+        monkeypatch.chdir(tmp_path)
+        all_ids = {s["id"] for s in _NARROW_GRAPH["skills"]}
+        show_tree(_NARROW_TREE, graph_data=_NARROW_GRAPH, registry_path=str(tmp_path),
+                  path_subset=all_ids)
+        out_narrow = capsys.readouterr().out
+
+        show_tree(_NARROW_TREE, graph_data=_NARROW_GRAPH, registry_path=str(tmp_path))
+        out_full = capsys.readouterr().out
+
+        assert out_narrow == out_full
+
+    def test_unrelated_subset_produces_no_skill_lines(self, tmp_path, monkeypatch, capsys):
+        """path_subset of IDs not in the tree → nothing rendered."""
+        monkeypatch.chdir(tmp_path)
+        show_tree(_NARROW_TREE, graph_data=_NARROW_GRAPH, registry_path=str(tmp_path),
+                  path_subset={"ghost-skill", "phantom"})
+        out = capsys.readouterr().out
+        assert "├" not in out and "└" not in out


### PR DESCRIPTION
## Summary

`treeManager.show_tree()` gains a `path_subset: set[str] | None` parameter. When set, the renderer keeps only nodes that are in the subset OR have a descendant in the subset, so the path slice survives intact. Default `None` preserves full-tree behavior.

Used by `gaia share` (downstream wiring) to render only the path slice for shared bundles rather than the entire registry.

## Implementation

- `_collect_ancestors(node_id, skill_map, visited=None)` — recursive transitive-closure walk of prerequisites.
- `prune_to_subset(node_ids, skill_map, path_subset)` — public helper; returns `node_ids` unchanged when `path_subset is None`, otherwise keeps only nodes in subset or on an ancestor path.
- `_render_subtree` gains a `narrow=False` flag; when `True`, filters `prereqs` to only nodes in `display_ids` (prevents sibling leaves from appearing when parent is kept as ancestor).

## Tests

11 tests (39 total in `tests/test_treeManager.py`, all pass; macOS local pass green):
- `TestPruneToSubset` (6): None passthrough, 3-skill narrow, empty subset, full coverage, unrelated IDs, leaf-only.
- `TestShowTreePathSubset` (5): backward compat, narrow with siblings absent, empty subset, full subset = full render, unrelated subset.

## share.py wiring

Deferred. `share.py` uses its own `render_bundle_tree_lines` (operates on pre-resolved `skillMeta`), not `show_tree`. The `path_subset` parameter is exposed and ready for any downstream caller that wants to pass a bundle's skill ID set.

## Closes

#642. G6 of Phase 1 closeout.

---

Token spend: `2026-06-16 Sonnet 4.6: ~55k in, ~8k out. ~$0.20`
