### PR TITLE
fix(trust): ToC renders in-body, not fixed to top

### DIFF
--- a/docs/codex/trust-methodology.html
+++ b/docs/codex/trust-methodology.html
@@ -335,7 +335,7 @@
     </section>
 
     <!-- ─── TABLE OF CONTENTS ─── -->
-    <nav class="codex-toc" aria-label="Page contents">
+    <div class="codex-toc" role="navigation" aria-label="Page contents">
       <p class="codex-toc__title">On this page</p>
       <ol class="codex-toc__list">
         <li><a href="#trust-magnitude">Trust Magnitude formula</a></li>
@@ -346,7 +346,7 @@
         <li><a href="#worked-example">Worked example — mattpocock/skills</a></li>
         <li><a href="#gameability">Gameability vectors closed</a></li>
       </ol>
-    </nav>
+    </div>
 
     <!-- ─── §1 TRUST MAGNITUDE FORMULA ─── -->
     <section class="process-section" id="trust-magnitude">

--- a/docs/trust/index.html
+++ b/docs/trust/index.html
@@ -335,7 +335,7 @@
     </section>
 
     <!-- ─── TABLE OF CONTENTS ─── -->
-    <nav class="codex-toc" aria-label="Page contents">
+    <div class="codex-toc" role="navigation" aria-label="Page contents">
       <p class="codex-toc__title">On this page</p>
       <ol class="codex-toc__list">
         <li><a href="#trust-magnitude">Trust Magnitude formula</a></li>
@@ -346,7 +346,7 @@
         <li><a href="#worked-example">Worked example — mattpocock/skills</a></li>
         <li><a href="#gameability">Gameability vectors closed</a></li>
       </ol>
-    </nav>
+    </div>
 
     <!-- ─── §1 TRUST MAGNITUDE FORMULA ─── -->
     <section class="process-section" id="trust-magnitude">


### PR DESCRIPTION
## Summary

- `nav:not(.footer-cols) { position: fixed }` in `styles.css` was catching the in-body `<nav class="codex-toc">` on both Trust Methodology pages, pinning it to the top of the viewport instead of rendering it in the document flow
- Changed `<nav class="codex-toc">` → `<div class="codex-toc" role="navigation">` in both `docs/trust/index.html` and `docs/codex/trust-methodology.html`
- `role="navigation"` preserves accessibility landmark semantics while being exempt from the `nav:not(.footer-cols)` selector

## Files changed

| File | Change |
|---|---|
| `docs/trust/index.html` | `<nav>` → `<div role="navigation">` |
| `docs/codex/trust-methodology.html` | `<nav>` → `<div role="navigation">` |

## Verification

Local server running at **http://localhost:8899/trust/** — please verify:
1. "On this page" ToC renders below the page hero, in the document body
2. ToC is not pinned/floating at the top of the viewport
3. Back link and all section anchor links still work

## Refs

Follows #716 (Trust Methodology standalone page)