### PR TITLE
feat(migration): I3 -- big-bang regrade + stamp report (Phase 1.5)

### DIFF
--- a/docs/graph/named/index.json
+++ b/docs/graph/named/index.json
@@ -27,6 +27,13 @@
         },
         "createdAt": "2026-04-30",
         "updatedAt": "2026-04-30",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:13Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "type": "extra",
         "role": "origin",
         "overallTrustGrade": "B"
@@ -76,6 +83,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/health/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -137,6 +149,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/design-consultation/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -188,6 +205,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/Manavarya09/design-extract as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -254,6 +276,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/addyosmani/agent-skills/blob/main/skills/performance-optimization/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -290,6 +317,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Origin status removed. Transferred to addy-osmani/performance-optimization."
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -322,6 +354,13 @@
         },
         "createdAt": "2026-05-19",
         "updatedAt": "2026-05-19",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "ruvnet/ruflo-v3",
         "type": "basic",
         "role": "variant",
@@ -378,6 +417,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/addyosmani/agent-skills/blob/main/skills/test-driven-development/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -439,6 +483,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/document-generate/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -493,6 +542,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/anthropics/skills/blob/main/skills/pptx/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -544,6 +598,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/document-release/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -604,6 +663,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/personal/edit-article/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "mattpocock/personal",
@@ -643,6 +707,11 @@
             "action": "rank_up",
             "contributor": "unknown",
             "details": "Origin status set to true."
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "mattpocock/productivity",
@@ -679,6 +748,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Origin status removed. Transferred to mattpocock/write-a-skill."
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -725,6 +799,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/bradautomates/claude-video as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -796,6 +875,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/browse/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/garrytan",
@@ -847,6 +931,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/browser-use/browser-harness as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -898,6 +987,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/open-gstack-browser/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -950,6 +1044,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/setup-browser-cookies/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -980,6 +1079,13 @@
         },
         "createdAt": "2026-05-17",
         "updatedAt": "2026-05-17",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "type": "extra",
         "role": "variant",
         "overallTrustGrade": "A"
@@ -1007,6 +1113,13 @@
         },
         "createdAt": "2026-05-19",
         "updatedAt": "2026-05-19",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "ruvnet/ruflo",
         "type": "extra",
         "role": "variant",
@@ -1041,6 +1154,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Calibrated level from 3★ to 1★"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:17Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -1096,6 +1214,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/engineering/diagnose/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "mattpocock/engineering",
@@ -1151,6 +1274,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/cognition-labs/devin as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -1210,6 +1338,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/scrape/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -1269,6 +1402,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/firecrawl/firecrawl as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -1322,6 +1460,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/benchmark-models/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -1352,6 +1495,13 @@
         },
         "createdAt": "2026-05-19",
         "updatedAt": "2026-05-19",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "ruvnet/ruflo",
         "type": "extra",
         "role": "variant",
@@ -1405,6 +1555,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/benchmark/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -1458,6 +1613,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/plan-ceo-review/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -1513,6 +1673,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/canary/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -1567,6 +1732,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/guard/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -1619,6 +1789,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/careful/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -1671,6 +1846,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/freeze/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -1723,6 +1903,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/unfreeze/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:16Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -1777,6 +1962,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/codex/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -1801,6 +1991,13 @@
         },
         "createdAt": "2026-05-21",
         "updatedAt": "2026-06-04",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "mattpocock/productivity",
         "type": "basic",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
@@ -1852,6 +2049,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/context-restore/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -1904,6 +2106,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/context-save/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -1960,6 +2167,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/cso/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/garrytan",
@@ -2007,6 +2219,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/intelligentcode-ai/skills/blob/main/skills/security-engineer/SKILL.md as C (trustNumber: 50.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:17Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -2036,6 +2253,13 @@
         },
         "createdAt": "2026-05-19",
         "updatedAt": "2026-05-19",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "ruvnet/ruflo-v3",
         "type": "extra",
         "role": "variant",
@@ -2095,6 +2319,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/design-html/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -2149,6 +2378,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/pbakaus/impeccable as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -2201,6 +2435,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/plan-design-review/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -2254,6 +2493,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/plan-devex-review/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -2318,6 +2562,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/design-review/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/garrytan",
@@ -2382,6 +2631,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/devex-review/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -2436,6 +2690,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mastepanoski/claude-skills/blob/main/skills/nielsen-heuristics-audit/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -2490,6 +2749,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/design-shotgun/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -2558,6 +2822,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/autoplan/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -2619,6 +2888,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/engineering/to-issues/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "mattpocock/engineering",
@@ -2674,6 +2948,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/gstack-upgrade/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -2726,6 +3005,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteComponents": [
@@ -2839,6 +3123,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/investigate/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -2892,6 +3181,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/systematic-debugging/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "obra/superpowers",
@@ -2947,6 +3241,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/land-and-deploy/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -2999,6 +3298,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/setup-deploy/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -3047,6 +3351,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/intelligentcode-ai/skills/blob/main/skills/devops-engineer/SKILL.md as C (trustNumber: 50.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:17Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -3103,6 +3412,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mbtiongson1/gaia-skill-tree/blob/main/.agents/skills/gaia-preview/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -3156,6 +3470,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/landing-report/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -3186,6 +3505,13 @@
         },
         "createdAt": "2026-05-19",
         "updatedAt": "2026-05-19",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "ruvnet/github-suite",
         "type": "extra",
         "role": "variant",
@@ -3238,6 +3564,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/learn/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -3268,6 +3599,13 @@
         },
         "createdAt": "2026-05-19",
         "updatedAt": "2026-05-19",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "ruvnet/ruflo-v3",
         "type": "extra",
         "role": "variant",
@@ -3332,6 +3670,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/make-pdf/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -3388,6 +3731,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/office-hours/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/garrytan",
@@ -3442,6 +3790,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/pair-agent/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -3487,6 +3840,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/intelligentcode-ai/skills/blob/main/skills/mcp-client/SKILL.md as C (trustNumber: 50.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:17Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -3516,6 +3874,13 @@
         },
         "createdAt": "2026-05-19",
         "updatedAt": "2026-05-19",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "ruvnet/ruflo-v3",
         "type": "basic",
         "role": "variant",
@@ -3569,6 +3934,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/plan-eng-review/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -3622,6 +3992,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/review/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -3657,6 +4032,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Calibrated level from 3★ to 1★"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/github-suite",
@@ -3711,6 +4091,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/plan-tune/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -3743,6 +4128,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Calibrated level from 3★ to 1★"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -3797,6 +4187,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/qa/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -3849,6 +4244,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/qa-only/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -3896,6 +4296,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/intelligentcode-ai/skills/blob/main/skills/user-tester/SKILL.md as C (trustNumber: 50.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -3967,6 +4372,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/retro/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -4026,6 +4436,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/GLINCKER/claude-code-marketplace/blob/main/skills/documentation/readme-generator/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:16Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -4079,6 +4494,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/spring-ai-alibaba/examples/blob/main/.claude/skills/readme-generate/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -4132,6 +4552,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/setup-gbrain/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -4184,6 +4609,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/sync-gbrain/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:16Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -4245,6 +4675,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/ship/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:16Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -4298,6 +4733,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/finishing-a-development-branch/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "obra/superpowers",
@@ -4352,6 +4792,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/skillify/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:16Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -4382,6 +4827,13 @@
         },
         "createdAt": "2026-05-19",
         "updatedAt": "2026-05-19",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "ruvnet/ruflo",
         "type": "extra",
         "role": "variant",
@@ -4427,6 +4879,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/getagentseal/codeburn as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:16Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -4458,6 +4915,13 @@
         },
         "createdAt": "2026-05-03",
         "updatedAt": "2026-05-03",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:17Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "type": "basic",
         "role": "variant",
         "overallTrustGrade": "A"
@@ -4487,6 +4951,13 @@
         },
         "createdAt": "2026-05-03",
         "updatedAt": "2026-05-03",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:17Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "type": "extra",
         "role": "variant",
         "overallTrustGrade": "B"
@@ -4516,6 +4987,13 @@
         },
         "createdAt": "2026-05-03",
         "updatedAt": "2026-05-03",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:17Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "type": "basic",
         "role": "variant",
         "overallTrustGrade": "A"
@@ -4545,6 +5023,13 @@
         },
         "createdAt": "2026-05-03",
         "updatedAt": "2026-05-03",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:17Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "type": "extra",
         "role": "variant",
         "overallTrustGrade": "A"
@@ -4574,6 +5059,13 @@
         },
         "createdAt": "2026-05-03",
         "updatedAt": "2026-05-03",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:17Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "type": "basic",
         "role": "variant",
         "overallTrustGrade": "A"
@@ -4648,6 +5140,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/codefuse-ai/ModelCache as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:17Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -4679,6 +5176,13 @@
         },
         "createdAt": "2026-05-03",
         "updatedAt": "2026-05-03",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:17Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "type": "extra",
         "role": "variant",
         "overallTrustGrade": "A"
@@ -4726,6 +5230,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/intelligentcode-ai/skills/blob/main/skills/database-engineer/SKILL.md as C (trustNumber: 50.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:17Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -4772,6 +5281,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/intelligentcode-ai/skills/blob/main/skills/parallel-execution/SKILL.md as C (trustNumber: 50.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:17Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -4820,6 +5334,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/intelligentcode-ai/skills/blob/main/skills/release/SKILL.md as C (trustNumber: 50.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:17Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -4855,6 +5374,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Calibrated level from 3★ to 1★"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/github-suite",
@@ -4902,6 +5426,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/intelligentcode-ai/skills/blob/main/skills/requirements-engineer/SKILL.md as C (trustNumber: 50.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:17Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -4949,6 +5478,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/karpathy/autoresearch as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -4997,6 +5531,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/laravel/boost/issues/698 as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -5017,6 +5556,13 @@
         "title": "The Matt Pocock Engineering Discipline",
         "createdAt": "2026-05-21",
         "updatedAt": "2026-06-10",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "mattpocock/skills",
         "suiteComponents": [
           "mattpocock/diagnose",
@@ -5082,6 +5628,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/productivity/grill-me/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "mattpocock/productivity",
@@ -5135,6 +5686,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/engineering/grill-with-docs/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "mattpocock/engineering",
@@ -5178,6 +5734,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/productivity/handoff/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "mattpocock/productivity",
@@ -5212,6 +5773,13 @@
         },
         "createdAt": "2026-04-30",
         "updatedAt": "2026-04-30",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "mattpocock/engineering",
         "type": "basic",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
@@ -5253,6 +5821,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/personal/obsidian-vault/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "mattpocock/personal",
@@ -5275,6 +5848,13 @@
         "title": "The Matt Pocock Personal Suite",
         "createdAt": "2026-05-21",
         "updatedAt": "2026-06-10",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "mattpocock/skills",
         "suiteComponents": [
           "mattpocock/edit-article",
@@ -5299,6 +5879,13 @@
         "title": "The Matt Pocock Productivity Suite",
         "createdAt": "2026-05-21",
         "updatedAt": "2026-06-10",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "mattpocock/skills",
         "suiteComponents": [
           "mattpocock/caveman",
@@ -5346,6 +5933,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/engineering/prototype/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "mattpocock/engineering",
@@ -5389,6 +5981,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/engineering/setup-matt-pocock-skills/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "mattpocock/engineering",
@@ -5414,6 +6011,13 @@
         },
         "createdAt": "2026-05-22",
         "updatedAt": "2026-05-22",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteComponents": [
           "mattpocock/caveman",
           "mattpocock/diagnose",
@@ -5487,6 +6091,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/engineering/to-prd/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "mattpocock/engineering",
@@ -5538,6 +6147,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/engineering/triage/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "mattpocock/engineering",
@@ -5572,6 +6186,11 @@
             "action": "add",
             "contributor": "mbtiongson1",
             "details": "Added named skill mbtiongson1/gaia-triage"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -5622,6 +6241,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/engineering/ubiquitous-language/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "mattpocock/engineering",
@@ -5677,6 +6301,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo-v3",
@@ -5709,6 +6338,13 @@
         },
         "createdAt": "2026-04-30",
         "updatedAt": "2026-04-30",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "mattpocock/engineering",
         "type": "basic",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
@@ -5768,6 +6404,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mbtiongson1/gaia-skill-tree/blob/main/.agents/skills/gaia-audit/skill.md as C (trustNumber: 50.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -5830,6 +6471,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mbtiongson1/gaia-skill-tree/blob/main/.agents/skills/gaia-curation-review/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -5872,6 +6518,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Calibrated level from 4★ to 2★"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -5910,6 +6561,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Calibrated level from 3★ to 2★"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -5942,6 +6598,11 @@
             "action": "add",
             "contributor": "mbtiongson1",
             "details": "Added named skill mbtiongson1/gaia-docs-sync"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -5980,6 +6641,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Calibrated level from 3★ to 2★"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -6019,6 +6685,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Calibrated level from 3★ to 2★"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -6051,6 +6722,11 @@
             "action": "add",
             "contributor": "mbtiongson1",
             "details": "Added named skill mbtiongson1/gaia-wiki-sync"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -6118,6 +6794,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mbtiongson1/gaia-skill-tree as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -6177,6 +6858,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mbtiongson1/gaia-skill-tree/blob/main/.agents/skills/graphify-triage/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -6230,6 +6916,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/nexu-io/open-design as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -6285,6 +6976,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/NousResearch/hermes-agent/blob/main/skills/research/blogwatcher/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -6333,6 +7029,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/brainstorming/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "obra/superpowers",
@@ -6382,6 +7083,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/dispatching-parallel-agents/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "obra/superpowers",
@@ -6430,6 +7136,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/executing-plans/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "obra/superpowers",
@@ -6479,6 +7190,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/receiving-code-review/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "obra/superpowers",
@@ -6528,6 +7244,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/requesting-code-review/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "obra/superpowers",
@@ -6577,6 +7298,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/subagent-driven-development/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "obra/superpowers",
@@ -6631,6 +7357,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -6680,6 +7411,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/obra/superpowers as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteComponents": [
@@ -6746,6 +7482,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "obra/superpowers",
@@ -6795,6 +7536,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/verification-before-completion/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "obra/superpowers",
@@ -6849,6 +7595,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -6898,6 +7649,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/writing-plans/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "obra/superpowers",
@@ -6931,6 +7687,13 @@
         },
         "createdAt": "2026-05-15",
         "updatedAt": "2026-05-15",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "type": "basic",
         "role": "origin",
         "overallTrustGrade": "A"
@@ -6961,6 +7724,13 @@
         },
         "createdAt": "2026-05-15",
         "updatedAt": "2026-05-15",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "type": "basic",
         "role": "variant",
         "overallTrustGrade": "A"
@@ -7014,6 +7784,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/agentdb",
@@ -7045,6 +7820,13 @@
         },
         "createdAt": "2026-05-19",
         "updatedAt": "2026-05-19",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "ruvnet/reasoningbank",
         "type": "extra",
         "role": "variant",
@@ -7078,6 +7860,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Calibrated level from 3★ to 1★"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/agentdb",
@@ -7127,6 +7914,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/agentdb",
@@ -7176,6 +7968,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/agentdb",
@@ -7226,6 +8023,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/agentdb",
@@ -7276,6 +8078,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -7338,6 +8145,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -7389,6 +8201,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/dual-mode",
@@ -7439,6 +8256,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/dual-mode",
@@ -7489,6 +8311,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -7545,6 +8372,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/dual-mode",
@@ -7601,6 +8433,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/flow-nexus",
@@ -7657,6 +8494,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/flow-nexus",
@@ -7695,6 +8537,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Calibrated level from 3★ to 1★"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/flow-nexus",
@@ -7731,6 +8578,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Calibrated level from 3★ to 1★"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo-v3",
@@ -7783,6 +8635,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -7839,6 +8696,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/github-suite",
@@ -7889,6 +8751,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -7929,6 +8796,13 @@
         },
         "createdAt": "2026-05-19",
         "updatedAt": "2026-05-19",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "ruvnet/ruflo",
         "type": "extra",
         "role": "variant",
@@ -7962,6 +8836,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Calibrated level from 3★ to 1★"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/github-suite",
@@ -8029,6 +8908,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -8085,6 +8969,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/reasoningbank",
@@ -8134,6 +9023,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -8190,6 +9084,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -8255,6 +9154,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteComponents": [
@@ -8346,6 +9250,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Calibrated level from 3★ to 1★"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -8397,6 +9306,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -8454,6 +9368,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo-v3",
@@ -8511,6 +9430,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo-v3",
@@ -8562,6 +9486,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo-v3",
@@ -8613,6 +9542,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo-v3",
@@ -8664,6 +9598,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo-v3",
@@ -8715,6 +9654,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -8751,6 +9695,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Calibrated level from 3★ to 1★"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -8797,6 +9746,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/santifer/career-ops as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -8828,6 +9782,13 @@
         },
         "createdAt": "2026-04-30",
         "updatedAt": "2026-04-30",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "type": "basic",
         "role": "origin",
         "overallTrustGrade": "A"
@@ -8874,6 +9835,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/vercel-labs/skills/blob/main/skills/find-skills/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -8913,6 +9879,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Calibrated level from 3★ to 1★"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -8933,6 +9904,13 @@
       "description": "AI-powered cascading development framework.",
       "createdAt": "2026-05-23",
       "updatedAt": "2026-06-10",
+      "timeline": [
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:21Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+        }
+      ],
       "type": "basic",
       "installBody": "No public installable artifact is currently registered for this skill; it is tracked from its description only."
     },
@@ -8947,6 +9925,13 @@
       "description": "Chat, specs, tasks, and code. An autonomous engineering platform.",
       "createdAt": "2026-05-23",
       "updatedAt": "2026-06-10",
+      "timeline": [
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:14Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+        }
+      ],
       "type": "basic",
       "installBody": "No public installable artifact is currently registered for this skill; it is tracked from its description only."
     },
@@ -8971,6 +9956,13 @@
       },
       "createdAt": "2026-05-10",
       "updatedAt": "2026-05-10",
+      "timeline": [
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:14Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+        }
+      ],
       "type": "basic"
     },
     {
@@ -9018,6 +10010,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/mbtiongson1/gaia-skill-tree as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:14Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9054,6 +10051,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/alphafold_database_fetch_and_analyze/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "extra"
@@ -9090,6 +10092,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/alphagenome_single_variant_analysis/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "extra"
@@ -9126,6 +10133,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/chembl_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9162,6 +10174,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/clinical_trials_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9198,6 +10215,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/clinvar_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9234,6 +10256,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/dbsnp_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9270,6 +10297,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/embl_ebi_ols/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9306,6 +10338,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/encode_ccres_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9342,6 +10379,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/ensembl_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9378,6 +10420,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/foldseek_structural_search/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9414,6 +10461,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/gnomad_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9450,6 +10502,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/gtex_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9486,6 +10543,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/human_protein_atlas_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9522,6 +10584,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/interpro_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9558,6 +10625,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/jaspar_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9594,6 +10666,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/literature_search_arxiv/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9630,6 +10707,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/literature_search_biorxiv/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9666,6 +10748,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/literature_search_europepmc/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9702,6 +10789,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/literature_search_openalex/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9738,6 +10830,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/ncbi_sequence_fetch/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9774,6 +10871,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/openfda_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9810,6 +10912,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/opentargets_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9846,6 +10953,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/pdb_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9882,6 +10994,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/protein_sequence_msa/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:17Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "extra"
@@ -9934,6 +11051,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/protein_sequence_similarity_search/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:17Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9970,6 +11092,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/pubchem_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:17Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -10006,6 +11133,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/pubmed_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:17Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -10042,6 +11174,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/pymol/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:17Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -10078,6 +11215,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/quickgo_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:17Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -10114,6 +11256,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/reactome_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:17Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -10150,6 +11297,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/science_skills_common/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:17Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -10186,6 +11338,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/string_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:17Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -10222,6 +11379,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/ucsc_conservation_and_tfbs/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:17Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -10258,6 +11420,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/unibind_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:17Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -10294,6 +11461,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/uniprot_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:17Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -10330,6 +11502,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/uv/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:17Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -10366,6 +11543,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/workflow_skill_creator/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:17Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "extra"
@@ -10390,6 +11572,11 @@
           "action": "add",
           "contributor": "unknown",
           "details": "Added named skill langgenius/backend-code-review"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:18Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "extra",
@@ -10415,6 +11602,11 @@
           "action": "add",
           "contributor": "unknown",
           "details": "Added named skill langgenius/component-refactoring"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:18Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic",
@@ -10440,6 +11632,11 @@
           "action": "add",
           "contributor": "unknown",
           "details": "Added named skill langgenius/e2e-cucumber-playwright"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:18Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "extra",
@@ -10465,6 +11662,11 @@
           "action": "add",
           "contributor": "unknown",
           "details": "Added named skill langgenius/frontend-code-review"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:18Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "extra",
@@ -10490,6 +11692,11 @@
           "action": "add",
           "contributor": "unknown",
           "details": "Added named skill langgenius/frontend-testing"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:18Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "extra",
@@ -10506,6 +11713,13 @@
       "description": "Classifies the affective polarity (positive / negative / neutral, or fine-grained) of user-generated text. Covers the full pipeline from raw noisy input through preprocessing, inference, and output normalisation. Stack is intentionally tool-agnostic — three implementation tracks are documented below.\n",
       "createdAt": "2026-05-17",
       "updatedAt": "2026-05-17",
+      "timeline": [
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:19Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+        }
+      ],
       "type": "basic"
     },
     {
@@ -10519,6 +11733,13 @@
       "description": "MCP tool for finding AI dev jobs.",
       "createdAt": "2026-05-22",
       "updatedAt": "2026-06-10",
+      "timeline": [
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:21Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+        }
+      ],
       "type": "basic",
       "installBody": "No public installable artifact is currently registered for this skill; it is tracked from its description only."
     },
@@ -10545,6 +11766,11 @@
           "action": "demote",
           "contributor": "unknown",
           "details": "No installable code available; marked installable: false."
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:21Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "extra",
@@ -10561,6 +11787,13 @@
       "description": "Expert at integrating n8n with MCP (Model Context Protocol). Build n8n workflows that expose MCP tools, or use MCP tools within n8n workflows.",
       "createdAt": "2026-05-22",
       "updatedAt": "2026-06-10",
+      "timeline": [
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:21Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+        }
+      ],
       "type": "basic",
       "installBody": "No public installable artifact is currently registered for this skill; it is tracked from its description only."
     },
@@ -10604,6 +11837,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/Xquik-dev/hermes-tweet as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:21Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "extra"
@@ -10619,6 +11857,13 @@
       "description": "Build Model Context Protocol (MCP) servers and tools from scratch. Full-stack MCP development with TypeScript/Python, testing, deployment, and registry publishing.",
       "createdAt": "2026-05-22",
       "updatedAt": "2026-06-10",
+      "timeline": [
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:21Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+        }
+      ],
       "type": "basic",
       "installBody": "No public installable artifact is currently registered for this skill; it is tracked from its description only."
     }

