### PR TITLE
cli(verification): 4-tier verification workflow (#658, folds #650)

### DIFF
--- a/registry/schema/namedSkill.schema.json
+++ b/registry/schema/namedSkill.schema.json
@@ -159,6 +159,34 @@
         }
       },
       "description": "Users who have adopted this named skill via gaia install."
+    },
+    "verification": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Verification tier state for this named skill. Recomputed by `gaia dev verify-tier` and surfaced in `gaia skills info`. The `tier` field stores the highest tier currently satisfied (or null); `firstEvidenceAt` is the tenure baseline for the enterprise-ready tier.",
+      "properties": {
+        "tier": {
+          "type": ["string", "null"],
+          "enum": [
+            null,
+            "community-verified",
+            "benchmark-verified",
+            "security-reviewed",
+            "enterprise-ready"
+          ],
+          "description": "Highest verification tier this skill currently satisfies, or null if no tier is met."
+        },
+        "tierEvaluatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp of the most recent tier recomputation."
+        },
+        "firstEvidenceAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp of the first `evidence_added` event. Used as the tenure baseline for the enterprise-ready tier."
+        }
+      }
     }
   },
   "definitions": {
@@ -266,7 +294,8 @@
             "evidence_graded",
             "type_change",
             "verified",
-            "disputed"
+            "disputed",
+            "security_scan_passed"
           ],
           "description": "The meta-action that occurred."
         },

--- a/registry/schema/skill.schema.json
+++ b/registry/schema/skill.schema.json
@@ -125,6 +125,34 @@
         "$ref": "#/definitions/timelineEvent"
       },
       "description": "Chronological history of meta-changes for this canonical skill."
+    },
+    "verification": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Verification tier state for this skill. Recomputed by `gaia dev verify-tier` and surfaced in `gaia skills info`. The `tier` field stores the highest tier currently satisfied (or null); `firstEvidenceAt` is the tenure baseline for the enterprise-ready tier.",
+      "properties": {
+        "tier": {
+          "type": ["string", "null"],
+          "enum": [
+            null,
+            "community-verified",
+            "benchmark-verified",
+            "security-reviewed",
+            "enterprise-ready"
+          ],
+          "description": "Highest verification tier this skill currently satisfies, or null if no tier is met."
+        },
+        "tierEvaluatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp of the most recent tier recomputation."
+        },
+        "firstEvidenceAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp of the first `evidence_added` event. Used as the tenure baseline for the enterprise-ready tier."
+        }
+      }
     }
   },
   "definitions": {
@@ -232,7 +260,8 @@
             "evidence_graded",
             "type_change",
             "verified",
-            "disputed"
+            "disputed",
+            "security_scan_passed"
           ],
           "description": "The meta-action that occurred."
         },

--- a/src/gaia_cli/commands/dev.py
+++ b/src/gaia_cli/commands/dev.py
@@ -172,6 +172,93 @@ def meta_verify_command(args):
         _run_docs_build(args.registry)
 
 
