### PR TITLE
feat(schema): G7 Trust Magnitude + 10-type taxonomy + 6-predicate apex gate (Phase 1.5 I1)

### DIFF
--- a/registry/schema/meta.json
+++ b/registry/schema/meta.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "description": "Gaia schema metadata — single source of truth for nomenclature, theming, and validation rules. Technical policy is documented in META.md.",
+  "version": "5.0.0-schema",
   "levels": {
     "order": [
       "0★",
@@ -143,9 +144,133 @@
       "B"
     ],
     "types": [
-      "arxiv",
-      "repo",
-      "github-stars"
+      {
+        "id": "fusion-recipe",
+        "description": "Skill emerges from composition of graded prior work. Auto-derived for every fused/Ultimate skill from suiteComponents (RFC §10.8). Only graded≥C origins count toward origin tally.",
+        "magnitude": "20 * origins for origins <= 10; 200 + 20 * sqrt(origins - 10) for origins > 10",
+        "weight": 1.5,
+        "cap": "softened (no hard cap; sqrt curve limits growth past 10 origins)",
+        "gradeCeiling": "S",
+        "freshness": "1.0 (intrinsic — no decay)",
+        "selfProducible": true,
+        "notes": "Mandatory for any fused or Ultimate skill. A skill with suiteComponents and no fusion-recipe row fails validation (RFC §10.2). Only graded≥C origins count (RFC §3.5)."
+      },
+      {
+        "id": "github-stars-own",
+        "description": "Stars on the skill's own repository. Mothership-discounted when the repo contains multiple skills.",
+        "magnitude": "min(200, stars / 1000) / mothership_divisor where mothership_divisor = min(skill_count_in_repo, 4)",
+        "weight": 1.0,
+        "cap": 200,
+        "gradeCeiling": "S",
+        "freshness": "re-fetch quarterly; no time decay (gaia refresh-stars re-stamps lastVerified)",
+        "selfProducible": false,
+        "notes": "Same-source dedup collapses multiple entries pointing at same canonical URL to one. Fork-network canonicalization merges forks of same upstream unless evidence entry sets links.canonicalRepo. S-capable at 100k+ stars."
+      },
+      {
+        "id": "proxy-containment",
+        "description": "The skill's artifact is bundled inside a separately-starred external project.",
+        "magnitude": "min(160, (external_stars / 1000) * 0.8)",
+        "weight": 1.0,
+        "cap": 160,
+        "gradeCeiling": "S",
+        "freshness": "re-fetch quarterly; no time decay",
+        "selfProducible": false,
+        "maxEntriesPerSkill": 3,
+        "plateau": [1.0, 0.5, 0.25],
+        "externalStarFloor": 10000,
+        "notes": "Until proxy-containment validator ships, claims count at full magnitude with explicit unverified=true flag. S-capable at 125k+ external stars (RFC §2.4)."
+      },
+      {
+        "id": "verifier-attestation",
+        "description": "A 4★+ Verifier signs an attestation that the skill is real and graded fairly.",
+        "magnitude": "30 * verifiers",
+        "weight": 1.5,
+        "cap": null,
+        "gradeCeiling": "S",
+        "freshness": "null on derank — evaluates to null (not zero) when attesting Verifier drops below 4★ (RFC §5.6)",
+        "selfProducible": false,
+        "notes": "No cap on verifier count for magnitude. Diversity gate for S counts max 3 verifiers as one distinct type slot. Null-on-derank: the row is removed from TM sum; flag preserved for audit. S-capable at 3+ verifiers."
+      },
+      {
+        "id": "benchmark-result",
+        "description": "A reproducible benchmark on a public dataset, scored as percentile rank within the field.",
+        "magnitude": "percentile (0–100)",
+        "weight": 1.4,
+        "cap": 100,
+        "gradeCeiling": "S",
+        "freshness": "50%/year decay (half-life ≈ 1 year)",
+        "selfProducible": false,
+        "notes": "S-capable at 95th+ percentile. Weight 1.4 because percentiles are externally verifiable. Only at 1.4 (not 1.5) because benchmark choice can be cherry-picked."
+      },
+      {
+        "id": "arxiv",
+        "description": "Academic citation count for a published paper associated with the skill.",
+        "magnitude": "min(100, citations / 5)",
+        "weight": 1.0,
+        "cap": 100,
+        "gradeCeiling": "A",
+        "freshness": "re-fetch quarterly; no time decay",
+        "selfProducible": false,
+        "notes": "A-cap: high citation counts cluster around surveys, not executable skills. 500-citation paper hits cap (m=100) but cannot reach S without complementary types."
+      },
+      {
+        "id": "peer-review",
+        "description": "Structured walkthrough with written critique by 4★+ reviewers (distinct from verifier-attestation).",
+        "magnitude": "25 * reviewers",
+        "weight": 1.2,
+        "cap": null,
+        "gradeCeiling": "A",
+        "freshness": "25%/2yr decay (linear)",
+        "selfProducible": false,
+        "plateau": [1.0, 0.5, 0.25],
+        "notes": "A-cap — peer-review without external adoption signals does not justify S. Plateau applies for stacked entries."
+      },
+      {
+        "id": "repo-own",
+        "description": "Artifact volume evidence from the contributor's own repository (commits + contributors).",
+        "magnitude": "min(60, commits/200 + contributors^2 * 2)",
+        "weight": 0.6,
+        "cap": 60,
+        "gradeCeiling": "B",
+        "freshness": "re-fetch quarterly; no time decay",
+        "selfProducible": true,
+        "notes": "B-cap and weight 0.6 ensure repo-own alone cannot carry a skill past B. Diversity gate classes repo-own as self-producible: A or S requires non-self-producible evidence on top."
+      },
+      {
+        "id": "self-attestation",
+        "description": "Contributor declaration that the skill exists and is real. Flat 10 magnitude, max 1 entry per skill.",
+        "magnitude": "10 (flat)",
+        "weight": 0.5,
+        "cap": 10,
+        "gradeCeiling": "C",
+        "freshness": "static — never decays",
+        "selfProducible": true,
+        "maxEntriesPerSkill": 1,
+        "notes": "C-cap. A skill with only self-attestation scores 5 artifact score (10 × 0.5) and lands ungraded. Placeholder for newly-added skills with no external trail yet."
+      },
+      {
+        "id": "social-signal",
+        "description": "Creator/audience evidence — video views, engagement, topical authority from external creators.",
+        "magnitude": "log10(views) * 8 * creator_mult * engagement_ratio where engagement_ratio = min(1.5, (likes + comments*5) / views * 50)",
+        "weight": 1.0,
+        "cap": 80,
+        "gradeCeiling": "A",
+        "freshness": "50%/year decay (half-life ≈ 1 year)",
+        "selfProducible": false,
+        "maxEntriesPerSkill": 3,
+        "plateau": [1.0, 0.5, 0.25],
+        "creatorMultipliers": {
+          "sameAsAuthor": 0,
+          "anonymous": 0.3,
+          "established": 0.6,
+          "topicalAuthority": 1.0,
+          "recognizedVoice": 1.2,
+          "reserved": 1.4
+        },
+        "viewFloor": 1000,
+        "publishCooldownDays": 30,
+        "notes": "Hard A-cap (RFC §10.7): social-signal contribution to TM never exceeds 80. Same-creator dedup: 2nd entry at 0.5×, 3rd at 0.25× regardless of slot. recognizedVoice (1.2×) requires 2 cross-org 4★+ verifier cosigns via gaia dev evidence --cosign-with."
+      }
     ],
     "gradeThresholds": {
       "S": 90,
@@ -161,6 +286,56 @@
       },
       "componentFloor": "C"
     }
+  },
+  "trustMagnitudeThresholds": {
+    "description": "G7 Trust Magnitude grade thresholds (RFC §4). trustMagnitude must meet the minimum AND the diversity gate (distinct types + non-self-producible rule at S) to earn the grade.",
+    "S": 250,
+    "A": 100,
+    "B": 50,
+    "C": 20,
+    "ungraded": 0,
+    "softDisplayCap": 500,
+    "diversityGate": {
+      "S": {
+        "minDistinctTypes": 3,
+        "requiresNonSelfProducible": true,
+        "plusRule": ">=1 S-capable type present OR >=3 A-capable types of distinct kinds; AND >=1 non-self-producible type"
+      },
+      "A": {
+        "minDistinctTypes": 1,
+        "requiresNonSelfProducible": false,
+        "plusRule": ">=1 A-capable type present (pure github-stars-own at A is valid)"
+      },
+      "B": {
+        "minDistinctTypes": 1,
+        "requiresNonSelfProducible": false,
+        "plusRule": ">=1 B-capable type or higher"
+      },
+      "C": {
+        "minDistinctTypes": 0,
+        "requiresNonSelfProducible": false,
+        "plusRule": "none"
+      }
+    },
+    "selfProducibleTypes": ["fusion-recipe", "self-attestation", "repo-own"]
+  },
+  "apexGate": {
+    "description": "6★ apex gate configuration (RFC §11.12, amended by G7 delta §A). All 6 active predicates must be simultaneously satisfied. Two predicates are feature-flagged OFF until 2026-Q4 review.",
+    "predicates": [
+      "aGradedOriginsGte5",
+      "sourceTenureDaysGte180AorS",
+      "directNestedSuiteGte1",
+      "depth2OnlyReachableGte1",
+      "overallGradeS",
+      "apexPromotionPrSigned"
+    ],
+    "featureFlaggedOff": [
+      "crossOrgVerifierGte2",
+      "systemWideCapRespected"
+    ],
+    "systemWideCap": 5,
+    "featureFlaggedOffReviewDate": "2026-Q4",
+    "notes": "crossOrgVerifierGte2 and systemWideCapRespected are implemented in passesApexGate() but return null (skipped) until re-enabled. System-wide cap enforcement lives in CI (meta-guard.yml I4), not in per-skill predicate evaluation. gaia promote rejects target_level==6★ at CLI layer; apex requires a manually-opened PR labeled apex-promotion with >=2 verifier approvals from >=2 distinct GitHub orgs."
   },
   "demerits": {
     "order": [
@@ -203,11 +378,7 @@
       }
     },
     "6★": {
-      "description": "Apex path: Reaching Apex rank requires Tier A evidence and a fusion involving at least one Origin 5★ Transcendent skill.",
-      "apexPath": {
-        "minUltimateSkills": 1,
-        "minUltimateLevel": "5★"
-      }
+      "description": "Apex path: Reaching Apex rank (6★) requires satisfying all 6 active apex gate predicates simultaneously (RFC §11.12, amended by G7 delta §A). gaia promote rejects target_level==6★ at CLI layer. A PR labeled apex-promotion with >=2 cross-org verifier approvals is required. Legacy apexPath (minUltimateSkills/minUltimateLevel) is superseded by apexGate block above."
     }
   },
   "customInstallation": {

--- a/registry/schema/meta.json
+++ b/registry/schema/meta.json
@@ -152,6 +152,9 @@
         "gradeCeiling": "S",
         "freshness": "1.0 (intrinsic — no decay)",
         "selfProducible": true,
+        "allowedLayers": [
+          "named"
+        ],
         "notes": "Mandatory for any fused or Ultimate skill. A skill with suiteComponents and no fusion-recipe row fails validation (RFC §10.2). Only graded≥C origins count (RFC §3.5)."
       },
       {
@@ -163,6 +166,9 @@
         "gradeCeiling": "S",
         "freshness": "re-fetch quarterly; no time decay (gaia refresh-stars re-stamps lastVerified)",
         "selfProducible": false,
+        "allowedLayers": [
+          "named"
+        ],
         "notes": "Same-source dedup collapses multiple entries pointing at same canonical URL to one. Fork-network canonicalization merges forks of same upstream unless evidence entry sets links.canonicalRepo. S-capable at 100k+ stars."
       },
       {
@@ -174,8 +180,17 @@
         "gradeCeiling": "S",
         "freshness": "re-fetch quarterly; no time decay",
         "selfProducible": false,
+        "allowedLayers": [
+          "generic",
+          "named"
+        ],
+        "inheritMultiplier": 0.25,
         "maxEntriesPerSkill": 3,
-        "plateau": [1.0, 0.5, 0.25],
+        "plateau": [
+          1.0,
+          0.5,
+          0.25
+        ],
         "externalStarFloor": 10000,
         "notes": "Until proxy-containment validator ships, claims count at full magnitude with explicit unverified=true flag. S-capable at 125k+ external stars (RFC §2.4)."
       },
@@ -188,6 +203,9 @@
         "gradeCeiling": "S",
         "freshness": "null on derank — evaluates to null (not zero) when attesting Verifier drops below 4★ (RFC §5.6)",
         "selfProducible": false,