--- a/docs/meta/JUN_2026_TRUST_REGRADE.md
+++ b/docs/meta/JUN_2026_TRUST_REGRADE.md
@@ -1,0 +1,218 @@
+# June 2026 Trust Regrade (G7 Cutover)
+
+> Migration: `scripts/migrateTrustMagnitude.py`
+> Date: 2026-06-18 (Phase 1.5 I3)
+> Skills processed: 235 named skills across `registry/named/`
+
+This is the cutover stamp for the **G7 Trust Magnitude** model (Phase 1.5 I1
+schema + I2 compute pipeline). The migration script ran the I2 trust pipeline
+over every named skill and stamped four new fields per file:
+`trustMagnitude`, `overallTrustGrade`, `apexGateStatus`, and
+`trustMagnitudeInputHash`. A `migrate_trust_magnitude` event was appended to
+each skill's timeline.
+
+## 1. Apex Demotions
+
+The 6-predicate Apex Gate (see § 5) was applied to the two skills carrying
+6★ apex status pre-G7. Both fail every active predicate at cutover.
+
+### `mattpocock/skills`
+
+| Predicate                     | Result |
+|-------------------------------|--------|
+| `aGradedOriginsGte5`          | FAIL   |
+| `sourceTenureDaysGte180AorS`  | FAIL   |
+| `directNestedSuiteGte1`       | FAIL   |
+| `depth2OnlyReachableGte1`     | FAIL   |
+| `overallGradeS`               | FAIL   |
+| `apexPromotionPrSigned`       | FAIL   |
+| `crossOrgVerifier`            | OFF    |
+| `systemWideCap`               | OFF    |
+
+`isApex = false`. TM = 0.0. Grade = `ungraded`.
+
+### `ruvnet/ruflo`
+
+| Predicate                     | Result |
+|-------------------------------|--------|
+| `aGradedOriginsGte5`          | FAIL   |
+| `sourceTenureDaysGte180AorS`  | FAIL   |
+| `directNestedSuiteGte1`       | FAIL   |
+| `depth2OnlyReachableGte1`     | FAIL   |
+| `overallGradeS`               | FAIL   |
+| `apexPromotionPrSigned`       | FAIL   |
+| `crossOrgVerifier`            | OFF    |
+| `systemWideCap`               | OFF    |
+
+`isApex = false`. TM = 0.0. Grade = `ungraded`.
+
+### Summary
+
+| Metric                                | Pre-G7 | Post-G7 |
+|---------------------------------------|--------|---------|
+| System-wide effective apex skills (6★)| 2      | 0       |
+| Apex re-application bar               | n/a    | All 6 active predicates must pass |
+
+Note: the I3 migration **does not** mutate the `level` field on either
+record; level demotion is I5's scope. What changes here is the *effective*
+trust posture (`apexGateStatus.isApex`), which downstream consumers (graph,
+explorer, badges) will use as the source of truth post-G7.
+
+## 2. Aggregate Drift
+
+Trust Magnitude distribution after migration (all 235 skills):
+
+| Bucket   | Count |
+|----------|-------|
+| TM = 0.0 | 235   |
+| 0.0 < TM < 1.0 | 0 |
+| 1.0 ≤ TM < 5.0 | 0 |
+| TM ≥ 5.0 | 0     |
+
+**Top 10 TM drops:** every skill in the registry transitioned from `null`
+(no TM field) to `0.0`. There is no positive-magnitude skill at this
+cutover — the I2 pipeline requires graded rows of the new 10-type evidence
+taxonomy (Phase 1.5 I1), and no skill yet carries one. Every existing
+evidence row pre-dates the new taxonomy and contributes 0 to the effective
+pool.
+
+**Top 10 TM gains:** none. No skill increased from `null`.
+
+Implication: the entire registry now sits at the `ungraded` trust floor
+until evidence is upgraded to the 10-type taxonomy with explicit grades.
+
+## 3. Grade Migration
+
+| Transition          | Count |
+|---------------------|-------|
+| `ungraded → ungraded` | 235 |
+
+Pre-G7 there was no `overallTrustGrade` field; every skill is `ungraded`
+post-migration as well, because `computeOverallTrustGradeFromSkill` returns
+`ungraded` when no graded evidence rows survive `enforceAntiAutoMint` and
+`_dedupeSameSource`. Once contributors begin landing typed evidence, this
+table will populate with `ungraded → C/B/A/S` transitions on subsequent
+recompute passes (the input-hash idempotency guard ensures only changed
+skills are touched).
+
+## 4. Phantom-Row Removals
+
+Phantom-row removals at cutover: **0**.
+
+Anti-auto-mint (`enforceAntiAutoMint`) strips evidence rows that look
+auto-minted (e.g. a `community-verified` row with no `eventClass`, or a
+contradictory `falsified` shadow on the same source). The legacy registry
+has no rows in those shapes — every existing evidence row is either the
+old free-form schema or already typed correctly. No skills had rows
+silently stripped.
+
+| skillId | evidenceUrl | evidenceType |
+|---------|-------------|--------------|
+| _(none)_ | _(none)_ | _(none)_ |
+
+## 5. Apex-Gate Methodology
+
+The 6-predicate Apex Gate (`passesApexGate` in
+`src/gaia_cli/trustMagnitude.py:1048`) is the single gate that decides
+*effective* 6★ apex status post-G7. All six **active** predicates must
+return `True` for `isApex` to be `True`. Predicates returning `None` are
+feature-flagged OFF and skipped.
+
+### Active predicates (6)
+
+1. **`aGradedOriginsGte5`** — at least 5 origin contributors of the skill
+   (or its suite components, walked transitively) must hold an A or S
+   grade across the registry. Prevents single-author apex.
+2. **`sourceTenureDaysGte180AorS`** — at least one A or S graded evidence
+   row must have `sourceStartedAt` ≥ 180 days before the apex check.
+   Prevents fresh-source apex.
+3. **`directNestedSuiteGte1`** — the skill must `suiteComponents` at least
+   one other suite (depth ≥ 1 nested suite). Prevents flat-suite apex.
+4. **`depth2OnlyReachableGte1`** — at least one component must be reachable
+   only via depth ≥ 2 nesting. Prevents shallow nesting apex.
+5. **`overallGradeS`** — `computeOverallTrustGradeFromSkill` must return
+   `"S"`. Prevents apex without top-tier composite trust.
+6. **`apexPromotionPrSigned`** — the skill's record must include a signed
+   apex-promotion PR reference (a `apex_promotion_pr` event in the
+   timeline with `signed: true`). Prevents apex without governance trail.
+
+### Feature-flagged OFF until 2026-Q4
+
+- **`crossOrgVerifier`** — at least one verifier from a different
+  organization signs off. Pending the cross-org verifier registry.
+- **`systemWideCap`** — caps total system-wide apex count at N. Pending
+  the system-wide cap policy.
+
+## 6. Provisional Grades
+
+Provisional skills (A/S graded row missing `sourceStartedAt`): **0**.
+
+Because no skill yet carries an A or S graded row of the new taxonomy, the
+provisional flag is unused at this cutover. Once contributors land A/S
+evidence, any row missing `sourceStartedAt` will set
+`frontmatter.provisional: true` with a 6-month grace period from the
+migration date (2026-06-18 → 2026-12-18).
+
+## 7. Calibration Table
+
+Three exemplar skills with full before/after stamp:
+
+| Skill | TM (pre/post) | Grade (pre/post) | Apex predicates passed (post) |
+|-------|---------------|------------------|------------------------------|
+| `mattpocock/skills` | `null` / `0.0` | `ungraded` / `ungraded` | 0/6 (was 6★ pre-G7) |
+| `ruvnet/ruflo`      | `null` / `0.0` | `ungraded` / `ungraded` | 0/6 (was 6★ pre-G7) |
+| `anthropic/skill-creator` | `null` / `0.0` | `ungraded` / `ungraded` | 0/6 |
+
+All three skills converge on the same `ungraded` floor at cutover because
+no skill in the registry has a single graded row of the new 10-type
+evidence taxonomy. Each skill's `trustMagnitudeInputHash` is now stamped,
+so re-running the migration over an unchanged record is a no-op
+(idempotency confirmed — second-run `git diff --stat` is empty).
+
+## 8. Migration Shape
+
+```
+named skill .md files (registry/named/**/*.md)
+      │
+      ▼
+enforceAntiAutoMint() → strips phantom evidence rows
+      │
+      ▼
+computeTrustMagnitude() → TM float (effective pool walk, anti-auto-mint,
+                          same-source dedup, optional fusion-recipe row,
+                          per-row scores × inherit multipliers)
+      │
+      ▼
+computeOverallTrustGradeFromSkill() → S / A / B / C / ungraded
+      │
+      ▼
+passesApexGate() → per-predicate pass / fail / None dict
+      │
+      ▼
+write back to frontmatter:
+  trustMagnitude, overallTrustGrade, apexGateStatus,
+  trustMagnitudeInputHash, provisional?, verification.firstEvidenceAt?
+      │
+      ▼
+append migrate_trust_magnitude timeline event
+      │
+      ▼
+registry/named-skills.json regenerated (scripts/generateNamedIndex.py)
+```
+
+### Idempotency
+
+The script computes a stable `trustMagnitudeInputHash` over
+`(skillId, sorted(url|type|grade) per evidence row)`. On re-run, any skill
+whose hash matches the stamped value is skipped before any computation.
+Verified: second run reports `processed=0, skipped=235` and `git diff
+--stat` is empty.
+
+### Re-running
+
+```bash
+GAIA_OPERATOR_OVERRIDE=1 python scripts/migrateTrustMagnitude.py
+python scripts/generateNamedIndex.py
+```
+
+Re-runs are safe and only touch skills whose evidence has changed.

--- a/registry/named-skills.json
+++ b/registry/named-skills.json
@@ -27,6 +27,13 @@
         },
         "createdAt": "2026-04-30",
         "updatedAt": "2026-04-30",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:13Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "type": "extra",
         "role": "origin",
         "overallTrustGrade": "B"
@@ -76,6 +83,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/health/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -137,6 +149,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/design-consultation/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -188,6 +205,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/Manavarya09/design-extract as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -254,6 +276,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/addyosmani/agent-skills/blob/main/skills/performance-optimization/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -290,6 +317,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Origin status removed. Transferred to addy-osmani/performance-optimization."
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -322,6 +354,13 @@
         },
         "createdAt": "2026-05-19",
         "updatedAt": "2026-05-19",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "ruvnet/ruflo-v3",
         "type": "basic",
         "role": "variant",
@@ -378,6 +417,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/addyosmani/agent-skills/blob/main/skills/test-driven-development/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -439,6 +483,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/document-generate/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -493,6 +542,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/anthropics/skills/blob/main/skills/pptx/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -544,6 +598,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/document-release/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -604,6 +663,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/personal/edit-article/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "mattpocock/personal",
@@ -643,6 +707,11 @@
             "action": "rank_up",
             "contributor": "unknown",
             "details": "Origin status set to true."
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "mattpocock/productivity",
@@ -679,6 +748,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Origin status removed. Transferred to mattpocock/write-a-skill."
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -725,6 +799,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/bradautomates/claude-video as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -796,6 +875,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/browse/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/garrytan",
@@ -847,6 +931,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/browser-use/browser-harness as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -898,6 +987,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/open-gstack-browser/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -950,6 +1044,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/setup-browser-cookies/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -980,6 +1079,13 @@
         },
         "createdAt": "2026-05-17",
         "updatedAt": "2026-05-17",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "type": "extra",
         "role": "variant",
         "overallTrustGrade": "A"
@@ -1007,6 +1113,13 @@
         },
         "createdAt": "2026-05-19",
         "updatedAt": "2026-05-19",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "ruvnet/ruflo",
         "type": "extra",
         "role": "variant",
@@ -1041,6 +1154,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Calibrated level from 3★ to 1★"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:17Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -1096,6 +1214,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/engineering/diagnose/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "mattpocock/engineering",
@@ -1151,6 +1274,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/cognition-labs/devin as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -1210,6 +1338,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/scrape/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -1269,6 +1402,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/firecrawl/firecrawl as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -1322,6 +1460,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/benchmark-models/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -1352,6 +1495,13 @@
         },
         "createdAt": "2026-05-19",
         "updatedAt": "2026-05-19",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "ruvnet/ruflo",
         "type": "extra",
         "role": "variant",
@@ -1405,6 +1555,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/benchmark/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -1458,6 +1613,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/plan-ceo-review/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -1513,6 +1673,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/canary/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -1567,6 +1732,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/guard/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -1619,6 +1789,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/careful/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -1671,6 +1846,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/freeze/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -1723,6 +1903,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/unfreeze/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:16Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -1777,6 +1962,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/codex/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -1801,6 +1991,13 @@
         },
         "createdAt": "2026-05-21",
         "updatedAt": "2026-06-04",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "mattpocock/productivity",
         "type": "basic",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
@@ -1852,6 +2049,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/context-restore/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -1904,6 +2106,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/context-save/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -1960,6 +2167,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/cso/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/garrytan",
@@ -2007,6 +2219,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/intelligentcode-ai/skills/blob/main/skills/security-engineer/SKILL.md as C (trustNumber: 50.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:17Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -2036,6 +2253,13 @@
         },
         "createdAt": "2026-05-19",
         "updatedAt": "2026-05-19",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "ruvnet/ruflo-v3",
         "type": "extra",
         "role": "variant",
@@ -2095,6 +2319,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/design-html/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -2149,6 +2378,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/pbakaus/impeccable as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -2201,6 +2435,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/plan-design-review/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -2254,6 +2493,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/plan-devex-review/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -2318,6 +2562,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/design-review/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/garrytan",
@@ -2382,6 +2631,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/devex-review/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -2436,6 +2690,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mastepanoski/claude-skills/blob/main/skills/nielsen-heuristics-audit/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -2490,6 +2749,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/design-shotgun/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:14Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -2558,6 +2822,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/autoplan/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -2619,6 +2888,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/engineering/to-issues/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "mattpocock/engineering",
@@ -2674,6 +2948,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/gstack-upgrade/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -2726,6 +3005,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteComponents": [
@@ -2839,6 +3123,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/investigate/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -2892,6 +3181,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/systematic-debugging/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "obra/superpowers",
@@ -2947,6 +3241,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/land-and-deploy/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -2999,6 +3298,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/setup-deploy/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -3047,6 +3351,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/intelligentcode-ai/skills/blob/main/skills/devops-engineer/SKILL.md as C (trustNumber: 50.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:17Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -3103,6 +3412,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mbtiongson1/gaia-skill-tree/blob/main/.agents/skills/gaia-preview/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -3156,6 +3470,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/landing-report/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -3186,6 +3505,13 @@
         },
         "createdAt": "2026-05-19",
         "updatedAt": "2026-05-19",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "ruvnet/github-suite",
         "type": "extra",
         "role": "variant",
@@ -3238,6 +3564,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/learn/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -3268,6 +3599,13 @@
         },
         "createdAt": "2026-05-19",
         "updatedAt": "2026-05-19",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "ruvnet/ruflo-v3",
         "type": "extra",
         "role": "variant",
@@ -3332,6 +3670,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/make-pdf/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -3388,6 +3731,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/office-hours/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/garrytan",
@@ -3442,6 +3790,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/pair-agent/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -3487,6 +3840,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/intelligentcode-ai/skills/blob/main/skills/mcp-client/SKILL.md as C (trustNumber: 50.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:17Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -3516,6 +3874,13 @@
         },
         "createdAt": "2026-05-19",
         "updatedAt": "2026-05-19",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "ruvnet/ruflo-v3",
         "type": "basic",
         "role": "variant",
@@ -3569,6 +3934,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/plan-eng-review/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -3622,6 +3992,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/review/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -3657,6 +4032,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Calibrated level from 3★ to 1★"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/github-suite",
@@ -3711,6 +4091,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/plan-tune/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -3743,6 +4128,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Calibrated level from 3★ to 1★"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -3797,6 +4187,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/qa/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -3849,6 +4244,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/qa-only/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -3896,6 +4296,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/intelligentcode-ai/skills/blob/main/skills/user-tester/SKILL.md as C (trustNumber: 50.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -3967,6 +4372,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/retro/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -4026,6 +4436,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/GLINCKER/claude-code-marketplace/blob/main/skills/documentation/readme-generator/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:16Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -4079,6 +4494,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/spring-ai-alibaba/examples/blob/main/.claude/skills/readme-generate/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -4132,6 +4552,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/setup-gbrain/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:15Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -4184,6 +4609,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/sync-gbrain/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:16Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -4245,6 +4675,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/ship/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:16Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -4298,6 +4733,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/finishing-a-development-branch/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "obra/superpowers",
@@ -4352,6 +4792,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/garrytan/gstack/blob/main/skillify/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:16Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -4382,6 +4827,13 @@
         },
         "createdAt": "2026-05-19",
         "updatedAt": "2026-05-19",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "ruvnet/ruflo",
         "type": "extra",
         "role": "variant",
@@ -4427,6 +4879,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/getagentseal/codeburn as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:16Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -4458,6 +4915,13 @@
         },
         "createdAt": "2026-05-03",
         "updatedAt": "2026-05-03",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:17Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "type": "basic",
         "role": "variant",
         "overallTrustGrade": "A"
@@ -4487,6 +4951,13 @@
         },
         "createdAt": "2026-05-03",
         "updatedAt": "2026-05-03",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:17Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "type": "extra",
         "role": "variant",
         "overallTrustGrade": "B"
@@ -4516,6 +4987,13 @@
         },
         "createdAt": "2026-05-03",
         "updatedAt": "2026-05-03",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:17Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "type": "basic",
         "role": "variant",
         "overallTrustGrade": "A"
@@ -4545,6 +5023,13 @@
         },
         "createdAt": "2026-05-03",
         "updatedAt": "2026-05-03",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:17Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "type": "extra",
         "role": "variant",
         "overallTrustGrade": "A"
@@ -4574,6 +5059,13 @@
         },
         "createdAt": "2026-05-03",
         "updatedAt": "2026-05-03",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:17Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "type": "basic",
         "role": "variant",
         "overallTrustGrade": "A"
@@ -4648,6 +5140,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/codefuse-ai/ModelCache as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:17Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -4679,6 +5176,13 @@
         },
         "createdAt": "2026-05-03",
         "updatedAt": "2026-05-03",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:17Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "type": "extra",
         "role": "variant",
         "overallTrustGrade": "A"
@@ -4726,6 +5230,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/intelligentcode-ai/skills/blob/main/skills/database-engineer/SKILL.md as C (trustNumber: 50.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:17Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -4772,6 +5281,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/intelligentcode-ai/skills/blob/main/skills/parallel-execution/SKILL.md as C (trustNumber: 50.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:17Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -4820,6 +5334,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/intelligentcode-ai/skills/blob/main/skills/release/SKILL.md as C (trustNumber: 50.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:17Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -4855,6 +5374,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Calibrated level from 3★ to 1★"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/github-suite",
@@ -4902,6 +5426,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/intelligentcode-ai/skills/blob/main/skills/requirements-engineer/SKILL.md as C (trustNumber: 50.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:17Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -4949,6 +5478,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/karpathy/autoresearch as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -4997,6 +5531,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/laravel/boost/issues/698 as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -5017,6 +5556,13 @@
         "title": "The Matt Pocock Engineering Discipline",
         "createdAt": "2026-05-21",
         "updatedAt": "2026-06-10",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "mattpocock/skills",
         "suiteComponents": [
           "mattpocock/diagnose",
@@ -5082,6 +5628,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/productivity/grill-me/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "mattpocock/productivity",
@@ -5135,6 +5686,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/engineering/grill-with-docs/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "mattpocock/engineering",
@@ -5178,6 +5734,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/productivity/handoff/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "mattpocock/productivity",
@@ -5212,6 +5773,13 @@
         },
         "createdAt": "2026-04-30",
         "updatedAt": "2026-04-30",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "mattpocock/engineering",
         "type": "basic",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
@@ -5253,6 +5821,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/personal/obsidian-vault/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "mattpocock/personal",
@@ -5275,6 +5848,13 @@
         "title": "The Matt Pocock Personal Suite",
         "createdAt": "2026-05-21",
         "updatedAt": "2026-06-10",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "mattpocock/skills",
         "suiteComponents": [
           "mattpocock/edit-article",
@@ -5299,6 +5879,13 @@
         "title": "The Matt Pocock Productivity Suite",
         "createdAt": "2026-05-21",
         "updatedAt": "2026-06-10",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "mattpocock/skills",
         "suiteComponents": [
           "mattpocock/caveman",
@@ -5346,6 +5933,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/engineering/prototype/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "mattpocock/engineering",
@@ -5389,6 +5981,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/engineering/setup-matt-pocock-skills/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "mattpocock/engineering",
@@ -5414,6 +6011,13 @@
         },
         "createdAt": "2026-05-22",
         "updatedAt": "2026-05-22",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteComponents": [
           "mattpocock/caveman",
           "mattpocock/diagnose",
@@ -5487,6 +6091,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/engineering/to-prd/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "mattpocock/engineering",
@@ -5538,6 +6147,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/engineering/triage/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "mattpocock/engineering",
@@ -5572,6 +6186,11 @@
             "action": "add",
             "contributor": "mbtiongson1",
             "details": "Added named skill mbtiongson1/gaia-triage"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -5622,6 +6241,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/engineering/ubiquitous-language/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "mattpocock/engineering",
@@ -5677,6 +6301,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo-v3",
@@ -5709,6 +6338,13 @@
         },
         "createdAt": "2026-04-30",
         "updatedAt": "2026-04-30",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:18Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "mattpocock/engineering",
         "type": "basic",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
@@ -5768,6 +6404,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mbtiongson1/gaia-skill-tree/blob/main/.agents/skills/gaia-audit/skill.md as C (trustNumber: 50.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -5830,6 +6471,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mbtiongson1/gaia-skill-tree/blob/main/.agents/skills/gaia-curation-review/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -5872,6 +6518,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Calibrated level from 4★ to 2★"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -5910,6 +6561,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Calibrated level from 3★ to 2★"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -5942,6 +6598,11 @@
             "action": "add",
             "contributor": "mbtiongson1",
             "details": "Added named skill mbtiongson1/gaia-docs-sync"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -5980,6 +6641,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Calibrated level from 3★ to 2★"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -6019,6 +6685,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Calibrated level from 3★ to 2★"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -6051,6 +6722,11 @@
             "action": "add",
             "contributor": "mbtiongson1",
             "details": "Added named skill mbtiongson1/gaia-wiki-sync"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -6118,6 +6794,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mbtiongson1/gaia-skill-tree as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -6177,6 +6858,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/mbtiongson1/gaia-skill-tree/blob/main/.agents/skills/graphify-triage/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -6230,6 +6916,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/nexu-io/open-design as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -6285,6 +6976,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/NousResearch/hermes-agent/blob/main/skills/research/blogwatcher/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -6333,6 +7029,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/brainstorming/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "obra/superpowers",
@@ -6382,6 +7083,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/dispatching-parallel-agents/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "obra/superpowers",
@@ -6430,6 +7136,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/executing-plans/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "obra/superpowers",
@@ -6479,6 +7190,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/receiving-code-review/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "obra/superpowers",
@@ -6528,6 +7244,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/requesting-code-review/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "obra/superpowers",
@@ -6577,6 +7298,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/subagent-driven-development/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "obra/superpowers",
@@ -6631,6 +7357,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -6680,6 +7411,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/obra/superpowers as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteComponents": [
@@ -6746,6 +7482,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "obra/superpowers",
@@ -6795,6 +7536,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/verification-before-completion/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "obra/superpowers",
@@ -6849,6 +7595,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -6898,6 +7649,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/writing-plans/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "obra/superpowers",
@@ -6931,6 +7687,13 @@
         },
         "createdAt": "2026-05-15",
         "updatedAt": "2026-05-15",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "type": "basic",
         "role": "origin",
         "overallTrustGrade": "A"
@@ -6961,6 +7724,13 @@
         },
         "createdAt": "2026-05-15",
         "updatedAt": "2026-05-15",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:19Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "type": "basic",
         "role": "variant",
         "overallTrustGrade": "A"
@@ -7014,6 +7784,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/agentdb",
@@ -7045,6 +7820,13 @@
         },
         "createdAt": "2026-05-19",
         "updatedAt": "2026-05-19",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "ruvnet/reasoningbank",
         "type": "extra",
         "role": "variant",
@@ -7078,6 +7860,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Calibrated level from 3★ to 1★"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/agentdb",
@@ -7127,6 +7914,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/agentdb",
@@ -7176,6 +7968,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/agentdb",
@@ -7226,6 +8023,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/agentdb",
@@ -7276,6 +8078,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -7338,6 +8145,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -7389,6 +8201,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/dual-mode",
@@ -7439,6 +8256,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/dual-mode",
@@ -7489,6 +8311,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -7545,6 +8372,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/dual-mode",
@@ -7601,6 +8433,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/flow-nexus",
@@ -7657,6 +8494,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/flow-nexus",
@@ -7695,6 +8537,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Calibrated level from 3★ to 1★"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/flow-nexus",
@@ -7731,6 +8578,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Calibrated level from 3★ to 1★"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo-v3",
@@ -7783,6 +8635,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -7839,6 +8696,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/github-suite",
@@ -7889,6 +8751,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -7929,6 +8796,13 @@
         },
         "createdAt": "2026-05-19",
         "updatedAt": "2026-05-19",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "suiteRef": "ruvnet/ruflo",
         "type": "extra",
         "role": "variant",
@@ -7962,6 +8836,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Calibrated level from 3★ to 1★"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/github-suite",
@@ -8029,6 +8908,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -8085,6 +8969,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/reasoningbank",
@@ -8134,6 +9023,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -8190,6 +9084,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -8255,6 +9154,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:20Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteComponents": [
@@ -8346,6 +9250,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Calibrated level from 3★ to 1★"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -8397,6 +9306,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -8454,6 +9368,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo-v3",
@@ -8511,6 +9430,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo-v3",
@@ -8562,6 +9486,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo-v3",
@@ -8613,6 +9542,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo-v3",
@@ -8664,6 +9598,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo-v3",
@@ -8715,6 +9654,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -8751,6 +9695,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Calibrated level from 3★ to 1★"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -8797,6 +9746,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/santifer/career-ops as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -8828,6 +9782,13 @@
         },
         "createdAt": "2026-04-30",
         "updatedAt": "2026-04-30",