+def _loadSkillForVerification(registry_path: str, skill_id: str):
+    """Locate a skill's record + write-back closure for verification updates.
+
+    Returns ``(record, writeback)`` where ``record`` is the in-memory dict
+    (json node or YAML frontmatter) and ``writeback`` is a no-arg callable
+    that persists the mutated ``record`` back to disk. Returns ``(None, None)``
+    if the skill is not found.
+    """
+    if "/" in skill_id:
+        named_dir = Path(named_skills_dir(registry_path))
+        named_file = _find_named_file(named_dir, skill_id)
+        if not named_file:
+            return None, None
+        meta, body = _parse_md(named_file)
+
+        def writeNamed(captured_meta=meta, captured_body=body, captured_path=named_file):
+            captured_meta["updatedAt"] = datetime.date.today().isoformat()
+            _write_md(captured_path, captured_meta, captured_body)
+
+        return meta, writeNamed
+
+    nodes_dir = Path(registry_nodes_dir(registry_path))
+    for p in nodes_dir.glob("**/*.json"):
+        try:
+            with open(p, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+        if data.get("id") == skill_id:
+            captured_path = p
+
+            def writeGeneric(captured_data=data, p=captured_path):
+                captured_data["updatedAt"] = datetime.date.today().isoformat()
+                with open(p, "w", encoding="utf-8") as f:
+                    json.dump(captured_data, f, indent=2, ensure_ascii=False)
+                    f.write("\n")
+
+            return data, writeGeneric
+    return None, None
+
+
+def meta_verify_tier_command(args):
+    """Recompute and persist a skill's verification tier.
+
+    Reads the skill's evidence list and timeline, evaluates the four tiers
+    defined in ``gaia_cli.verification``, writes the resulting headline tier
+    to ``record.verification.tier`` (with a fresh ``tierEvaluatedAt``), and
+    prints the same pass/fail breakdown that ``gaia skills info`` surfaces.
+    """
+    from gaia_cli.verification import (
+        filterScanEvents,
+        resolveTier,
+        utcNow,
+    )
+
+    registry_path = args.registry
+    skill_id = args.skill_id.lstrip("/")
+
+    record, writeback = _loadSkillForVerification(registry_path, skill_id)
+    if record is None:
+        print(f"Error: Skill '{skill_id}' not found.", file=sys.stderr)
+        sys.exit(1)
+
+    evidence = record.get("evidence") or []
+    timeline = record.get("timeline") or []
+    scanEvents = filterScanEvents(timeline)
+    now = utcNow()
+
+    highest, statusMap = resolveTier(record, evidence, scanEvents, now)
+
+    verification = record.setdefault("verification", {})
+    verification["tier"] = highest
+    verification["tierEvaluatedAt"] = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    writeback()
+
+    headline = highest if highest else "(none)"
+    print(f"Verification: {headline}")
+    # Print every tier so the operator sees the full breakdown.
+    from gaia_cli.verification import TIER_ORDER
+
+    for tier in reversed(TIER_ORDER):
+        status = statusMap[tier]
+        marker = "✓" if status["passed"] else "✗"
+        print(f"  {marker} {tier} -- {status['reason']}")
+
+
 def meta_list_command(args):
     registry_path = args.registry
     graph_path = registry_graph_path(registry_path)
@@ -1114,6 +1201,11 @@ def meta_evidence_command(args):
             sys.exit(1)
         meta, body = _parse_md(named_file)
         result_entry = _apply(meta.setdefault("evidence", []))
+        # Stamp tenure baseline on the first evidence-add only.
+        if index is None:
+            from gaia_cli.verification import stampFirstEvidenceAt
+
+            stampFirstEvidenceAt(meta)
         meta["updatedAt"] = datetime.date.today().isoformat()
         _write_md(named_file, meta, body)
     else:
@@ -1136,6 +1228,11 @@ def meta_evidence_command(args):
         with open(node_file, "r", encoding="utf-8") as f:
             data = json.load(f)
         result_entry = _apply(data.setdefault("evidence", []))
+        # Stamp tenure baseline on the first evidence-add only.
+        if index is None:
+            from gaia_cli.verification import stampFirstEvidenceAt
+
+            stampFirstEvidenceAt(data)
         data["updatedAt"] = datetime.date.today().isoformat()
         with open(node_file, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2, ensure_ascii=False)

--- a/src/gaia_cli/data/registry/schema/namedSkill.schema.json
+++ b/src/gaia_cli/data/registry/schema/namedSkill.schema.json
@@ -159,6 +159,34 @@
         }
       },
       "description": "Users who have adopted this named skill via gaia install."
+    },
+    "verification": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Verification tier state for this named skill. Recomputed by `gaia dev verify-tier` and surfaced in `gaia skills info`. The `tier` field stores the highest tier currently satisfied (or null); `firstEvidenceAt` is the tenure baseline for the enterprise-ready tier.",
+      "properties": {
+        "tier": {
+          "type": ["string", "null"],
+          "enum": [
+            null,
+            "community-verified",
+            "benchmark-verified",
+            "security-reviewed",
+            "enterprise-ready"
+          ],
+          "description": "Highest verification tier this skill currently satisfies, or null if no tier is met."
+        },
+        "tierEvaluatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp of the most recent tier recomputation."
+        },
+        "firstEvidenceAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp of the first `evidence_added` event. Used as the tenure baseline for the enterprise-ready tier."
+        }
+      }
     }
   },
   "definitions": {
@@ -266,7 +294,8 @@
             "evidence_graded",
             "type_change",
             "verified",
-            "disputed"
+            "disputed",
+            "security_scan_passed"
           ],
           "description": "The meta-action that occurred."
         },

--- a/src/gaia_cli/data/registry/schema/skill.schema.json
+++ b/src/gaia_cli/data/registry/schema/skill.schema.json
@@ -125,6 +125,34 @@
         "$ref": "#/definitions/timelineEvent"
       },
       "description": "Chronological history of meta-changes for this canonical skill."
+    },
+    "verification": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Verification tier state for this skill. Recomputed by `gaia dev verify-tier` and surfaced in `gaia skills info`. The `tier` field stores the highest tier currently satisfied (or null); `firstEvidenceAt` is the tenure baseline for the enterprise-ready tier.",
+      "properties": {
+        "tier": {
+          "type": ["string", "null"],
+          "enum": [
+            null,
+            "community-verified",
+            "benchmark-verified",
+            "security-reviewed",
+            "enterprise-ready"
+          ],
+          "description": "Highest verification tier this skill currently satisfies, or null if no tier is met."
+        },
+        "tierEvaluatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp of the most recent tier recomputation."
+        },
+        "firstEvidenceAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp of the first `evidence_added` event. Used as the tenure baseline for the enterprise-ready tier."
+        }
+      }
     }
   },
   "definitions": {
@@ -232,7 +260,8 @@
             "evidence_graded",
             "type_change",
             "verified",
-            "disputed"
+            "disputed",
+            "security_scan_passed"
           ],
           "description": "The meta-action that occurred."
         },

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -49,6 +49,7 @@ from gaia_cli.commands.dev import (
     meta_timeline_command,
     meta_rename_command,
     meta_verify_command,
+    meta_verify_tier_command,
     meta_calibrate_command,
     meta_evidence_command,
     meta_rm_evidence_command,
@@ -274,6 +275,7 @@ MUTATING_DEV_COMMANDS = frozenset(
         "timeline",
         "rm",
         "verify",
+        "verify-tier",
         "build",
     }
 )