+        "allowedLayers": [
+          "named"
+        ],
         "notes": "No cap on verifier count for magnitude. Diversity gate for S counts max 3 verifiers as one distinct type slot. Null-on-derank: the row is removed from TM sum; flag preserved for audit. S-capable at 3+ verifiers."
       },
       {
@@ -199,6 +217,11 @@
         "gradeCeiling": "S",
         "freshness": "50%/year decay (half-life ≈ 1 year)",
         "selfProducible": false,
+        "allowedLayers": [
+          "generic",
+          "named"
+        ],
+        "inheritMultiplier": 0.15,
         "notes": "S-capable at 95th+ percentile. Weight 1.4 because percentiles are externally verifiable. Only at 1.4 (not 1.5) because benchmark choice can be cherry-picked."
       },
       {
@@ -210,6 +233,11 @@
         "gradeCeiling": "A",
         "freshness": "re-fetch quarterly; no time decay",
         "selfProducible": false,
+        "allowedLayers": [
+          "generic",
+          "named"
+        ],
+        "inheritMultiplier": 0.7,
         "notes": "A-cap: high citation counts cluster around surveys, not executable skills. 500-citation paper hits cap (m=100) but cannot reach S without complementary types."
       },
       {
@@ -221,7 +249,16 @@
         "gradeCeiling": "A",
         "freshness": "25%/2yr decay (linear)",
         "selfProducible": false,
-        "plateau": [1.0, 0.5, 0.25],
+        "allowedLayers": [
+          "generic",
+          "named"
+        ],
+        "inheritMultiplier": 0.3,
+        "plateau": [
+          1.0,
+          0.5,
+          0.25
+        ],
         "notes": "A-cap — peer-review without external adoption signals does not justify S. Plateau applies for stacked entries."
       },
       {
@@ -233,6 +270,9 @@
         "gradeCeiling": "B",
         "freshness": "re-fetch quarterly; no time decay",
         "selfProducible": true,
+        "allowedLayers": [
+          "named"
+        ],
         "notes": "B-cap and weight 0.6 ensure repo-own alone cannot carry a skill past B. Diversity gate classes repo-own as self-producible: A or S requires non-self-producible evidence on top."
       },
       {
@@ -244,6 +284,9 @@
         "gradeCeiling": "C",
         "freshness": "static — never decays",
         "selfProducible": true,
+        "allowedLayers": [
+          "named"
+        ],
         "maxEntriesPerSkill": 1,
         "notes": "C-cap. A skill with only self-attestation scores 5 artifact score (10 × 0.5) and lands ungraded. Placeholder for newly-added skills with no external trail yet."
       },
@@ -256,8 +299,17 @@
         "gradeCeiling": "A",
         "freshness": "50%/year decay (half-life ≈ 1 year)",
         "selfProducible": false,
+        "allowedLayers": [
+          "generic",
+          "named"
+        ],
+        "inheritMultiplier": 0.35,
         "maxEntriesPerSkill": 3,
-        "plateau": [1.0, 0.5, 0.25],
+        "plateau": [
+          1.0,
+          0.5,
+          0.25
+        ],
         "creatorMultipliers": {
           "sameAsAuthor": 0,
           "anonymous": 0.3,
@@ -316,7 +368,11 @@
         "plusRule": "none"
       }
     },
-    "selfProducibleTypes": ["fusion-recipe", "self-attestation", "repo-own"]
+    "selfProducibleTypes": [
+      "fusion-recipe",
+      "self-attestation",
+      "repo-own"
+    ]
   },
   "apexGate": {
     "description": "6★ apex gate configuration (RFC §11.12, amended by G7 delta §A). All 6 active predicates must be simultaneously satisfied. Two predicates are feature-flagged OFF until 2026-Q4 review.",

--- a/registry/schema/meta.json
+++ b/registry/schema/meta.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "description": "Gaia schema metadata — single source of truth for nomenclature, theming, and validation rules. Technical policy is documented in META.md.",
-  "version": "5.0.0-schema",
   "levels": {
     "order": [
       "0★",

--- a/registry/schema/namedSkill.schema.json
+++ b/registry/schema/namedSkill.schema.json
@@ -85,6 +85,11 @@
           "type": "string",
           "format": "uri",
           "description": "Documentation or landing page URL."
+        },
+        "canonicalRepo": {
+          "type": "string",
+          "format": "uri",
+          "description": "Canonical upstream repository URL. Used as the fork-network canonicalization anchor for this named skill's github-stars-own evidence (RFC §11.5). When set, star pools from all forks of this URL are merged into one."
         }
       }
     },
@@ -187,6 +192,65 @@
           "description": "ISO 8601 timestamp of the first `evidence_added` event. Used as the tenure baseline for the enterprise-ready tier."
         }
       }
+    },
+    "trustMagnitude": {
+      "type": "number",
+      "minimum": 0,
+      "description": "G7 Trust Magnitude — unbounded aggregate artifact score computed from the 10-type evidence taxonomy (RFC §3). Sum of per-evidence artifact scores (magnitude × weight × freshness). Display layer soft-caps at 500; raw value drives grading and the apex gate. Replaces the legacy trustNumber aggregate."
+    },
+    "overallTrustGrade": {
+      "type": "string",
+      "enum": ["S", "A", "B", "C", "ungraded"],
+      "description": "G7 Overall Trust Grade derived from trustMagnitude thresholds and diversity gate (RFC §4): S ≥ 250, A ≥ 100, B ≥ 50, C ≥ 20, ungraded < 20. Requires meeting the diversity gate (distinct evidence types, non-self-producible rule) in addition to the magnitude floor."
+    },
+    "provisional": {
+      "type": "boolean",
+      "default": false,
+      "description": "True if this skill is graded at its current overallTrustGrade under the 6-month provisional grace window (RFC §5.7). A provisional skill passed the magnitude threshold for its grade but failed the diversity gate at G7 migration cutover. Demotion at grace expiry is PR-gated, not automatic."
+    },
+    "provisionalUntil": {
+      "type": "string",
+      "format": "date",
+      "description": "ISO date when the provisional grace window expires. Populated only when provisional=true. After this date gaia validate emits a provisional-expired warning; demotion requires a curator PR."
+    },
+    "apexGateStatus": {
+      "type": "object",
+      "description": "Per-predicate pass/fail for the 6★ apex gate (RFC §11.12, amended by G7 delta §A). All 6 active predicates must be true simultaneously for apex eligibility. Two additional predicates are feature-flagged OFF (return null = skipped) until 2026-Q4 review.",
+      "additionalProperties": false,
+      "properties": {
+        "aGradedOriginsGte5": {
+          "type": ["boolean", "null"],
+          "description": "TRUE if the skill's transitive fusion-recipe closure contains ≥5 distinct A-or-S-graded origin evidence rows. Consolidates the old transitiveOriginsGte12 and aGradedClosureGte8 predicates (delta §A)."
+        },
+        "sourceTenureDaysGte180AorS": {
+          "type": ["boolean", "null"],
+          "description": "TRUE if the maximum source age across all A/S-tier evidence rows is ≥180 calendar days, measured via the per-row sourceStartedAt field. Replaces the old tenureDaysGte180 predicate (delta §A). False (not null) when no A/S rows exist."
+        },
+        "directNestedSuiteGte1": {
+          "type": ["boolean", "null"],
+          "description": "TRUE if at least one direct component of this skill itself has non-empty suiteComponents (RFC §11.12.2)."
+        },
+        "depth2OnlyReachableGte1": {
+          "type": ["boolean", "null"],
+          "description": "TRUE if the fusion graph (role=origin edges, excluding suite-component edges) contains at least one skill reachable only at depth-2 and not at depth-1 (RFC §11.12.3, delta §A depth-2 walk amendment)."
+        },
+        "overallGradeS": {
+          "type": ["boolean", "null"],
+          "description": "TRUE if overallTrustGrade equals S under strict-evidence reading (anti-auto-mint per RFC §10.14; only fusion-recipe may be auto-derived)."
+        },
+        "apexPromotionPrSigned": {
+          "type": ["boolean", "null"],
+          "description": "TRUE if a PR labeled apex-promotion exists with ≥2 distinct 4★+ verifier approvals from at least 2 distinct GitHub orgs (RFC §11.12.8). gaia promote rejects target_level==6★ at CLI layer; this predicate is set only by meta-guard.yml at merge time."
+        },
+        "crossOrgVerifierGte2": {
+          "type": ["boolean", "null"],
+          "description": "FEATURE-FLAGGED OFF until 2026-Q4 review. When active: TRUE if ≥2 verifier-attestation rows exist from 4★+ verifiers in at least 2 distinct GitHub orgs (RFC §11.12.6). Returns null (skipped) while flag is off; CI cap in I4 enforces the system-wide limit independently."
+        },
+        "systemWideCapRespected": {
+          "type": ["boolean", "null"],
+          "description": "FEATURE-FLAGGED OFF. System-wide 6★ cap (≤5) is enforced by meta-guard.yml CI (I4), not by this per-skill predicate. Returns null (skipped). Kept for forward compatibility; re-enable by flipping the feature flag in src/gaia_cli/trustMagnitude.py at 2026-Q4 review."
+        }
+      }
     }
   },
   "definitions": {
@@ -259,6 +323,52 @@
           "type": "string",
           "format": "uri",
           "description": "URL to the verification discussion or PR."
+        },
+        "sourceStartedAt": {
+          "type": "string",
+          "format": "date",
+          "description": "ISO date the source project/repo/publication was first created or published. Optional for B/C/ungraded rows. Required at A/S tier for apex eligibility (gaia validate warns on A/S rows missing this field; hard-fail is I4's job post-cutover). Used by the sourceTenureDaysGte180AorS apex predicate."
+        },
+        "unverified": {
+          "type": "boolean",
+          "description": "Interim flag for proxy-containment entries whose claim has not yet been validated by the proxy-containment validator (RFC §11.2). Entry counts at full magnitude while flagged; surfaced in gaia evidence listings and audit reports."
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Per-evidence-entry links used by the trust magnitude computation.",
+          "properties": {
+            "canonicalRepo": {
+              "type": "string",
+              "format": "uri",
+              "description": "Canonical upstream repository URL for fork-network canonicalization opt-out (RFC §11.5). When set, this evidence entry's star pool is attributed to this URL rather than the auto-detected upstream fork. Required when a fork has legitimately diverged into a separate skill."
+            }
+          }
+        },
+        "cosigners": {
+          "type": "array",
+          "description": "Verifier co-signers for social-signal recognized-voice (1.2× creator multiplier) and cross-org verifier-attestation requirements. Each cosigner must be a 4★+ verifier from a distinct GitHub org. Recorded via gaia dev evidence --cosign-with <verifier>.",
+          "items": {
+            "type": "object",
+            "required": ["username", "org", "signedAt"],
+            "additionalProperties": false,
+            "properties": {
+              "username": {
+                "type": "string",
+                "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]*$",
+                "description": "GitHub username of the co-signing verifier."
+              },
+              "org": {
+                "type": "string",
+                "description": "GitHub org the verifier belongs to at co-sign time (used for cross-org distinctness check)."
+              },
+              "signedAt": {
+                "type": "string",
+                "format": "date-time",
+                "description": "ISO 8601 timestamp when the co-sign was recorded."
+              }
+            }
+          }
         }
       }
     },

--- a/registry/schema/namedSkill.schema.json
+++ b/registry/schema/namedSkill.schema.json
@@ -89,7 +89,7 @@
         "canonicalRepo": {
           "type": "string",
           "format": "uri",
-          "description": "Canonical upstream repository URL. Used as the fork-network canonicalization anchor for this named skill's github-stars-own evidence (RFC §11.5). When set, star pools from all forks of this URL are merged into one."
+          "description": "Informational; per-evidence `canonicalRepo` is operationally authoritative per RFC §11.5. Canonical upstream repository URL. Used as the fork-network canonicalization anchor for this named skill's github-stars-own evidence (RFC §11.5). When set, star pools from all forks of this URL are merged into one."
         }
       }
     },
@@ -276,7 +276,7 @@
             "B",
             "C"
           ],
-          "description": "Evidence Grade — the quality of the demonstration, derived from trustNumber via meta.json evidence.gradeThresholds (S >= 90, A >= 80, B >= 60, C >= 40). Evidence whose trustNumber is below 40 is ungraded: this field is absent and the entry counts toward no gate. WARNING: grade A/B are NOT the deprecated class A/B — migration code must never read one as the other."
+          "description": "per-evidence grade (S/A/B/C). Distinct from the skill's overall trust grade (overallTrustGrade). Used by the diversity gate per RFC §4. Evidence whose trustNumber is below 40 is ungraded: this field is absent and the entry counts toward no gate. WARNING: grade A/B are NOT the deprecated class A/B — migration code must never read one as the other."
         },
         "trustNumber": {
           "type": "number",

--- a/registry/schema/namedSkill.schema.json
+++ b/registry/schema/namedSkill.schema.json
@@ -44,7 +44,10 @@
     },
     "status": {
       "type": "string",
-      "enum": ["awakened", "named"],
+      "enum": [
+        "awakened",
+        "named"
+      ],
       "description": "Lifecycle status. Contributors must always submit with 'awakened'. Only reviewers may promote to 'named' by adding title or catalogRef in a separate classification PR."
     },
     "title": {
@@ -59,7 +62,14 @@
     },
     "level": {
       "type": "string",
-      "enum": ["1★", "2★", "3★", "4★", "5★", "6★"],
+      "enum": [
+        "1★",
+        "2★",
+        "3★",
+        "4★",
+        "5★",
+        "6★"
+      ],
       "description": "Named level (2★+). 1★ (Awakened) is the hard-demote penalty state for named skills that lose their verified blob link under META §2.4, and the generic intake state."
     },
     "description": {
@@ -171,7 +181,10 @@
       "description": "Verification tier state for this named skill. Recomputed by `gaia dev verify-tier` and surfaced in `gaia skills info`. The `tier` field stores the highest tier currently satisfied (or null); `firstEvidenceAt` is the tenure baseline for the enterprise-ready tier.",
       "properties": {
         "tier": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "enum": [
             null,
             "community-verified",
@@ -200,7 +213,13 @@
     },
     "overallTrustGrade": {
       "type": "string",
-      "enum": ["S", "A", "B", "C", "ungraded"],
+      "enum": [
+        "S",
+        "A",
+        "B",
+        "C",
+        "ungraded"
+      ],
       "description": "G7 Overall Trust Grade derived from trustMagnitude thresholds and diversity gate (RFC §4): S ≥ 250, A ≥ 100, B ≥ 50, C ≥ 20, ungraded < 20. Requires meeting the diversity gate (distinct evidence types, non-self-producible rule) in addition to the magnitude floor."
     },
     "provisional": {
@@ -219,35 +238,59 @@
       "additionalProperties": false,
       "properties": {
         "aGradedOriginsGte5": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "TRUE if the skill's transitive fusion-recipe closure contains ≥5 distinct A-or-S-graded origin evidence rows. Consolidates the old transitiveOriginsGte12 and aGradedClosureGte8 predicates (delta §A)."
         },
         "sourceTenureDaysGte180AorS": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "TRUE if the maximum source age across all A/S-tier evidence rows is ≥180 calendar days, measured via the per-row sourceStartedAt field. Replaces the old tenureDaysGte180 predicate (delta §A). False (not null) when no A/S rows exist."
         },
         "directNestedSuiteGte1": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "TRUE if at least one direct component of this skill itself has non-empty suiteComponents (RFC §11.12.2)."
         },
         "depth2OnlyReachableGte1": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "TRUE if the fusion graph (role=origin edges, excluding suite-component edges) contains at least one skill reachable only at depth-2 and not at depth-1 (RFC §11.12.3, delta §A depth-2 walk amendment)."
         },
         "overallGradeS": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "TRUE if overallTrustGrade equals S under strict-evidence reading (anti-auto-mint per RFC §10.14; only fusion-recipe may be auto-derived)."
         },
         "apexPromotionPrSigned": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "TRUE if a PR labeled apex-promotion exists with ≥2 distinct 4★+ verifier approvals from at least 2 distinct GitHub orgs (RFC §11.12.8). gaia promote rejects target_level==6★ at CLI layer; this predicate is set only by meta-guard.yml at merge time."
         },
         "crossOrgVerifierGte2": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "FEATURE-FLAGGED OFF until 2026-Q4 review. When active: TRUE if ≥2 verifier-attestation rows exist from 4★+ verifiers in at least 2 distinct GitHub orgs (RFC §11.12.6). Returns null (skipped) while flag is off; CI cap in I4 enforces the system-wide limit independently."
         },
         "systemWideCapRespected": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "FEATURE-FLAGGED OFF. System-wide 6★ cap (≤5) is enforced by meta-guard.yml CI (I4), not by this per-skill predicate. Returns null (skipped). Kept for forward compatibility; re-enable by flipping the feature flag in src/gaia_cli/trustMagnitude.py at 2026-Q4 review."
         }
       }