+        "timeline": [
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+          }
+        ],
         "type": "basic",
         "role": "origin",
         "overallTrustGrade": "A"
@@ -8874,6 +9835,11 @@
             "action": "evidence_graded",
             "contributor": "unknown",
             "details": "Re-graded evidence from https://github.com/vercel-labs/skills/blob/main/skills/find-skills/SKILL.md as B (trustNumber: 70.0)"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "basic",
@@ -8913,6 +9879,11 @@
             "action": "demote",
             "contributor": "unknown",
             "details": "Calibrated level from 3★ to 1★"
+          },
+          {
+            "action": "migrate_trust_magnitude",
+            "timestamp": "2026-06-18T11:27:21Z",
+            "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
           }
         ],
         "type": "extra",
@@ -8933,6 +9904,13 @@
       "description": "AI-powered cascading development framework.",
       "createdAt": "2026-05-23",
       "updatedAt": "2026-06-10",
+      "timeline": [
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:21Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+        }
+      ],
       "type": "basic",
       "installBody": "No public installable artifact is currently registered for this skill; it is tracked from its description only."
     },
@@ -8947,6 +9925,13 @@
       "description": "Chat, specs, tasks, and code. An autonomous engineering platform.",
       "createdAt": "2026-05-23",
       "updatedAt": "2026-06-10",
+      "timeline": [
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:14Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+        }
+      ],
       "type": "basic",
       "installBody": "No public installable artifact is currently registered for this skill; it is tracked from its description only."
     },
@@ -8971,6 +9956,13 @@
       },
       "createdAt": "2026-05-10",
       "updatedAt": "2026-05-10",
+      "timeline": [
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:14Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+        }
+      ],
       "type": "basic"
     },
     {
@@ -9018,6 +10010,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/mbtiongson1/gaia-skill-tree as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:14Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9054,6 +10051,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/alphafold_database_fetch_and_analyze/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "extra"
@@ -9090,6 +10092,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/alphagenome_single_variant_analysis/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "extra"
@@ -9126,6 +10133,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/chembl_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9162,6 +10174,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/clinical_trials_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9198,6 +10215,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/clinvar_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9234,6 +10256,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/dbsnp_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9270,6 +10297,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/embl_ebi_ols/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9306,6 +10338,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/encode_ccres_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9342,6 +10379,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/ensembl_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9378,6 +10420,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/foldseek_structural_search/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9414,6 +10461,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/gnomad_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9450,6 +10502,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/gtex_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9486,6 +10543,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/human_protein_atlas_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9522,6 +10584,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/interpro_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9558,6 +10625,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/jaspar_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9594,6 +10666,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/literature_search_arxiv/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9630,6 +10707,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/literature_search_biorxiv/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9666,6 +10748,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/literature_search_europepmc/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9702,6 +10789,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/literature_search_openalex/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9738,6 +10830,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/ncbi_sequence_fetch/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9774,6 +10871,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/openfda_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9810,6 +10912,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/opentargets_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9846,6 +10953,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/pdb_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:16Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9882,6 +10994,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/protein_sequence_msa/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:17Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "extra"
@@ -9934,6 +11051,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/protein_sequence_similarity_search/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:17Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -9970,6 +11092,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/pubchem_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:17Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -10006,6 +11133,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/pubmed_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:17Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -10042,6 +11174,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/pymol/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:17Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -10078,6 +11215,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/quickgo_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:17Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -10114,6 +11256,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/reactome_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:17Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -10150,6 +11297,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/science_skills_common/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:17Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -10186,6 +11338,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/string_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:17Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -10222,6 +11379,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/ucsc_conservation_and_tfbs/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:17Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -10258,6 +11420,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/unibind_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:17Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -10294,6 +11461,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/uniprot_database/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:17Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -10330,6 +11502,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/uv/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:17Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic"
@@ -10366,6 +11543,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/workflow_skill_creator/SKILL.md as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:17Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "extra"
@@ -10390,6 +11572,11 @@
           "action": "add",
           "contributor": "unknown",
           "details": "Added named skill langgenius/backend-code-review"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:18Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "extra",
@@ -10415,6 +11602,11 @@
           "action": "add",
           "contributor": "unknown",
           "details": "Added named skill langgenius/component-refactoring"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:18Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "basic",
@@ -10440,6 +11632,11 @@
           "action": "add",
           "contributor": "unknown",
           "details": "Added named skill langgenius/e2e-cucumber-playwright"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:18Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "extra",
@@ -10465,6 +11662,11 @@
           "action": "add",
           "contributor": "unknown",
           "details": "Added named skill langgenius/frontend-code-review"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:18Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "extra",
@@ -10490,6 +11692,11 @@
           "action": "add",
           "contributor": "unknown",
           "details": "Added named skill langgenius/frontend-testing"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:18Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "extra",
@@ -10506,6 +11713,13 @@
       "description": "Classifies the affective polarity (positive / negative / neutral, or fine-grained) of user-generated text. Covers the full pipeline from raw noisy input through preprocessing, inference, and output normalisation. Stack is intentionally tool-agnostic — three implementation tracks are documented below.\n",
       "createdAt": "2026-05-17",
       "updatedAt": "2026-05-17",
+      "timeline": [
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:19Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+        }
+      ],
       "type": "basic"
     },
     {
@@ -10519,6 +11733,13 @@
       "description": "MCP tool for finding AI dev jobs.",
       "createdAt": "2026-05-22",
       "updatedAt": "2026-06-10",
+      "timeline": [
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:21Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+        }
+      ],
       "type": "basic",
       "installBody": "No public installable artifact is currently registered for this skill; it is tracked from its description only."
     },
@@ -10545,6 +11766,11 @@
           "action": "demote",
           "contributor": "unknown",
           "details": "No installable code available; marked installable: false."
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:21Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "extra",
@@ -10561,6 +11787,13 @@
       "description": "Expert at integrating n8n with MCP (Model Context Protocol). Build n8n workflows that expose MCP tools, or use MCP tools within n8n workflows.",
       "createdAt": "2026-05-22",
       "updatedAt": "2026-06-10",
+      "timeline": [
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:21Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+        }
+      ],
       "type": "basic",
       "installBody": "No public installable artifact is currently registered for this skill; it is tracked from its description only."
     },
@@ -10604,6 +11837,11 @@
           "action": "evidence_graded",
           "contributor": "unknown",
           "details": "Re-graded evidence from https://github.com/Xquik-dev/hermes-tweet as B (trustNumber: 70.0)"
+        },
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:21Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
         }
       ],
       "type": "extra"
@@ -10619,6 +11857,13 @@
       "description": "Build Model Context Protocol (MCP) servers and tools from scratch. Full-stack MCP development with TypeScript/Python, testing, deployment, and registry publishing.",
       "createdAt": "2026-05-22",
       "updatedAt": "2026-06-10",
+      "timeline": [
+        {
+          "action": "migrate_trust_magnitude",
+          "timestamp": "2026-06-18T11:27:21Z",
+          "details": "TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)"
+        }
+      ],
       "type": "basic",
       "installBody": "No public installable artifact is currently registered for this skill; it is tracked from its description only."
     }

--- a/registry/named/0xdarkmatter/pytest-patterns.md
+++ b/registry/named/0xdarkmatter/pytest-patterns.md
@@ -5,22 +5,40 @@ contributor: 0xdarkmatter
 origin: true
 genericSkillRef: automated-testing
 status: named
-title: "The Quality Guardian"
+title: The Quality Guardian
 catalogRef: 0xdarkmatter-pytest-patterns
-level: "3★"
-description: Comprehensive pytest skill covering modern patterns for Python test automation including fixtures, parametrize, async testing, mocking, coverage strategies, integration tests, and conftest organisation for pytest 7.0+ projects.
+level: 3★
+description: Comprehensive pytest skill covering modern patterns for Python test automation
+  including fixtures, parametrize, async testing, mocking, coverage strategies, integration
+  tests, and conftest organisation for pytest 7.0+ projects.
 links:
   github: https://github.com/aiskillstore/marketplace/blob/main/skills/0xdarkmatter/python-pytest-patterns/SKILL.md
 tags:
-  - pytest
-  - python
-  - test-automation
-  - fixtures
-  - async-testing
-  - coverage
-  - mocking
-createdAt: "2026-04-30"
-updatedAt: "2026-04-30"
+- pytest
+- python
+- test-automation
+- fixtures
+- async-testing
+- coverage
+- mocking
+createdAt: '2026-04-30'
+updatedAt: '2026-04-30'
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 2f3e1ba5002985e006b783ad926dd2f680c0ab51116a1f7d4be9758d61940b00
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:13Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/registry/named/Manavarya09/design-extract.md
+++ b/registry/named/Manavarya09/design-extract.md
@@ -37,6 +37,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/Manavarya09/design-extract
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:18Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 6af22344e814422a02919bc89a207e0151dbd5d1aa46c1dbfde5a541e96be325
 ---
 
 ## Overview

--- a/registry/named/Taoidle/plan-decompose-gh-plan-cascade.md
+++ b/registry/named/Taoidle/plan-decompose-gh-plan-cascade.md
@@ -9,6 +9,22 @@ level: 2★
 description: AI-powered cascading development framework.
 createdAt: '2026-05-23'
 updatedAt: '2026-06-10'
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 02dc2d145623d6de7b66527267c520722a6a0797c30c8b222d6b09373b99fba4
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:21Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/registry/named/addy-osmani/performance-optimization.md
+++ b/registry/named/addy-osmani/performance-optimization.md
@@ -39,6 +39,9 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/addyosmani/agent-skills/blob/main/skills/performance-optimization/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:14Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 evidence:
 - class: A
   source: https://github.com/addyosmani/agent-skills/blob/main/skills/performance-optimization/SKILL.md
@@ -52,6 +55,18 @@ evidence:
   type: repo
   trustNumber: 70.0
   grade: B
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: eeb8bcc6135c6b8fd737e704be7957613a070715c0e377c311f5a1b7a27af1fb
 ---
 
 ## Installation

--- a/registry/named/addy-osmani/test-driven-development.md
+++ b/registry/named/addy-osmani/test-driven-development.md
@@ -34,6 +34,9 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/addyosmani/agent-skills/blob/main/skills/test-driven-development/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:14Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 evidence:
 - class: B
   source: https://github.com/addyosmani/agent-skills/blob/main/skills/test-driven-development/SKILL.md
@@ -44,6 +47,18 @@ evidence:
   type: repo
   trustNumber: 70.0
   grade: B
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: f9f365b9ff2ed82fb1e28f2ccaf2e7697e01e5446ee38dd2f78b113b9bf7b791
 ---
 
 ## Overview

--- a/registry/named/anthropic/pptx.md
+++ b/registry/named/anthropic/pptx.md
@@ -41,6 +41,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/anthropics/skills/blob/main/skills/pptx/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:14Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: db745e194100bed50b4bac4873a2adb8101d55d012f74ec4095bd0e00871443d
 ---
 
 ## Overview

--- a/registry/named/anthropic/skill-creator.md
+++ b/registry/named/anthropic/skill-creator.md
@@ -25,6 +25,21 @@ timeline:
   action: demote
   contributor: unknown
   details: Origin status removed. Transferred to mattpocock/write-a-skill.
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:14Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: ce4a2092ef8853b1b7310389a5a9e4c154e94d31b01c351cb655c77a17596f55
 ---
 
 ## Overview

--- a/registry/named/bradautomates/claude-video.md
+++ b/registry/named/bradautomates/claude-video.md
@@ -33,6 +33,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/bradautomates/claude-video
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:14Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 849dd3681def81781177344323b0a52d336bd4768f0b39c17a9b633441e6143f
 ---
 
 ## Overview

--- a/registry/named/browser-use/browser-harness.md
+++ b/registry/named/browser-use/browser-harness.md
@@ -37,6 +37,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/browser-use/browser-harness
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:14Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 80b954336c6990877bec2de6e17a70e8d721837fa12de3b43e35595cf72eca0c
 ---
 
 ## Overview

--- a/registry/named/browserbase/stagehand.md
+++ b/registry/named/browserbase/stagehand.md
@@ -5,18 +5,35 @@ contributor: browserbase
 origin: false
 genericSkillRef: browser-automation
 status: named
-title: "The SDK of Intent"
+title: The SDK of Intent
 catalogRef: browserbase-stagehand
-level: "2★"
-description: SDK for browser agents that combines deterministic browser automation with AI-assisted page interaction.
+level: 2★
+description: SDK for browser agents that combines deterministic browser automation
+  with AI-assisted page interaction.
 links:
   github: https://github.com/browserbase/stagehand
 tags:
-  - browser-automation
-  - agent
-  - sdk
-createdAt: "2026-05-17"
-updatedAt: "2026-05-17"
+- browser-automation
+- agent
+- sdk
+createdAt: '2026-05-17'
+updatedAt: '2026-05-17'
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 4254bb4cfe4ddbce381964096ff18c4e9de6a0d3edc82ffcc78afb983b07dced
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:14Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/registry/named/changkun/plan-decompose-gh-wallfacer.md
+++ b/registry/named/changkun/plan-decompose-gh-wallfacer.md
@@ -9,6 +9,22 @@ level: 2★
 description: Chat, specs, tasks, and code. An autonomous engineering platform.
 createdAt: '2026-05-23'
 updatedAt: '2026-06-10'
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 2f16b68aa16168862c81ce5bb4875945e20514ed86ef97eac0ae504fe1fc6c0e
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:14Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/registry/named/devin-ai/autonomous-swe.md
+++ b/registry/named/devin-ai/autonomous-swe.md
@@ -40,6 +40,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/cognition-labs/devin as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:14Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 75d8a46784a357df8b7c7abce35767c994ea0f514842fce452ea1381b1502215
 ---
 
 ## Overview

--- a/registry/named/firecrawl/firecrawl.md
+++ b/registry/named/firecrawl/firecrawl.md
@@ -33,6 +33,9 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/firecrawl/firecrawl as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:14Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 evidence:
 - class: B
   source: https://github.com/firecrawl/firecrawl
@@ -44,6 +47,20 @@ evidence:
   type: repo
   trustNumber: 70.0
   grade: B
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 90c0823722780cb6ce523dca4ace8738d12d62e2f0ff49a1a5d4c660b4ff41e2
+verification:
+  firstEvidenceAt: '2026-06-10T05:38:16Z'
 ---
 
 ## Overview

--- a/registry/named/gaiabot/gaia-triage.md
+++ b/registry/named/gaiabot/gaia-triage.md
@@ -5,18 +5,36 @@ contributor: gaiabot
 origin: false
 genericSkillRef: issue-triage
 status: awakened
-level: "2★"
-description: Automates repository triage for the Gaia Skill Tree, including fixing documentation drift, managing build dependencies (build, setuptools, wheel), and synchronizing generated graph projections and GEXF exports.
+level: 2★
+description: Automates repository triage for the Gaia Skill Tree, including fixing
+  documentation drift, managing build dependencies (build, setuptools, wheel), and
+  synchronizing generated graph projections and GEXF exports.
 links:
   github: https://github.com/mbtiongson1/gaia-skill-tree/blob/main/.agents/skills/gaia-triage/SKILL.md
 tags:
-  - maintenance
-  - triage
-  - automation
-  - ci-fix
-  - packaging
-createdAt: "2026-05-10"
-updatedAt: "2026-05-10"
+- maintenance
+- triage
+- automation
+- ci-fix
+- packaging
+createdAt: '2026-05-10'
+updatedAt: '2026-05-10'
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 0e6c1cdd17c08563dd2ea5858af28a0bc90910bc13d532e8104aab858dd10156
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:14Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/registry/named/gaiabot/repo-docs-before-pr.md
+++ b/registry/named/gaiabot/repo-docs-before-pr.md
@@ -40,6 +40,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/mbtiongson1/gaia-skill-tree
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:14Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: d02eca188ada0d54c2033455cbee19d9b9c211973872c0bc4346a3aa4673f5f2
+verification:
+  firstEvidenceAt: '2026-06-10T05:38:16Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/benchmark-models.md
+++ b/registry/named/garrytan/benchmark-models.md
@@ -42,6 +42,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/benchmark-models/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:14Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: f7364bd644ab9f17fc1a96ecf2db691e807aa3c039fb21aa9754cf586a835dad
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:29Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/benchmark.md
+++ b/registry/named/garrytan/benchmark.md
@@ -42,6 +42,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/benchmark/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:14Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: e4e51edccd685ad24c6a2208ff9ecae7c12231ac6e1eeeae6a98849513dfe7e3
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:29Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/browse.md
+++ b/registry/named/garrytan/browse.md
@@ -42,6 +42,9 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/browse/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:14Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 evidence:
 - class: B
   source: https://github.com/garrytan/gstack/blob/main/browse/SKILL.md
@@ -53,6 +56,20 @@ evidence:
   type: repo
   trustNumber: 70.0
   grade: B
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 0f0c3d3a7de27a43a257aea0995f66b6dd58dae3af701b8708b24dc2f3514f0a
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:28Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/canary.md
+++ b/registry/named/garrytan/canary.md
@@ -43,6 +43,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/canary/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:14Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 6400a59b811244e2db2c9c93d5217fd1f6474339a06bd9922e68ced46c0d40c2
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:29Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/careful.md
+++ b/registry/named/garrytan/careful.md
@@ -42,6 +42,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/careful/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:14Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 544d4af7f8ef2c067105e8f1d321465001a05587ea1c57ad5b597ba45457e0b7
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:30Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/codex.md
+++ b/registry/named/garrytan/codex.md
@@ -42,6 +42,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/codex/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:14Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 84970de7eedc57d4f2736b37fc3682f900d042390ba6215e5949be9c4764c0c6
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:31Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/context-restore.md
+++ b/registry/named/garrytan/context-restore.md
@@ -41,6 +41,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/context-restore/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:14Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 3853d4dc897b7a750348e721e768d51a372fc00f2dbdc84be0d0f6febcbc8366
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:31Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/context-save.md
+++ b/registry/named/garrytan/context-save.md
@@ -41,6 +41,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/context-save/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:14Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: c8c7c5e3de3e15b6d1108e650d9df31bef8f40673f2642880da3a83730b647b5
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:31Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/cso.md
+++ b/registry/named/garrytan/cso.md
@@ -44,6 +44,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/cso/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:14Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 785ad467878c05429ff87435ea15a0af0f7baa4b8027f16395e012bb1eb3c7b0
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:31Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/design-consultation.md
+++ b/registry/named/garrytan/design-consultation.md
@@ -36,6 +36,9 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/design-consultation/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:14Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 evidence:
 - class: B
   source: https://github.com/garrytan/gstack/blob/main/design-consultation/SKILL.md
@@ -48,6 +51,20 @@ evidence:
   type: repo
   trustNumber: 70.0
   grade: B
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: bd3a08ef06d671469728b7a74e9365b1aaaed1eab5da406fe334f7b5eb104e51
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:27Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/design-html.md
+++ b/registry/named/garrytan/design-html.md
@@ -36,6 +36,9 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/design-html/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:14Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 evidence:
 - class: B
   source: https://github.com/garrytan/gstack/blob/main/design-html/SKILL.md
@@ -48,6 +51,20 @@ evidence:
   type: repo
   trustNumber: 70.0
   grade: B
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 370da294cd86d152f2a16910c9e8f58e871a2159f2314c9f7cb63c9b02d7ae38
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:32Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/design-review.md
+++ b/registry/named/garrytan/design-review.md
@@ -38,6 +38,9 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/design-review/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:14Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 evidence:
 - class: B
   source: https://github.com/garrytan/gstack/blob/main/design-review/SKILL.md