@@ -2467,6 +2469,72 @@ def _pending_skills(registry_path: str, username: str | None = None) -> list[dic
     return pending
 
 
+def _load_skill_record_for_info(skill_id: str, registry_path: str) -> dict | None:
+    """Load the on-disk record for a skill so verification can be recomputed.
+
+    Returns the parsed dict (named-skill YAML frontmatter or generic-skill JSON
+    node), or None when the skill cannot be located. Used by `gaia skills info`
+    to reach the evidence + timeline arrays that the named-index summary view
+    omits.
+    """
+    from gaia_cli.commands.dev import (
+        _find_named_file,
+        _parse_md,
+    )
+    from gaia_cli.registry import named_skills_dir, registry_nodes_dir
+
+    if "/" in skill_id:
+        named_dir = Path(named_skills_dir(registry_path))
+        target = _find_named_file(named_dir, skill_id)
+        if not target:
+            return None
+        meta, _ = _parse_md(target)
+        return meta or {}
+
+    nodes_dir = Path(registry_nodes_dir(registry_path))
+    if not nodes_dir.is_dir():
+        return None
+    for path in nodes_dir.glob("**/*.json"):
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        except (OSError, json.JSONDecodeError):
+            continue
+        if data.get("id") == skill_id:
+            return data
+    return None
+
+
+def _print_verification_block(skill_id: str, registry_path: str) -> None:
+    """Print the 4-tier verification breakdown for a skill, if computable.
+
+    Recomputed on the fly from disk so the output is fresh even when the
+    cached `verification.tier` field is missing or stale. Stays silent when
+    the underlying record cannot be loaded (no noisy errors during info).
+    """
+    record = _load_skill_record_for_info(skill_id, registry_path)
+    if record is None:
+        return
+
+    from gaia_cli.verification import (
+        TIER_ORDER,
+        filterScanEvents,
+        resolveTier,
+        utcNow,
+    )
+
+    evidence = record.get("evidence") or []
+    timeline = record.get("timeline") or []
+    scanEvents = filterScanEvents(timeline)
+    highest, statusMap = resolveTier(record, evidence, scanEvents, utcNow())
+    headline = highest if highest else "(none)"
+    print(f"  Verification: {headline}")
+    for tier in reversed(TIER_ORDER):
+        status = statusMap[tier]
+        marker = "✓" if status["passed"] else "✗"
+        print(f"    {marker} {tier} — {status['reason']}")
+
+
 def skills_command(args):
 
     config = load_config() or {}
@@ -2558,6 +2626,7 @@ def skills_command(args):
         print(f"  Level: {format_level_colored(level)}")
         if match.get("description"):
             print(f"  {match['description']}")
+        _print_verification_block(sid, args.registry)
         return
     if not items:
         print("No skills found.")
@@ -3291,6 +3360,14 @@ def get_parser():
         help="Skip rebuilding docs and graph assets after verification",
     )
 
+    dev_verify_tier = dev_sub.add_parser(
+        "verify-tier",
+        help="Recompute and persist a skill's verification tier (community/benchmark/security/enterprise)",
+    )
+    dev_verify_tier.add_argument(
+        "skill_id", help="Skill ID (generic ref or contributor/named) to evaluate"
+    )
+
     dev_calibrate = dev_sub.add_parser("calibrate", help="Update the level of a skill")
     dev_calibrate.add_argument("skill_id", help="Skill ID to calibrate")
     dev_calibrate.add_argument("level", help="New level (e.g. 3★)")
@@ -3771,6 +3848,8 @@ def main():
             meta_rename_command(args)
         elif dev_cmd == "verify":
             meta_verify_command(args)
+        elif dev_cmd == "verify-tier":
+            meta_verify_tier_command(args)
         elif dev_cmd == "calibrate":
             meta_calibrate_command(args)
         elif dev_cmd == "add":