@@ -333,6 +376,14 @@
           "type": "boolean",
           "description": "Interim flag for proxy-containment entries whose claim has not yet been validated by the proxy-containment validator (RFC §11.2). Entry counts at full magnitude while flagged; surfaced in gaia evidence listings and audit reports."
         },
+        "layer": {
+          "type": "string",
+          "enum": [
+            "generic",
+            "named"
+          ],
+          "description": "The layer at which this evidence row is attached. Defaults to the layer of the containing skill node — generic skills default to 'generic', named skills default to 'named'. Used by the per-type allowedLayers validator and the inheritance multiplier."
+        },
         "links": {
           "type": "object",
           "additionalProperties": false,
@@ -350,7 +401,11 @@
           "description": "Verifier co-signers for social-signal recognized-voice (1.2× creator multiplier) and cross-org verifier-attestation requirements. Each cosigner must be a 4★+ verifier from a distinct GitHub org. Recorded via gaia dev evidence --cosign-with <verifier>.",
           "items": {
             "type": "object",
-            "required": ["username", "org", "signedAt"],
+            "required": [
+              "username",
+              "org",
+              "signedAt"
+            ],
             "additionalProperties": false,
             "properties": {
               "username": {

--- a/registry/schema/skill.schema.json
+++ b/registry/schema/skill.schema.json
@@ -153,6 +153,65 @@
           "description": "ISO 8601 timestamp of the first `evidence_added` event. Used as the tenure baseline for the enterprise-ready tier."
         }
       }
+    },
+    "trustMagnitude": {
+      "type": "number",
+      "minimum": 0,
+      "description": "G7 Trust Magnitude — unbounded aggregate artifact score computed from the 10-type evidence taxonomy (RFC §3). Sum of per-evidence artifact scores (magnitude × weight × freshness). Display layer soft-caps at 500; raw value drives grading and the apex gate. Replaces the legacy trustNumber aggregate."
+    },
+    "overallTrustGrade": {
+      "type": "string",
+      "enum": ["S", "A", "B", "C", "ungraded"],
+      "description": "G7 Overall Trust Grade derived from trustMagnitude thresholds and diversity gate (RFC §4): S ≥ 250, A ≥ 100, B ≥ 50, C ≥ 20, ungraded < 20. Requires meeting the diversity gate (distinct evidence types, non-self-producible rule) in addition to the magnitude floor."
+    },
+    "provisional": {
+      "type": "boolean",
+      "default": false,
+      "description": "True if this skill is graded at its current overallTrustGrade under the 6-month provisional grace window (RFC §5.7). A provisional skill passed the magnitude threshold for its grade but failed the diversity gate at G7 migration cutover. Demotion at grace expiry is PR-gated, not automatic."
+    },
+    "provisionalUntil": {
+      "type": "string",
+      "format": "date",
+      "description": "ISO date when the provisional grace window expires. Populated only when provisional=true. After this date gaia validate emits a provisional-expired warning; demotion requires a curator PR."
+    },
+    "apexGateStatus": {
+      "type": "object",
+      "description": "Per-predicate pass/fail for the 6★ apex gate (RFC §11.12, amended by G7 delta §A). All 6 active predicates must be true simultaneously for apex eligibility. Two additional predicates are feature-flagged OFF (return null = skipped) until 2026-Q4 review.",
+      "additionalProperties": false,
+      "properties": {
+        "aGradedOriginsGte5": {
+          "type": ["boolean", "null"],
+          "description": "TRUE if the skill's transitive fusion-recipe closure contains ≥5 distinct A-or-S-graded origin evidence rows. Consolidates the old transitiveOriginsGte12 and aGradedClosureGte8 predicates (delta §A)."
+        },
+        "sourceTenureDaysGte180AorS": {
+          "type": ["boolean", "null"],
+          "description": "TRUE if the maximum source age across all A/S-tier evidence rows is ≥180 calendar days, measured via the per-row sourceStartedAt field. Replaces the old tenureDaysGte180 predicate (delta §A). False (not null) when no A/S rows exist."
+        },
+        "directNestedSuiteGte1": {
+          "type": ["boolean", "null"],
+          "description": "TRUE if at least one direct component of this skill itself has non-empty suiteComponents (RFC §11.12.2)."
+        },
+        "depth2OnlyReachableGte1": {
+          "type": ["boolean", "null"],
+          "description": "TRUE if the fusion graph (role=origin edges, excluding suite-component edges) contains at least one skill reachable only at depth-2 and not at depth-1 (RFC §11.12.3, delta §A depth-2 walk amendment)."
+        },
+        "overallGradeS": {
+          "type": ["boolean", "null"],
+          "description": "TRUE if overallTrustGrade equals S under strict-evidence reading (anti-auto-mint per RFC §10.14; only fusion-recipe may be auto-derived)."
+        },
+        "apexPromotionPrSigned": {
+          "type": ["boolean", "null"],
+          "description": "TRUE if a PR labeled apex-promotion exists with ≥2 distinct 4★+ verifier approvals from at least 2 distinct GitHub orgs (RFC §11.12.8). gaia promote rejects target_level==6★ at CLI layer; this predicate is set only by meta-guard.yml at merge time."
+        },
+        "crossOrgVerifierGte2": {
+          "type": ["boolean", "null"],
+          "description": "FEATURE-FLAGGED OFF until 2026-Q4 review. When active: TRUE if ≥2 verifier-attestation rows exist from 4★+ verifiers in at least 2 distinct GitHub orgs (RFC §11.12.6). Returns null (skipped) while flag is off; CI cap in I4 enforces the system-wide limit independently."
+        },
+        "systemWideCapRespected": {
+          "type": ["boolean", "null"],
+          "description": "FEATURE-FLAGGED OFF. System-wide 6★ cap (≤5) is enforced by meta-guard.yml CI (I4), not by this per-skill predicate. Returns null (skipped). Kept for forward compatibility; re-enable by flipping the feature flag in src/gaia_cli/trustMagnitude.py at 2026-Q4 review."
+        }
+      }
     }
   },
   "definitions": {
@@ -225,6 +284,52 @@
           "type": "string",
           "format": "uri",
           "description": "URL to the verification discussion or PR."
+        },
+        "sourceStartedAt": {
+          "type": "string",
+          "format": "date",
+          "description": "ISO date the source project/repo/publication was first created or published. Optional for B/C/ungraded rows. Required at A/S tier for apex eligibility (gaia validate warns on A/S rows missing this field; hard-fail is I4's job post-cutover). Used by the sourceTenureDaysGte180AorS apex predicate."
+        },
+        "unverified": {
+          "type": "boolean",
+          "description": "Interim flag for proxy-containment entries whose claim has not yet been validated by the proxy-containment validator (RFC §11.2). Entry counts at full magnitude while flagged; surfaced in gaia evidence listings and audit reports."
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Per-evidence-entry links used by the trust magnitude computation.",
+          "properties": {
+            "canonicalRepo": {
+              "type": "string",
+              "format": "uri",
+              "description": "Canonical upstream repository URL for fork-network canonicalization opt-out (RFC §11.5). When set, this evidence entry's star pool is attributed to this URL rather than the auto-detected upstream fork. Required when a fork has legitimately diverged into a separate skill."
+            }
+          }
+        },
+        "cosigners": {
+          "type": "array",
+          "description": "Verifier co-signers for social-signal recognized-voice (1.2× creator multiplier) and cross-org verifier-attestation requirements. Each cosigner must be a 4★+ verifier from a distinct GitHub org. Recorded via gaia dev evidence --cosign-with <verifier>.",
+          "items": {
+            "type": "object",
+            "required": ["username", "org", "signedAt"],
+            "additionalProperties": false,
+            "properties": {
+              "username": {
+                "type": "string",
+                "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]*$",
+                "description": "GitHub username of the co-signing verifier."
+              },
+              "org": {
+                "type": "string",
+                "description": "GitHub org the verifier belongs to at co-sign time (used for cross-org distinctness check)."
+              },
+              "signedAt": {
+                "type": "string",
+                "format": "date-time",
+                "description": "ISO 8601 timestamp when the co-sign was recorded."
+              }
+            }
+          }
         }
       }
     },

--- a/registry/schema/skill.schema.json
+++ b/registry/schema/skill.schema.json
@@ -132,7 +132,10 @@
       "description": "Verification tier state for this skill. Recomputed by `gaia dev verify-tier` and surfaced in `gaia skills info`. The `tier` field stores the highest tier currently satisfied (or null); `firstEvidenceAt` is the tenure baseline for the enterprise-ready tier.",
       "properties": {
         "tier": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "enum": [
             null,
             "community-verified",
@@ -161,7 +164,13 @@
     },
     "overallTrustGrade": {
       "type": "string",
-      "enum": ["S", "A", "B", "C", "ungraded"],
+      "enum": [
+        "S",
+        "A",
+        "B",
+        "C",
+        "ungraded"
+      ],
       "description": "G7 Overall Trust Grade derived from trustMagnitude thresholds and diversity gate (RFC §4): S ≥ 250, A ≥ 100, B ≥ 50, C ≥ 20, ungraded < 20. Requires meeting the diversity gate (distinct evidence types, non-self-producible rule) in addition to the magnitude floor."
     },
     "provisional": {
@@ -180,35 +189,59 @@
       "additionalProperties": false,
       "properties": {
         "aGradedOriginsGte5": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "TRUE if the skill's transitive fusion-recipe closure contains ≥5 distinct A-or-S-graded origin evidence rows. Consolidates the old transitiveOriginsGte12 and aGradedClosureGte8 predicates (delta §A)."
         },
         "sourceTenureDaysGte180AorS": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "TRUE if the maximum source age across all A/S-tier evidence rows is ≥180 calendar days, measured via the per-row sourceStartedAt field. Replaces the old tenureDaysGte180 predicate (delta §A). False (not null) when no A/S rows exist."
         },
         "directNestedSuiteGte1": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "TRUE if at least one direct component of this skill itself has non-empty suiteComponents (RFC §11.12.2)."
         },
         "depth2OnlyReachableGte1": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "TRUE if the fusion graph (role=origin edges, excluding suite-component edges) contains at least one skill reachable only at depth-2 and not at depth-1 (RFC §11.12.3, delta §A depth-2 walk amendment)."
         },
         "overallGradeS": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "TRUE if overallTrustGrade equals S under strict-evidence reading (anti-auto-mint per RFC §10.14; only fusion-recipe may be auto-derived)."
         },
         "apexPromotionPrSigned": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "TRUE if a PR labeled apex-promotion exists with ≥2 distinct 4★+ verifier approvals from at least 2 distinct GitHub orgs (RFC §11.12.8). gaia promote rejects target_level==6★ at CLI layer; this predicate is set only by meta-guard.yml at merge time."
         },
         "crossOrgVerifierGte2": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "FEATURE-FLAGGED OFF until 2026-Q4 review. When active: TRUE if ≥2 verifier-attestation rows exist from 4★+ verifiers in at least 2 distinct GitHub orgs (RFC §11.12.6). Returns null (skipped) while flag is off; CI cap in I4 enforces the system-wide limit independently."
         },
         "systemWideCapRespected": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "FEATURE-FLAGGED OFF. System-wide 6★ cap (≤5) is enforced by meta-guard.yml CI (I4), not by this per-skill predicate. Returns null (skipped). Kept for forward compatibility; re-enable by flipping the feature flag in src/gaia_cli/trustMagnitude.py at 2026-Q4 review."
         }
       }
@@ -294,6 +327,14 @@
           "type": "boolean",
           "description": "Interim flag for proxy-containment entries whose claim has not yet been validated by the proxy-containment validator (RFC §11.2). Entry counts at full magnitude while flagged; surfaced in gaia evidence listings and audit reports."
         },