@@ -50,6 +53,20 @@ evidence:
   type: repo
   trustNumber: 70.0
   grade: B
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 70a7c8c37195ae126dd34abcb7d35ee79f71f2e0ebd2c37b572dcc21ab949d9d
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:32Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/design-shotgun.md
+++ b/registry/named/garrytan/design-shotgun.md
@@ -43,6 +43,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/design-shotgun/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:14Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 50c4344b29e7e7fd8a636814ddb8cc63d761d7632c0e91a66b856c13a7233960
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:33Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/devex-review.md
+++ b/registry/named/garrytan/devex-review.md
@@ -37,6 +37,9 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/devex-review/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:14Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 evidence:
 - class: B
   source: https://github.com/garrytan/gstack/blob/main/devex-review/SKILL.md
@@ -49,6 +52,20 @@ evidence:
   type: repo
   trustNumber: 70.0
   grade: B
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: b541b6dd9b5503f4c40cdf6eaf5791da839ab09639d67cdbf0fa7fda53653484
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:32Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/document-generate.md
+++ b/registry/named/garrytan/document-generate.md
@@ -35,6 +35,9 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/document-generate/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:14Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 evidence:
 - class: B
   source: https://github.com/garrytan/gstack/blob/main/document-generate/SKILL.md
@@ -47,6 +50,20 @@ evidence:
   type: repo
   trustNumber: 70.0
   grade: B
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: a9699b7a91bbbd6ba73fa85b35ddc562590e5ab21d0bc25aaac7de3c5b62f083
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:27Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/document-release.md
+++ b/registry/named/garrytan/document-release.md
@@ -40,6 +40,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/document-release/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:15Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 48c94ee165b8447dd053d08400232e1503ca718b3093aa0012267ea7b30a9a2c
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:27Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/freeze.md
+++ b/registry/named/garrytan/freeze.md
@@ -41,6 +41,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/freeze/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:15Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 7e81891d649c006cd1b5065cb4e7da8d11430d170061cacdf648dd7fbf8c2cc7
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:30Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/garrytan.md
+++ b/registry/named/garrytan/garrytan.md
@@ -46,6 +46,9 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/autoplan/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:15Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 evidence:
 - class: B
   source: https://github.com/garrytan/gstack/blob/main/autoplan/SKILL.md
@@ -57,6 +60,20 @@ evidence:
   type: repo
   trustNumber: 70.0
   grade: B
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 2da79a1ddb73d30429b34da71373f2c6d55eb083f481548e9c94abcac84dd769
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:33Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/gstack-upgrade.md
+++ b/registry/named/garrytan/gstack-upgrade.md
@@ -41,6 +41,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/gstack-upgrade/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:15Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 4c390af4682aa78d69b385238ab94e024894ddb0654f5f2e525267420504036a
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:33Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/gstack.md
+++ b/registry/named/garrytan/gstack.md
@@ -90,6 +90,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:15Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 3343789dd0080e1e3088010242684ddea2b81d89271e86417485bfbba3e2a901
 ---
 
 ## Overview

--- a/registry/named/garrytan/guard.md
+++ b/registry/named/garrytan/guard.md
@@ -42,6 +42,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/guard/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:15Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 3a600e5f09fa33a6c2c44c68f7ba3a71e057e9d21ede03ff69f3a3322065f2eb
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:30Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/health.md
+++ b/registry/named/garrytan/health.md
@@ -42,6 +42,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/health/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:15Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: f7cc8e7aee67b2a8c2b7d4bb78ba19680960eaba651053704c791efc7dadf773
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:27Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/investigate.md
+++ b/registry/named/garrytan/investigate.md
@@ -36,6 +36,9 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/investigate/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:15Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 evidence:
 - class: B
   source: https://github.com/garrytan/gstack/blob/main/investigate/SKILL.md
@@ -48,6 +51,20 @@ evidence:
   type: repo
   trustNumber: 70.0
   grade: B
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: c2974bbb20026833030846d1f2b296fbe322cecf5598aed3e3899e7e96eefeeb
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:33Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/land-and-deploy.md
+++ b/registry/named/garrytan/land-and-deploy.md
@@ -43,6 +43,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/land-and-deploy/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:15Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 09a39173b8251326bd70cfe1b391a11c5520bda425fdb6fb29b04944732f660b
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:34Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/landing-report.md
+++ b/registry/named/garrytan/landing-report.md
@@ -42,6 +42,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/landing-report/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:15Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 4e1355e9b0e03ac092929f4392def1f4a97895c67c7f7f05655af0cfcf36f758
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:34Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/learn.md
+++ b/registry/named/garrytan/learn.md
@@ -42,6 +42,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/learn/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:15Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 073ddf2e2e53254d51938f63755cbe8eae0f8eedd59b279f6decbd926e43a239
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:34Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/make-pdf.md
+++ b/registry/named/garrytan/make-pdf.md
@@ -37,6 +37,9 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/make-pdf/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:15Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 evidence:
 - class: B
   source: https://github.com/garrytan/gstack/blob/main/make-pdf/SKILL.md
@@ -49,6 +52,20 @@ evidence:
   type: repo
   trustNumber: 70.0
   grade: B
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 7f8e039a54f5d866e6bf7200118ff7c87aa30fae2bdcf4b7e188d888d18418a9
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:34Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/office-hours.md
+++ b/registry/named/garrytan/office-hours.md
@@ -45,6 +45,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/office-hours/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:15Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 495d646eccff796aa940f3a5f5d4ade660715d7d3500d846165ac74ddf189029
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:35Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/open-gstack-browser.md
+++ b/registry/named/garrytan/open-gstack-browser.md
@@ -41,6 +41,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/open-gstack-browser/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:15Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: c272ee9f5d080fa861790c1b6b6027612c924e530d6036953f79d118a30f30d3
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:28Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/pair-agent.md
+++ b/registry/named/garrytan/pair-agent.md
@@ -41,6 +41,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/pair-agent/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:15Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 240e918f413b2ffb84c652a4bd40fd2488eed326c06bb8517b22a01bdefc8cc2
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:35Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/plan-ceo-review.md
+++ b/registry/named/garrytan/plan-ceo-review.md
@@ -43,6 +43,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/plan-ceo-review/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:15Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 77918505751a08a39d1cb97e5bf67796f664228a4b73590cd31c080dd7bf991c
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:29Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/plan-design-review.md
+++ b/registry/named/garrytan/plan-design-review.md
@@ -43,6 +43,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/plan-design-review/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:15Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: ec4424355042f0bdde1f158ef2de7b395f813316f608e71ae6da92a531db7ed9
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:32Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/plan-devex-review.md
+++ b/registry/named/garrytan/plan-devex-review.md
@@ -44,6 +44,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/plan-devex-review/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:15Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 641dace52431bbda3b143e4d8e9e7c94c3063f34b6f9c1bc08d262682cffbdc2
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:32Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/plan-eng-review.md
+++ b/registry/named/garrytan/plan-eng-review.md
@@ -43,6 +43,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/plan-eng-review/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:15Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: dc99860f07e2e83d76e28a436a96e90be74f1b1783419042ca2270139b92b721
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:35Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/plan-tune.md
+++ b/registry/named/garrytan/plan-tune.md
@@ -41,6 +41,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/plan-tune/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:15Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 39c78b5bde246b38dc0205e2518adb3d26a18b470306b20038c277a897e03218
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:35Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/qa-only.md
+++ b/registry/named/garrytan/qa-only.md
@@ -41,6 +41,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/qa-only/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:15Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: e0023e69cf93975395f8dcd011882caa01efdf1d4240dad774447cecc277768f
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:36Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/qa.md
+++ b/registry/named/garrytan/qa.md
@@ -43,6 +43,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/qa/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:15Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 568352b35775a6f04a0e9b58bd53eb1cfc53965a1d868635d7e1a0dd075b0f43
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:36Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/retro.md
+++ b/registry/named/garrytan/retro.md
@@ -41,6 +41,9 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/retro/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:15Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 evidence:
 - class: B
   source: https://github.com/garrytan/gstack/blob/main/retro/SKILL.md
@@ -53,6 +56,20 @@ evidence:
   type: repo
   trustNumber: 70.0
   grade: B
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: a3b676a7a49b869b3d76cb57b2b0159d27d444bed509ec46aafd2f110fce3026
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:36Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/review.md
+++ b/registry/named/garrytan/review.md
@@ -44,6 +44,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/review/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:15Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: fedf2342695ce810d9818253e6009d6e56802e604ffed8d85a50f53bcba1519a
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:35Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/scrape.md
+++ b/registry/named/garrytan/scrape.md
@@ -34,6 +34,9 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/scrape/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:15Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 evidence:
 - class: B
   source: https://github.com/garrytan/gstack/blob/main/scrape/SKILL.md
@@ -46,6 +49,20 @@ evidence:
   type: repo
   trustNumber: 70.0
   grade: B
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 3f6a28329eecf2207d82a0d257f77b6b90d65051a6e8039bf7c9d2be88b330e8
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:28Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/setup-browser-cookies.md
+++ b/registry/named/garrytan/setup-browser-cookies.md
@@ -41,6 +41,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/setup-browser-cookies/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:15Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 5689c5c9774db6dca1f09ad8b6e495e85fd2eaf576d4cce2c03501072eb24263
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:28Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/setup-deploy.md
+++ b/registry/named/garrytan/setup-deploy.md
@@ -42,6 +42,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/setup-deploy/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:15Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 590e36924c0d8903168062c538a7e0e2d545e896db5744150503a4010bde3107
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:34Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/setup-gbrain.md
+++ b/registry/named/garrytan/setup-gbrain.md
@@ -40,6 +40,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/setup-gbrain/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:15Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: f0ddfec4a6c2c9c971b5553630112f04d36d50a6c3c677699d45fa126710dcc6
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:36Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/ship.md
+++ b/registry/named/garrytan/ship.md
@@ -35,6 +35,9 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/ship/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:16Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 evidence:
 - class: B
   source: https://github.com/garrytan/gstack/blob/main/ship/SKILL.md
@@ -47,6 +50,20 @@ evidence:
   type: repo
   trustNumber: 70.0
   grade: B
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: e764ac08e8cac9e313e956b40ebbd8bfc97e279d9cf174fdd48ecd3a9629578f
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:37Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/skillify.md
+++ b/registry/named/garrytan/skillify.md
@@ -41,6 +41,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/skillify/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:16Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 85f5c7b4f135bb2886f24e89055f05578055d5a303faca33e44cad4496b22da8
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:37Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/sync-gbrain.md
+++ b/registry/named/garrytan/sync-gbrain.md
@@ -40,6 +40,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/sync-gbrain/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:16Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 7270c1930b22d388c3dfa3945cae43cc57cacfa07a5ef5c3662ec67a8cc67d0a
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:37Z'
 ---
 
 ## Overview

--- a/registry/named/garrytan/unfreeze.md
+++ b/registry/named/garrytan/unfreeze.md
@@ -41,6 +41,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/garrytan/gstack/blob/main/unfreeze/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:16Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 876d84293ed8e5a89a4ca73b3747dc4285bbc09725b55c81f010c754ff18e58a
+verification:
+  firstEvidenceAt: '2026-06-03T05:51:30Z'
 ---
 
 ## Overview