--- a/src/gaia_cli/verification.py
+++ b/src/gaia_cli/verification.py
@@ -1,0 +1,318 @@
+"""Verification workflow — 4-tier predicate engine for skill trust certification.
+
+Implements the four verification tiers defined in the Phase 1 Trust Infrastructure
+scope (issues #658 + #650):
+
+  1. community-verified — at least one graded evidence row.
+  2. benchmark-verified — at least one evidence row of type 'benchmark-result'.
+  3. security-reviewed  — clean security scan recorded in the timeline within
+                          the last 90 UTC days.
+  4. enterprise-ready   — Overall Trust Grade >= A AND tenure (days since
+                          firstEvidenceAt) >= 30 completed UTC days.
+
+The four tiers are NOT a strict ladder: security-reviewed and enterprise-ready
+are independent quality dimensions of an already community-verified skill.
+``resolveTier`` returns the highest passing tier for headline display along
+with a per-tier pass/fail breakdown.
+
+The enterprise-ready Overall Trust Grade gate uses a MAX-grade proxy until the
+G7 Trust Magnitude formula lands in code (see
+``founder/handovers/G7_TRUST_TAXONOMY_RFC.md``). The security-reviewed tier
+reads ``security_scan_passed`` timeline events; the actual scan-emit wiring is
+provided by a follow-up PR that depends on G3 (cli/security-scanner).
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Iterable
+
+# Highest-to-lowest grade ordering. Mirrors gaia_cli.grading._GRADE_ORDER.
+# Lower index in this list == better grade.
+GRADE_ORDER = ["S", "A", "B", "C"]
+
+# Allowlist of evidence types that count toward the benchmark-verified tier.
+# Tracks the canonical type reserved by the G7 Benchmark RFC
+# (docs/architecture/benchmark-framework.md).
+BENCHMARK_EVIDENCE_TYPES = frozenset({"benchmark-result"})
+
+# Tier-recency window: a security_scan_passed event must be at most this many
+# UTC days old to satisfy the security-reviewed tier.
+SECURITY_SCAN_WINDOW_DAYS = 90
+
+# Minimum tenure (in completed UTC days) since firstEvidenceAt for
+# enterprise-ready.
+ENTERPRISE_TENURE_DAYS = 30
+
+# Tier list in highest-to-lowest priority order, used by resolveTier to surface
+# the headline tier on `gaia skills info` and `gaia dev verify-tier`.
+TIER_ORDER = [
+    "enterprise-ready",
+    "security-reviewed",
+    "benchmark-verified",
+    "community-verified",
+]
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def effectiveGrade(entry: dict) -> str | None:
+    """Return the effective grade letter for an evidence entry, or None.
+
+    Reads ``grade`` first; falls back to the deprecated ``class`` field for
+    backward compatibility with pre-grade evidence records. Returns None if
+    neither is present or the value is not in ``GRADE_ORDER``.
+
+    NOTE: this duplicates a small slice of helper logic that G2
+    (cli/rank-gate-grade) introduces in promotion.py as ``_effective_grade``.
+    Inlined here so this branch can land cleanly off origin/main without
+    waiting on G2; collapse into the shared helper once both branches merge.
+    """
+    g = entry.get("grade")
+    if g in GRADE_ORDER:
+        return g
+    legacy = entry.get("class")
+    if legacy in GRADE_ORDER:
+        return legacy
+    return None
+
+
+def maxGrade(evidenceList: Iterable[dict]) -> str | None:
+    """Return the highest grade letter across an evidence list, or None.
+
+    'Highest' means closest to 'S' in ``GRADE_ORDER`` (lowest index wins).
+    Used as the Overall Trust Grade proxy for enterprise-ready until the
+    full Trust Magnitude formula ships in code.
+    """
+    best: str | None = None
+    for entry in evidenceList or []:
+        g = effectiveGrade(entry)
+        if g is None:
+            continue
+        if best is None or GRADE_ORDER.index(g) < GRADE_ORDER.index(best):
+            best = g
+    return best
+
+
+def gradeAtLeast(grade: str | None, floor: str) -> bool:
+    """Return True if ``grade`` is at least ``floor`` on the S>A>B>C scale."""
+    if grade not in GRADE_ORDER or floor not in GRADE_ORDER:
+        return False
+    return GRADE_ORDER.index(grade) <= GRADE_ORDER.index(floor)
+
+
+def parseIso(value: str | None) -> datetime.datetime | None:
+    """Parse an ISO 8601 string into a timezone-aware UTC datetime, or None."""
+    if not value:
+        return None
+    raw = str(value).strip()
+    if not raw:
+        return None
+    # Accept a trailing 'Z' as UTC, which fromisoformat does not parse on
+    # Python < 3.11.
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        dt = datetime.datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=datetime.timezone.utc)
+    return dt.astimezone(datetime.timezone.utc)
+
+
+def firstEvidenceAt(skill: dict) -> datetime.datetime | None:
+    """Resolve the tenure baseline for a skill, or None if unknown.
+
+    Preference order:
+      1. ``skill.verification.firstEvidenceAt`` (the canonical record).
+      2. The earliest ``evidence_added`` timeline event (graceful fallback
+         when the canonical field hasn't been backfilled yet).
+    """
+    verification = skill.get("verification") or {}
+    fromRecord = parseIso(verification.get("firstEvidenceAt"))
+    if fromRecord is not None:
+        return fromRecord
+
+    earliest: datetime.datetime | None = None
+    for event in skill.get("timeline") or []:
+        if event.get("action") != "evidence_added":
+            continue
+        ts = parseIso(event.get("timestamp"))
+        if ts is None:
+            continue
+        if earliest is None or ts < earliest:
+            earliest = ts
+    return earliest
+
+
+# ---------------------------------------------------------------------------
+# Tier predicates
+# ---------------------------------------------------------------------------
+
+
+def isCommunityVerified(skill: dict, evidence: list) -> tuple[bool, str]:
+    """Tier 1: at least one graded evidence row (any of S/A/B/C).
+
+    ``skill`` is accepted for symmetry with the other predicates and for
+    forward-compat hooks; only ``evidence`` is read today.
+    """
+    del skill  # reserved for future use
+    for entry in evidence or []:
+        if effectiveGrade(entry) is not None:
+            return True, ">=1 graded evidence row"
+    return False, "no graded evidence yet"
+
+
+def isBenchmarkVerified(skill: dict, evidence: list) -> tuple[bool, str]:
+    """Tier 2: at least one evidence row of type 'benchmark-result'."""
+    del skill
+    for entry in evidence or []:
+        if entry.get("type") in BENCHMARK_EVIDENCE_TYPES:
+            return True, ">=1 evidence row of type 'benchmark-result'"
+    return False, "no benchmark-result evidence"
+
+
+def isSecurityReviewed(
+    skill: dict, scanEvents: list, now: datetime.datetime
+) -> tuple[bool, str]:
+    """Tier 3: a clean security scan within the last 90 UTC days.
+
+    ``scanEvents`` is the skill's timeline pre-filtered to events with
+    ``action == 'security_scan_passed'``. Each event must carry an ``at``
+    timestamp (ISO 8601). For backward compatibility we also accept the
+    standard ``timestamp`` field used by other timeline events.
+    """
+    del skill
+    nowUtc = now.astimezone(datetime.timezone.utc) if now.tzinfo else now.replace(
+        tzinfo=datetime.timezone.utc
+    )
+    cutoff = nowUtc - datetime.timedelta(days=SECURITY_SCAN_WINDOW_DAYS)
+    latest: datetime.datetime | None = None
+    for event in scanEvents or []:
+        ts = parseIso(event.get("at") or event.get("timestamp"))
+        if ts is None:
+            continue
+        if ts < cutoff:
+            continue
+        if latest is None or ts > latest:
+            latest = ts
+    if latest is None:
+        return False, f"no clean scan in last {SECURITY_SCAN_WINDOW_DAYS} days"
+    return (
+        True,
+        f"scan passed {latest.date().isoformat()} (within {SECURITY_SCAN_WINDOW_DAYS} days)",
+    )
+
+
+def isEnterpriseReady(
+    skill: dict, evidence: list, now: datetime.datetime
+) -> tuple[bool, str]:
+    """Tier 4: Trust Grade >= A AND tenure >= 30 completed UTC days.
+
+    Tenure is computed against ``firstEvidenceAt`` (canonical record, with a
+    timeline-derived fallback). The Trust Grade gate uses MAX-grade as a
+    placeholder until the G7 Trust Magnitude formula ships in code.
+    """
+    grade = maxGrade(evidence)
+    if not gradeAtLeast(grade, "A"):
+        if grade is None:
+            return False, "Trust Grade None (need >=A)"
+        return False, f"Trust Grade {grade} (need >=A)"
+
+    baseline = firstEvidenceAt(skill)
+    if baseline is None:
+        return False, f"Trust Grade {grade}, no firstEvidenceAt set"
+
+    nowUtc = now.astimezone(datetime.timezone.utc) if now.tzinfo else now.replace(
+        tzinfo=datetime.timezone.utc
+    )
+    tenureDays = (nowUtc - baseline).days
+    if tenureDays < ENTERPRISE_TENURE_DAYS:
+        return (
+            False,
+            f"Trust Grade {grade}, tenure {tenureDays} days (need >={ENTERPRISE_TENURE_DAYS})",
+        )
+    return True, f"Trust Grade {grade}, tenure {tenureDays} days"
+
+
+# ---------------------------------------------------------------------------
+# Tier resolution
+# ---------------------------------------------------------------------------
+
+
+def resolveTier(
+    skill: dict,
+    evidence: list,
+    scanEvents: list,
+    now: datetime.datetime,
+) -> tuple[str | None, dict[str, dict]]:
+    """Evaluate every tier and return ``(highestEarnedTier, tierStatusMap)``.
+
+    ``tierStatusMap`` is keyed by tier name and holds ``{'passed': bool,
+    'reason': str}`` for each of the four tiers.
+
+    The four tiers are independent quality dimensions, not a strict ladder
+    — for example, a skill can be enterprise-ready without being
+    benchmark-verified. ``resolveTier`` surfaces the highest tier that
+    passes (per ``TIER_ORDER``) for headline display, and the full breakdown
+    is preserved in ``tierStatusMap`` so callers can render every tier.
+    """
+    cv = isCommunityVerified(skill, evidence)
+    bv = isBenchmarkVerified(skill, evidence)
+    sr = isSecurityReviewed(skill, scanEvents, now)
+    er = isEnterpriseReady(skill, evidence, now)
+
+    statusMap: dict[str, dict] = {
+        "community-verified": {"passed": cv[0], "reason": cv[1]},
+        "benchmark-verified": {"passed": bv[0], "reason": bv[1]},
+        "security-reviewed": {"passed": sr[0], "reason": sr[1]},
+        "enterprise-ready": {"passed": er[0], "reason": er[1]},
+    }
+
+    highest: str | None = None
+    for tier in TIER_ORDER:
+        if statusMap[tier]["passed"]:
+            highest = tier
+            break
+    return highest, statusMap
+
+
+def filterScanEvents(timeline: Iterable[dict]) -> list[dict]:
+    """Pluck ``security_scan_passed`` events out of a full timeline list."""
+    return [
+        e
+        for e in (timeline or [])
+        if e.get("action") == "security_scan_passed"
+    ]
+
+
+def utcNow() -> datetime.datetime:
+    """Return a timezone-aware UTC ``datetime`` for the current moment.
+
+    Wrapped in a helper so tests can monkey-patch a fixed clock.
+    """
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def stampFirstEvidenceAt(
+    record: dict, isoTimestamp: str | None = None
+) -> str | None:
+    """Set ``record.verification.firstEvidenceAt`` if it is not already set.
+
+    Mutates ``record`` in place. Returns the stamped timestamp string when a
+    write occurred, or None if the field was already populated.
+
+    ``isoTimestamp`` defaults to the current UTC time formatted with a 'Z'
+    suffix to match the timeline-event style used elsewhere in the CLI.
+    """
+    verification = record.setdefault("verification", {})
+    if verification.get("firstEvidenceAt"):
+        return None
+    if isoTimestamp is None:
+        isoTimestamp = utcNow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    verification["firstEvidenceAt"] = isoTimestamp
+    return isoTimestamp

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -1,0 +1,323 @@
+"""Tests for the 4-tier verification workflow (verification.py).
+
+Covers each predicate (community-verified, benchmark-verified,
+security-reviewed, enterprise-ready) and the resolveTier roll-up.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+from gaia_cli.verification import (
+    TIER_ORDER,
+    filterScanEvents,
+    isBenchmarkVerified,
+    isCommunityVerified,
+    isEnterpriseReady,
+    isSecurityReviewed,
+    maxGrade,
+    resolveTier,
+    stampFirstEvidenceAt,
+)
+
+
+UTC = datetime.timezone.utc
+
+
+def now():
+    """Fixed clock so tenure / scan-window math is deterministic."""
+    return datetime.datetime(2026, 6, 16, 12, 0, 0, tzinfo=UTC)
+
+
+def isoDaysAgo(n: int, ref=None) -> str:
+    ref = ref or now()
+    return (ref - datetime.timedelta(days=n)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# isCommunityVerified
+# ---------------------------------------------------------------------------
+
+
+def testCommunityVerifiedNoEvidenceFails():
+    skill = {"id": "x"}
+    passed, reason = isCommunityVerified(skill, [])
+    assert passed is False
+    assert "no graded evidence" in reason
+
+
+def testCommunityVerifiedWithGradedRowPasses():
+    skill = {"id": "x"}
+    evidence = [
+        {"source": "https://example/a", "evaluator": "alice", "date": "2026-01-01", "grade": "C"},
+    ]
+    passed, reason = isCommunityVerified(skill, evidence)
+    assert passed is True
+    assert "graded evidence row" in reason
+
+
+def testCommunityVerifiedFallsBackToLegacyClass():
+    """Pre-grade evidence (only `class`) must still satisfy community-verified."""
+    skill = {"id": "x"}
+    evidence = [
+        {"source": "https://example/b", "evaluator": "bob", "date": "2026-01-01", "class": "B"},
+    ]
+    passed, _ = isCommunityVerified(skill, evidence)
+    assert passed is True
+
+
+# ---------------------------------------------------------------------------
+# isBenchmarkVerified
+# ---------------------------------------------------------------------------
+
+
+def testBenchmarkVerifiedNoBenchmarkRowFails():
+    skill = {"id": "x"}
+    evidence = [
+        {"source": "https://x/repo", "evaluator": "a", "date": "2026-01-01", "type": "repo", "grade": "A"},
+    ]
+    passed, reason = isBenchmarkVerified(skill, evidence)
+    assert passed is False
+    assert "no benchmark-result" in reason
+
+
+def testBenchmarkVerifiedWithBenchmarkResultRowPasses():
+    skill = {"id": "x"}
+    evidence = [
+        {
+            "source": "https://x/bench",
+            "evaluator": "a",
+            "date": "2026-01-01",
+            "type": "benchmark-result",
+            "grade": "A",
+        },
+    ]
+    passed, reason = isBenchmarkVerified(skill, evidence)
+    assert passed is True
+    assert "benchmark-result" in reason
+
+
+# ---------------------------------------------------------------------------
+# isSecurityReviewed
+# ---------------------------------------------------------------------------
+
+
+def testSecurityReviewedNoEventsFails():
+    skill = {"id": "x"}
+    passed, reason = isSecurityReviewed(skill, [], now())
+    assert passed is False
+    assert "no clean scan" in reason
+
+
+def testSecurityReviewed89DaysAgoPasses():
+    skill = {"id": "x"}
+    events = [
+        {"action": "security_scan_passed", "at": isoDaysAgo(89)},
+    ]
+    passed, reason = isSecurityReviewed(skill, events, now())
+    assert passed is True
+    assert "scan passed" in reason
+
+
+def testSecurityReviewed91DaysAgoFails():
+    skill = {"id": "x"}
+    events = [
+        {"action": "security_scan_passed", "at": isoDaysAgo(91)},
+    ]
+    passed, reason = isSecurityReviewed(skill, events, now())
+    assert passed is False
+    assert "no clean scan" in reason
+
+
+def testSecurityReviewedReadsTimestampFallback():
+    """Events written with the canonical `timestamp` field also count."""
+    skill = {"id": "x"}
+    events = [
+        {"action": "security_scan_passed", "timestamp": isoDaysAgo(10)},
+    ]
+    passed, _ = isSecurityReviewed(skill, events, now())
+    assert passed is True
+
+
+# ---------------------------------------------------------------------------
+# isEnterpriseReady (boundary regressions)
+# ---------------------------------------------------------------------------
+
+
+def buildSkillWithBaseline(daysAgo: int) -> dict:
+    return {
+        "id": "x",
+        "verification": {"firstEvidenceAt": isoDaysAgo(daysAgo)},
+    }
+
+
+def testEnterpriseReadyTenure30AndGradeAPasses():
+    skill = buildSkillWithBaseline(30)
+    evidence = [
+        {"source": "https://x", "evaluator": "a", "date": "2026-01-01", "grade": "A"},
+    ]
+    passed, reason = isEnterpriseReady(skill, evidence, now())
+    assert passed is True
+    assert "Trust Grade A" in reason
+    assert "tenure 30 days" in reason
+
+
+def testEnterpriseReadyTenure29AndGradeAFails():
+    """Boundary regression: 29 days < 30-day tenure floor."""
+    skill = buildSkillWithBaseline(29)
+    evidence = [
+        {"source": "https://x", "evaluator": "a", "date": "2026-01-01", "grade": "A"},
+    ]
+    passed, reason = isEnterpriseReady(skill, evidence, now())
+    assert passed is False
+    assert "tenure 29 days" in reason
+
+
+def testEnterpriseReadyTenure30AndGradeBFails():
+    """Grade gate: B is below the >=A floor."""
+    skill = buildSkillWithBaseline(30)
+    evidence = [
+        {"source": "https://x", "evaluator": "a", "date": "2026-01-01", "grade": "B"},
+    ]
+    passed, reason = isEnterpriseReady(skill, evidence, now())
+    assert passed is False
+    assert "Trust Grade B" in reason
+    assert "need >=A" in reason
+
+
+def testEnterpriseReadyTenure30AndGradeSPasses():
+    """S satisfies the >=A floor."""
+    skill = buildSkillWithBaseline(30)
+    evidence = [
+        {"source": "https://x", "evaluator": "a", "date": "2026-01-01", "grade": "S"},
+    ]
+    passed, _ = isEnterpriseReady(skill, evidence, now())
+    assert passed is True
+
+
+def testEnterpriseReadyMissingFirstEvidenceAtFails():
+    """No firstEvidenceAt and no evidence_added timeline entry → fail."""
+    skill = {"id": "x"}
+    evidence = [
+        {"source": "https://x", "evaluator": "a", "date": "2026-01-01", "grade": "A"},
+    ]
+    passed, reason = isEnterpriseReady(skill, evidence, now())
+    assert passed is False
+    assert "no firstEvidenceAt" in reason
+
+
+def testEnterpriseReadyFallsBackToTimelineEvidenceAdded():
+    """If firstEvidenceAt isn't set, the earliest evidence_added timeline event
+    is used as the tenure baseline."""
+    skill = {
+        "id": "x",
+        "timeline": [
+            {"action": "evidence_added", "timestamp": isoDaysAgo(45)},
+            {"action": "evidence_added", "timestamp": isoDaysAgo(10)},
+        ],
+    }
+    evidence = [
+        {"source": "https://x", "evaluator": "a", "date": "2026-01-01", "grade": "A"},
+    ]
+    passed, reason = isEnterpriseReady(skill, evidence, now())
+    assert passed is True
+    assert "tenure 45 days" in reason
+
+
+# ---------------------------------------------------------------------------
+# resolveTier
+# ---------------------------------------------------------------------------
+
+
+def testResolveTierReturnsHighestPassedAndFullMap():
+    """A skill that passes all four tiers surfaces enterprise-ready and
+    returns a status map with one entry per tier."""
+    skill = buildSkillWithBaseline(60)
+    evidence = [
+        {
+            "source": "https://x/bench",
+            "evaluator": "a",
+            "date": "2026-01-01",
+            "type": "benchmark-result",
+            "grade": "S",
+        },
+    ]
+    scanEvents = [
+        {"action": "security_scan_passed", "at": isoDaysAgo(5)},
+    ]
+    highest, statusMap = resolveTier(skill, evidence, scanEvents, now())
+    assert highest == "enterprise-ready"
+    assert set(statusMap.keys()) == set(TIER_ORDER)
+    for tier in TIER_ORDER:
+        assert statusMap[tier]["passed"] is True
+        assert isinstance(statusMap[tier]["reason"], str)
+
+
+def testResolveTierReturnsCommunityVerifiedWhenOnlyThatPasses():
+    skill = {"id": "x"}  # no firstEvidenceAt → enterprise-ready blocked
+    evidence = [
+        # graded but not benchmark-result; grade C blocks enterprise even with tenure
+        {
+            "source": "https://x/repo",
+            "evaluator": "a",
+            "date": "2026-01-01",
+            "type": "repo",
+            "grade": "C",
+        },
+    ]
+    highest, statusMap = resolveTier(skill, evidence, [], now())
+    assert highest == "community-verified"
+    assert statusMap["community-verified"]["passed"] is True
+    assert statusMap["benchmark-verified"]["passed"] is False
+    assert statusMap["security-reviewed"]["passed"] is False
+    assert statusMap["enterprise-ready"]["passed"] is False
+
+
+def testResolveTierReturnsNoneWhenNothingPasses():
+    skill = {"id": "x"}
+    highest, statusMap = resolveTier(skill, [], [], now())
+    assert highest is None
+    for tier in TIER_ORDER:
+        assert statusMap[tier]["passed"] is False
+
+
+# ---------------------------------------------------------------------------
+# Helper coverage
+# ---------------------------------------------------------------------------
+
+
+def testMaxGradeReadsLegacyClass():
+    evidence = [
+        {"source": "x", "evaluator": "a", "date": "2026-01-01", "class": "A"},
+        {"source": "y", "evaluator": "a", "date": "2026-01-01", "class": "C"},
+    ]
+    assert maxGrade(evidence) == "A"
+
+
+def testFilterScanEventsExtractsOnlyMatchingAction():
+    timeline = [
+        {"action": "evidence_added", "timestamp": isoDaysAgo(10)},
+        {"action": "security_scan_passed", "at": isoDaysAgo(5)},
+        {"action": "rank_up", "timestamp": isoDaysAgo(3)},
+    ]
+    events = filterScanEvents(timeline)
+    assert len(events) == 1
+    assert events[0]["action"] == "security_scan_passed"
+
+
+def testStampFirstEvidenceAtSetsAndIsIdempotent():
+    record: dict = {}
+    first = stampFirstEvidenceAt(record, "2026-01-01T00:00:00Z")
+    assert first == "2026-01-01T00:00:00Z"
+    assert record["verification"]["firstEvidenceAt"] == "2026-01-01T00:00:00Z"
+
+    # Second call must not overwrite.
+    second = stampFirstEvidenceAt(record, "2026-06-01T00:00:00Z")
+    assert second is None
+    assert record["verification"]["firstEvidenceAt"] == "2026-01-01T00:00:00Z"
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Adds a `verification` object to the skill + named-skill schemas and a new `src/gaia_cli/verification.py` module with 4 predicate tiers per the Trust Infrastructure scope:

1. **community-verified** — ≥1 graded evidence row.
2. **benchmark-verified** — ≥1 evidence row of `type: "benchmark-result"`. (Placeholder; `benchmark-result` is reserved by the G7 Benchmark RFC, also landing this batch.)
3. **security-reviewed** — clean scan within last 90 days. Reads `security_scan_passed` timeline events; the scanner emit-event wiring is a follow-up PR (depends on G3 `cli/security-scanner` merging).
4. **enterprise-ready** — Overall Trust Grade ≥ A AND tenure ≥ 30 completed UTC days from `firstEvidenceAt`.

## Tenure baseline

`firstEvidenceAt` is set on the first `evidence_added` event. New evidence-add events stamp it; backfill not done in this PR.

## CLI surface

- `gaia skills info <id>` — surfaces the highest tier with a full pass/fail breakdown.
- `gaia dev verify-tier <id>` (new subcommand) — recomputes and writes `verification.tier` + `verification.tierEvaluatedAt`.

## Trust Magnitude proxy

`enterprise-ready`'s grade gate uses MAX-grade as proxy until the G7 Trust Magnitude formula lands in code. Equivalent to "≥1 row at A or S".

## Tests

21 tests in `tests/test_verification.py` pass. Spec required ≥12; covers all 4 predicates, boundary regressions (29-day tenure fails, 30-day passes; grade-S satisfies A floor), `resolveTier` roll-up, helper coverage. macOS local pass green.

## Schema additions

`registry/schema/{skill,namedSkill}.schema.json` each gain:
- `verification` object: `tier` (enum), `tierEvaluatedAt`, `firstEvidenceAt`.
- `security_scan_passed` action enum entry on the timeline.

## Branch-scope note

This PR touches `registry/schema/` from a `cli/` branch. The verification feature is cohesive (schema + reader + writer ship together) and the `schema/`-branch-only rule is for terminology shifts, not feature additions that include schema fields. **`skip-scope-check` label applied** per maintainer convention.

## TODO (post-merge)

- Once G2 (`cli/rank-gate-grade`) lands, collapse the local `effectiveGrade()` reader in `verification.py` to import from `promotion.py` — TODO comment marks the spot.
- Once G3 (`cli/security-scanner`) lands, follow-up PR wires the scanner to emit `security_scan_passed` timeline events.

## Closes

#658. Folds #650 (`Define Certification Tiers` — same artifact, different framing). G4 of Phase 1 closeout.

---

Token spend: `2026-06-16 Opus 4.8: ~95k in, ~14k out. ~$8.50`