+        "layer": {
+          "type": "string",
+          "enum": [
+            "generic",
+            "named"
+          ],
+          "description": "The layer at which this evidence row is attached. Defaults to the layer of the containing skill node — generic skills default to 'generic', named skills default to 'named'. Used by the per-type allowedLayers validator and the inheritance multiplier."
+        },
         "links": {
           "type": "object",
           "additionalProperties": false,
@@ -311,7 +352,11 @@
           "description": "Verifier co-signers for social-signal recognized-voice (1.2× creator multiplier) and cross-org verifier-attestation requirements. Each cosigner must be a 4★+ verifier from a distinct GitHub org. Recorded via gaia dev evidence --cosign-with <verifier>.",
           "items": {
             "type": "object",
-            "required": ["username", "org", "signedAt"],
+            "required": [
+              "username",
+              "org",
+              "signedAt"
+            ],
             "additionalProperties": false,
             "properties": {
               "username": {

--- a/registry/schema/skill.schema.json
+++ b/registry/schema/skill.schema.json
@@ -176,7 +176,7 @@
     },
     "apexGateStatus": {
       "type": "object",
-      "description": "Per-predicate pass/fail for the 6★ apex gate (RFC §11.12, amended by G7 delta §A). All 6 active predicates must be true simultaneously for apex eligibility. Two additional predicates are feature-flagged OFF (return null = skipped) until 2026-Q4 review.",
+      "description": "Reserved for forward-compat with namedSkill propagation — unused on canonical nodes. Per-predicate pass/fail for the 6★ apex gate (RFC §11.12, amended by G7 delta §A). All 6 active predicates must be true simultaneously for apex eligibility. Two additional predicates are feature-flagged OFF (return null = skipped) until 2026-Q4 review.",
       "additionalProperties": false,
       "properties": {
         "aGradedOriginsGte5": {
@@ -237,7 +237,7 @@
             "B",
             "C"
           ],
-          "description": "Evidence Grade — the quality of the demonstration, derived from trustNumber via meta.json evidence.gradeThresholds (S >= 90, A >= 80, B >= 60, C >= 40). Evidence whose trustNumber is below 40 is ungraded: this field is absent and the entry counts toward no gate. WARNING: grade A/B are NOT the deprecated class A/B — migration code must never read one as the other."
+          "description": "per-evidence grade (S/A/B/C). Distinct from the skill's overall trust grade (overallTrustGrade). Used by the diversity gate per RFC §4. Evidence whose trustNumber is below 40 is ungraded: this field is absent and the entry counts toward no gate. WARNING: grade A/B are NOT the deprecated class A/B — migration code must never read one as the other."
         },
         "trustNumber": {
           "type": "number",

--- a/src/gaia_cli/data/registry/schema/meta.json
+++ b/src/gaia_cli/data/registry/schema/meta.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "description": "Gaia schema metadata — single source of truth for nomenclature, theming, and validation rules. Technical policy is documented in META.md.",
+  "version": "5.0.0-schema",
   "levels": {
     "order": [
       "0★",
@@ -143,9 +144,133 @@
       "B"
     ],
     "types": [
-      "arxiv",
-      "repo",
-      "github-stars"
+      {
+        "id": "fusion-recipe",
+        "description": "Skill emerges from composition of graded prior work. Auto-derived for every fused/Ultimate skill from suiteComponents (RFC §10.8). Only graded≥C origins count toward origin tally.",
+        "magnitude": "20 * origins for origins <= 10; 200 + 20 * sqrt(origins - 10) for origins > 10",
+        "weight": 1.5,
+        "cap": "softened (no hard cap; sqrt curve limits growth past 10 origins)",
+        "gradeCeiling": "S",
+        "freshness": "1.0 (intrinsic — no decay)",
+        "selfProducible": true,
+        "notes": "Mandatory for any fused or Ultimate skill. A skill with suiteComponents and no fusion-recipe row fails validation (RFC §10.2). Only graded≥C origins count (RFC §3.5)."
+      },
+      {
+        "id": "github-stars-own",
+        "description": "Stars on the skill's own repository. Mothership-discounted when the repo contains multiple skills.",
+        "magnitude": "min(200, stars / 1000) / mothership_divisor where mothership_divisor = min(skill_count_in_repo, 4)",
+        "weight": 1.0,
+        "cap": 200,
+        "gradeCeiling": "S",
+        "freshness": "re-fetch quarterly; no time decay (gaia refresh-stars re-stamps lastVerified)",
+        "selfProducible": false,
+        "notes": "Same-source dedup collapses multiple entries pointing at same canonical URL to one. Fork-network canonicalization merges forks of same upstream unless evidence entry sets links.canonicalRepo. S-capable at 100k+ stars."
+      },
+      {
+        "id": "proxy-containment",
+        "description": "The skill's artifact is bundled inside a separately-starred external project.",
+        "magnitude": "min(160, (external_stars / 1000) * 0.8)",
+        "weight": 1.0,
+        "cap": 160,
+        "gradeCeiling": "S",
+        "freshness": "re-fetch quarterly; no time decay",
+        "selfProducible": false,
+        "maxEntriesPerSkill": 3,
+        "plateau": [1.0, 0.5, 0.25],
+        "externalStarFloor": 10000,
+        "notes": "Until proxy-containment validator ships, claims count at full magnitude with explicit unverified=true flag. S-capable at 125k+ external stars (RFC §2.4)."
+      },
+      {
+        "id": "verifier-attestation",
+        "description": "A 4★+ Verifier signs an attestation that the skill is real and graded fairly.",
+        "magnitude": "30 * verifiers",
+        "weight": 1.5,
+        "cap": null,
+        "gradeCeiling": "S",
+        "freshness": "null on derank — evaluates to null (not zero) when attesting Verifier drops below 4★ (RFC §5.6)",
+        "selfProducible": false,
+        "notes": "No cap on verifier count for magnitude. Diversity gate for S counts max 3 verifiers as one distinct type slot. Null-on-derank: the row is removed from TM sum; flag preserved for audit. S-capable at 3+ verifiers."
+      },
+      {
+        "id": "benchmark-result",
+        "description": "A reproducible benchmark on a public dataset, scored as percentile rank within the field.",
+        "magnitude": "percentile (0–100)",
+        "weight": 1.4,
+        "cap": 100,
+        "gradeCeiling": "S",
+        "freshness": "50%/year decay (half-life ≈ 1 year)",
+        "selfProducible": false,
+        "notes": "S-capable at 95th+ percentile. Weight 1.4 because percentiles are externally verifiable. Only at 1.4 (not 1.5) because benchmark choice can be cherry-picked."
+      },
+      {
+        "id": "arxiv",
+        "description": "Academic citation count for a published paper associated with the skill.",
+        "magnitude": "min(100, citations / 5)",
+        "weight": 1.0,
+        "cap": 100,
+        "gradeCeiling": "A",
+        "freshness": "re-fetch quarterly; no time decay",
+        "selfProducible": false,
+        "notes": "A-cap: high citation counts cluster around surveys, not executable skills. 500-citation paper hits cap (m=100) but cannot reach S without complementary types."
+      },
+      {
+        "id": "peer-review",
+        "description": "Structured walkthrough with written critique by 4★+ reviewers (distinct from verifier-attestation).",
+        "magnitude": "25 * reviewers",
+        "weight": 1.2,
+        "cap": null,
+        "gradeCeiling": "A",
+        "freshness": "25%/2yr decay (linear)",
+        "selfProducible": false,
+        "plateau": [1.0, 0.5, 0.25],
+        "notes": "A-cap — peer-review without external adoption signals does not justify S. Plateau applies for stacked entries."
+      },
+      {
+        "id": "repo-own",
+        "description": "Artifact volume evidence from the contributor's own repository (commits + contributors).",
+        "magnitude": "min(60, commits/200 + contributors^2 * 2)",
+        "weight": 0.6,
+        "cap": 60,
+        "gradeCeiling": "B",
+        "freshness": "re-fetch quarterly; no time decay",
+        "selfProducible": true,
+        "notes": "B-cap and weight 0.6 ensure repo-own alone cannot carry a skill past B. Diversity gate classes repo-own as self-producible: A or S requires non-self-producible evidence on top."
+      },
+      {
+        "id": "self-attestation",
+        "description": "Contributor declaration that the skill exists and is real. Flat 10 magnitude, max 1 entry per skill.",
+        "magnitude": "10 (flat)",
+        "weight": 0.5,
+        "cap": 10,
+        "gradeCeiling": "C",
+        "freshness": "static — never decays",
+        "selfProducible": true,
+        "maxEntriesPerSkill": 1,
+        "notes": "C-cap. A skill with only self-attestation scores 5 artifact score (10 × 0.5) and lands ungraded. Placeholder for newly-added skills with no external trail yet."
+      },
+      {
+        "id": "social-signal",
+        "description": "Creator/audience evidence — video views, engagement, topical authority from external creators.",
+        "magnitude": "log10(views) * 8 * creator_mult * engagement_ratio where engagement_ratio = min(1.5, (likes + comments*5) / views * 50)",
+        "weight": 1.0,
+        "cap": 80,
+        "gradeCeiling": "A",
+        "freshness": "50%/year decay (half-life ≈ 1 year)",
+        "selfProducible": false,
+        "maxEntriesPerSkill": 3,
+        "plateau": [1.0, 0.5, 0.25],
+        "creatorMultipliers": {
+          "sameAsAuthor": 0,
+          "anonymous": 0.3,
+          "established": 0.6,
+          "topicalAuthority": 1.0,
+          "recognizedVoice": 1.2,
+          "reserved": 1.4
+        },
+        "viewFloor": 1000,
+        "publishCooldownDays": 30,
+        "notes": "Hard A-cap (RFC §10.7): social-signal contribution to TM never exceeds 80. Same-creator dedup: 2nd entry at 0.5×, 3rd at 0.25× regardless of slot. recognizedVoice (1.2×) requires 2 cross-org 4★+ verifier cosigns via gaia dev evidence --cosign-with."
+      }
     ],
     "gradeThresholds": {
       "S": 90,
@@ -161,6 +286,56 @@
       },
       "componentFloor": "C"
     }
+  },
+  "trustMagnitudeThresholds": {
+    "description": "G7 Trust Magnitude grade thresholds (RFC §4). trustMagnitude must meet the minimum AND the diversity gate (distinct types + non-self-producible rule at S) to earn the grade.",
+    "S": 250,
+    "A": 100,
+    "B": 50,
+    "C": 20,
+    "ungraded": 0,
+    "softDisplayCap": 500,
+    "diversityGate": {
+      "S": {
+        "minDistinctTypes": 3,
+        "requiresNonSelfProducible": true,
+        "plusRule": ">=1 S-capable type present OR >=3 A-capable types of distinct kinds; AND >=1 non-self-producible type"
+      },
+      "A": {
+        "minDistinctTypes": 1,
+        "requiresNonSelfProducible": false,
+        "plusRule": ">=1 A-capable type present (pure github-stars-own at A is valid)"
+      },
+      "B": {
+        "minDistinctTypes": 1,
+        "requiresNonSelfProducible": false,
+        "plusRule": ">=1 B-capable type or higher"
+      },
+      "C": {
+        "minDistinctTypes": 0,
+        "requiresNonSelfProducible": false,
+        "plusRule": "none"
+      }
+    },
+    "selfProducibleTypes": ["fusion-recipe", "self-attestation", "repo-own"]
+  },
+  "apexGate": {
+    "description": "6★ apex gate configuration (RFC §11.12, amended by G7 delta §A). All 6 active predicates must be simultaneously satisfied. Two predicates are feature-flagged OFF until 2026-Q4 review.",
+    "predicates": [
+      "aGradedOriginsGte5",
+      "sourceTenureDaysGte180AorS",
+      "directNestedSuiteGte1",
+      "depth2OnlyReachableGte1",
+      "overallGradeS",
+      "apexPromotionPrSigned"
+    ],
+    "featureFlaggedOff": [
+      "crossOrgVerifierGte2",
+      "systemWideCapRespected"
+    ],
+    "systemWideCap": 5,
+    "featureFlaggedOffReviewDate": "2026-Q4",
+    "notes": "crossOrgVerifierGte2 and systemWideCapRespected are implemented in passesApexGate() but return null (skipped) until re-enabled. System-wide cap enforcement lives in CI (meta-guard.yml I4), not in per-skill predicate evaluation. gaia promote rejects target_level==6★ at CLI layer; apex requires a manually-opened PR labeled apex-promotion with >=2 verifier approvals from >=2 distinct GitHub orgs."
   },
   "demerits": {
     "order": [
@@ -203,11 +378,7 @@
       }
     },
     "6★": {
-      "description": "Apex path: Reaching Apex rank requires Tier A evidence and a fusion involving at least one Origin 5★ Transcendent skill.",
-      "apexPath": {
-        "minUltimateSkills": 1,
-        "minUltimateLevel": "5★"
-      }
+      "description": "Apex path: Reaching Apex rank (6★) requires satisfying all 6 active apex gate predicates simultaneously (RFC §11.12, amended by G7 delta §A). gaia promote rejects target_level==6★ at CLI layer. A PR labeled apex-promotion with >=2 cross-org verifier approvals is required. Legacy apexPath (minUltimateSkills/minUltimateLevel) is superseded by apexGate block above."
     }
   },
   "customInstallation": {

--- a/src/gaia_cli/data/registry/schema/meta.json
+++ b/src/gaia_cli/data/registry/schema/meta.json
@@ -152,6 +152,9 @@
         "gradeCeiling": "S",
         "freshness": "1.0 (intrinsic — no decay)",
         "selfProducible": true,
+        "allowedLayers": [
+          "named"
+        ],
         "notes": "Mandatory for any fused or Ultimate skill. A skill with suiteComponents and no fusion-recipe row fails validation (RFC §10.2). Only graded≥C origins count (RFC §3.5)."
       },
       {
@@ -163,6 +166,9 @@
         "gradeCeiling": "S",
         "freshness": "re-fetch quarterly; no time decay (gaia refresh-stars re-stamps lastVerified)",
         "selfProducible": false,
+        "allowedLayers": [
+          "named"
+        ],
         "notes": "Same-source dedup collapses multiple entries pointing at same canonical URL to one. Fork-network canonicalization merges forks of same upstream unless evidence entry sets links.canonicalRepo. S-capable at 100k+ stars."
       },
       {
@@ -174,8 +180,17 @@
         "gradeCeiling": "S",
         "freshness": "re-fetch quarterly; no time decay",
         "selfProducible": false,
+        "allowedLayers": [
+          "generic",
+          "named"
+        ],
+        "inheritMultiplier": 0.25,
         "maxEntriesPerSkill": 3,
-        "plateau": [1.0, 0.5, 0.25],
+        "plateau": [
+          1.0,
+          0.5,
+          0.25
+        ],
         "externalStarFloor": 10000,
         "notes": "Until proxy-containment validator ships, claims count at full magnitude with explicit unverified=true flag. S-capable at 125k+ external stars (RFC §2.4)."
       },
@@ -188,6 +203,9 @@
         "gradeCeiling": "S",
         "freshness": "null on derank — evaluates to null (not zero) when attesting Verifier drops below 4★ (RFC §5.6)",
         "selfProducible": false,
+        "allowedLayers": [
+          "named"
+        ],
         "notes": "No cap on verifier count for magnitude. Diversity gate for S counts max 3 verifiers as one distinct type slot. Null-on-derank: the row is removed from TM sum; flag preserved for audit. S-capable at 3+ verifiers."
       },
       {
@@ -199,6 +217,11 @@
         "gradeCeiling": "S",
         "freshness": "50%/year decay (half-life ≈ 1 year)",
         "selfProducible": false,
+        "allowedLayers": [
+          "generic",
+          "named"
+        ],
+        "inheritMultiplier": 0.15,
         "notes": "S-capable at 95th+ percentile. Weight 1.4 because percentiles are externally verifiable. Only at 1.4 (not 1.5) because benchmark choice can be cherry-picked."
       },
       {
@@ -210,6 +233,11 @@
         "gradeCeiling": "A",
         "freshness": "re-fetch quarterly; no time decay",
         "selfProducible": false,
+        "allowedLayers": [
+          "generic",
+          "named"
+        ],
+        "inheritMultiplier": 0.7,
         "notes": "A-cap: high citation counts cluster around surveys, not executable skills. 500-citation paper hits cap (m=100) but cannot reach S without complementary types."
       },
       {
@@ -221,7 +249,16 @@
         "gradeCeiling": "A",
         "freshness": "25%/2yr decay (linear)",
         "selfProducible": false,
-        "plateau": [1.0, 0.5, 0.25],
+        "allowedLayers": [
+          "generic",
+          "named"
+        ],
+        "inheritMultiplier": 0.3,
+        "plateau": [
+          1.0,
+          0.5,
+          0.25
+        ],
         "notes": "A-cap — peer-review without external adoption signals does not justify S. Plateau applies for stacked entries."
       },
       {
@@ -233,6 +270,9 @@
         "gradeCeiling": "B",
         "freshness": "re-fetch quarterly; no time decay",
         "selfProducible": true,
+        "allowedLayers": [
+          "named"
+        ],
         "notes": "B-cap and weight 0.6 ensure repo-own alone cannot carry a skill past B. Diversity gate classes repo-own as self-producible: A or S requires non-self-producible evidence on top."
       },
       {
@@ -244,6 +284,9 @@
         "gradeCeiling": "C",
         "freshness": "static — never decays",
         "selfProducible": true,
+        "allowedLayers": [
+          "named"
+        ],
         "maxEntriesPerSkill": 1,
         "notes": "C-cap. A skill with only self-attestation scores 5 artifact score (10 × 0.5) and lands ungraded. Placeholder for newly-added skills with no external trail yet."
       },
@@ -256,8 +299,17 @@
         "gradeCeiling": "A",
         "freshness": "50%/year decay (half-life ≈ 1 year)",
         "selfProducible": false,
+        "allowedLayers": [
+          "generic",
+          "named"
+        ],
+        "inheritMultiplier": 0.35,
         "maxEntriesPerSkill": 3,
-        "plateau": [1.0, 0.5, 0.25],
+        "plateau": [
+          1.0,
+          0.5,
+          0.25
+        ],
         "creatorMultipliers": {
           "sameAsAuthor": 0,
           "anonymous": 0.3,
@@ -316,7 +368,11 @@
         "plusRule": "none"
       }
     },
-    "selfProducibleTypes": ["fusion-recipe", "self-attestation", "repo-own"]
+    "selfProducibleTypes": [
+      "fusion-recipe",
+      "self-attestation",
+      "repo-own"
+    ]
   },
   "apexGate": {
     "description": "6★ apex gate configuration (RFC §11.12, amended by G7 delta §A). All 6 active predicates must be simultaneously satisfied. Two predicates are feature-flagged OFF until 2026-Q4 review.",

--- a/src/gaia_cli/data/registry/schema/meta.json
+++ b/src/gaia_cli/data/registry/schema/meta.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "description": "Gaia schema metadata — single source of truth for nomenclature, theming, and validation rules. Technical policy is documented in META.md.",
-  "version": "5.0.0-schema",
   "levels": {
     "order": [
       "0★",

--- a/src/gaia_cli/data/registry/schema/namedSkill.schema.json
+++ b/src/gaia_cli/data/registry/schema/namedSkill.schema.json
@@ -85,6 +85,11 @@
           "type": "string",
           "format": "uri",
           "description": "Documentation or landing page URL."
+        },
+        "canonicalRepo": {
+          "type": "string",
+          "format": "uri",
+          "description": "Canonical upstream repository URL. Used as the fork-network canonicalization anchor for this named skill's github-stars-own evidence (RFC §11.5). When set, star pools from all forks of this URL are merged into one."
         }
       }
     },