--- a/registry/named/getagentseal/codeburn.md
+++ b/registry/named/getagentseal/codeburn.md
@@ -34,6 +34,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/getagentseal/codeburn as B
     (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:16Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 39512c0e2632410dfe632da83b285ac721018a51deffb577fb8de4d122b52e28
 ---
 
 ## Overview

--- a/registry/named/glincker/readme-generator.md
+++ b/registry/named/glincker/readme-generator.md
@@ -34,6 +34,9 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/GLINCKER/claude-code-marketplace/blob/main/skills/documentation/readme-generator/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:16Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 evidence:
 - class: B
   source: https://github.com/GLINCKER/claude-code-marketplace/blob/main/skills/documentation/readme-generator/SKILL.md
@@ -44,6 +47,20 @@ evidence:
   type: repo
   trustNumber: 70.0
   grade: B
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 6cc4f4860ea86ad034181702eb1ead696daced2fc23d13a65f6b72477bcba5d3
+verification:
+  firstEvidenceAt: '2026-06-10T05:38:16Z'
 ---
 
 ## Overview

--- a/registry/named/google-deepmind/alphafold_database_fetch_and_analyze.md
+++ b/registry/named/google-deepmind/alphafold_database_fetch_and_analyze.md
@@ -31,6 +31,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/alphafold_database_fetch_and_analyze/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:16Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: fbc4da63a54f7899950b8f2ee9dc7d5222b23d5fbf43176d5f6bae53eba20e48
 ---
 
 # AlphaFold Database: Fetch and Analyze

--- a/registry/named/google-deepmind/alphagenome_single_variant_analysis.md
+++ b/registry/named/google-deepmind/alphagenome_single_variant_analysis.md
@@ -33,6 +33,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/alphagenome_single_variant_analysis/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:16Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 1891e3e98d95809ff7f25e8047602056165bf8a6fba433b91be10ba8cf380042
 ---
 
 # Variant Analysis using AlphaGenome

--- a/registry/named/google-deepmind/chembl_database.md
+++ b/registry/named/google-deepmind/chembl_database.md
@@ -29,6 +29,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/chembl_database/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:16Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 1bf7bbca26299efff7088354617d566d570baf556ea52b79c698a16d3764e5c9
 ---
 
 # ChEMBL Database Query

--- a/registry/named/google-deepmind/clinical_trials_database.md
+++ b/registry/named/google-deepmind/clinical_trials_database.md
@@ -30,6 +30,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/clinical_trials_database/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:16Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 4197cc36d57f22999f31f67d3c35363280a0ccb79ec113064eff90e7b2294a4f
 ---
 
 # Clinical Trials Database

--- a/registry/named/google-deepmind/clinvar_database.md
+++ b/registry/named/google-deepmind/clinvar_database.md
@@ -29,6 +29,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/clinvar_database/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:16Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: c6b70857405df9d2772242eb44bc8f6c9006361fb3aecea6142f4638829d4e08
 ---
 
 # ClinVar Database

--- a/registry/named/google-deepmind/dbsnp_database.md
+++ b/registry/named/google-deepmind/dbsnp_database.md
@@ -30,6 +30,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/dbsnp_database/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:16Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 1b898d0fefc6889ddb3d12bd03d95371f65c5ac8f20ff8c59a02913d19e6bc2f
 ---
 
 # dbSNP Database Integration

--- a/registry/named/google-deepmind/embl_ebi_ols.md
+++ b/registry/named/google-deepmind/embl_ebi_ols.md
@@ -31,6 +31,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/embl_ebi_ols/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:16Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: d3a008461b4d264c6e03292e6bbd062ff8108af255807cec072e5b1007a3eba4
 ---
 
 # EMBL-EBI Ontology Lookup Service (OLS)

--- a/registry/named/google-deepmind/encode_ccres_database.md
+++ b/registry/named/google-deepmind/encode_ccres_database.md
@@ -30,6 +30,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/encode_ccres_database/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:16Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: eb4ec3bcc4f01dda0b2dbe60c4b3442ae225d19ab093742535da9f531dd1653e
 ---
 
 # ENCODE Database Skill

--- a/registry/named/google-deepmind/ensembl_database.md
+++ b/registry/named/google-deepmind/ensembl_database.md
@@ -30,6 +30,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/ensembl_database/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:16Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: ae2b1ccea82511091e166f37668f4a8d60df8ced2fa293f7a6a064a62caadcce
 ---
 
 # Ensembl Database: ID Mapping and Genomic Features

--- a/registry/named/google-deepmind/foldseek_structural_search.md
+++ b/registry/named/google-deepmind/foldseek_structural_search.md
@@ -31,6 +31,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/foldseek_structural_search/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:16Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: c4e269455dea054c2b4a787f30892bc03c6f07740c89a2db9805176cde1e1994
 ---
 
 ## Prerequisites

--- a/registry/named/google-deepmind/gnomad_database.md
+++ b/registry/named/google-deepmind/gnomad_database.md
@@ -32,6 +32,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/gnomad_database/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:16Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: ce98399fb38cb7bb4160a23f815e393233a7913f1fcce3b57dcf8e8f14a6638d
 ---
 
 # gnomAD Database

--- a/registry/named/google-deepmind/gtex_database.md
+++ b/registry/named/google-deepmind/gtex_database.md
@@ -29,6 +29,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/gtex_database/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:16Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: b7b26923b308d3b404a89f2f17fa1605bc9abe6fa83d1cf45e4dcf2d80c469cf
 ---
 
 # GTEx Database Integration

--- a/registry/named/google-deepmind/human_protein_atlas_database.md
+++ b/registry/named/google-deepmind/human_protein_atlas_database.md
@@ -28,6 +28,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/human_protein_atlas_database/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:16Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 39f3984bf001a6c9ff7188f939877e8155ae8115f46861fbaf57560637187814
 ---
 
 # Human Protein Atlas (HPA) Database Integration

--- a/registry/named/google-deepmind/interpro_database.md
+++ b/registry/named/google-deepmind/interpro_database.md
@@ -31,6 +31,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/interpro_database/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:16Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 98daf3bdc72a6a9e8276e3755edcdfe628db6dfbc6fdf9dad5bedd886860b049
 ---
 
 # InterPro Database Access

--- a/registry/named/google-deepmind/jaspar_database.md
+++ b/registry/named/google-deepmind/jaspar_database.md
@@ -30,6 +30,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/jaspar_database/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:16Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 593f29b8a21656cca424153d26fea286d9a8527f48814642d5c2b7128e81d0ef
 ---
 
 # JASPAR Skill

--- a/registry/named/google-deepmind/literature_search_arxiv.md
+++ b/registry/named/google-deepmind/literature_search_arxiv.md
@@ -29,6 +29,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/literature_search_arxiv/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:16Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 028a063469f070705a49fa9ed3e7b0be1f611c82c012e609eed756462c7240e9
 ---
 
 # arXiv Search and Retrieval

--- a/registry/named/google-deepmind/literature_search_biorxiv.md
+++ b/registry/named/google-deepmind/literature_search_biorxiv.md
@@ -30,6 +30,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/literature_search_biorxiv/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:16Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: f144a5f2eb02be0217c74e320889b0ac728b30b2538881d23167cd926de64cb1
 ---
 
 # bioRxiv and medRxiv Literature Search

--- a/registry/named/google-deepmind/literature_search_europepmc.md
+++ b/registry/named/google-deepmind/literature_search_europepmc.md
@@ -29,6 +29,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/literature_search_europepmc/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:16Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 4d34f47f61a6cb22cc7673a46035248085d5682d09ca94ec92fe2770f73c8cc7
 ---
 
 # Europe PMC Database

--- a/registry/named/google-deepmind/literature_search_openalex.md
+++ b/registry/named/google-deepmind/literature_search_openalex.md
@@ -31,6 +31,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/literature_search_openalex/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:16Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: caff8108e3a08ed7c12f7a47dd2c6a21b8880d750a1dfbd1ddc8c0efdceff8d4
 ---
 
 # OpenAlex Skill

--- a/registry/named/google-deepmind/ncbi_sequence_fetch.md
+++ b/registry/named/google-deepmind/ncbi_sequence_fetch.md
@@ -31,6 +31,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/ncbi_sequence_fetch/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:16Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 8b13fbe84f049c015b1c0ae823b9cf1bb36619f48d0f73611f2ddbb5b3632960
 ---
 
 # NCBI Sequence Fetch

--- a/registry/named/google-deepmind/openfda_database.md
+++ b/registry/named/google-deepmind/openfda_database.md
@@ -31,6 +31,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/openfda_database/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:16Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: f1ca00f6723a18dec25a37f1d67947b362278716078ba83d5713e722b8feaba2
 ---
 
 # openFDA Search and Query

--- a/registry/named/google-deepmind/opentargets_database.md
+++ b/registry/named/google-deepmind/opentargets_database.md
@@ -29,6 +29,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/opentargets_database/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:16Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 0b0c7f26e368e10d37ca9668a3e0e7a4f28892792bd3db30164480d4d09cc88e
 ---
 
 # Open Targets Database Skill

--- a/registry/named/google-deepmind/pdb_database.md
+++ b/registry/named/google-deepmind/pdb_database.md
@@ -30,6 +30,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/pdb_database/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:16Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: b6d2e891fe9e6dac0d4b7f88f9b2c26fa381767dcad0eea8cc5dbdef8f8c0c09
 ---
 
 # RCSB Protein Data Bank skill

--- a/registry/named/google-deepmind/protein_sequence_msa.md
+++ b/registry/named/google-deepmind/protein_sequence_msa.md
@@ -32,6 +32,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/protein_sequence_msa/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:17Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 933145e9e7e599279d69e211b891d2f71f679ed87f74941f2c8ebb2d2beea1e9
 ---
 
 ## Prerequisites

--- a/registry/named/google-deepmind/protein_sequence_similarity_search.md
+++ b/registry/named/google-deepmind/protein_sequence_similarity_search.md
@@ -45,6 +45,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/protein_sequence_similarity_search/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:17Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: cc0f1ff57992b3de6be27e25dfd870220af603a804c1533190ebd036b68dc1f7
 ---
 
 ## Prerequisites

--- a/registry/named/google-deepmind/pubchem_database.md
+++ b/registry/named/google-deepmind/pubchem_database.md
@@ -29,6 +29,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/pubchem_database/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:17Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 45a1f71aeae4f1c281aef1c9c32f53699013ad28fe6f87810fd920816928318f
 ---
 
 # PubChem Database

--- a/registry/named/google-deepmind/pubmed_database.md
+++ b/registry/named/google-deepmind/pubmed_database.md
@@ -31,6 +31,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/pubmed_database/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:17Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 98823ca7579eb86dcf4b5114dce33e6c3acf999714bceb247d697d947669b3e0
 ---
 
 # PubMed API

--- a/registry/named/google-deepmind/pymol.md
+++ b/registry/named/google-deepmind/pymol.md
@@ -31,6 +31,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/pymol/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:17Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 8153e8139130b197fbb8a4ef55defbf7996d6050a16455ef0eda1a9541dbdb2f
 ---
 
 # PyMOL

--- a/registry/named/google-deepmind/quickgo_database.md
+++ b/registry/named/google-deepmind/quickgo_database.md
@@ -31,6 +31,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/quickgo_database/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:17Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: e3aa82fa803c56231c1e739fbeba448dbb387c2ea3071a4bfd89963555b05ed7
 ---
 
 # QuickGO Database Skill

--- a/registry/named/google-deepmind/reactome_database.md
+++ b/registry/named/google-deepmind/reactome_database.md
@@ -31,6 +31,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/reactome_database/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:17Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 938fdc6e9930b8126a424b31f2e389877c35c3b715856d1778da7197499f8b70
 ---
 
 # Reactome Analysis & Content Service

--- a/registry/named/google-deepmind/science_skills_common.md
+++ b/registry/named/google-deepmind/science_skills_common.md
@@ -29,6 +29,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/science_skills_common/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:17Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 40ce4ee4b951ea5564a50a05266e5bcef67bfc1f4cd06ee097113c6aeb3d6131
 ---
 
 # Science Skills Common

--- a/registry/named/google-deepmind/string_database.md
+++ b/registry/named/google-deepmind/string_database.md
@@ -30,6 +30,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/string_database/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:17Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 69ba78660c603a0cdb297eac0d07ebaa38b1f82a804178c54f79b0ef39d186c5
 ---
 
 # STRING Database Skill

--- a/registry/named/google-deepmind/ucsc_conservation_and_tfbs.md
+++ b/registry/named/google-deepmind/ucsc_conservation_and_tfbs.md
@@ -30,6 +30,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/ucsc_conservation_and_tfbs/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:17Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 3495b5b9a2a67c9bbfc6ddb161528c51daf621c8ae8904951953a63a2694621e
 ---
 
 # Conservation Scores & TFBS Lookup (UCSC)

--- a/registry/named/google-deepmind/unibind_database.md
+++ b/registry/named/google-deepmind/unibind_database.md
@@ -31,6 +31,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/unibind_database/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:17Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: af233800324c5923e4eee256265a1f0622c1f816f05bb8827fc461df38d7baa8
 ---
 
 # UniBind Database Skill

--- a/registry/named/google-deepmind/uniprot_database.md
+++ b/registry/named/google-deepmind/uniprot_database.md
@@ -30,6 +30,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/uniprot_database/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:17Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 32168ee930391e0db8886ee77b564f027e2727644432922ada1c88981ead1e37
 ---
 
 # UniProt Database Access

--- a/registry/named/google-deepmind/uv.md
+++ b/registry/named/google-deepmind/uv.md
@@ -28,6 +28,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/uv/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:17Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: a0df18a5e38cfce8d4c083abfae57c741e5727d18eb1c1b5795aeb00ed303705
 ---
 
 # uv (Python Package Manager)

--- a/registry/named/google-deepmind/workflow_skill_creator.md
+++ b/registry/named/google-deepmind/workflow_skill_creator.md
@@ -31,6 +31,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/google-deepmind/science-skills/blob/main/skills/workflow_skill_creator/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:17Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: c01785fb536548e46243610824c86b590ffca27f37d6fef1372e6a2a603b24ba
 ---
 
 # Workflow-to-Skill Distiller

--- a/registry/named/gooseworks/notte-browser.md
+++ b/registry/named/gooseworks/notte-browser.md
@@ -26,6 +26,21 @@ timeline:
   action: demote
   contributor: unknown
   details: Calibrated level from 3★ to 1★
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:17Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 4571a10727388b22661b5c1a264fa7fef57e1810b9ba5f8538b691647ba5970f
 ---
 
 ## Overview

--- a/registry/named/huggingface/hf-cli.md
+++ b/registry/named/huggingface/hf-cli.md
@@ -5,20 +5,37 @@ contributor: huggingface
 origin: false
 genericSkillRef: api-call
 status: named
-title: "The Hub Operator"
+title: The Hub Operator
 catalogRef: huggingface-hf-cli
-level: "2★"
-description: Guides Hugging Face Hub CLI operations for downloading, uploading, managing repos, running Jobs, querying datasets, configuring Spaces, and handling Hub authentication.
+level: 2★
+description: Guides Hugging Face Hub CLI operations for downloading, uploading, managing
+  repos, running Jobs, querying datasets, configuring Spaces, and handling Hub authentication.
 links:
   github: https://github.com/huggingface/skills/blob/main/skills/hf-cli/SKILL.md
 tags:
-  - huggingface
-  - hub
-  - cli
-  - jobs
-  - datasets
-createdAt: "2026-05-03"
-updatedAt: "2026-05-03"
+- huggingface
+- hub
+- cli
+- jobs
+- datasets
+createdAt: '2026-05-03'
+updatedAt: '2026-05-03'
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: da5d8b0ae08be9fc5a30464c347ec2cf7b7a4f11f0add631358093c8575e6ba1
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:17Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/registry/named/huggingface/huggingface-datasets.md
+++ b/registry/named/huggingface/huggingface-datasets.md
@@ -5,20 +5,38 @@ contributor: huggingface
 origin: false
 genericSkillRef: data-analysis
 status: named
-title: "The Dataset Cartographer"
+title: The Dataset Cartographer
 catalogRef: huggingface-datasets
-level: "2★"
-description: Explores Hugging Face datasets through the Dataset Viewer API, resolving configs and splits, previewing rows, paginating records, searching text, filtering rows, and retrieving parquet metadata.
+level: 2★
+description: Explores Hugging Face datasets through the Dataset Viewer API, resolving
+  configs and splits, previewing rows, paginating records, searching text, filtering
+  rows, and retrieving parquet metadata.
 links:
   github: https://github.com/huggingface/skills/blob/main/skills/huggingface-datasets/SKILL.md
 tags:
-  - huggingface
-  - datasets
-  - dataset-viewer
-  - parquet
-  - data-analysis
-createdAt: "2026-05-03"
-updatedAt: "2026-05-03"
+- huggingface
+- datasets
+- dataset-viewer
+- parquet
+- data-analysis
+createdAt: '2026-05-03'
+updatedAt: '2026-05-03'
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: b410953c25a40d2b6263da53a4121551574e683e09c26b0294cf23e276c9edf5
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:17Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/registry/named/huggingface/huggingface-llm-trainer.md
+++ b/registry/named/huggingface/huggingface-llm-trainer.md
@@ -5,20 +5,38 @@ contributor: huggingface
 origin: false
 genericSkillRef: fine-tune
 status: named
-title: "The Cloud Fine-Tuner"
+title: The Cloud Fine-Tuner
 catalogRef: huggingface-llm-trainer
-level: "3★"
-description: Runs LLM fine-tuning on Hugging Face Jobs using TRL or Unsloth, covering SFT, DPO, GRPO, reward modeling, dataset validation, hardware selection, Trackio monitoring, and Hub persistence.
+level: 3★
+description: Runs LLM fine-tuning on Hugging Face Jobs using TRL or Unsloth, covering
+  SFT, DPO, GRPO, reward modeling, dataset validation, hardware selection, Trackio
+  monitoring, and Hub persistence.
 links:
   github: https://github.com/huggingface/skills/blob/main/skills/huggingface-llm-trainer/SKILL.md
 tags:
-  - huggingface
-  - fine-tuning
-  - trl
-  - jobs
-  - trackio
-createdAt: "2026-05-03"
-updatedAt: "2026-05-03"
+- huggingface
+- fine-tuning
+- trl
+- jobs
+- trackio
+createdAt: '2026-05-03'
+updatedAt: '2026-05-03'
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 767259314529948bdc83a1c8c532b7c988f9ebe3d78ae0aacd2bd59f1f035839
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:17Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/registry/named/huggingface/huggingface-papers.md
+++ b/registry/named/huggingface/huggingface-papers.md
@@ -5,20 +5,38 @@ contributor: huggingface
 origin: false
 genericSkillRef: literature-review
 status: named
-title: "The Paper Indexer"
+title: The Paper Indexer
 catalogRef: huggingface-papers
-level: "2★"
-description: Looks up Hugging Face paper pages and arXiv IDs, fetching markdown paper content and structured metadata such as authors, linked models, datasets, Spaces, GitHub repos, and project pages.
+level: 2★
+description: Looks up Hugging Face paper pages and arXiv IDs, fetching markdown paper
+  content and structured metadata such as authors, linked models, datasets, Spaces,
+  GitHub repos, and project pages.
 links:
   github: https://github.com/huggingface/skills/blob/main/skills/huggingface-papers/SKILL.md
 tags:
-  - huggingface
-  - papers
-  - arxiv
-  - metadata
-  - research
-createdAt: "2026-05-03"
-updatedAt: "2026-05-03"
+- huggingface
+- papers
+- arxiv
+- metadata
+- research
+createdAt: '2026-05-03'
+updatedAt: '2026-05-03'
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 599e87473e2579557701861c44e82339f3ce490cf83fae97e013992c0c90945e
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:17Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/registry/named/huggingface/huggingface-vision-trainer.md
+++ b/registry/named/huggingface/huggingface-vision-trainer.md
@@ -5,20 +5,38 @@ contributor: huggingface
 origin: false
 genericSkillRef: object-detection
 status: named
-title: "The Vision Forge"
+title: The Vision Forge
 catalogRef: huggingface-vision-trainer
-level: "3★"
-description: Trains and fine-tunes object detection, image classification, and SAM/SAM2 segmentation models on Hugging Face Jobs or locally with dataset validation, metrics, Trackio, and Hub persistence.
+level: 3★
+description: Trains and fine-tunes object detection, image classification, and SAM/SAM2
+  segmentation models on Hugging Face Jobs or locally with dataset validation, metrics,
+  Trackio, and Hub persistence.
 links:
   github: https://github.com/huggingface/skills/blob/main/skills/huggingface-vision-trainer/SKILL.md
 tags:
-  - huggingface
-  - vision
-  - object-detection
-  - segmentation
-  - fine-tuning
-createdAt: "2026-05-03"
-updatedAt: "2026-05-03"
+- huggingface
+- vision
+- object-detection
+- segmentation
+- fine-tuning
+createdAt: '2026-05-03'
+updatedAt: '2026-05-03'
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 9c1399eed3413efcf51d9478aee5d8f1c6b7c642899701954c4a48cf7b099bc4
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:17Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/registry/named/huggingface/semantic-cache.md
+++ b/registry/named/huggingface/semantic-cache.md
@@ -53,7 +53,22 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/codefuse-ai/ModelCache as B
     (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:17Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 installable: false
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: ecb93fc8843593f1af5202ba8a5ec8bde934dd8fcd7d961b11599e8d07ba9499
 ---
 
 ## Overview

--- a/registry/named/huggingface/transformers-js.md
+++ b/registry/named/huggingface/transformers-js.md
@@ -5,20 +5,38 @@ contributor: huggingface
 origin: false
 genericSkillRef: multimodal-reasoning
 status: named
-title: "The Browser Modelwright"
+title: The Browser Modelwright
 catalogRef: huggingface-transformers-js
-level: "2★"
-description: Runs Hugging Face Transformers.js models directly in JavaScript and TypeScript across browser and server runtimes for NLP, vision, audio, and multimodal inference with WebGPU or WASM.
+level: 2★
+description: Runs Hugging Face Transformers.js models directly in JavaScript and TypeScript
+  across browser and server runtimes for NLP, vision, audio, and multimodal inference
+  with WebGPU or WASM.
 links:
   github: https://github.com/huggingface/skills/blob/main/skills/transformers-js/SKILL.md
 tags:
-  - huggingface
-  - transformers-js
-  - javascript
-  - webgpu
-  - inference
-createdAt: "2026-05-03"
-updatedAt: "2026-05-03"
+- huggingface
+- transformers-js
+- javascript
+- webgpu
+- inference
+createdAt: '2026-05-03'
+updatedAt: '2026-05-03'
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 8545726f306ed0aa1e150468e8d86925168a6df79cda0de64a9c5abe364b47c0
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:17Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/registry/named/intelligentcode-ai/database-engineer.md
+++ b/registry/named/intelligentcode-ai/database-engineer.md
@@ -37,6 +37,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/intelligentcode-ai/skills/blob/main/skills/database-engineer/SKILL.md
     as C (trustNumber: 50.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:17Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 2ad1e6509c7a531104baddaa2279972f4648e026348058e3afb1226af35447dc
 ---
 
 ## Overview

--- a/registry/named/intelligentcode-ai/devops-engineer.md
+++ b/registry/named/intelligentcode-ai/devops-engineer.md
@@ -37,6 +37,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/intelligentcode-ai/skills/blob/main/skills/devops-engineer/SKILL.md
     as C (trustNumber: 50.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:17Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 87e8cac0c5e9bf4f5d3212289fddaa0679b2781a2e71e081b35c6efddc13563a
 ---
 
 ## Overview

--- a/registry/named/intelligentcode-ai/mcp-client.md
+++ b/registry/named/intelligentcode-ai/mcp-client.md
@@ -35,6 +35,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/intelligentcode-ai/skills/blob/main/skills/mcp-client/SKILL.md
     as C (trustNumber: 50.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:17Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 6cc6a92f0534296cb6e64910e386c2e4646c2c991030e35f19adb0f5c5311d4c
 ---
 
 ## Overview

--- a/registry/named/intelligentcode-ai/parallel-execution.md
+++ b/registry/named/intelligentcode-ai/parallel-execution.md
@@ -34,6 +34,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/intelligentcode-ai/skills/blob/main/skills/parallel-execution/SKILL.md
     as C (trustNumber: 50.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:17Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 31059cb648f62a2975d21363e0d97409a7799ce0028a43e77f135eb46679f9ac
 ---
 
 ## Overview

--- a/registry/named/intelligentcode-ai/release.md
+++ b/registry/named/intelligentcode-ai/release.md
@@ -36,6 +36,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/intelligentcode-ai/skills/blob/main/skills/release/SKILL.md
     as C (trustNumber: 50.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:17Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 04d59c0e12b9abc89d0b128d8e941dbd8d0384f97a899237a290d45c8846b13a
 ---
 
 ## Overview

--- a/registry/named/intelligentcode-ai/requirements-engineer.md
+++ b/registry/named/intelligentcode-ai/requirements-engineer.md
@@ -36,6 +36,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/intelligentcode-ai/skills/blob/main/skills/requirements-engineer/SKILL.md
     as C (trustNumber: 50.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:17Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 994401292c2e33038d70882403ffb719a16db587ea2e39bf054a915b740d43ff
 ---
 
 ## Overview

--- a/registry/named/intelligentcode-ai/security-engineer.md
+++ b/registry/named/intelligentcode-ai/security-engineer.md
@@ -37,6 +37,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/intelligentcode-ai/skills/blob/main/skills/security-engineer/SKILL.md
     as C (trustNumber: 50.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:17Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 35c90d07a2f2975d56a5213918c274e86426ab544dcca7d3ef4bfd33ad469bc5
 ---
 
 ## Overview

--- a/registry/named/intelligentcode-ai/user-tester.md
+++ b/registry/named/intelligentcode-ai/user-tester.md
@@ -36,6 +36,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/intelligentcode-ai/skills/blob/main/skills/user-tester/SKILL.md
     as C (trustNumber: 50.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:18Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 5c2bde2c36d41380fac68a7fe69ee324bf9df70896760c5dfad3e69694bbe508
 ---
 
 ## Overview

--- a/registry/named/karpathy/autoresearch.md
+++ b/registry/named/karpathy/autoresearch.md
@@ -34,6 +34,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/karpathy/autoresearch as B
     (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:18Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: fc9b0a2b3ee407e4112f851596a03d6d00844cbbebdc0aa4814e93e6200311de
 ---
 
 ## Overview

--- a/registry/named/langgenius/backend-code-review.md
+++ b/registry/named/langgenius/backend-code-review.md
@@ -17,6 +17,21 @@ timeline:
   action: add
   contributor: unknown
   details: Added named skill langgenius/backend-code-review
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:18Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: f514e5e7a20fb28c0844b113818039a6a5e72981ee6c88ec53ac40dde218ed4e
 ---
 
 ## Installation

--- a/registry/named/langgenius/component-refactoring.md
+++ b/registry/named/langgenius/component-refactoring.md
@@ -16,6 +16,21 @@ timeline:
   action: add
   contributor: unknown
   details: Added named skill langgenius/component-refactoring
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:18Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: d3633687044885b7fdd90d673bf9b5dd8d70cf24b07356c68d07ef4b85308c4a
 ---
 
 ## Installation

--- a/registry/named/langgenius/e2e-cucumber-playwright.md
+++ b/registry/named/langgenius/e2e-cucumber-playwright.md
@@ -17,6 +17,21 @@ timeline:
   action: add
   contributor: unknown
   details: Added named skill langgenius/e2e-cucumber-playwright
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:18Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: f78ad09ff08b5c0c5fd2f36c1c2e30f46abbc590203ed203cc78163e232cd57e
 ---
 
 ## Installation

--- a/registry/named/langgenius/frontend-code-review.md
+++ b/registry/named/langgenius/frontend-code-review.md
@@ -16,6 +16,21 @@ timeline:
   action: add
   contributor: unknown
   details: Added named skill langgenius/frontend-code-review
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:18Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 5f6f1c4417a65709432ab0600b6a481d847f71b39581c0897fb998c6c472220e
 ---
 
 ## Installation

--- a/registry/named/langgenius/frontend-testing.md
+++ b/registry/named/langgenius/frontend-testing.md
@@ -16,6 +16,21 @@ timeline:
   action: add
   contributor: unknown
   details: Added named skill langgenius/frontend-testing
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:18Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 8994408481a509c18836b2a048509c834c157798ba410aaf2b0a1f595f10cd87
 ---
 
 ## Installation

--- a/registry/named/laravel/upgrade-laravel-v13.md
+++ b/registry/named/laravel/upgrade-laravel-v13.md
@@ -36,6 +36,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/laravel/boost/issues/698 as
     B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:18Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: e105e6ce092ba33bda9b2fc9119f9b6599ed0af2bc8a1c4585c5196ebd932bba
 ---
 
 ## Overview

--- a/registry/named/martin-stepanoski/nielsen-heuristics-audit.md
+++ b/registry/named/martin-stepanoski/nielsen-heuristics-audit.md
@@ -42,6 +42,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/mastepanoski/claude-skills/blob/main/skills/nielsen-heuristics-audit/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:18Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 939993febaef44a14d5522e1df36595de64071fe7e4d98347f187ea3b353edfd
 ---
 
 ## Overview

--- a/registry/named/mattpocock/caveman.md
+++ b/registry/named/mattpocock/caveman.md
@@ -5,15 +5,31 @@ contributor: mattpocock
 origin: false
 genericSkillRef: context-compression
 status: named
-title: "The Caveman Console"
+title: The Caveman Console
 level: 3★
 description: An ultra-compressed communication mode designed to save tokens by dropping
   articles and filler words.
 createdAt: '2026-05-21'
 updatedAt: '2026-06-04'
-suiteRef: "mattpocock/productivity"
+suiteRef: mattpocock/productivity
 links:
   github: https://github.com/mattpocock/skills/blob/main/skills/productivity/caveman
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 824d0ee57a81400c9f094afd384391937368692461e12b046375a540a8f1d8d9
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:18Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Installation

--- a/registry/named/mattpocock/diagnose.md
+++ b/registry/named/mattpocock/diagnose.md
@@ -43,6 +43,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/engineering/diagnose/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:18Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 8b89ddfb192097b469f84d620bb6df2b0f28ba9c0b10f1aee8ad8d2d4f819efb
+verification:
+  firstEvidenceAt: '2026-06-10T05:38:16Z'
 ---
 
 ## Overview

--- a/registry/named/mattpocock/edit-article.md
+++ b/registry/named/mattpocock/edit-article.md
@@ -36,6 +36,9 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/personal/edit-article/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:18Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 evidence:
 - class: B
   source: https://github.com/mattpocock/skills/blob/main/skills/personal/edit-article/SKILL.md
@@ -46,6 +49,20 @@ evidence:
   type: repo
   trustNumber: 70.0
   grade: B
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: b57f4d661a6459b45a592c9dbde8b4bd8ee78e61a9c49697bcbe2232896174a9
+verification:
+  firstEvidenceAt: '2026-06-10T05:38:17Z'
 ---
 
 ## Overview

--- a/registry/named/mattpocock/engineering.md
+++ b/registry/named/mattpocock/engineering.md
@@ -22,6 +22,22 @@ suiteComponents:
 - mattpocock/triage
 - mattpocock/ubiquitous-language
 - mattpocock/zoom-out
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 7d257b90e6e19e12a665695a758ce86cb9d614b96686bd3eb9bf61f9f0a81aae
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:18Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/registry/named/mattpocock/grill-me.md
+++ b/registry/named/mattpocock/grill-me.md
@@ -39,6 +39,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/productivity/grill-me/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:18Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 90f863093ccde55b568743eb8c28bcc7ab1c5b3e82627d14a2484e6080a07111
 ---
 
 ## Overview

--- a/registry/named/mattpocock/grill-with-docs.md
+++ b/registry/named/mattpocock/grill-with-docs.md
@@ -40,6 +40,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/engineering/grill-with-docs/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:18Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 02939ad2abd2f950ba96603c4fe20508673bd7db88d2edde606879c55ccbc07a
 ---
 
 ## Overview

--- a/registry/named/mattpocock/handoff.md
+++ b/registry/named/mattpocock/handoff.md
@@ -30,6 +30,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/productivity/handoff/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:18Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 50f47d5e66a654ba2b92dc1089e5ce8b8f5c52fd4ec651ad0ec34824684e679a
 ---
 
 ## Installation

--- a/registry/named/mattpocock/improve-codebase-architecture.md
+++ b/registry/named/mattpocock/improve-codebase-architecture.md
@@ -5,23 +5,41 @@ contributor: mattpocock
 origin: false
 genericSkillRef: refactor-code
 status: named
-title: "The Architecture Improver"
-title: "The Depth Seeker"
+title: The Depth Seeker
 catalogRef: mattpocock-improve-codebase-architecture
-level: "3★"
-description: Identifies architectural deepening opportunities in a codebase — shallow modules with high interface-to-implementation ratios — using domain-glossary vocabulary and the deletion test, then grills the developer on the chosen candidate to design a deep-module replacement with better locality and testability.
+level: 3★
+description: Identifies architectural deepening opportunities in a codebase — shallow
+  modules with high interface-to-implementation ratios — using domain-glossary vocabulary
+  and the deletion test, then grills the developer on the chosen candidate to design
+  a deep-module replacement with better locality and testability.
 links:
   github: https://github.com/mattpocock/skills/blob/main/skills/engineering/improve-codebase-architecture/SKILL.md
 tags:
-  - architecture-review
-  - deep-modules
-  - refactoring
-  - locality
-  - testability
-  - deletion-test
-createdAt: "2026-04-30"
-updatedAt: "2026-04-30"
-suiteRef: "mattpocock/engineering"
+- architecture-review
+- deep-modules
+- refactoring
+- locality
+- testability
+- deletion-test
+createdAt: '2026-04-30'
+updatedAt: '2026-04-30'
+suiteRef: mattpocock/engineering
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 46af657cc4ee9beff6e5b00c676dc3299efb9800417a4954aa2e60e869ec3a51
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:18Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/registry/named/mattpocock/obsidian-vault.md
+++ b/registry/named/mattpocock/obsidian-vault.md
@@ -30,6 +30,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/personal/obsidian-vault/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:18Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 0ee69bbc686dda25ae6d4c4135c6d6345d640de8d0ee2b9cf454c8b83107fb8e
 ---
 
 ## Installation

--- a/registry/named/mattpocock/personal.md
+++ b/registry/named/mattpocock/personal.md
@@ -14,6 +14,22 @@ suiteRef: mattpocock/skills
 suiteComponents:
 - mattpocock/edit-article
 - mattpocock/obsidian-vault
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: a5475109344aec0705426f33006e04cce471d96312dfd3df743c910a303d68be
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:18Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/registry/named/mattpocock/productivity.md
+++ b/registry/named/mattpocock/productivity.md
@@ -16,6 +16,22 @@ suiteComponents:
 - mattpocock/grill-me
 - mattpocock/handoff
 - mattpocock/write-a-skill
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 8e95ca6e88ff9b1d549b68af2ca8a93a53a1998a78d3de0bad4b329bdda860e8
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:18Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/registry/named/mattpocock/prototype.md
+++ b/registry/named/mattpocock/prototype.md
@@ -29,6 +29,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/engineering/prototype/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:18Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 6a0e60adeae1a369647cc2763775b8f808abdd217d3438c90b18896304da3a14
 ---
 
 ## Installation

--- a/registry/named/mattpocock/setup-matt-pocock-skills.md
+++ b/registry/named/mattpocock/setup-matt-pocock-skills.md
@@ -30,6 +30,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/engineering/setup-matt-pocock-skills/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:18Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 0b401098cd4ff24816ee416efbe60b3fd9f64590f4e65e822d21fd9e5038d84a
 ---
 
 ## Installation

--- a/registry/named/mattpocock/skills.md
+++ b/registry/named/mattpocock/skills.md
@@ -33,6 +33,22 @@ suiteComponents:
 - mattpocock/ubiquitous-language
 - mattpocock/write-a-skill
 - mattpocock/zoom-out
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 11fc6fb44298c99eebaad9c04de5334bd4a643ed72bf140d9f252f493b7e5184
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:18Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Installation

--- a/registry/named/mattpocock/to-issues.md
+++ b/registry/named/mattpocock/to-issues.md
@@ -44,6 +44,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/engineering/to-issues/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:18Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: f67cd6c0575631756de66dfe9073794164288dc38d922d6750ec3f9e3bf67002
 ---
 
 ## Overview

--- a/registry/named/mattpocock/to-prd.md
+++ b/registry/named/mattpocock/to-prd.md
@@ -39,6 +39,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/engineering/to-prd/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:18Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: e560b51c837148d4f7e4c5cf724261c219e496425f45c6f56262d828e7a8c73f
 ---
 
 ## Overview

--- a/registry/named/mattpocock/triage.md
+++ b/registry/named/mattpocock/triage.md
@@ -40,6 +40,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/engineering/triage/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:18Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 069837d2974cd1d37131c79ea042ec49dfdae8d3bb6c70a596f0fb4a8195e64b
 ---
 
 ## Overview

--- a/registry/named/mattpocock/ubiquitous-language.md
+++ b/registry/named/mattpocock/ubiquitous-language.md
@@ -39,6 +39,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/mattpocock/skills/blob/main/skills/engineering/ubiquitous-language/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:18Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 81a7d449adc5944348c5b9e623fb4887d1cbc181a59dce7d932526eedbed0811
 ---
 
 ## Overview

--- a/registry/named/mattpocock/write-a-skill.md
+++ b/registry/named/mattpocock/write-a-skill.md
@@ -28,6 +28,21 @@ timeline:
   action: rank_up
   contributor: unknown
   details: Origin status set to true.
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:18Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: b183da119865e57bcb36ecf0b580b07960f04cdb18337bea4893eaf7cb7422bf
 ---
 
 ## Overview

--- a/registry/named/mattpocock/zoom-out.md
+++ b/registry/named/mattpocock/zoom-out.md
@@ -5,22 +5,39 @@ contributor: mattpocock
 origin: true
 genericSkillRef: code-explain
 status: named
-title: "The Architecture Zoom-Out"
-title: "The Abstraction Lift"
+title: The Abstraction Lift
 catalogRef: mattpocock-zoom-out
-level: "2★"
-description: Signals the agent to ascend one layer of abstraction and produce a map of all relevant modules, callers, and domain-glossary terms in the unfamiliar code area, without explaining implementation details.
+level: 2★
+description: Signals the agent to ascend one layer of abstraction and produce a map
+  of all relevant modules, callers, and domain-glossary terms in the unfamiliar code
+  area, without explaining implementation details.
 links:
   github: https://github.com/mattpocock/skills/blob/main/skills/engineering/zoom-out/SKILL.md
 tags:
-  - code-navigation
-  - abstraction
-  - module-map
-  - domain-glossary
-  - codebase-orientation
-createdAt: "2026-04-30"
-updatedAt: "2026-04-30"
-suiteRef: "mattpocock/engineering"
+- code-navigation
+- abstraction
+- module-map
+- domain-glossary
+- codebase-orientation
+createdAt: '2026-04-30'
+updatedAt: '2026-04-30'
+suiteRef: mattpocock/engineering
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 2d68edb314be3bd508fa140c4d61b80f43a6b67f52ddb9dc2fe6e11a04f68661
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:18Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/registry/named/mbtiongson1/gaia-audit.md
+++ b/registry/named/mbtiongson1/gaia-audit.md
@@ -33,6 +33,9 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/mbtiongson1/gaia-skill-tree/blob/main/.agents/skills/gaia-audit/skill.md
     as C (trustNumber: 50.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:19Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 evidence:
 - class: C
   source: https://github.com/mbtiongson1/gaia-skill-tree/blob/main/.agents/skills/gaia-audit/skill.md
@@ -45,6 +48,18 @@ evidence:
   type: repo
   trustNumber: 50.0
   grade: C
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 6ff56148ec05d0010fb091a104fb3866d2682c41e32f16d0658fd80e43166418
 ---
 
 ## Overview

--- a/registry/named/mbtiongson1/gaia-bot-curate.md
+++ b/registry/named/mbtiongson1/gaia-bot-curate.md
@@ -27,6 +27,21 @@ timeline:
   action: demote
   contributor: unknown
   details: Calibrated level from 3★ to 2★
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:19Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 93670271b29108e5f207a99b701f761c80c5286b82007277a1196ec176e4295a
 ---
 
 ## Overview

--- a/registry/named/mbtiongson1/gaia-curate.md
+++ b/registry/named/mbtiongson1/gaia-curate.md
@@ -29,6 +29,21 @@ timeline:
   action: demote
   contributor: unknown
   details: Calibrated level from 4★ to 2★
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:19Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: e4fa74b913e879797820ddf34465c3106d1a1b48d7ebc598b3e73a7720691c30
 ---
 
 ## Overview

--- a/registry/named/mbtiongson1/gaia-curation-review.md
+++ b/registry/named/mbtiongson1/gaia-curation-review.md
@@ -36,6 +36,9 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/mbtiongson1/gaia-skill-tree/blob/main/.agents/skills/gaia-curation-review/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:19Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 evidence:
 - class: B
   source: https://github.com/mbtiongson1/gaia-skill-tree/blob/main/.agents/skills/gaia-curation-review/SKILL.md
@@ -46,6 +49,20 @@ evidence:
   type: repo
   trustNumber: 70.0
   grade: B
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: f682cbd19ddd24d961e8aca6f2e81fb5b6c0d4bffb026c5e7531ad48a82c3aaf
+verification:
+  firstEvidenceAt: '2026-06-10T05:38:17Z'
 ---
 
 ## Overview

--- a/registry/named/mbtiongson1/gaia-docs-sync.md
+++ b/registry/named/mbtiongson1/gaia-docs-sync.md
@@ -23,6 +23,21 @@ timeline:
   action: add
   contributor: mbtiongson1
   details: Added named skill mbtiongson1/gaia-docs-sync
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:19Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 7a95ed86539cce929d6511b828bfc5354cc3c28e73f4546d75def6e804e6ee38
 ---
 
 ## Overview

--- a/registry/named/mbtiongson1/gaia-draft-curate.md
+++ b/registry/named/mbtiongson1/gaia-draft-curate.md
@@ -27,6 +27,21 @@ timeline:
   action: demote
   contributor: unknown
   details: Calibrated level from 3★ to 2★
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:19Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 0e1c76dc30ca6b78d59294600915e1df6aa128c805a04a3c0dcbc0e38fa4f648
 ---
 
 ## Overview

--- a/registry/named/mbtiongson1/gaia-integrity.md
+++ b/registry/named/mbtiongson1/gaia-integrity.md
@@ -28,6 +28,21 @@ timeline:
   action: demote
   contributor: unknown
   details: Calibrated level from 3★ to 2★
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:19Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 1a156a1b396fce8db27f3a5c902a0884cf523f5cae5a2e68e5158089855c53a6
 ---
 
 ## Overview

--- a/registry/named/mbtiongson1/gaia-meta-audit.md
+++ b/registry/named/mbtiongson1/gaia-meta-audit.md
@@ -40,6 +40,9 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/mbtiongson1/gaia-skill-tree
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:19Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 evidence:
 - class: B
   source: https://github.com/mbtiongson1/gaia-skill-tree
@@ -51,6 +54,18 @@ evidence:
   type: repo
   trustNumber: 70.0
   grade: B
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: e99b3d80b1875e1d923666537f143f495100309d7cd7bea3c9a6a74e23d0f31f
 ---
 
 ## Overview

--- a/registry/named/mbtiongson1/gaia-preview.md
+++ b/registry/named/mbtiongson1/gaia-preview.md
@@ -32,6 +32,9 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/mbtiongson1/gaia-skill-tree/blob/main/.agents/skills/gaia-preview/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:19Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 evidence:
 - class: B
   source: https://github.com/mbtiongson1/gaia-skill-tree/blob/main/.agents/skills/gaia-preview/SKILL.md
@@ -42,6 +45,20 @@ evidence:
   type: repo
   trustNumber: 70.0
   grade: B
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 3a5d74bb37e0f4fad2bcae34b2209fb45472f4bd11f941075a5caab34c618eeb
+verification:
+  firstEvidenceAt: '2026-06-10T05:38:17Z'
 ---
 
 ## Overview

--- a/registry/named/mbtiongson1/gaia-triage.md
+++ b/registry/named/mbtiongson1/gaia-triage.md
@@ -23,6 +23,21 @@ timeline:
   action: add
   contributor: mbtiongson1
   details: Added named skill mbtiongson1/gaia-triage
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:19Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: de0e5a7594c733a202463b2197f827e360e33c1ef37412c2e0f21461489b8c7a
 ---
 
 ## Overview

--- a/registry/named/mbtiongson1/gaia-wiki-sync.md
+++ b/registry/named/mbtiongson1/gaia-wiki-sync.md
@@ -23,6 +23,21 @@ timeline:
   action: add
   contributor: mbtiongson1
   details: Added named skill mbtiongson1/gaia-wiki-sync
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:19Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 8fde1da7d147e87cd0f447f7995a4dba3ba92b2961c9221caf126afd3f3485d5
 ---
 
 ## Overview

--- a/registry/named/mbtiongson1/graphify-triage.md
+++ b/registry/named/mbtiongson1/graphify-triage.md
@@ -33,6 +33,9 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/mbtiongson1/gaia-skill-tree/blob/main/.agents/skills/graphify-triage/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:19Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 evidence:
 - class: B
   source: https://github.com/mbtiongson1/gaia-skill-tree/blob/main/.agents/skills/graphify-triage/SKILL.md
@@ -45,6 +48,18 @@ evidence:
   type: repo
   trustNumber: 70.0
   grade: B
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 1b81b72edb95f86db5b13cc1bb7b9240ecb27f57c25fbe8bcd023cfb2bab8385
 ---
 
 ## Overview

--- a/registry/named/nexu-io/open-design.md
+++ b/registry/named/nexu-io/open-design.md
@@ -38,6 +38,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/nexu-io/open-design as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:19Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: ac4206d4c2f7db2a2372b19ada0f7ad0c7fb0356776899eb695fa95ae8cf5e6d
 ---
 
 ## Overview

--- a/registry/named/nousresearch/feed-monitoring.md
+++ b/registry/named/nousresearch/feed-monitoring.md
@@ -41,6 +41,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/NousResearch/hermes-agent/blob/main/skills/research/blogwatcher/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:19Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 3a328514ffd4463161e2b1d853b2f1914d79bff82948e387989ccc846e21b279
 ---
 
 ## Overview

--- a/registry/named/obra/brainstorming.md
+++ b/registry/named/obra/brainstorming.md
@@ -37,6 +37,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/brainstorming/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:19Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 8bebae4b110070d8e7b64344b057dca63e306a620fd52a8b836bce7d1cb8b42f
 ---
 
 ## Overview

--- a/registry/named/obra/dispatching-parallel-agents.md
+++ b/registry/named/obra/dispatching-parallel-agents.md
@@ -37,6 +37,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/dispatching-parallel-agents/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:19Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: f2a45ff4a2a2a0040ca62adef73f53720130256f2b04d440711dbd1e6695844f
 ---
 
 ## Overview

--- a/registry/named/obra/executing-plans.md
+++ b/registry/named/obra/executing-plans.md
@@ -37,6 +37,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/executing-plans/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:19Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 3c6ef1b0016067d400e9236581ed80b6d334a95b8ab1afb57c1692c9a26ac5da
 ---
 
 ## Overview

--- a/registry/named/obra/finishing-a-development-branch.md
+++ b/registry/named/obra/finishing-a-development-branch.md
@@ -42,6 +42,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/finishing-a-development-branch/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:19Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 2d033d083f12c773cf4f16762939ecaba0e6ec5f8a6014d9c3eea1a59c66b3ec
 ---
 
 ## Overview

--- a/registry/named/obra/receiving-code-review.md
+++ b/registry/named/obra/receiving-code-review.md
@@ -38,6 +38,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/receiving-code-review/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:19Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 1e5b1bec8cc30c52fe9d1c8096457c5aaebdcc5de48eff84a18c2c6c3ed3b4b6
 ---
 
 ## Overview

--- a/registry/named/obra/requesting-code-review.md
+++ b/registry/named/obra/requesting-code-review.md
@@ -38,6 +38,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/requesting-code-review/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:19Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 60630571fd3658e36a4c7885ff7520dc56080a9a6166e136d6e41e072f182fdf
 ---
 
 ## Overview

--- a/registry/named/obra/subagent-driven-development.md
+++ b/registry/named/obra/subagent-driven-development.md
@@ -38,6 +38,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/subagent-driven-development/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:19Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: f7e77293b8bf52d41a681f9b445a664246acd2e7ed065976d54a48af29a46066
 ---
 
 ## Overview

--- a/registry/named/obra/superpowers.md
+++ b/registry/named/obra/superpowers.md
@@ -50,6 +50,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/obra/superpowers as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:19Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: cafa1991e6185004c11f6e0dc81600458ffc102a148f1d959a8e97e29bfd7976
 ---
 
 ## Overview

--- a/registry/named/obra/systematic-debugging.md
+++ b/registry/named/obra/systematic-debugging.md
@@ -42,6 +42,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/systematic-debugging/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:19Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 0c4c22fbd349ae69f160bcbdd6925b14b791b068ef163a1fc7e9e7b6e316a8b0
 ---
 
 ## Overview

--- a/registry/named/obra/using-git-worktrees.md
+++ b/registry/named/obra/using-git-worktrees.md
@@ -38,6 +38,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:19Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 2a31affb21edfd6d7fb3da6e4e55314e9514efdafe69e182d4120ad45ca07339
 ---
 
 ## Overview

--- a/registry/named/obra/verification-before-completion.md
+++ b/registry/named/obra/verification-before-completion.md
@@ -37,6 +37,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/verification-before-completion/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:19Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: ebee612b016560457e8ba4faf5f42d20db61731ca408ed89b38fc6caa00a0737
 ---
 
 ## Overview

--- a/registry/named/obra/writing-plans.md
+++ b/registry/named/obra/writing-plans.md
@@ -37,6 +37,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/obra/superpowers/blob/main/skills/writing-plans/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:19Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 743dabec12e20aabdde446ca709ec55b70bd7907d9f86ca1d154e5c2586b68c6
 ---
 
 ## Overview

--- a/registry/named/openai/few-shot-learning.md
+++ b/registry/named/openai/few-shot-learning.md
@@ -5,21 +5,38 @@ contributor: openai
 origin: true
 genericSkillRef: few-shot-learning
 status: named
-title: "The In-Context Learner"
+title: The In-Context Learner
 catalogRef: openai-few-shot-learning
-level: "2★"
-description: Conditions the model on a small set of examples within the prompt to adapt to new tasks without weight updates.
+level: 2★
+description: Conditions the model on a small set of examples within the prompt to
+  adapt to new tasks without weight updates.
 links:
   installable: false
   arxiv: https://arxiv.org/abs/2005.14165
 tags:
-  - few-shot
-  - icl
-  - prompt-engineering
-  - gpt-3
-  - unique
-createdAt: "2026-05-15"
-updatedAt: "2026-05-15"
+- few-shot
+- icl
+- prompt-engineering
+- gpt-3
+- unique
+createdAt: '2026-05-15'
+updatedAt: '2026-05-15'
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 55008cdf22ea7876abb446dbba090b867652ee56e608c9aecd6ee8908ef5c69a
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:19Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/registry/named/openai/self-consistency.md
+++ b/registry/named/openai/self-consistency.md
@@ -5,21 +5,38 @@ contributor: openai
 origin: false
 genericSkillRef: self-consistency
 status: named
-title: "The Majority Consensus"
+title: The Majority Consensus
 catalogRef: openai-self-consistency
-level: "2★"
-description: Samples multiple reasoning paths and selects the most consistent answer by majority vote.
+level: 2★
+description: Samples multiple reasoning paths and selects the most consistent answer
+  by majority vote.
 links:
   installable: false
   arxiv: https://arxiv.org/abs/2203.11171
 tags:
-  - self-consistency
-  - reasoning
-  - ensemble
-  - cot
-  - unique
-createdAt: "2026-05-15"
-updatedAt: "2026-05-15"
+- self-consistency
+- reasoning
+- ensemble
+- cot
+- unique
+createdAt: '2026-05-15'
+updatedAt: '2026-05-15'
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 140e60e64eb52479386604e5f0d20a6c86bafc335c6bfb9d89dfd4880b870c81
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:19Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/registry/named/pbakaus/impeccable.md
+++ b/registry/named/pbakaus/impeccable.md
@@ -38,6 +38,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/pbakaus/impeccable as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:19Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: b9fad4a425c6e9350b92311f83d47ec92297738932f1c24371d5f411fc0e0261
 ---
 
 ## Overview

--- a/registry/named/pexp13/sentiment-analysis.md
+++ b/registry/named/pexp13/sentiment-analysis.md
@@ -5,14 +5,31 @@ contributor: pexp13
 origin: true
 genericSkillRef: sentiment-analysis
 status: awakened
-level: "2★"
-description: >
-  Classifies the affective polarity (positive / negative / neutral, or fine-grained)
-  of user-generated text. Covers the full pipeline from raw noisy input through
-  preprocessing, inference, and output normalisation. Stack is intentionally
+level: 2★
+description: 'Classifies the affective polarity (positive / negative / neutral, or
+  fine-grained) of user-generated text. Covers the full pipeline from raw noisy input
+  through preprocessing, inference, and output normalisation. Stack is intentionally
   tool-agnostic — three implementation tracks are documented below.
-createdAt: "2026-05-17"
-updatedAt: "2026-05-17"
+
+  '
+createdAt: '2026-05-17'
+updatedAt: '2026-05-17'
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 41e3f2d64cb47eba1a1fc6f381dc9ac171580047df0d7528cbb03185361d77c7
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:19Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Implementation

--- a/registry/named/ruvnet/agentdb-advanced.md
+++ b/registry/named/ruvnet/agentdb-advanced.md
@@ -41,6 +41,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:20Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 289c9d43cef098d205dd36171a771d829dc1fe632490d0db9b180d79b470fc7d
 ---
 
 ## Overview

--- a/registry/named/ruvnet/agentdb-learning.md
+++ b/registry/named/ruvnet/agentdb-learning.md
@@ -25,6 +25,21 @@ timeline:
   action: demote
   contributor: unknown
   details: Calibrated level from 3★ to 1★
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:20Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 401dd746e5b57e408099ca79eb4a5156c0b4055aac4ea97cbc8f3f1aad5ccb39
 ---
 
 ## Overview

--- a/registry/named/ruvnet/agentdb-memory-patterns.md
+++ b/registry/named/ruvnet/agentdb-memory-patterns.md
@@ -36,6 +36,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:20Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 2e284b7bb9a55e73a86d5c89c71bf74af25beccc9683f0c98f55e4525a8d2fa2
 ---
 
 ## Overview

--- a/registry/named/ruvnet/agentdb-optimization.md
+++ b/registry/named/ruvnet/agentdb-optimization.md
@@ -36,6 +36,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:20Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 0d6592a871a39f55d8e04a32536460ee2fbd45f56046abcf4b0c676011e96939
 ---
 
 ## Overview

--- a/registry/named/ruvnet/agentdb-vector-search.md
+++ b/registry/named/ruvnet/agentdb-vector-search.md
@@ -37,6 +37,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:20Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 7828f934567afe6ee667b3966e3ca0c37e2ff77d4079a377a4d03c8863c1865c
 ---
 
 ## Overview

--- a/registry/named/ruvnet/agentdb.md
+++ b/registry/named/ruvnet/agentdb.md
@@ -44,6 +44,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:20Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 1d9fd98e4b2fb18e7e2b0bda1a01273d694aba5f7fe66cda5c5dea4078308c6a
 ---
 
 ## Overview

--- a/registry/named/ruvnet/agentic-jujutsu.md
+++ b/registry/named/ruvnet/agentic-jujutsu.md
@@ -37,6 +37,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:20Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 84e3631c9c0681fb2cf75f77b133dcadc3f45873bc7e45574384ef1b2edae1ce
 ---
 
 ## Overview

--- a/registry/named/ruvnet/browser.md
+++ b/registry/named/ruvnet/browser.md
@@ -5,21 +5,38 @@ contributor: ruvnet
 origin: false
 genericSkillRef: browser-automation
 status: named
-title: "The Web Navigator"
+title: The Web Navigator
 catalogRef: ruvnet-browser
-level: "2★"
-description: Playwright-based browser automation for web scraping, E2E testing, form interaction, and screenshot capture within agent workflows.
+level: 2★
+description: Playwright-based browser automation for web scraping, E2E testing, form
+  interaction, and screenshot capture within agent workflows.
 links:
   github: https://github.com/ruvnet/ruflo
 tags:
-  - browser
-  - playwright
-  - automation
-  - web-scraping
-  - e2e-testing
-createdAt: "2026-05-19"
-updatedAt: "2026-05-19"
-suiteRef: "ruvnet/ruflo"
+- browser
+- playwright
+- automation
+- web-scraping
+- e2e-testing
+createdAt: '2026-05-19'
+updatedAt: '2026-05-19'
+suiteRef: ruvnet/ruflo
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: e78f3eb47962063b20995ad16048ac9675287d2d459facfc24a50698534d9657
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:20Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/registry/named/ruvnet/dual-collect.md
+++ b/registry/named/ruvnet/dual-collect.md
@@ -37,6 +37,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:20Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 7b5951d02a17f93a36c6720d3ac577cb4dfe388684e0e5fe72470345d13263b1
 ---
 
 ## Overview

--- a/registry/named/ruvnet/dual-coordinate.md
+++ b/registry/named/ruvnet/dual-coordinate.md
@@ -37,6 +37,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:20Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: e651ae7f221eff7f8151f367fe49d14f1964f8b94aa93cb1ca4dceccf1ff3546
 ---
 
 ## Overview

--- a/registry/named/ruvnet/dual-mode.md
+++ b/registry/named/ruvnet/dual-mode.md
@@ -41,6 +41,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:20Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 3e2a68364b3bf4d478d1dc2b9d87ab56c1dac1cb4e0e77d8cb56c0dfe03bd422
 ---
 
 ## Overview

--- a/registry/named/ruvnet/dual-spawn.md
+++ b/registry/named/ruvnet/dual-spawn.md
@@ -37,6 +37,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:20Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 658763c4fb90c61ae2b21e451ec55a9462855dd662543613cbb60e4e5c59e02b
 ---
 
 ## Overview

--- a/registry/named/ruvnet/flow-nexus-neural.md
+++ b/registry/named/ruvnet/flow-nexus-neural.md
@@ -42,6 +42,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:20Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: aa274e11a7a142d771f83764421435cf7798c02c1b092bc90bf6b98f6368651c
 ---
 
 ## Overview

--- a/registry/named/ruvnet/flow-nexus-platform.md
+++ b/registry/named/ruvnet/flow-nexus-platform.md
@@ -42,6 +42,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:20Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 8bdce1863f8839c14b6d945ca3d414ce1336c5c4956b34add70f98612eb4bfb6
 ---
 
 ## Overview

--- a/registry/named/ruvnet/flow-nexus-swarm.md
+++ b/registry/named/ruvnet/flow-nexus-swarm.md
@@ -27,6 +27,21 @@ timeline:
   action: demote
   contributor: unknown
   details: Calibrated level from 3★ to 1★
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:20Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 2466370323eec4995a2023cf62013da85de7e9c072ed63c5f5c37ed8643ec100
 ---
 
 ## Overview

--- a/registry/named/ruvnet/flow-nexus.md
+++ b/registry/named/ruvnet/flow-nexus.md
@@ -42,6 +42,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:20Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: b893b11b88d20099e9a71bef7bf00f2ca25b93536492968bc9d940480cd8e75c
 ---
 
 ## Overview

--- a/registry/named/ruvnet/github-code-review.md
+++ b/registry/named/ruvnet/github-code-review.md
@@ -26,6 +26,21 @@ timeline:
   action: demote
   contributor: unknown
   details: Calibrated level from 3★ to 1★
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:20Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 86f530f9610eeabd8007d624c93b4ee8649b751526b2801b6c47a248bc5ab89c
 ---
 
 ## Overview

--- a/registry/named/ruvnet/github-multi-repo.md
+++ b/registry/named/ruvnet/github-multi-repo.md
@@ -37,6 +37,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:20Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: f96a48116b3c58e8f197b8537b239f0fbc3a82a688ddfcc8f01477db4ef88a47
 ---
 
 ## Overview

--- a/registry/named/ruvnet/github-project-management.md
+++ b/registry/named/ruvnet/github-project-management.md
@@ -6,21 +6,38 @@ origin: false
 role: variant
 genericSkillRef: project-management
 status: named
-title: "The Backlog Warden"
+title: The Backlog Warden
 catalogRef: ruvnet-github-project-management
-level: "2★"
-description: Manages GitHub Projects boards, milestones, issue tracking, and sprint planning through automated workflow integration.
+level: 2★
+description: Manages GitHub Projects boards, milestones, issue tracking, and sprint
+  planning through automated workflow integration.
 links:
   github: https://github.com/ruvnet/ruflo
 tags:
-  - github
-  - project-management
-  - issues
-  - milestones
-  - sprints
-createdAt: "2026-05-19"
-updatedAt: "2026-05-19"
-suiteRef: "ruvnet/github-suite"
+- github
+- project-management
+- issues
+- milestones
+- sprints
+createdAt: '2026-05-19'
+updatedAt: '2026-05-19'
+suiteRef: ruvnet/github-suite
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 85126e156e1297b4da5b2a545824357adc176003f63ce50344f5dd6c56dd3bb5
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:20Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/registry/named/ruvnet/github-release-management.md
+++ b/registry/named/ruvnet/github-release-management.md
@@ -27,6 +27,21 @@ timeline:
   action: demote
   contributor: unknown
   details: Calibrated level from 3★ to 1★
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:20Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 1c5886d0485ffd2f1ddc346d22c4701b8dc9f4751fa88a10e6c10749bf7d5b9e
 ---
 
 ## Overview

--- a/registry/named/ruvnet/github-suite.md
+++ b/registry/named/ruvnet/github-suite.md
@@ -43,6 +43,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:20Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 42d137afbe235dc0ae85e3c1b98d1aa733e630cf1d4e8726eeb6d2eebfb8b70a
 ---
 
 ## Overview

--- a/registry/named/ruvnet/github-workflow-automation.md
+++ b/registry/named/ruvnet/github-workflow-automation.md
@@ -26,6 +26,21 @@ timeline:
   action: demote
   contributor: unknown
   details: Calibrated level from 3★ to 1★
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:20Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 56ef67fd2744b41e908767f24d1c2e4986a4e0373fb1520d6eb0c095d2667276
 ---
 
 ## Overview

--- a/registry/named/ruvnet/hive-mind-coordination.md
+++ b/registry/named/ruvnet/hive-mind-coordination.md
@@ -48,7 +48,22 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:20Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 suiteRef: ruvnet/ruflo
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 3d807defe8b683e18bbdc8a8cfda69384322f84eef38f37f67924c7947094cd7
 ---
 
 ## Overview

--- a/registry/named/ruvnet/hooks-automation.md
+++ b/registry/named/ruvnet/hooks-automation.md
@@ -5,21 +5,38 @@ contributor: ruvnet
 origin: false
 genericSkillRef: workflow-automation
 status: named
-title: "The Event Weaver"
+title: The Event Weaver
 catalogRef: ruvnet-hooks-automation
-level: "2★"
-description: Designs agent lifecycle hooks and timer-based background tasks for automated quality gates and scheduled workflows.
+level: 2★
+description: Designs agent lifecycle hooks and timer-based background tasks for automated
+  quality gates and scheduled workflows.
 links:
   github: https://github.com/ruvnet/ruflo
 tags:
-  - hooks
-  - automation
-  - lifecycle
-  - background-workers
-  - quality-gates
-createdAt: "2026-05-19"
-updatedAt: "2026-05-19"
-suiteRef: "ruvnet/ruflo"
+- hooks
+- automation
+- lifecycle
+- background-workers
+- quality-gates
+createdAt: '2026-05-19'
+updatedAt: '2026-05-19'
+suiteRef: ruvnet/ruflo
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: cdd234b77192dd6ae2f24bea07f3cf202644fdecc3b03dc6768796bee9c6890c
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:20Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/registry/named/ruvnet/pair-programming.md
+++ b/registry/named/ruvnet/pair-programming.md
@@ -41,6 +41,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:20Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: cd0ee1abc6692112202d00b217acbba00ffd22fd5a68dcb7c2f1c5812185f70a
+verification:
+  firstEvidenceAt: '2026-06-10T05:38:18Z'
 ---
 
 ## Overview

--- a/registry/named/ruvnet/performance-analysis.md
+++ b/registry/named/ruvnet/performance-analysis.md
@@ -26,6 +26,21 @@ timeline:
   action: demote
   contributor: unknown
   details: Origin status removed. Transferred to addy-osmani/performance-optimization.
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:20Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 74ab6c2dd0ec35a59dc19cf1ca2a43e5cc6ca5b5761e322ddb85ba4ddaf3f100
 ---
 
 ## Overview

--- a/registry/named/ruvnet/reasoningbank-agentdb.md
+++ b/registry/named/ruvnet/reasoningbank-agentdb.md
@@ -3,22 +3,39 @@ id: ruvnet/reasoningbank-agentdb
 name: ReasoningBank AgentDB
 contributor: ruvnet
 origin: false
-genericSkillRef: "agent-memory-learning"
+genericSkillRef: agent-memory-learning
 status: named
-title: "The Knowledge Crystallizer"
+title: The Knowledge Crystallizer
 catalogRef: ruvnet-reasoningbank-agentdb
-level: "2★"
-description: Persists agent reasoning patterns in AgentDB vector memory and retrieves them semantically for continuous self-improvement across sessions.
+level: 2★
+description: Persists agent reasoning patterns in AgentDB vector memory and retrieves
+  them semantically for continuous self-improvement across sessions.
 links:
   github: https://github.com/ruvnet/ruflo
 tags:
-  - reasoning-persistence
-  - vector-memory
-  - agentdb
-  - self-improvement
-createdAt: "2026-05-19"
-updatedAt: "2026-05-19"
-suiteRef: "ruvnet/reasoningbank"
+- reasoning-persistence
+- vector-memory
+- agentdb
+- self-improvement
+createdAt: '2026-05-19'
+updatedAt: '2026-05-19'
+suiteRef: ruvnet/reasoningbank
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 13c4bacd8f4c6d457a87854d994a3607db129a5b8db4f980b49af15c2e5d5769
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:20Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/registry/named/ruvnet/reasoningbank-intelligence.md
+++ b/registry/named/ruvnet/reasoningbank-intelligence.md
@@ -40,6 +40,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:20Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: bbf9a8e5f2af46d70258cf07c08ee2891312f57a833aaff0eb465df5f138b0de
 ---
 
 ## Overview

--- a/registry/named/ruvnet/reasoningbank.md
+++ b/registry/named/ruvnet/reasoningbank.md
@@ -39,6 +39,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:20Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: f2f5d7a532ae38efd6f520b2fb610e2ea77d34e28e1f8e3b17d3fafa2a8f30dd
 ---
 
 ## Overview

--- a/registry/named/ruvnet/ruflo-v3.md
+++ b/registry/named/ruvnet/ruflo-v3.md
@@ -51,6 +51,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:20Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 9893a5d0b732d521d9fb151599d0bedcbcc493960631c9c406b38a1739225436
 ---
 
 ## Overview

--- a/registry/named/ruvnet/ruflo.md
+++ b/registry/named/ruvnet/ruflo.md
@@ -87,6 +87,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:20Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: b16f8d0f6a17e08434d7f18056a220edb0fd9539e94356467f5f6ec91469a395
 ---
 
 ## Overview

--- a/registry/named/ruvnet/skill-builder.md
+++ b/registry/named/ruvnet/skill-builder.md
@@ -5,21 +5,38 @@ contributor: ruvnet
 origin: false
 genericSkillRef: skill-authoring
 status: named
-title: "The Skill Forger"
+title: The Skill Forger
 catalogRef: ruvnet-skill-builder
-level: "2★"
-description: Guides creation of new Ruflo skills through templating, testing, and publishing workflows.
+level: 2★
+description: Guides creation of new Ruflo skills through templating, testing, and
+  publishing workflows.
 links:
   github: https://github.com/ruvnet/ruflo
 tags:
-  - skill-authoring
-  - templating
-  - publishing
-  - skill-development
-  - testing
-createdAt: "2026-05-19"
-updatedAt: "2026-05-19"
-suiteRef: "ruvnet/ruflo"
+- skill-authoring
+- templating
+- publishing
+- skill-development
+- testing
+createdAt: '2026-05-19'
+updatedAt: '2026-05-19'
+suiteRef: ruvnet/ruflo
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 0b52c83856300cbda3f04271753334f10b5080e8433875b265886df0dc619255
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:21Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/registry/named/ruvnet/sparc-methodology.md
+++ b/registry/named/ruvnet/sparc-methodology.md
@@ -26,6 +26,21 @@ timeline:
   action: demote
   contributor: unknown
   details: Calibrated level from 3★ to 1★
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:21Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: b4b6f65a22ab711473a31ee852f24f0123a56a60a01a072a53d79458f18f612a
 ---
 
 ## Overview

--- a/registry/named/ruvnet/stream-chain.md
+++ b/registry/named/ruvnet/stream-chain.md
@@ -37,6 +37,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:21Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 6830e91820fe2ef7acbe42d298da6f5cf64e95c8d7d853cda625165486d0b2a4
 ---
 
 ## Overview

--- a/registry/named/ruvnet/swarm-advanced.md
+++ b/registry/named/ruvnet/swarm-advanced.md
@@ -41,6 +41,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:21Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 0ed752ab0179b50c86c1c4fcdb26b063a33bf050478e564b8a41f4d0e592c64f
 ---
 
 ## Overview

--- a/registry/named/ruvnet/swarm-orchestration.md
+++ b/registry/named/ruvnet/swarm-orchestration.md
@@ -42,6 +42,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:21Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: f0b8a688bedd3bd788dec68460d174156b62c27fc648ec10f8eb98a702bdec74
 ---
 
 ## Overview

--- a/registry/named/ruvnet/v3-cli-modernization.md
+++ b/registry/named/ruvnet/v3-cli-modernization.md
@@ -37,6 +37,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:21Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 01f17bff602c4e84498997f3cc41c232e8c23326ef5a93a8fc2f9bf02c9f057b
 ---
 
 ## Overview

--- a/registry/named/ruvnet/v3-core-implementation.md
+++ b/registry/named/ruvnet/v3-core-implementation.md
@@ -37,6 +37,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:21Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 9c8fe7429e12253f730b4167fc3c37c9ee10db3f7ff1f79d966d21c169213bc2
 ---
 
 ## Overview

--- a/registry/named/ruvnet/v3-ddd-architecture.md
+++ b/registry/named/ruvnet/v3-ddd-architecture.md
@@ -42,6 +42,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:21Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 094889ea462aaa6aa32db5de9bfdc450369d28892f44164aec813202c1b4b27a
+verification:
+  firstEvidenceAt: '2026-06-10T05:38:18Z'
 ---
 
 ## Overview

--- a/registry/named/ruvnet/v3-integration-deep.md
+++ b/registry/named/ruvnet/v3-integration-deep.md
@@ -37,6 +37,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:21Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 1ac15dc4fd77f2b3e0de68473b96521727df904c5176713499c431ad655b7f38
 ---
 
 ## Overview

--- a/registry/named/ruvnet/v3-mcp-optimization.md
+++ b/registry/named/ruvnet/v3-mcp-optimization.md
@@ -6,21 +6,38 @@ origin: false
 role: variant
 genericSkillRef: mcp-integration
 status: named
-title: "The Protocol Tuner"
+title: The Protocol Tuner
 catalogRef: ruvnet-v3-mcp-optimization
-level: "2★"
-description: Optimizes Ruflo v3 MCP server performance through connection pooling, request batching, tool schema caching, and latency reduction strategies.
+level: 2★
+description: Optimizes Ruflo v3 MCP server performance through connection pooling,
+  request batching, tool schema caching, and latency reduction strategies.
 links:
   github: https://github.com/ruvnet/ruflo
 tags:
-  - mcp
-  - optimization
-  - connection-pooling
-  - caching
-  - v3-sprint
-createdAt: "2026-05-19"
-updatedAt: "2026-05-19"
-suiteRef: "ruvnet/ruflo-v3"
+- mcp
+- optimization
+- connection-pooling
+- caching
+- v3-sprint
+createdAt: '2026-05-19'
+updatedAt: '2026-05-19'
+suiteRef: ruvnet/ruflo-v3
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 655b97b924800adc92374bbf1da63189a0f4838e9cd28a984bd995c13d7d0267
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:21Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/registry/named/ruvnet/v3-memory-unification.md
+++ b/registry/named/ruvnet/v3-memory-unification.md
@@ -6,21 +6,38 @@ origin: false
 role: variant
 genericSkillRef: memory-manage
 status: named
-title: "The Memory Consolidator"
+title: The Memory Consolidator
 catalogRef: ruvnet-v3-memory-unification
-level: "2★"
-description: Unifies disparate Ruflo v3 memory subsystems (AgentDB, RVF, RAG memory) into a single coherent memory management layer.
+level: 2★
+description: Unifies disparate Ruflo v3 memory subsystems (AgentDB, RVF, RAG memory)
+  into a single coherent memory management layer.
 links:
   github: https://github.com/ruvnet/ruflo
 tags:
-  - memory-unification
-  - agentdb
-  - rvf
-  - rag-memory
-  - v3-sprint
-createdAt: "2026-05-19"
-updatedAt: "2026-05-19"
-suiteRef: "ruvnet/ruflo-v3"
+- memory-unification
+- agentdb
+- rvf
+- rag-memory
+- v3-sprint
+createdAt: '2026-05-19'
+updatedAt: '2026-05-19'
+suiteRef: ruvnet/ruflo-v3
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 150734ff43ea2c6ee818aa81987c34fbd2cc5dee97092a166c72a73fecd11ec7
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:21Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/registry/named/ruvnet/v3-performance-optimization.md
+++ b/registry/named/ruvnet/v3-performance-optimization.md
@@ -6,22 +6,39 @@ origin: false
 role: variant
 genericSkillRef: performance-tuning
 status: named
-title: "The Speed Sculptor"
+title: The Speed Sculptor
 catalogRef: ruvnet-v3-performance-optimization
-level: "2★"
-description: Profiles and optimizes Ruflo v3 platform performance across startup time, request latency, memory footprint, and throughput.
+level: 2★
+description: Profiles and optimizes Ruflo v3 platform performance across startup time,
+  request latency, memory footprint, and throughput.
 links:
   github: https://github.com/ruvnet/ruflo
 tags:
-  - performance
-  - profiling
-  - optimization
-  - latency
-  - throughput
-  - v3-sprint
-createdAt: "2026-05-19"
-updatedAt: "2026-05-19"
-suiteRef: "ruvnet/ruflo-v3"
+- performance
+- profiling
+- optimization
+- latency
+- throughput
+- v3-sprint
+createdAt: '2026-05-19'
+updatedAt: '2026-05-19'
+suiteRef: ruvnet/ruflo-v3
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 54fbface325ef8317ac15abe6860fbd216c17d47d2d12f5d53ee2d1fac558f22
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:21Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/registry/named/ruvnet/v3-security-overhaul.md
+++ b/registry/named/ruvnet/v3-security-overhaul.md
@@ -5,21 +5,38 @@ contributor: ruvnet
 origin: false
 genericSkillRef: security-audit
 status: named
-title: "The Security Sentinel"
+title: The Security Sentinel
 catalogRef: ruvnet-v3-security-overhaul
-level: "2★"
-description: "Comprehensive Ruflo v3 security overhaul: zero-trust federation, PII detection, mTLS/ed25519 authentication, and CVE scanning."
+level: 2★
+description: 'Comprehensive Ruflo v3 security overhaul: zero-trust federation, PII
+  detection, mTLS/ed25519 authentication, and CVE scanning.'
 links:
   github: https://github.com/ruvnet/ruflo
 tags:
-  - security
-  - zero-trust
-  - mtls
-  - pii-detection
-  - v3-sprint
-createdAt: "2026-05-19"
-updatedAt: "2026-05-19"
-suiteRef: "ruvnet/ruflo-v3"
+- security
+- zero-trust
+- mtls
+- pii-detection
+- v3-sprint
+createdAt: '2026-05-19'
+updatedAt: '2026-05-19'
+suiteRef: ruvnet/ruflo-v3
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 7e12f11fa1f1ac2caf4db573b3770dfb9840ff18e4dd8f22aaadf0aafc250546
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:21Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/registry/named/ruvnet/v3-swarm-coordination.md
+++ b/registry/named/ruvnet/v3-swarm-coordination.md
@@ -26,6 +26,21 @@ timeline:
   action: demote
   contributor: unknown
   details: Calibrated level from 3★ to 1★
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:21Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 1222251f5fac1c889088797ad9c9dc68a172ca605d03be8405078889f1725547
 ---
 
 ## Overview

--- a/registry/named/ruvnet/verification-quality.md
+++ b/registry/named/ruvnet/verification-quality.md
@@ -41,6 +41,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:21Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 8d6db844a06c7f63f568d505bc3446c22ec1fecf315df8bfa405ee4b6f44e4f5
+verification:
+  firstEvidenceAt: '2026-06-10T05:38:18Z'
 ---
 
 ## Overview

--- a/registry/named/ruvnet/worker-benchmarks.md
+++ b/registry/named/ruvnet/worker-benchmarks.md
@@ -5,21 +5,38 @@ contributor: ruvnet
 origin: false
 genericSkillRef: skill-performance-benchmarking
 status: named
-title: "The Performance Judge"
+title: The Performance Judge
 catalogRef: ruvnet-worker-benchmarks
-level: "2★"
-description: Benchmarks Ruflo background worker performance across latency, throughput, memory usage, and quality score dimensions.
+level: 2★
+description: Benchmarks Ruflo background worker performance across latency, throughput,
+  memory usage, and quality score dimensions.
 links:
   github: https://github.com/ruvnet/ruflo
 tags:
-  - benchmarking
-  - workers
-  - performance
-  - throughput
-  - quality-scoring
-createdAt: "2026-05-19"
-updatedAt: "2026-05-19"
-suiteRef: "ruvnet/ruflo"
+- benchmarking
+- workers
+- performance
+- throughput
+- quality-scoring
+createdAt: '2026-05-19'
+updatedAt: '2026-05-19'
+suiteRef: ruvnet/ruflo
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: a72e7525ce4b2141a2a0fe4e5262455f62766aced5fee196738bf80f3509142d
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:21Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/registry/named/ruvnet/worker-integration.md
+++ b/registry/named/ruvnet/worker-integration.md
@@ -37,6 +37,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/ruvnet/ruflo as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:21Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 52c011fc283222b7deaf6a629e0bf0301003ec3b2a57d3724324799d9f69818f
 ---
 
 ## Overview

--- a/registry/named/safishamsi/graphify.md
+++ b/registry/named/safishamsi/graphify.md
@@ -22,6 +22,21 @@ timeline:
   action: demote
   contributor: unknown
   details: Calibrated level from 3★ to 1★
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:21Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 82aa4345c52f1895c80cefd295461b4b9ce97c210857844029e92d39e3529262
 ---
 
 ## Overview

--- a/registry/named/santifer/career-ops.md
+++ b/registry/named/santifer/career-ops.md
@@ -33,6 +33,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/santifer/career-ops as B (trustNumber:
     70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:21Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 816b7b8f9272f509c3964429ecc13649d2a4f9d90c2ef5b3a1a90c46d5814d0e
 ---
 
 ## Overview

--- a/registry/named/sickn33/ai-dev-jobs-mcp.md
+++ b/registry/named/sickn33/ai-dev-jobs-mcp.md
@@ -9,6 +9,22 @@ level: 2★
 description: MCP tool for finding AI dev jobs.
 createdAt: '2026-05-22'
 updatedAt: '2026-06-10'
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 619997cf2c895cb2fce112ecfe33a83f4076e4b0f08c75cd6da01c2fad1d0722
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:21Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/registry/named/sickn33/mcp-builder.md
+++ b/registry/named/sickn33/mcp-builder.md
@@ -20,6 +20,21 @@ timeline:
   action: demote
   contributor: unknown
   details: 'No installable code available; marked installable: false.'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:21Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 25bed875fecdefdd35343a14046b32afc93f7292258b5b09b1c3e3d05ebdc97c
 ---
 
 ## Overview

--- a/registry/named/sickn33/n8n-mcp-tools-expert.md
+++ b/registry/named/sickn33/n8n-mcp-tools-expert.md
@@ -10,6 +10,22 @@ description: Expert at integrating n8n with MCP (Model Context Protocol). Build 
   workflows that expose MCP tools, or use MCP tools within n8n workflows.
 createdAt: '2026-05-22'
 updatedAt: '2026-06-10'
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 6bcc87a9e889f913888d3e054899ae59836cdadb37372b69f9e321fcbf5d59ff
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:21Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/registry/named/spring-ai/readme-generate.md
+++ b/registry/named/spring-ai/readme-generate.md
@@ -41,6 +41,23 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/spring-ai-alibaba/examples/blob/main/.claude/skills/readme-generate/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:21Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 4cf895d5a5f8779f9c1de5171cd00d3dc625a73f16f33f573d952cfa64f5030c
+verification:
+  firstEvidenceAt: '2026-06-10T05:38:19Z'
 ---
 
 ## Overview

--- a/registry/named/stanfordnlp/dspy.md
+++ b/registry/named/stanfordnlp/dspy.md
@@ -23,6 +23,21 @@ timeline:
   action: demote
   contributor: unknown
   details: Calibrated level from 3★ to 1★
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:21Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: e9cd537f39b5215dc5121b19ca2017995236c6ded320a1680389a13114c4edaa
 ---
 
 # DSPy

--- a/registry/named/upsonic/unittest-generator.md
+++ b/registry/named/upsonic/unittest-generator.md
@@ -5,20 +5,38 @@ contributor: upsonic
 origin: true
 genericSkillRef: generate-test
 status: named
-title: "The Test Weaver"
+title: The Test Weaver
 catalogRef: upsonic-unittest-generator
-level: "2★"
-description: Autonomous Claude agent that generates comprehensive unittest.TestCase suites from source code, organising tests into concept-based subfolders under a tests/ directory with proper imports, fixtures, and edge-case coverage.
+level: 2★
+description: Autonomous Claude agent that generates comprehensive unittest.TestCase
+  suites from source code, organising tests into concept-based subfolders under a
+  tests/ directory with proper imports, fixtures, and edge-case coverage.
 links:
   github: https://github.com/Upsonic/Upsonic
 tags:
-  - unit-testing
-  - unittest
-  - test-generation
-  - python
-  - autonomous-agent
-createdAt: "2026-04-30"
-updatedAt: "2026-04-30"
+- unit-testing
+- unittest
+- test-generation
+- python
+- autonomous-agent
+createdAt: '2026-04-30'
+updatedAt: '2026-04-30'
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 7f7489e8b6f6bf764848f67353bd9aa1a358de71cb9eb72e0ffbbe3f837ce1d1
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:21Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/registry/named/vercel/find-skills.md
+++ b/registry/named/vercel/find-skills.md
@@ -37,6 +37,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/vercel-labs/skills/blob/main/skills/find-skills/SKILL.md
     as B (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:21Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: ed2fea85251c76fa7de44219179ac06726c163f4775ff2821d1e12faa2c13082
 ---
 
 ## Overview

--- a/registry/named/xquik-dev/hermes-tweet.md
+++ b/registry/named/xquik-dev/hermes-tweet.md
@@ -37,6 +37,21 @@ timeline:
   contributor: unknown
   details: 'Re-graded evidence from https://github.com/Xquik-dev/hermes-tweet as B
     (trustNumber: 70.0)'
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:21Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 487dda9ad1b68b4569a83c8caaf6a10c465273d22fb4625ead283e7af75e6ab3
 ---
 
 ## Overview

--- a/registry/named/yonatangross/orchestkit-rag.md
+++ b/registry/named/yonatangross/orchestkit-rag.md
@@ -28,6 +28,21 @@ timeline:
   action: demote
   contributor: unknown
   details: Calibrated level from 3★ to 1★
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:21Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: 2528f786519fe409ae12e87863564d436fa87ed3d41549f4bd20c16eb9dd9cb1
 ---
 
 ## Overview

--- a/registry/named/yundu-ai/mcp-tool-developer.md
+++ b/registry/named/yundu-ai/mcp-tool-developer.md
@@ -10,6 +10,22 @@ description: Build Model Context Protocol (MCP) servers and tools from scratch. 
   MCP development with TypeScript/Python, testing, deployment, and registry publishing.
 createdAt: '2026-05-22'
 updatedAt: '2026-06-10'
+trustMagnitude: 0.0
+overallTrustGrade: ungraded
+apexGateStatus:
+  aGradedOriginsGte5: false
+  sourceTenureDaysGte180AorS: false
+  directNestedSuiteGte1: false
+  depth2OnlyReachableGte1: false
+  overallGradeS: false
+  apexPromotionPrSigned: false
+  crossOrgVerifier: null
+  systemWideCap: null
+trustMagnitudeInputHash: d3e1aabb80b299e289d6f18bc68c03ccd90dc2a0b89622d55d6a4d74386cc9b8
+timeline:
+- action: migrate_trust_magnitude
+  timestamp: '2026-06-18T11:27:21Z'
+  details: TM None -> 0.0, grade ungraded -> ungraded (direct edit -- CLI gap)
 ---
 
 ## Overview

--- a/scripts/collectStampReportData.py
+++ b/scripts/collectStampReportData.py
@@ -1,0 +1,103 @@
+"""One-off: recompute stats from current state for the stamp report.
+
+Reads each migrated frontmatter, recomputes TM/grade/gate from the (already
+clean) evidence, and emits a fresh summary covering every skill — without
+writing files. Used to populate JUN_2026_TRUST_REGRADE.md.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "src"))
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from migrateTrustMagnitude import (  # noqa: E402
+    NAMED_DIR, NODES_DIR, OUT_DIR,
+    buildGenericSkillMap, hasMissingSourceStartedAt, loadNamedSkill,
+)
+from gaia_cli.trustMagnitude import (  # noqa: E402
+    computeOverallTrustGradeFromSkill,
+    computeTrustMagnitude,
+    passesApexGate,
+)
+
+
+def main() -> int:
+    genericSkillMap = buildGenericSkillMap(NODES_DIR)
+    paths = sorted(NAMED_DIR.rglob("*.md"))
+
+    stats: dict = {
+        "totalFiles": len(paths),
+        "tmDeltas": [],
+        "gradeTransitions": {},
+        "phantomRemovals": [],  # Already applied; cannot recover
+        "provisionalSkills": [],
+        "apexGateInspected": {},
+        "perSkill": [],
+    }
+
+    for p in paths:
+        fm, _ = loadNamedSkill(p)
+        if fm is None:
+            continue
+        sid = fm.get("id") or p.stem
+        relPath = p.relative_to(REPO_ROOT).as_posix()
+
+        # Stamped values (post-migration current state)
+        tm = fm.get("trustMagnitude")
+        grade = fm.get("overallTrustGrade") or "ungraded"
+        gate = fm.get("apexGateStatus") or {}
+        provisional = bool(fm.get("provisional", False))
+
+        # Pre-migration legacy: skills previously had no trustMagnitude/grade
+        # so transition is ungraded -> grade
+        oldTm = None
+        oldGrade = "ungraded"
+
+        delta = (tm - 0) if isinstance(tm, (int, float)) else None
+        stats["tmDeltas"].append({
+            "skillId": sid,
+            "path": relPath,
+            "oldTm": oldTm,
+            "newTm": tm,
+            "delta": delta,
+        })
+        transition = f"{oldGrade} -> {grade}"
+        stats["gradeTransitions"][transition] = stats["gradeTransitions"].get(transition, 0) + 1
+        if provisional:
+            stats["provisionalSkills"].append({"skillId": sid, "path": relPath})
+
+        if sid in {"mattpocock/skills", "ruvnet/ruflo"}:
+            isApex = all(v is True for v in gate.values() if v is not None)
+            stats["apexGateInspected"][sid] = {
+                "tm": tm,
+                "grade": grade,
+                "gate": gate,
+                "isApex": isApex,
+            }
+
+        stats["perSkill"].append({
+            "skillId": sid,
+            "tm": tm,
+            "grade": grade,
+            "provisional": provisional,
+        })
+
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    outPath = OUT_DIR / "stamp_report_data.json"
+    outPath.write_text(json.dumps(stats, indent=2), encoding="utf-8")
+    print(f"Wrote {outPath.relative_to(REPO_ROOT)}")
+    print(f"Total: {stats['totalFiles']}")
+    print(f"Grade transitions: {stats['gradeTransitions']}")
+    print(f"Provisional: {len(stats['provisionalSkills'])}")
+    print(f"Apex inspected: {list(stats['apexGateInspected'].keys())}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/migrateTrustMagnitude.py
+++ b/scripts/migrateTrustMagnitude.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""I3 — big-bang Trust Magnitude regrade migration.
+
+For each named skill .md:
+  1. Strip phantom (anti-auto-mint) rows.
+  2. Compute trustMagnitude.
+  3. Compute overallTrustGrade.
+  4. Compute apexGateStatus (per-predicate).
+  5. Mark provisional if any A/S row lacks sourceStartedAt.
+  6. Stamp verification.firstEvidenceAt from earliest evidence_added timeline event
+     if missing.
+  7. Append a migrate_trust_magnitude timeline event (CLI gap — direct edit).
+  8. Skip if input hash unchanged (idempotency).
+
+Writes generated-output/migration_summary.json with per-skill stats.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# Make repo root and src/ importable. trustMagnitude imports `gaia_cli.evidence`
+# directly, so we need src/ on sys.path (not just repo root).
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from gaia_cli.trustMagnitude import (  # noqa: E402
+    computeOverallTrustGradeFromSkill,
+    computeTrustMagnitude,
+    enforceAntiAutoMint,
+    passesApexGate,
+)
+
+NAMED_DIR = REPO_ROOT / "registry" / "named"
+NODES_DIR = REPO_ROOT / "registry" / "nodes"
+OUT_DIR = REPO_ROOT / "generated-output"
+SUMMARY_PATH = OUT_DIR / "migration_summary.json"
+
+FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n?(.*)$", re.DOTALL)
+
+
+def loadNamedSkill(path: Path) -> tuple[dict | None, str]:
+    text = path.read_text(encoding="utf-8")
+    m = FRONTMATTER_RE.match(text)
+    if not m:
+        return None, text
+    fm = yaml.safe_load(m.group(1)) or {}
+    return fm, m.group(2)
+
+
+def saveNamedSkill(path: Path, frontmatter: dict, body: str) -> None:
+    serialized = yaml.dump(frontmatter, allow_unicode=True, sort_keys=False)
+    path.write_text(f"---\n{serialized}---\n{body}", encoding="utf-8")
+
+
+def buildGenericSkillMap(nodesDir: Path) -> dict[str, dict]:
+    gmap: dict[str, dict] = {}
+    for p in nodesDir.rglob("*.json"):
+        try:
+            d = json.loads(p.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        sid = d.get("id")
+        if sid:
+            gmap[sid] = d
+    return gmap
+
+
+def computeInputHash(skill: dict) -> str:
+    """Stable hash of (skillId + sorted evidence row keys)."""
+    sid = skill.get("id") or ""
+    rows = []
+    for r in skill.get("evidence") or []:
+        if not isinstance(r, dict):
+            continue
+        url = r.get("url") or ""
+        evType = r.get("type") or ""
+        grade = r.get("grade") or ""
+        rows.append(f"{url}|{evType}|{grade}")
+    rows.sort()
+    payload = sid + "::" + "||".join(rows)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def hasMissingSourceStartedAt(skill: dict) -> bool:
+    """True if any A or S graded evidence row is missing sourceStartedAt."""
+    for r in skill.get("evidence") or []:
+        if not isinstance(r, dict):
+            continue
+        grade = (r.get("grade") or "").upper()
+        if grade in {"A", "S"} and not r.get("sourceStartedAt"):
+            return True
+    return False
+
+
+def firstEvidenceAddedTimestamp(skill: dict) -> str | None:
+    timeline = skill.get("timeline") or []
+    earliest: str | None = None
+    for ev in timeline:
+        if not isinstance(ev, dict):
+            continue
+        if ev.get("action") == "evidence_added":
+            ts = ev.get("timestamp")
+            if ts and (earliest is None or ts < earliest):
+                earliest = ts
+    return earliest
+
+
+def nowIso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def migrateSkill(
+    path: Path,
+    genericSkillMap: dict[str, dict],
+    stats: dict[str, Any],
+    dryRun: bool,
+) -> None:
+    fm, body = loadNamedSkill(path)
+    if fm is None:
+        print(f"  [skip] {path.relative_to(REPO_ROOT)} — no frontmatter")
+        return
+
+    skillId = fm.get("id") or path.stem
+    relPath = path.relative_to(REPO_ROOT).as_posix()
+
+    # Idempotency check
+    inputHash = computeInputHash(fm)
+    if fm.get("trustMagnitudeInputHash") == inputHash:
+        stats["skipped"] += 1
+        print(f"  [skip] {skillId} — hash unchanged")
+        return
+
+    # Snapshot before for delta tracking
+    oldTm = fm.get("trustMagnitude")
+    oldGrade = fm.get("overallTrustGrade") or "ungraded"
+
+    # Phantom-row removal — capture which rows would be stripped
+    originalEvidence = list(fm.get("evidence") or [])
+    cleanedEvidence = enforceAntiAutoMint(fm)
+    removed = []
+    cleanedKeys = {(r.get("url"), r.get("type")) for r in cleanedEvidence if isinstance(r, dict)}
+    for r in originalEvidence:
+        if not isinstance(r, dict):
+            continue
+        key = (r.get("url"), r.get("type"))
+        if key not in cleanedKeys:
+            removed.append({
+                "skillId": skillId,
+                "url": r.get("url"),
+                "type": r.get("type"),
+                "grade": r.get("grade"),
+            })
+    if removed:
+        # Strip phantom rows in-place
+        fm["evidence"] = cleanedEvidence
+        stats["phantomRemovals"].extend(removed)
+
+    # Compute new TM, grade, apex gate
+    tmRaw = computeTrustMagnitude(fm, genericSkillMap)
+    tm = round(float(tmRaw), 2) if tmRaw is not None else 0.0
+    grade = computeOverallTrustGradeFromSkill(fm, genericSkillMap) or "ungraded"
+    gateResult = passesApexGate(fm, {"genericSkillMap": genericSkillMap})
+
+    # Provisional check — A/S rows missing sourceStartedAt
+    provisional = hasMissingSourceStartedAt(fm)
+
+    # firstEvidenceAt backfill
+    verification = fm.get("verification") if isinstance(fm.get("verification"), dict) else {}
+    firstEvidenceAt = verification.get("firstEvidenceAt")
+    newlySetFirstEvidenceAt = False
+    if not firstEvidenceAt:
+        backfill = firstEvidenceAddedTimestamp(fm)
+        if backfill:
+            verification = dict(verification)
+            verification["firstEvidenceAt"] = backfill
+            newlySetFirstEvidenceAt = True
+
+    # Write back
+    fm["trustMagnitude"] = tm
+    fm["overallTrustGrade"] = grade
+    fm["apexGateStatus"] = gateResult
+    fm["trustMagnitudeInputHash"] = inputHash
+    if provisional:
+        fm["provisional"] = True
+    elif "provisional" in fm:
+        # Clear stale provisional flag if no longer applicable
+        del fm["provisional"]
+    if newlySetFirstEvidenceAt:
+        fm["verification"] = verification
+
+    # Append timeline event
+    timeline = fm.get("timeline")
+    if not isinstance(timeline, list):
+        timeline = []
+    timeline.append({
+        "action": "migrate_trust_magnitude",
+        "timestamp": nowIso(),
+        "details": (
+            f"TM {oldTm} -> {tm}, grade {oldGrade} -> {grade} "
+            "(direct edit -- CLI gap)"
+        ),
+    })
+    fm["timeline"] = timeline
+
+    # Stats
+    stats["processed"] += 1
+    stats["tmDeltas"].append({
+        "skillId": skillId,
+        "path": relPath,
+        "oldTm": oldTm,
+        "newTm": tm,
+        "delta": (tm - float(oldTm)) if isinstance(oldTm, (int, float)) else None,
+    })
+    transition = f"{oldGrade} -> {grade}"
+    stats["gradeTransitions"][transition] = stats["gradeTransitions"].get(transition, 0) + 1
+    if provisional:
+        stats["provisionalSkills"].append({"skillId": skillId, "path": relPath})
+
+    # Track apex gate status for known apex skills
+    if skillId in {"mattpocock/skills", "ruvnet/ruflo"}:
+        stats["apexGateInspected"][skillId] = {
+            "tm": tm,
+            "grade": grade,
+            "gate": gateResult,
+            "isApex": all(v is True for v in gateResult.values() if v is not None),
+        }
+
+    if dryRun:
+        print(f"  [dry] {skillId} TM {oldTm} -> {tm}, grade {oldGrade} -> {grade}")
+    else:
+        saveNamedSkill(path, fm, body)
+        print(f"  [ok]  {skillId} TM {oldTm} -> {tm}, grade {oldGrade} -> {grade}")
+
+
+def main(args: argparse.Namespace) -> int:
+    if not NAMED_DIR.exists():
+        print(f"ERROR: named dir not found: {NAMED_DIR}", file=sys.stderr)
+        return 2
+
+    print(f"Building genericSkillMap from {NODES_DIR}...")
+    genericSkillMap = buildGenericSkillMap(NODES_DIR)
+    print(f"  loaded {len(genericSkillMap)} generic skills")
+
+    paths = sorted(NAMED_DIR.rglob("*.md"))
+    print(f"Found {len(paths)} named skill files")
+
+    stats: dict[str, Any] = {
+        "startedAt": nowIso(),
+        "totalFiles": len(paths),
+        "processed": 0,
+        "skipped": 0,
+        "tmDeltas": [],
+        "gradeTransitions": {},
+        "phantomRemovals": [],
+        "provisionalSkills": [],
+        "apexGateInspected": {},
+        "dryRun": bool(args.dryRun),
+    }
+
+    for p in paths:
+        try:
+            migrateSkill(p, genericSkillMap, stats, args.dryRun)
+        except Exception as exc:
+            print(f"  [err] {p.relative_to(REPO_ROOT)}: {exc}", file=sys.stderr)
+            stats.setdefault("errors", []).append({
+                "path": p.relative_to(REPO_ROOT).as_posix(),
+                "error": str(exc),
+            })
+
+    stats["finishedAt"] = nowIso()
+
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    SUMMARY_PATH.write_text(json.dumps(stats, indent=2, sort_keys=False), encoding="utf-8")
+    print()
+    print(f"Summary: processed={stats['processed']} skipped={stats['skipped']} "
+          f"phantomRemovals={len(stats['phantomRemovals'])} "
+          f"provisional={len(stats['provisionalSkills'])}")
+    print(f"Summary written to {SUMMARY_PATH.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="I3 — big-bang Trust Magnitude regrade")
+    parser.add_argument("--dry-run", dest="dryRun", action="store_true",
+                        help="Compute fields but don't write files")
+    parsed = parser.parse_args()
+    sys.exit(main(parsed))


### PR DESCRIPTION
Closes #721.

## Summary

Phase 1.5 I3 — big-bang Trust Magnitude regrade.

- Migration script `scripts/migrateTrustMagnitude.py` — idempotent, runs over all 235 `registry/named/` skills
- Helper script `scripts/collectStampReportData.py` — recomputes per-skill stats from current state for the stamp report (no-op on data)
- Fields written per skill: `trustMagnitude`, `overallTrustGrade`, `apexGateStatus`, `trustMagnitudeInputHash`, `provisional` (when applicable)
- `migrate_trust_magnitude` timeline event appended per skill (CLI gap — direct edit, see CLAUDE.md)
- `registry/named-skills.json` regenerated via `scripts/generateNamedIndex.py`
- Stamp report at `docs/meta/JUN_2026_TRUST_REGRADE.md`

## Stats

- **Total skills processed:** 235
- **Phantom evidence rows removed:** 0 (legacy registry has no auto-mint shapes)
- **Provisional skills:** 0 at cutover (no A/S graded rows yet)
- **Grade distribution post-migration:** 235 × `ungraded` (no skill yet carries the new 10-type evidence taxonomy)
- **TM distribution post-migration:** 235 × `0.0`

### Apex demotions

Both pre-G7 6★ apex skills fail all 6 active predicates and are now **non-apex** under the I2 gate:

- `mattpocock/skills`: 0/6 active predicates pass — `isApex = false`
- `ruvnet/ruflo`: 0/6 active predicates pass — `isApex = false`

System-wide effective apex (6★) count: **2 → 0** at G7 cutover.
Re-application bar: all 6 active predicates must pass.

Note: the migration does **not** mutate `level` fields on these records — apex level demotion is I5's scope. What changes is the *effective* trust posture (`apexGateStatus.isApex`).

## Idempotency

Second run confirmed:

```
Summary: processed=0 skipped=235 phantomRemovals=0 provisional=0
```

`git diff --stat` empty after second run. The `trustMagnitudeInputHash` field guarantees re-runs only touch skills whose evidence has changed.

## Verification

- `pytest tests/test_trust_magnitude.py`: **56/56 pass**
- Other failures in the full suite (`test_install`, `test_path_command`, `test_named_skills`, `test_share`, `test_redaction`, `test_timelines`) are **pre-existing** Windows environmental issues (cp1252 encoding for Unicode glyphs, symlink permission requirements). Verified by running the same suite on `main` pre-migration: identical 27 failed / 945 passed / 57 errors profile.
- `mattpocock/skills` and `ruvnet/ruflo` `apexGateStatus` inspected and recorded in the stamp report.

## Critical constraints respected

- ❌ Did **not** touch `skill-trees/<username>/skill-tree.json`
- ❌ Did **not** change `level` fields (I5's job)
- ❌ Did **not** change `evidence[].grade` fields
- ❌ Did **not** modify any Hermes-managed file
- ✅ All trust-pipeline functions imported from `src.gaia_cli.trustMagnitude` (no re-implementation)

## Token spend

`2026-06-18 claude-opus-4-8-1m: ~70k in, ~12k out. ~$1.50`