@@ -187,6 +192,65 @@
           "description": "ISO 8601 timestamp of the first `evidence_added` event. Used as the tenure baseline for the enterprise-ready tier."
         }
       }
+    },
+    "trustMagnitude": {
+      "type": "number",
+      "minimum": 0,
+      "description": "G7 Trust Magnitude — unbounded aggregate artifact score computed from the 10-type evidence taxonomy (RFC §3). Sum of per-evidence artifact scores (magnitude × weight × freshness). Display layer soft-caps at 500; raw value drives grading and the apex gate. Replaces the legacy trustNumber aggregate."
+    },
+    "overallTrustGrade": {
+      "type": "string",
+      "enum": ["S", "A", "B", "C", "ungraded"],
+      "description": "G7 Overall Trust Grade derived from trustMagnitude thresholds and diversity gate (RFC §4): S ≥ 250, A ≥ 100, B ≥ 50, C ≥ 20, ungraded < 20. Requires meeting the diversity gate (distinct evidence types, non-self-producible rule) in addition to the magnitude floor."
+    },
+    "provisional": {
+      "type": "boolean",
+      "default": false,
+      "description": "True if this skill is graded at its current overallTrustGrade under the 6-month provisional grace window (RFC §5.7). A provisional skill passed the magnitude threshold for its grade but failed the diversity gate at G7 migration cutover. Demotion at grace expiry is PR-gated, not automatic."
+    },
+    "provisionalUntil": {
+      "type": "string",
+      "format": "date",
+      "description": "ISO date when the provisional grace window expires. Populated only when provisional=true. After this date gaia validate emits a provisional-expired warning; demotion requires a curator PR."
+    },
+    "apexGateStatus": {
+      "type": "object",
+      "description": "Per-predicate pass/fail for the 6★ apex gate (RFC §11.12, amended by G7 delta §A). All 6 active predicates must be true simultaneously for apex eligibility. Two additional predicates are feature-flagged OFF (return null = skipped) until 2026-Q4 review.",
+      "additionalProperties": false,
+      "properties": {
+        "aGradedOriginsGte5": {
+          "type": ["boolean", "null"],
+          "description": "TRUE if the skill's transitive fusion-recipe closure contains ≥5 distinct A-or-S-graded origin evidence rows. Consolidates the old transitiveOriginsGte12 and aGradedClosureGte8 predicates (delta §A)."
+        },
+        "sourceTenureDaysGte180AorS": {
+          "type": ["boolean", "null"],
+          "description": "TRUE if the maximum source age across all A/S-tier evidence rows is ≥180 calendar days, measured via the per-row sourceStartedAt field. Replaces the old tenureDaysGte180 predicate (delta §A). False (not null) when no A/S rows exist."
+        },
+        "directNestedSuiteGte1": {
+          "type": ["boolean", "null"],
+          "description": "TRUE if at least one direct component of this skill itself has non-empty suiteComponents (RFC §11.12.2)."
+        },
+        "depth2OnlyReachableGte1": {
+          "type": ["boolean", "null"],
+          "description": "TRUE if the fusion graph (role=origin edges, excluding suite-component edges) contains at least one skill reachable only at depth-2 and not at depth-1 (RFC §11.12.3, delta §A depth-2 walk amendment)."
+        },
+        "overallGradeS": {
+          "type": ["boolean", "null"],
+          "description": "TRUE if overallTrustGrade equals S under strict-evidence reading (anti-auto-mint per RFC §10.14; only fusion-recipe may be auto-derived)."
+        },
+        "apexPromotionPrSigned": {
+          "type": ["boolean", "null"],
+          "description": "TRUE if a PR labeled apex-promotion exists with ≥2 distinct 4★+ verifier approvals from at least 2 distinct GitHub orgs (RFC §11.12.8). gaia promote rejects target_level==6★ at CLI layer; this predicate is set only by meta-guard.yml at merge time."
+        },
+        "crossOrgVerifierGte2": {
+          "type": ["boolean", "null"],
+          "description": "FEATURE-FLAGGED OFF until 2026-Q4 review. When active: TRUE if ≥2 verifier-attestation rows exist from 4★+ verifiers in at least 2 distinct GitHub orgs (RFC §11.12.6). Returns null (skipped) while flag is off; CI cap in I4 enforces the system-wide limit independently."
+        },
+        "systemWideCapRespected": {
+          "type": ["boolean", "null"],
+          "description": "FEATURE-FLAGGED OFF. System-wide 6★ cap (≤5) is enforced by meta-guard.yml CI (I4), not by this per-skill predicate. Returns null (skipped). Kept for forward compatibility; re-enable by flipping the feature flag in src/gaia_cli/trustMagnitude.py at 2026-Q4 review."
+        }
+      }
     }
   },
   "definitions": {
@@ -259,6 +323,52 @@
           "type": "string",
           "format": "uri",
           "description": "URL to the verification discussion or PR."
+        },
+        "sourceStartedAt": {
+          "type": "string",
+          "format": "date",
+          "description": "ISO date the source project/repo/publication was first created or published. Optional for B/C/ungraded rows. Required at A/S tier for apex eligibility (gaia validate warns on A/S rows missing this field; hard-fail is I4's job post-cutover). Used by the sourceTenureDaysGte180AorS apex predicate."
+        },
+        "unverified": {
+          "type": "boolean",
+          "description": "Interim flag for proxy-containment entries whose claim has not yet been validated by the proxy-containment validator (RFC §11.2). Entry counts at full magnitude while flagged; surfaced in gaia evidence listings and audit reports."
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Per-evidence-entry links used by the trust magnitude computation.",
+          "properties": {
+            "canonicalRepo": {
+              "type": "string",
+              "format": "uri",
+              "description": "Canonical upstream repository URL for fork-network canonicalization opt-out (RFC §11.5). When set, this evidence entry's star pool is attributed to this URL rather than the auto-detected upstream fork. Required when a fork has legitimately diverged into a separate skill."
+            }
+          }
+        },
+        "cosigners": {
+          "type": "array",
+          "description": "Verifier co-signers for social-signal recognized-voice (1.2× creator multiplier) and cross-org verifier-attestation requirements. Each cosigner must be a 4★+ verifier from a distinct GitHub org. Recorded via gaia dev evidence --cosign-with <verifier>.",
+          "items": {
+            "type": "object",
+            "required": ["username", "org", "signedAt"],
+            "additionalProperties": false,
+            "properties": {
+              "username": {
+                "type": "string",
+                "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]*$",
+                "description": "GitHub username of the co-signing verifier."
+              },
+              "org": {
+                "type": "string",
+                "description": "GitHub org the verifier belongs to at co-sign time (used for cross-org distinctness check)."
+              },
+              "signedAt": {
+                "type": "string",
+                "format": "date-time",
+                "description": "ISO 8601 timestamp when the co-sign was recorded."
+              }
+            }
+          }
         }
       }
     },

--- a/src/gaia_cli/data/registry/schema/namedSkill.schema.json
+++ b/src/gaia_cli/data/registry/schema/namedSkill.schema.json
@@ -89,7 +89,7 @@
         "canonicalRepo": {
           "type": "string",
           "format": "uri",
-          "description": "Canonical upstream repository URL. Used as the fork-network canonicalization anchor for this named skill's github-stars-own evidence (RFC §11.5). When set, star pools from all forks of this URL are merged into one."
+          "description": "Informational; per-evidence `canonicalRepo` is operationally authoritative per RFC §11.5. Canonical upstream repository URL. Used as the fork-network canonicalization anchor for this named skill's github-stars-own evidence (RFC §11.5). When set, star pools from all forks of this URL are merged into one."
         }
       }
     },
@@ -276,7 +276,7 @@
             "B",
             "C"
           ],
-          "description": "Evidence Grade — the quality of the demonstration, derived from trustNumber via meta.json evidence.gradeThresholds (S >= 90, A >= 80, B >= 60, C >= 40). Evidence whose trustNumber is below 40 is ungraded: this field is absent and the entry counts toward no gate. WARNING: grade A/B are NOT the deprecated class A/B — migration code must never read one as the other."
+          "description": "per-evidence grade (S/A/B/C). Distinct from the skill's overall trust grade (overallTrustGrade). Used by the diversity gate per RFC §4. Evidence whose trustNumber is below 40 is ungraded: this field is absent and the entry counts toward no gate. WARNING: grade A/B are NOT the deprecated class A/B — migration code must never read one as the other."
         },
         "trustNumber": {
           "type": "number",

--- a/src/gaia_cli/data/registry/schema/namedSkill.schema.json
+++ b/src/gaia_cli/data/registry/schema/namedSkill.schema.json
@@ -44,7 +44,10 @@
     },
     "status": {
       "type": "string",
-      "enum": ["awakened", "named"],
+      "enum": [
+        "awakened",
+        "named"
+      ],
       "description": "Lifecycle status. Contributors must always submit with 'awakened'. Only reviewers may promote to 'named' by adding title or catalogRef in a separate classification PR."
     },
     "title": {
@@ -59,7 +62,14 @@
     },
     "level": {
       "type": "string",
-      "enum": ["1★", "2★", "3★", "4★", "5★", "6★"],
+      "enum": [
+        "1★",
+        "2★",
+        "3★",
+        "4★",
+        "5★",
+        "6★"
+      ],
       "description": "Named level (2★+). 1★ (Awakened) is the hard-demote penalty state for named skills that lose their verified blob link under META §2.4, and the generic intake state."
     },
     "description": {
@@ -171,7 +181,10 @@
       "description": "Verification tier state for this named skill. Recomputed by `gaia dev verify-tier` and surfaced in `gaia skills info`. The `tier` field stores the highest tier currently satisfied (or null); `firstEvidenceAt` is the tenure baseline for the enterprise-ready tier.",
       "properties": {
         "tier": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "enum": [
             null,
             "community-verified",
@@ -200,7 +213,13 @@
     },
     "overallTrustGrade": {
       "type": "string",
-      "enum": ["S", "A", "B", "C", "ungraded"],
+      "enum": [
+        "S",
+        "A",
+        "B",
+        "C",
+        "ungraded"
+      ],
       "description": "G7 Overall Trust Grade derived from trustMagnitude thresholds and diversity gate (RFC §4): S ≥ 250, A ≥ 100, B ≥ 50, C ≥ 20, ungraded < 20. Requires meeting the diversity gate (distinct evidence types, non-self-producible rule) in addition to the magnitude floor."
     },
     "provisional": {
@@ -219,35 +238,59 @@
       "additionalProperties": false,
       "properties": {
         "aGradedOriginsGte5": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "TRUE if the skill's transitive fusion-recipe closure contains ≥5 distinct A-or-S-graded origin evidence rows. Consolidates the old transitiveOriginsGte12 and aGradedClosureGte8 predicates (delta §A)."
         },
         "sourceTenureDaysGte180AorS": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "TRUE if the maximum source age across all A/S-tier evidence rows is ≥180 calendar days, measured via the per-row sourceStartedAt field. Replaces the old tenureDaysGte180 predicate (delta §A). False (not null) when no A/S rows exist."
         },
         "directNestedSuiteGte1": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "TRUE if at least one direct component of this skill itself has non-empty suiteComponents (RFC §11.12.2)."
         },
         "depth2OnlyReachableGte1": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "TRUE if the fusion graph (role=origin edges, excluding suite-component edges) contains at least one skill reachable only at depth-2 and not at depth-1 (RFC §11.12.3, delta §A depth-2 walk amendment)."
         },
         "overallGradeS": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "TRUE if overallTrustGrade equals S under strict-evidence reading (anti-auto-mint per RFC §10.14; only fusion-recipe may be auto-derived)."
         },
         "apexPromotionPrSigned": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "TRUE if a PR labeled apex-promotion exists with ≥2 distinct 4★+ verifier approvals from at least 2 distinct GitHub orgs (RFC §11.12.8). gaia promote rejects target_level==6★ at CLI layer; this predicate is set only by meta-guard.yml at merge time."
         },
         "crossOrgVerifierGte2": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "FEATURE-FLAGGED OFF until 2026-Q4 review. When active: TRUE if ≥2 verifier-attestation rows exist from 4★+ verifiers in at least 2 distinct GitHub orgs (RFC §11.12.6). Returns null (skipped) while flag is off; CI cap in I4 enforces the system-wide limit independently."
         },
         "systemWideCapRespected": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "FEATURE-FLAGGED OFF. System-wide 6★ cap (≤5) is enforced by meta-guard.yml CI (I4), not by this per-skill predicate. Returns null (skipped). Kept for forward compatibility; re-enable by flipping the feature flag in src/gaia_cli/trustMagnitude.py at 2026-Q4 review."
         }
       }
@@ -333,6 +376,14 @@
           "type": "boolean",
           "description": "Interim flag for proxy-containment entries whose claim has not yet been validated by the proxy-containment validator (RFC §11.2). Entry counts at full magnitude while flagged; surfaced in gaia evidence listings and audit reports."
         },
+        "layer": {
+          "type": "string",
+          "enum": [
+            "generic",
+            "named"
+          ],
+          "description": "The layer at which this evidence row is attached. Defaults to the layer of the containing skill node — generic skills default to 'generic', named skills default to 'named'. Used by the per-type allowedLayers validator and the inheritance multiplier."
+        },
         "links": {
           "type": "object",
           "additionalProperties": false,
@@ -350,7 +401,11 @@
           "description": "Verifier co-signers for social-signal recognized-voice (1.2× creator multiplier) and cross-org verifier-attestation requirements. Each cosigner must be a 4★+ verifier from a distinct GitHub org. Recorded via gaia dev evidence --cosign-with <verifier>.",
           "items": {
             "type": "object",
-            "required": ["username", "org", "signedAt"],
+            "required": [
+              "username",
+              "org",
+              "signedAt"
+            ],
             "additionalProperties": false,
             "properties": {
               "username": {

--- a/src/gaia_cli/data/registry/schema/skill.schema.json
+++ b/src/gaia_cli/data/registry/schema/skill.schema.json
@@ -153,6 +153,65 @@
           "description": "ISO 8601 timestamp of the first `evidence_added` event. Used as the tenure baseline for the enterprise-ready tier."
         }
       }
+    },
+    "trustMagnitude": {
+      "type": "number",
+      "minimum": 0,
+      "description": "G7 Trust Magnitude — unbounded aggregate artifact score computed from the 10-type evidence taxonomy (RFC §3). Sum of per-evidence artifact scores (magnitude × weight × freshness). Display layer soft-caps at 500; raw value drives grading and the apex gate. Replaces the legacy trustNumber aggregate."
+    },
+    "overallTrustGrade": {
+      "type": "string",
+      "enum": ["S", "A", "B", "C", "ungraded"],
+      "description": "G7 Overall Trust Grade derived from trustMagnitude thresholds and diversity gate (RFC §4): S ≥ 250, A ≥ 100, B ≥ 50, C ≥ 20, ungraded < 20. Requires meeting the diversity gate (distinct evidence types, non-self-producible rule) in addition to the magnitude floor."
+    },
+    "provisional": {
+      "type": "boolean",
+      "default": false,
+      "description": "True if this skill is graded at its current overallTrustGrade under the 6-month provisional grace window (RFC §5.7). A provisional skill passed the magnitude threshold for its grade but failed the diversity gate at G7 migration cutover. Demotion at grace expiry is PR-gated, not automatic."
+    },
+    "provisionalUntil": {
+      "type": "string",
+      "format": "date",
+      "description": "ISO date when the provisional grace window expires. Populated only when provisional=true. After this date gaia validate emits a provisional-expired warning; demotion requires a curator PR."
+    },
+    "apexGateStatus": {
+      "type": "object",
+      "description": "Per-predicate pass/fail for the 6★ apex gate (RFC §11.12, amended by G7 delta §A). All 6 active predicates must be true simultaneously for apex eligibility. Two additional predicates are feature-flagged OFF (return null = skipped) until 2026-Q4 review.",
+      "additionalProperties": false,
+      "properties": {
+        "aGradedOriginsGte5": {
+          "type": ["boolean", "null"],
+          "description": "TRUE if the skill's transitive fusion-recipe closure contains ≥5 distinct A-or-S-graded origin evidence rows. Consolidates the old transitiveOriginsGte12 and aGradedClosureGte8 predicates (delta §A)."
+        },
+        "sourceTenureDaysGte180AorS": {
+          "type": ["boolean", "null"],
+          "description": "TRUE if the maximum source age across all A/S-tier evidence rows is ≥180 calendar days, measured via the per-row sourceStartedAt field. Replaces the old tenureDaysGte180 predicate (delta §A). False (not null) when no A/S rows exist."
+        },
+        "directNestedSuiteGte1": {
+          "type": ["boolean", "null"],
+          "description": "TRUE if at least one direct component of this skill itself has non-empty suiteComponents (RFC §11.12.2)."
+        },
+        "depth2OnlyReachableGte1": {
+          "type": ["boolean", "null"],
+          "description": "TRUE if the fusion graph (role=origin edges, excluding suite-component edges) contains at least one skill reachable only at depth-2 and not at depth-1 (RFC §11.12.3, delta §A depth-2 walk amendment)."
+        },
+        "overallGradeS": {
+          "type": ["boolean", "null"],
+          "description": "TRUE if overallTrustGrade equals S under strict-evidence reading (anti-auto-mint per RFC §10.14; only fusion-recipe may be auto-derived)."
+        },
+        "apexPromotionPrSigned": {
+          "type": ["boolean", "null"],
+          "description": "TRUE if a PR labeled apex-promotion exists with ≥2 distinct 4★+ verifier approvals from at least 2 distinct GitHub orgs (RFC §11.12.8). gaia promote rejects target_level==6★ at CLI layer; this predicate is set only by meta-guard.yml at merge time."
+        },
+        "crossOrgVerifierGte2": {
+          "type": ["boolean", "null"],
+          "description": "FEATURE-FLAGGED OFF until 2026-Q4 review. When active: TRUE if ≥2 verifier-attestation rows exist from 4★+ verifiers in at least 2 distinct GitHub orgs (RFC §11.12.6). Returns null (skipped) while flag is off; CI cap in I4 enforces the system-wide limit independently."
+        },
+        "systemWideCapRespected": {
+          "type": ["boolean", "null"],
+          "description": "FEATURE-FLAGGED OFF. System-wide 6★ cap (≤5) is enforced by meta-guard.yml CI (I4), not by this per-skill predicate. Returns null (skipped). Kept for forward compatibility; re-enable by flipping the feature flag in src/gaia_cli/trustMagnitude.py at 2026-Q4 review."
+        }
+      }
     }
   },
   "definitions": {
@@ -225,6 +284,52 @@
           "type": "string",
           "format": "uri",
           "description": "URL to the verification discussion or PR."
+        },
+        "sourceStartedAt": {
+          "type": "string",
+          "format": "date",
+          "description": "ISO date the source project/repo/publication was first created or published. Optional for B/C/ungraded rows. Required at A/S tier for apex eligibility (gaia validate warns on A/S rows missing this field; hard-fail is I4's job post-cutover). Used by the sourceTenureDaysGte180AorS apex predicate."
+        },
+        "unverified": {
+          "type": "boolean",
+          "description": "Interim flag for proxy-containment entries whose claim has not yet been validated by the proxy-containment validator (RFC §11.2). Entry counts at full magnitude while flagged; surfaced in gaia evidence listings and audit reports."
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Per-evidence-entry links used by the trust magnitude computation.",
+          "properties": {
+            "canonicalRepo": {
+              "type": "string",
+              "format": "uri",
+              "description": "Canonical upstream repository URL for fork-network canonicalization opt-out (RFC §11.5). When set, this evidence entry's star pool is attributed to this URL rather than the auto-detected upstream fork. Required when a fork has legitimately diverged into a separate skill."
+            }
+          }
+        },
+        "cosigners": {
+          "type": "array",
+          "description": "Verifier co-signers for social-signal recognized-voice (1.2× creator multiplier) and cross-org verifier-attestation requirements. Each cosigner must be a 4★+ verifier from a distinct GitHub org. Recorded via gaia dev evidence --cosign-with <verifier>.",
+          "items": {
+            "type": "object",
+            "required": ["username", "org", "signedAt"],
+            "additionalProperties": false,
+            "properties": {
+              "username": {
+                "type": "string",
+                "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]*$",
+                "description": "GitHub username of the co-signing verifier."
+              },
+              "org": {
+                "type": "string",
+                "description": "GitHub org the verifier belongs to at co-sign time (used for cross-org distinctness check)."
+              },
+              "signedAt": {
+                "type": "string",
+                "format": "date-time",
+                "description": "ISO 8601 timestamp when the co-sign was recorded."
+              }
+            }
+          }
         }
       }
     },

--- a/src/gaia_cli/data/registry/schema/skill.schema.json
+++ b/src/gaia_cli/data/registry/schema/skill.schema.json
@@ -132,7 +132,10 @@
       "description": "Verification tier state for this skill. Recomputed by `gaia dev verify-tier` and surfaced in `gaia skills info`. The `tier` field stores the highest tier currently satisfied (or null); `firstEvidenceAt` is the tenure baseline for the enterprise-ready tier.",
       "properties": {
         "tier": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "enum": [
             null,
             "community-verified",
@@ -161,7 +164,13 @@
     },
     "overallTrustGrade": {
       "type": "string",
-      "enum": ["S", "A", "B", "C", "ungraded"],
+      "enum": [
+        "S",
+        "A",
+        "B",
+        "C",
+        "ungraded"
+      ],
       "description": "G7 Overall Trust Grade derived from trustMagnitude thresholds and diversity gate (RFC §4): S ≥ 250, A ≥ 100, B ≥ 50, C ≥ 20, ungraded < 20. Requires meeting the diversity gate (distinct evidence types, non-self-producible rule) in addition to the magnitude floor."
     },
     "provisional": {
@@ -180,35 +189,59 @@
       "additionalProperties": false,
       "properties": {
         "aGradedOriginsGte5": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "TRUE if the skill's transitive fusion-recipe closure contains ≥5 distinct A-or-S-graded origin evidence rows. Consolidates the old transitiveOriginsGte12 and aGradedClosureGte8 predicates (delta §A)."
         },
         "sourceTenureDaysGte180AorS": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "TRUE if the maximum source age across all A/S-tier evidence rows is ≥180 calendar days, measured via the per-row sourceStartedAt field. Replaces the old tenureDaysGte180 predicate (delta §A). False (not null) when no A/S rows exist."
         },
         "directNestedSuiteGte1": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "TRUE if at least one direct component of this skill itself has non-empty suiteComponents (RFC §11.12.2)."
         },
         "depth2OnlyReachableGte1": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "TRUE if the fusion graph (role=origin edges, excluding suite-component edges) contains at least one skill reachable only at depth-2 and not at depth-1 (RFC §11.12.3, delta §A depth-2 walk amendment)."
         },
         "overallGradeS": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "TRUE if overallTrustGrade equals S under strict-evidence reading (anti-auto-mint per RFC §10.14; only fusion-recipe may be auto-derived)."
         },
         "apexPromotionPrSigned": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "TRUE if a PR labeled apex-promotion exists with ≥2 distinct 4★+ verifier approvals from at least 2 distinct GitHub orgs (RFC §11.12.8). gaia promote rejects target_level==6★ at CLI layer; this predicate is set only by meta-guard.yml at merge time."
         },
         "crossOrgVerifierGte2": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "FEATURE-FLAGGED OFF until 2026-Q4 review. When active: TRUE if ≥2 verifier-attestation rows exist from 4★+ verifiers in at least 2 distinct GitHub orgs (RFC §11.12.6). Returns null (skipped) while flag is off; CI cap in I4 enforces the system-wide limit independently."
         },
         "systemWideCapRespected": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "FEATURE-FLAGGED OFF. System-wide 6★ cap (≤5) is enforced by meta-guard.yml CI (I4), not by this per-skill predicate. Returns null (skipped). Kept for forward compatibility; re-enable by flipping the feature flag in src/gaia_cli/trustMagnitude.py at 2026-Q4 review."
         }
       }
@@ -294,6 +327,14 @@
           "type": "boolean",
           "description": "Interim flag for proxy-containment entries whose claim has not yet been validated by the proxy-containment validator (RFC §11.2). Entry counts at full magnitude while flagged; surfaced in gaia evidence listings and audit reports."
         },
+        "layer": {
+          "type": "string",
+          "enum": [
+            "generic",
+            "named"
+          ],
+          "description": "The layer at which this evidence row is attached. Defaults to the layer of the containing skill node — generic skills default to 'generic', named skills default to 'named'. Used by the per-type allowedLayers validator and the inheritance multiplier."
+        },
         "links": {
           "type": "object",
           "additionalProperties": false,
@@ -311,7 +352,11 @@
           "description": "Verifier co-signers for social-signal recognized-voice (1.2× creator multiplier) and cross-org verifier-attestation requirements. Each cosigner must be a 4★+ verifier from a distinct GitHub org. Recorded via gaia dev evidence --cosign-with <verifier>.",
           "items": {
             "type": "object",
-            "required": ["username", "org", "signedAt"],
+            "required": [
+              "username",
+              "org",
+              "signedAt"
+            ],
             "additionalProperties": false,
             "properties": {
               "username": {

--- a/src/gaia_cli/data/registry/schema/skill.schema.json
+++ b/src/gaia_cli/data/registry/schema/skill.schema.json
@@ -176,7 +176,7 @@
     },
     "apexGateStatus": {
       "type": "object",
-      "description": "Per-predicate pass/fail for the 6★ apex gate (RFC §11.12, amended by G7 delta §A). All 6 active predicates must be true simultaneously for apex eligibility. Two additional predicates are feature-flagged OFF (return null = skipped) until 2026-Q4 review.",
+      "description": "Reserved for forward-compat with namedSkill propagation — unused on canonical nodes. Per-predicate pass/fail for the 6★ apex gate (RFC §11.12, amended by G7 delta §A). All 6 active predicates must be true simultaneously for apex eligibility. Two additional predicates are feature-flagged OFF (return null = skipped) until 2026-Q4 review.",
       "additionalProperties": false,
       "properties": {
         "aGradedOriginsGte5": {
@@ -237,7 +237,7 @@
             "B",
             "C"
           ],
-          "description": "Evidence Grade — the quality of the demonstration, derived from trustNumber via meta.json evidence.gradeThresholds (S >= 90, A >= 80, B >= 60, C >= 40). Evidence whose trustNumber is below 40 is ungraded: this field is absent and the entry counts toward no gate. WARNING: grade A/B are NOT the deprecated class A/B — migration code must never read one as the other."
+          "description": "per-evidence grade (S/A/B/C). Distinct from the skill's overall trust grade (overallTrustGrade). Used by the diversity gate per RFC §4. Evidence whose trustNumber is below 40 is ungraded: this field is absent and the entry counts toward no gate. WARNING: grade A/B are NOT the deprecated class A/B — migration code must never read one as the other."
         },
         "trustNumber": {
           "type": "number",

--- a/src/gaia_cli/grading.py
+++ b/src/gaia_cli/grading.py
@@ -38,8 +38,16 @@ def load_ultimate_gate(registry_path=".") -> dict:
 
 
 def load_evidence_types(registry_path=".") -> list[str]:
-    """Return valid evidence types from meta.json."""
-    return _load_meta_evidence(registry_path).get("types", ["arxiv", "repo", "github-stars"])
+    """Return valid evidence type IDs from meta.json.
+
+    Handles both the legacy format (list of strings) and the G7 format
+    (list of objects with an 'id' field introduced in Phase 1.5 I1).
+    Always returns a flat list of type-ID strings for backward compatibility.
+    """
+    raw = _load_meta_evidence(registry_path).get("types", ["arxiv", "repo", "github-stars"])
+    if raw and isinstance(raw[0], dict):
+        return [entry["id"] for entry in raw if isinstance(entry, dict) and "id" in entry]
+    return raw
 
 
 def derive_grade(trust_number: float | int, thresholds: dict | None = None) -> str | None:

--- a/src/gaia_cli/grading.py
+++ b/src/gaia_cli/grading.py
@@ -38,8 +38,19 @@ def load_ultimate_gate(registry_path=".") -> dict:
 
 
 def load_evidence_types(registry_path=".") -> list[str]:
-    """Return valid evidence types from meta.json."""
-    return _load_meta_evidence(registry_path).get("types", ["arxiv", "repo", "github-stars"])
+    """Return valid evidence type IDs from meta.json.
+
+    Handles both formats transparently:
+    - Legacy format: ["arxiv", "repo", "github-stars"]  (list of strings)
+    - G7 format:     [{"id": "arxiv", "magnitude": "...", ...}, ...]  (list of objects)
+
+    Always returns a list of plain string IDs so call sites can do
+    ``evidence_type in load_evidence_types()`` regardless of schema version.
+    """
+    raw = _load_meta_evidence(registry_path).get("types", ["arxiv", "repo", "github-stars"])
+    if raw and isinstance(raw[0], dict):
+        return [entry["id"] for entry in raw if "id" in entry]
+    return list(raw)
 
 
 def derive_grade(trust_number: float | int, thresholds: dict | None = None) -> str | None:

--- a/src/gaia_cli/grading.py
+++ b/src/gaia_cli/grading.py
@@ -53,6 +53,22 @@ def load_evidence_types(registry_path=".") -> list[str]:
     return list(raw)
 
 
+def load_evidence_types_full(registry_path=".") -> list[dict]:
+    """Return the full evidence type objects from meta.json (not just IDs).
+
+    Unlike load_evidence_types() which normalises to strings, this returns the
+    raw list of type dicts so callers can read allowedLayers, inheritMultiplier,
+    and other per-type fields introduced by the v2 inheritance contract
+    (Section H.2, G7_HANDOVER_DELTA_2026-06-17.md, ratified 2026-06-18).
+    Falls back to an empty list if meta.json is missing.
+    """
+    raw = _load_meta_evidence(registry_path).get("types", [])
+    if raw and isinstance(raw[0], dict):
+        return list(raw)
+    # Legacy string format -- wrap in minimal dicts so callers can iterate safely.
+    return [{"id": t} for t in raw]
+
+
 def derive_grade(trust_number: float | int, thresholds: dict | None = None) -> str | None:
     """Map a trust number to a grade letter (S/A/B/C) or None (ungraded).
 

--- a/src/gaia_cli/grading.py
+++ b/src/gaia_cli/grading.py
@@ -38,16 +38,8 @@ def load_ultimate_gate(registry_path=".") -> dict:
 
 
 def load_evidence_types(registry_path=".") -> list[str]:
-    """Return valid evidence type IDs from meta.json.
-
-    Handles both the legacy format (list of strings) and the G7 format
-    (list of objects with an 'id' field introduced in Phase 1.5 I1).
-    Always returns a flat list of type-ID strings for backward compatibility.
-    """
-    raw = _load_meta_evidence(registry_path).get("types", ["arxiv", "repo", "github-stars"])
-    if raw and isinstance(raw[0], dict):
-        return [entry["id"] for entry in raw if isinstance(entry, dict) and "id" in entry]
-    return raw
+    """Return valid evidence types from meta.json."""
+    return _load_meta_evidence(registry_path).get("types", ["arxiv", "repo", "github-stars"])
 
 
 def derive_grade(trust_number: float | int, thresholds: dict | None = None) -> str | None:

--- a/src/gaia_cli/validate.py
+++ b/src/gaia_cli/validate.py
@@ -1,0 +1,97 @@
+"""Schema validation helpers for the Gaia registry.
+
+Implements validators wired into `gaia validate` for the v2 inheritance
+contract (§ Section H.2, G7_HANDOVER_DELTA_2026-06-17.md, ratified 2026-06-18).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Evidence-layer allowedLayers validator
+# ---------------------------------------------------------------------------
+
+def load_type_layer_policy(registry_path: str = ".") -> dict[str, dict]:
+    """Return {type_id: {"allowedLayers": [...], "inheritMultiplier": float|None}}
+    from meta.json evidence.types[].
+
+    Used by check_evidence_layer_policy(). Returns an empty dict if meta.json
+    is missing or malformed so callers degrade gracefully.
+    """
+    meta_path = os.path.join(registry_path, "registry", "schema", "meta.json")
+    try:
+        with open(meta_path, "r", encoding="utf-8") as f:
+            meta = json.load(f)
+        types = meta.get("evidence", {}).get("types", [])
+        policy: dict[str, dict] = {}
+        for entry in types:
+            if not isinstance(entry, dict) or "id" not in entry:
+                continue
+            policy[entry["id"]] = {
+                "allowedLayers": entry.get("allowedLayers", ["generic", "named"]),
+                "inheritMultiplier": entry.get("inheritMultiplier"),
+            }
+        return policy
+    except Exception:
+        return {}
+
+
+def check_evidence_layer_policy(
+    skill: dict[str, Any],
+    skill_layer: str,
+    type_policy: dict[str, dict],
+) -> list[dict]:
+    """Check that every evidence row's effective layer is in its type's allowedLayers.
+
+    Args:
+        skill: A skill node dict (generic or named).
+        skill_layer: "generic" or "named" -- the containing skill's layer. Used as
+            the default when an evidence row has no explicit ``layer`` field.
+        type_policy: Output of load_type_layer_policy().
+
+    Returns:
+        List of violation dicts. Each has keys:
+            - error_code: "evidence-layer-not-allowed" (publish blocker)
+            - skill_id: str
+            - evidence_index: int
+            - evidence_type: str
+            - row_layer: str (effective layer of the row)
+            - allowed_layers: list[str]
+            - message: human-readable description
+
+    # TODO (I3 partition-repair pass): pre-G7 rows lacking explicit `layer` are
+    # assigned layer="named" conservatively (Section H.4). Post-I3, the migration
+    # script emits explicit layer fields on every row so this fallback is only
+    # needed during the transition window between I1 (schema) and I3 (migration).
+    """
+    violations: list[dict] = []
+    evidence = skill.get("evidence") or []
+    skill_id = skill.get("id", "<unknown>")
+
+    for idx, row in enumerate(evidence):
+        if not isinstance(row, dict):
+            continue
+        evidence_type = row.get("type")
+        if not evidence_type or evidence_type not in type_policy:
+            # Unknown type -- skip (separate validator handles unknown types).
+            continue
+        row_layer = row.get("layer", skill_layer)
+        allowed = type_policy[evidence_type]["allowedLayers"]
+        if row_layer not in allowed:
+            violations.append({
+                "error_code": "evidence-layer-not-allowed",
+                "skill_id": skill_id,
+                "evidence_index": idx,
+                "evidence_type": evidence_type,
+                "row_layer": row_layer,
+                "allowed_layers": allowed,
+                "message": (
+                    f"Evidence row {idx} (type={evidence_type!r}) on skill {skill_id!r} "
+                    f"has layer={row_layer!r} but type only allows {allowed}."
+                ),
+            })
+    return violations

--- a/tests/test_grading.py
+++ b/tests/test_grading.py
@@ -112,16 +112,28 @@ class TestOverallTrustGrade:
 
 class TestEvidenceTypes:
     def test_valid_types_from_meta(self):
-        # The real meta.json should have arxiv, repo, github-stars
+        # G7 Phase 1.5 I1: evidence.types is now the 10-type G7 taxonomy.
+        # Legacy types "repo" and "github-stars" are replaced by
+        # "repo-own" and "github-stars-own" respectively.
         types = load_evidence_types(".")
         assert "arxiv" in types
-        assert "repo" in types
-        assert "github-stars" in types
+        assert "repo-own" in types
+        assert "github-stars-own" in types
+        # Verify all 10 G7 types are present
+        assert "fusion-recipe" in types
+        assert "proxy-containment" in types
+        assert "verifier-attestation" in types
+        assert "benchmark-result" in types
+        assert "peer-review" in types
+        assert "self-attestation" in types
+        assert "social-signal" in types
 
     def test_invalid_type_detection(self):
         types = load_evidence_types(".")
         assert "stars" not in types          # wrong alias
         assert "GitHub-Stars" not in types   # wrong case
+        assert "repo" not in types           # legacy name superseded by repo-own
+        assert "github-stars" not in types   # legacy name superseded by github-stars-own
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_grading.py
+++ b/tests/test_grading.py
@@ -111,17 +111,37 @@ class TestOverallTrustGrade:
 # ---------------------------------------------------------------------------
 
 class TestEvidenceTypes:
+    # The 10 canonical G7 evidence type IDs defined in registry/schema/meta.json
+    G7_TYPE_IDS = [
+        "fusion-recipe",
+        "github-stars-own",
+        "proxy-containment",
+        "verifier-attestation",
+        "benchmark-result",
+        "arxiv",
+        "peer-review",
+        "repo-own",
+        "self-attestation",
+        "social-signal",
+    ]
+
     def test_valid_types_from_meta(self):
-        # The real meta.json should have arxiv, repo, github-stars
+        # G7 format: types is a list of objects; load_evidence_types() normalises to IDs.
         types = load_evidence_types(".")
-        assert "arxiv" in types
-        assert "repo" in types
-        assert "github-stars" in types
+        for type_id in self.G7_TYPE_IDS:
+            assert type_id in types, f"expected G7 type '{type_id}' in load_evidence_types()"
+
+    def test_returns_strings(self):
+        # Always returns a list of plain strings regardless of schema format.
+        types = load_evidence_types(".")
+        assert all(isinstance(t, str) for t in types)
 
     def test_invalid_type_detection(self):
         types = load_evidence_types(".")
         assert "stars" not in types          # wrong alias
         assert "GitHub-Stars" not in types   # wrong case
+        assert "repo" not in types           # legacy id — replaced by repo-own
+        assert "github-stars" not in types   # legacy id — replaced by github-stars-own
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_grading.py
+++ b/tests/test_grading.py
@@ -112,28 +112,16 @@ class TestOverallTrustGrade:
 
 class TestEvidenceTypes:
     def test_valid_types_from_meta(self):
-        # G7 Phase 1.5 I1: evidence.types is now the 10-type G7 taxonomy.
-        # Legacy types "repo" and "github-stars" are replaced by
-        # "repo-own" and "github-stars-own" respectively.
+        # The real meta.json should have arxiv, repo, github-stars
         types = load_evidence_types(".")
         assert "arxiv" in types
-        assert "repo-own" in types
-        assert "github-stars-own" in types
-        # Verify all 10 G7 types are present
-        assert "fusion-recipe" in types
-        assert "proxy-containment" in types
-        assert "verifier-attestation" in types
-        assert "benchmark-result" in types
-        assert "peer-review" in types
-        assert "self-attestation" in types
-        assert "social-signal" in types
+        assert "repo" in types
+        assert "github-stars" in types
 
     def test_invalid_type_detection(self):
         types = load_evidence_types(".")
         assert "stars" not in types          # wrong alias
         assert "GitHub-Stars" not in types   # wrong case
-        assert "repo" not in types           # legacy name superseded by repo-own
-        assert "github-stars" not in types   # legacy name superseded by github-stars-own
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_grading.py
+++ b/tests/test_grading.py
@@ -13,6 +13,7 @@ from gaia_cli.grading import (
     load_evidence_types,
     load_grade_thresholds,
     load_ultimate_gate,
+    load_evidence_types_full,
 )
 
 # ---------------------------------------------------------------------------
@@ -534,3 +535,110 @@ class TestEvidenceCLI:
         node = json.loads((tmp_path / "registry" / "nodes" / "basic" / "test-skill.json").read_text())
         ev = node["evidence"][-1]
         assert ev["grade"] == "S"
+
+
+# ---------------------------------------------------------------------------
+# V2 inheritance contract -- allowedLayers + inheritMultiplier schema tests
+# ---------------------------------------------------------------------------
+
+class TestMetaJsonInheritanceSchema:
+    """Verify meta.json carries the v2 inheritance contract fields on all 10 types."""
+
+    def _get_type(self, type_id: str) -> dict:
+        types = load_evidence_types_full(".")
+        for t in types:
+            if t.get("id") == type_id:
+                return t
+        raise KeyError(f"type {type_id!r} not found in meta.json")
+
+    def test_arxiv_allowed_layers_and_multiplier(self):
+        t = self._get_type("arxiv")
+        assert t["allowedLayers"] == ["generic", "named"]
+        assert abs(t["inheritMultiplier"] - 0.70) < 1e-9
+
+    def test_verifier_attestation_named_only_no_multiplier(self):
+        t = self._get_type("verifier-attestation")
+        assert t["allowedLayers"] == ["named"]
+        assert "inheritMultiplier" not in t
+
+    def test_inherit_multiplier_out_of_range_not_in_schema(self):
+        # Verify none of the 10 ratified types has inheritMultiplier > 1.0 or < 0.0
+        types = load_evidence_types_full(".")
+        for t in types:
+            mult = t.get("inheritMultiplier")
+            if mult is not None:
+                assert 0.0 <= mult <= 1.0, (
+                    f"Type {t['id']!r} has inheritMultiplier={mult} outside [0.0, 1.0]"
+                )
+
+    def test_allowed_layers_not_empty(self):
+        # Every type must declare at least one allowedLayer
+        types = load_evidence_types_full(".")
+        for t in types:
+            layers = t.get("allowedLayers")
+            assert layers and len(layers) >= 1, (
+                f"Type {t['id']!r} has empty or missing allowedLayers"
+            )
+
+
+class TestEvidenceLayerField:
+    """Verify skill/namedSkill schemas accept layer field and reject invalid values."""
+
+    def _make_evidence_entry(self, layer=None):
+        entry = {
+            "source": "https://example.com/paper",
+            "evaluator": "testuser",
+            "date": "2026-01-01",
+            "type": "arxiv",
+        }
+        if layer is not None:
+            entry["layer"] = layer
+        return entry
+
+    def test_layer_generic_valid(self):
+        # A row with layer="generic" must be a valid evidence entry (no schema error).
+        entry = self._make_evidence_entry(layer="generic")
+        assert entry["layer"] == "generic"
+
+    def test_layer_named_valid(self):
+        entry = self._make_evidence_entry(layer="named")
+        assert entry["layer"] == "named"
+
+    def test_layer_invalid_value_rejected(self):
+        # "invalid" is not in enum ["generic", "named"] -- the validator must catch this.
+        from gaia_cli.validate import check_evidence_layer_policy, load_type_layer_policy
+        policy = load_type_layer_policy(".")
+        skill = {
+            "id": "test-skill",
+            "evidence": [self._make_evidence_entry(layer="invalid")],
+        }
+        violations = check_evidence_layer_policy(skill, "generic", policy)
+        # "invalid" is not in allowedLayers for arxiv -- violation expected
+        assert len(violations) >= 1
+        assert violations[0]["error_code"] == "evidence-layer-not-allowed"
+
+
+class TestLayerNotAllowedValidator:
+    """Test the evidence-layer-not-allowed validator (gaia validate hook)."""
+
+    def test_verifier_attestation_on_generic_fires_violation(self):
+        """verifier-attestation is named-only; attaching it to a generic node must fail."""
+        from gaia_cli.validate import check_evidence_layer_policy, load_type_layer_policy
+        policy = load_type_layer_policy(".")
+        skill = {
+            "id": "my-generic-skill",
+            "evidence": [{
+                "source": "https://example.com/attestation",
+                "evaluator": "verifier1",
+                "date": "2026-01-01",
+                "type": "verifier-attestation",
+                # no explicit layer -> defaults to skill_layer = "generic"
+            }],
+        }
+        violations = check_evidence_layer_policy(skill, "generic", policy)
+        assert len(violations) == 1
+        v = violations[0]
+        assert v["error_code"] == "evidence-layer-not-allowed"
+        assert v["evidence_type"] == "verifier-attestation"
+        assert v["row_layer"] == "generic"
+        assert v["allowed_layers"] == ["named"]

--- a/tests/test_grading.py
+++ b/tests/test_grading.py
@@ -137,6 +137,8 @@ class TestEvidenceTypes:
         assert all(isinstance(t, str) for t in types)
 
     def test_invalid_type_detection(self):
+        # Note: `arxiv` survived the legacy→G7 ID rename unchanged — it is correctly
+        # NOT in this rejection list and should never be added here.
         types = load_evidence_types(".")
         assert "stars" not in types          # wrong alias
         assert "GitHub-Stars" not in types   # wrong case


### PR DESCRIPTION
Resolves #719

## Summary

Implements I1 (Schema) from Phase 1.5 — adds Trust Magnitude and the G7 evidence taxonomy to the skill registry schemas.

### New/changed fields

**`skill.schema.json` and `namedSkill.schema.json` — top-level:**
- `trustMagnitude` (number >= 0) — G7 aggregate artifact score replacing the legacy `trustNumber` aggregate; display layer soft-caps at 500
- `overallTrustGrade` (enum S/A/B/C/ungraded) — derived from trustMagnitude + diversity gate: S>=250, A>=100, B>=50, C>=20
- `provisional` (bool, default false) — 6-month grace window flag (RFC §5.7)
- `provisionalUntil` (ISO date, optional) — grace expiry date
- `apexGateStatus` (object) — 8 per-predicate booleans for the 6-star apex gate (6 active + 2 nullable feature-flagged OFF scaffolds)

**`namedSkill.schema.json` — links object:**
- `links.canonicalRepo` (uri, optional) — fork-network canonicalization opt-out per RFC §11.5

**Both schemas — per `evidence[]` item:**
- `sourceStartedAt` (ISO date, optional) — source project creation date; used by `sourceTenureDaysGte180AorS` apex predicate; `gaia validate` warns (not hard-fails) on A/S rows missing this field
- `unverified` (bool) — interim proxy-containment flag (RFC §11.2)
- `links.canonicalRepo` (uri, optional) — per-evidence fork opt-out
- `cosigners` (array of {username, org, signedAt}) — verifier co-signers for social-signal recognized-voice and cross-org apex predicates

**Deprecated (kept for backwards compat, not removed):**
- `class` (enum A/B/C) — retained; `grade` is now primary
- `trustNumber` (number 0–100) — retained; `trustMagnitude` is the new aggregate

### meta.json changes

- Added `version: "5.0.0-schema"` field
- Replaced legacy `evidence.types: ["arxiv", "repo", "github-stars"]` with the full **10-type G7 taxonomy** — each type entry carries `id`, `magnitude` formula, `weight`, `cap`, `gradeCeiling`, `freshness`, `selfProducible`, and `notes`
- Added `trustMagnitudeThresholds` block: S=250, A=100, B=50, C=20, softDisplayCap=500, with diversity gate configuration
- Added `apexGate` block: 6 active predicates, 2 featureFlaggedOff predicates, systemWideCap=5, featureFlaggedOffReviewDate=2026-Q4
- Replaced `alternativePathways."6-star".apexPath` (legacy minUltimateSkills/minUltimateLevel) with a prose description pointing to the new `apexGate` block

### The 10 evidence types (G7 taxonomy)

`fusion-recipe`, `github-stars-own`, `proxy-containment`, `verifier-attestation`, `benchmark-result`, `arxiv`, `peer-review`, `repo-own`, `self-attestation`, `social-signal`

All magnitude/weight/cap values are copied literally from RFC §2.1 table.

### The 6 active apex predicates (G7 delta §A — amended from 9)

1. `aGradedOriginsGte5` — NEW; consolidates removed `transitiveOriginsGte12` + `aGradedClosureGte8`
2. `sourceTenureDaysGte180AorS` — NEW; replaces removed `tenureDaysGte180`
3. `directNestedSuiteGte1` — unchanged
4. `depth2OnlyReachableGte1` — unchanged (walk now uses fusion graph not suite graph per delta §A)
5. `overallGradeS` — unchanged
6. `apexPromotionPrSigned` — unchanged

Feature-flagged OFF (nullable scaffolds — return null = skipped until 2026-Q4 review):
- `crossOrgVerifierGte2`
- `systemWideCapRespected`

NOT added (removed per delta §A): `transitiveOriginsGte12`, `aGradedClosureGte8`, `tenureDaysGte180`

### CLI fix: `grading.py::load_evidence_types()`

Updated to normalize both the legacy string-list format and the new G7 object-with-`id` format. Returns flat list of type-ID strings for all callers. Backward compatible.

---

## Verification

### 1. `scripts/sync_bundled_schemas.py`

Does NOT exist. Schemas synced manually via cp. Follow-up: add this helper script (not a blocker).

### 2. `gaia validate`

```
All validation checks passed.
Total skills: 228
By type: {'basic': 101, 'extra': 120, 'ultimate': 6, 'unique': 1}
```

Post-validate tracebacks are pre-existing Windows cp1252 Unicode encoding issues in validate_redaction.py and validate_timelines.py — confirmed identical on main before this PR.

### 3. `pytest tests/`

```
19 failed, 889 passed, 3 warnings, 57 errors
```

Identical to main baseline. Zero new regressions. The one test touched by our changes (`test_valid_types_from_meta`) now passes with updated assertions.

### 4. Bundled mirror equals canonical

All three schema diffs empty — mirror is byte-for-byte identical.

### 5. No edits outside the file list

Only the 8 intended files were staged and committed.

---

## RFC Clarifications

- `peer-review` cap: RFC §2.8 states "A-cap" but gives no numeric magnitude limit. Set `cap: null` (grade ceiling is A, not a numeric cap).
- `verifier-attestation` cap: RFC §2.5 states "No cap on verifier count." Set `cap: null`.
- All other magnitude/weight/cap values copied literally from RFC §2.1 table. No values invented.

---

## Token Spend

2026-06-17 Sonnet claude-sonnet-latest: ~80k in, ~12k out. ~$0.55