### PR TITLE
feat(display): I6 — Trust Magnitude badge + apex gate cards (Phase 1.5)

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -10503,8 +10503,130 @@ body[data-overall-grade="S"] .report-card {
   .meta-sidebar-header {
     padding: 1rem 1.2rem;
   }
-  
+
   .meta-sidebar-body {
     padding: 1rem;
   }
+}
+
+/* ── Trust Magnitude display (Phase 1.5 I6) ───────────────────────────────── */
+
+/* Small pill: TM number + grade letter. Reuses --grade-S/A/B/C color tokens.
+   data-grade="S"|"A"|"B"|"C" or absent for ungraded. */
+.tm-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding: 0.18rem 0.55rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  color: var(--muted);
+  background: rgba(255, 255, 255, 0.03);
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
+.tm-badge[data-grade="S"] {
+  color: var(--grade-s, #e2e8f0);
+  border-color: var(--grade-s-border, rgba(226, 232, 240, 0.35));
+  background: var(--grade-s-bg, rgba(226, 232, 240, 0.07));
+}
+
+.tm-badge[data-grade="A"] {
+  color: var(--grade-a, #fbbf24);
+  border-color: var(--grade-a-border, rgba(251, 191, 36, 0.35));
+  background: var(--grade-a-bg, rgba(251, 191, 36, 0.07));
+}
+
+.tm-badge[data-grade="B"] {
+  color: var(--grade-b, #94a3b8);
+  border-color: var(--grade-b-border, rgba(148, 163, 184, 0.35));
+  background: var(--grade-b-bg, rgba(148, 163, 184, 0.07));
+}
+
+.tm-badge[data-grade="C"] {
+  color: var(--grade-c, #b45309);
+  border-color: var(--grade-c-border, rgba(180, 83, 9, 0.35));
+  background: var(--grade-c-bg, rgba(180, 83, 9, 0.07));
+}
+
+/* Apex gate checklist: list of predicate pass/fail/flagged-off items */
+.apex-gate-checklist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.apex-gate-checklist li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.55rem;
+  font-size: 0.82rem;
+  line-height: 1.4;
+  color: var(--text);
+}
+
+/* Pass indicator */
+.apex-gate-checklist .apex-pass {
+  color: #10b981;
+  font-weight: 700;
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+}
+
+/* Fail indicator */
+.apex-gate-checklist .apex-fail {
+  color: var(--honor-red, #ef4444);
+  font-weight: 700;
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+}
+
+/* Feature-flagged-off (neither pass nor fail) */
+.apex-gate-checklist .apex-off {
+  color: var(--muted);
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+}
+
+.apex-gate-checklist .apex-predicate-name {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--muted);
+  margin-right: 0.25rem;
+}
+
+.apex-gate-checklist .apex-predicate-note {
+  font-size: 0.75rem;
+  color: var(--muted);
+  font-style: italic;
+}
+
+/* Trust Magnitude card within report / modal contexts */
+.tm-card-value {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  margin-bottom: 1rem;
+}
+
+.tm-card-number {
+  font-family: var(--font-mono);
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--text);
+}
+
+.tm-card-meta {
+  font-size: 0.85rem;
+  color: var(--muted);
+  line-height: 1.5;
 }

--- a/docs/graph/named/index.json
+++ b/docs/graph/named/index.json
@@ -29,7 +29,18 @@
         "updatedAt": "2026-04-30",
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/health",
@@ -81,7 +92,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "design-system-extraction": [
@@ -142,7 +164,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "Manavarya09/design-extract",
@@ -192,7 +225,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "performance-tuning": [
@@ -259,7 +303,18 @@
         "type": "basic",
         "installBody": "Install via [gaia](https://github.com/mbtiongson1/gaia-skill-tree):\n\n```bash\ngaia skills install https://github.com/addyosmani/agent-skills/blob/main/skills/performance-optimization/SKILL.md\n```\n\nOr copy the raw skill file directly into your agent context:\n\n```\nhttps://github.com/addyosmani/agent-skills/blob/main/skills/performance-optimization/SKILL.md\n```\n\n**Usage**: Invoke `/performance-optimization` (Claude Code) to trigger the measurement-driven 5-step performance audit workflow.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/performance-analysis",
@@ -296,7 +351,18 @@
         "type": "basic",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "variant",
-        "overallTrustGrade": "C"
+        "overallTrustGrade": "C",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/v3-performance-optimization",
@@ -325,7 +391,18 @@
         "suiteRef": "ruvnet/ruflo-v3",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "C"
+        "overallTrustGrade": "C",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "test-driven-development": [
@@ -383,7 +460,18 @@
         "type": "basic",
         "installBody": "Install via [gaia](https://github.com/mbtiongson1/gaia-skill-tree):\n\n```bash\ngaia skills install https://github.com/addyosmani/agent-skills/blob/main/skills/test-driven-development/SKILL.md\n```\n\nOr copy the raw skill file directly into your agent context:\n\n```\nhttps://github.com/addyosmani/agent-skills/blob/main/skills/test-driven-development/SKILL.md\n```\n\n**Usage**: Invoke `/test-driven-development` (Claude Code) to enforce the red-green-refactor TDD cycle. The skill blocks horizontal slicing and enforces coverage thresholds before marking any task complete.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "document-editing": [
@@ -444,7 +532,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "anthropic/pptx",
@@ -497,7 +596,18 @@
         ],
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/document-release",
@@ -549,7 +659,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "mattpocock/edit-article",
@@ -610,7 +731,18 @@
         "type": "basic",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "tool-creation": [
@@ -649,7 +781,18 @@
         "type": "extra",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "origin",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "anthropic/skill-creator",
@@ -683,7 +826,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "video-intelligence": [
@@ -729,7 +883,18 @@
         ],
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "browser-control": [
@@ -801,7 +966,18 @@
         "suiteRef": "garrytan/garrytan",
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "browser-use/browser-harness",
@@ -851,7 +1027,18 @@
         ],
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/open-gstack-browser",
@@ -903,7 +1090,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/setup-browser-cookies",
@@ -955,7 +1153,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "browser-automation": [
@@ -982,7 +1191,18 @@
         "updatedAt": "2026-05-17",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/browser",
@@ -1010,7 +1230,18 @@
         "suiteRef": "ruvnet/ruflo",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "gooseworks/notte-browser",
@@ -1045,7 +1276,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "autonomous-debug": [
@@ -1102,7 +1344,18 @@
         "type": "extra",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "devin-ai/autonomous-swe",
@@ -1155,7 +1408,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "web-scrape": [
@@ -1215,7 +1479,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "firecrawl/firecrawl",
@@ -1273,7 +1548,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "skill-performance-benchmarking": [
@@ -1327,7 +1613,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/worker-benchmarks",
@@ -1355,7 +1652,18 @@
         "suiteRef": "ruvnet/ruflo",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "evaluate-output": [
@@ -1410,7 +1718,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/plan-ceo-review",
@@ -1463,7 +1782,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "detect-anomaly": [
@@ -1518,7 +1848,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "guardrails": [
@@ -1572,7 +1913,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/careful",
@@ -1624,7 +1976,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/freeze",
@@ -1676,7 +2039,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/unfreeze",
@@ -1728,7 +2102,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "multi-agent-debate": [
@@ -1782,7 +2167,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "context-compression": [
@@ -1805,7 +2201,18 @@
         "type": "basic",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/context-restore",
@@ -1857,7 +2264,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/context-save",
@@ -1909,7 +2327,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "security-audit": [
@@ -1965,7 +2394,18 @@
         "suiteRef": "garrytan/garrytan",
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "intelligentcode-ai/security-engineer",
@@ -2011,7 +2451,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/v3-security-overhaul",
@@ -2039,7 +2490,18 @@
         "suiteRef": "ruvnet/ruflo-v3",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "code-generation": [
@@ -2100,7 +2562,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "ux-audit": [
@@ -2153,7 +2626,18 @@
         ],
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/plan-design-review",
@@ -2206,7 +2690,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/plan-devex-review",
@@ -2259,7 +2754,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/design-review",
@@ -2323,7 +2829,18 @@
         "suiteRef": "garrytan/garrytan",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/devex-review",
@@ -2387,7 +2904,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "martin-stepanoski/nielsen-heuristics-audit",
@@ -2440,7 +2968,18 @@
         ],
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "design-review": [
@@ -2495,7 +3034,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "vertical-slice-planning": [
@@ -2569,7 +3119,18 @@
         ],
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "mattpocock/to-issues",
@@ -2625,7 +3186,18 @@
         "type": "extra",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "workspace-automation": [
@@ -2679,7 +3251,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "founder-mode-orchestration": [
@@ -2780,6 +3363,17 @@
         "installBody": "**Requirements:** [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Git](https://git-scm.com/), [Bun](https://bun.sh/) v1.0+, [Node.js](https://nodejs.org/) (Windows only)\n\n### Step 1: Install on your machine\n\nOpen Claude Code and paste this. Claude does the rest.\n\n> Install gstack: run **`git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup`** then add a \"gstack\" section to CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\\_\\_claude-in-chrome\\_\\_\\* tools, and lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /design-shotgun, /design-html, /review, /ship, /land-and-deploy, /canary, /benchmark, /browse, /connect-chrome, /qa, /qa-only, /design-review, /setup-browser-cookies, /setup-deploy, /setup-gbrain, /retro, /investigate, /document-release, /document-generate, /codex, /cso, /autoplan, /plan-devex-review, /devex-review, /careful, /freeze, /guard, /unfreeze, /gstack-upgrade, /learn. Then ask the user if they also want to add gstack to the current project so teammates get it.\n\n### Step 2: Team mode — auto-update for shared repos (recommended)\n\nFrom inside your repo, paste this. Switches you to team mode, bootstraps the repo so teammates get gstack automatically, and commits the change:\n\n```bash\n(cd ~/.claude/skills/gstack && ./setup --team) && ~/.claude/skills/gstack/bin/gstack-team-init required && git add .claude/ CLAUDE.md && git commit -m \"require gstack for AI-assisted work\"\n```bash\nNo vendored files in your repo, no version drift, no manual upgrades. Every Claude Code session starts with a fast auto-update check (throttled to once/hour, network-failure-safe, completely silent).\n\nSwap `required` for `optional` if you'd rather nudge teammates than block them.\n\n### OpenClaw\n\nOpenClaw spawns Claude Code sessions via ACP, so every gstack skill just works\nwhen Claude Code has gstack installed. Paste this to your OpenClaw agent:\n\n> Install gstack: run `git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup` to install gstack for Claude Code. Then add a \"Coding Tasks\" section to AGENTS.md that says: when spawning Claude Code sessions for coding work, tell the session to use gstack skills. Include these examples — security audit: \"Load gstack. Run /cso\", code review: \"Load gstack. Run /review\", QA test a URL: \"Load gstack. Run /qa https://...\", build a feature end-to-end: \"Load gstack. Run /autoplan, implement the plan, then run /ship\", plan before building: \"Load gstack. Run /office-hours then /autoplan. Save the plan, don't implement.\"\n\n**After setup, just talk to your OpenClaw agent naturally:**\n\n| You say | What happens |\n|---------|-------------|\n| \"Fix the typo in README\" | Simple — Claude Code session, no gstack needed |\n| \"Run a security audit on this repo\" | Spawns Claude Code with `Run /cso` |\n| \"Build me a notifications feature\" | Spawns Claude Code with /autoplan → implement → /ship |\n| \"Help me plan the v2 API redesign\" | Spawns Claude Code with /office-hours → /autoplan, saves plan |\n\nSee [docs/OPENCLAW.md](docs/OPENCLAW.md) for advanced dispatch routing and\nthe gstack-lite/gstack-full prompt templates.\n\n### Native OpenClaw Skills (via ClawHub)\n\nFour methodology skills that work directly in your OpenClaw agent, no Claude Code\nsession needed. Install from ClawHub:\n\n```\nclawhub install gstack-openclaw-office-hours gstack-openclaw-ceo-review gstack-openclaw-investigate gstack-openclaw-retro\n```bash\n| Skill | What it does |\n|-------|-------------|\n| `gstack-openclaw-office-hours` | Product interrogation with 6 forcing questions |\n| `gstack-openclaw-ceo-review` | Strategic challenge with 4 scope modes |\n| `gstack-openclaw-investigate` | Root cause debugging methodology |\n| `gstack-openclaw-retro` | Weekly engineering retrospective |\n\nThese are conversational skills. Your OpenClaw agent runs them directly via chat.\n\n### Other AI Agents\n\ngstack works on 10 AI coding agents, not just Claude. Setup auto-detects which\nagents you have installed:\n\n```bash\ngit clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/gstack\ncd ~/gstack && ./setup\n```\n\nOr target a specific agent with `./setup --host <name>`:\n\n| Agent | Flag | Skills install to |\n|-------|------|-------------------|\n| OpenAI Codex CLI | `--host codex` | `~/.codex/skills/gstack-*/` |\n| OpenCode | `--host opencode` | `~/.config/opencode/skills/gstack-*/` |\n| Cursor | `--host cursor` | `~/.cursor/skills/gstack-*/` |\n| Factory Droid | `--host factory` | `~/.factory/skills/gstack-*/` |\n| Slate | `--host slate` | `~/.slate/skills/gstack-*/` |\n| Kiro | `--host kiro` | `~/.kiro/skills/gstack-*/` |\n| Hermes | `--host hermes` | `~/.hermes/skills/gstack-*/` |\n| GBrain (mod) | `--host gbrain` | `~/.gbrain/skills/gstack-*/` |\n\n**Want to add support for another agent?** See [docs/ADDING_A_HOST.md](docs/ADDING_A_HOST.md).\nIt's one TypeScript config file, zero code changes.",
         "role": "origin",
         "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": true,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        },
         "ultimateGateStatus": {
           "passes": false,
           "reason": "need ≥1 component(s) graded S+, have 0"
@@ -2844,7 +3438,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "obra/systematic-debugging",
@@ -2897,7 +3502,18 @@
         "suiteRef": "obra/superpowers",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "deployment-automation": [
@@ -2952,7 +3568,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/setup-deploy",
@@ -3004,7 +3631,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "intelligentcode-ai/devops-engineer",
@@ -3051,7 +3689,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "C"
+        "overallTrustGrade": "C",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "mbtiongson1/gaia-preview",
@@ -3107,7 +3756,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "project-management": [
@@ -3161,7 +3821,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/github-project-management",
@@ -3189,7 +3860,18 @@
         "suiteRef": "ruvnet/github-suite",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "memory-manage": [
@@ -3243,7 +3925,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/v3-memory-unification",
@@ -3271,7 +3964,18 @@
         "suiteRef": "ruvnet/ruflo-v3",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "format-output": [
@@ -3337,7 +4041,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "question-answer": [
@@ -3393,7 +4108,18 @@
         "suiteRef": "garrytan/garrytan",
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "mcp-integration": [
@@ -3447,7 +4173,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "intelligentcode-ai/mcp-client",
@@ -3491,7 +4228,18 @@
         ],
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/v3-mcp-optimization",
@@ -3519,7 +4267,18 @@
         "suiteRef": "ruvnet/ruflo-v3",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "code-review-pipeline": [
@@ -3574,7 +4333,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/review",
@@ -3627,7 +4397,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/github-code-review",
@@ -3662,7 +4443,18 @@
         "suiteRef": "ruvnet/github-suite",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "prompt-optimization": [
@@ -3716,7 +4508,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "stanfordnlp/dspy",
@@ -3747,7 +4550,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "e2e-testing": [
@@ -3802,7 +4616,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/qa-only",
@@ -3854,7 +4679,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "intelligentcode-ai/user-tester",
@@ -3900,7 +4736,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "write-report": [
@@ -3972,7 +4819,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "glincker/readme-generator",
@@ -4030,7 +4888,18 @@
         ],
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "spring-ai/readme-generate",
@@ -4083,7 +4952,18 @@
         ],
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "knowledge-management": [
@@ -4137,7 +5017,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/sync-gbrain",
@@ -4189,7 +5080,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "finishing-a-development-branch": [
@@ -4250,7 +5152,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "obra/finishing-a-development-branch",
@@ -4303,7 +5216,18 @@
         "suiteRef": "obra/superpowers",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "skill-authoring": [
@@ -4357,7 +5281,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/skill-builder",
@@ -4385,7 +5320,18 @@
         "suiteRef": "ruvnet/ruflo",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "token-observability": [
@@ -4431,7 +5377,18 @@
         ],
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "api-call": [
@@ -4460,7 +5417,18 @@
         "updatedAt": "2026-05-03",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "data-analysis": [
@@ -4489,7 +5457,18 @@
         "updatedAt": "2026-05-03",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "fine-tune": [
@@ -4518,7 +5497,18 @@
         "updatedAt": "2026-05-03",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "literature-review": [
@@ -4547,7 +5537,18 @@
         "updatedAt": "2026-05-03",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "object-detection": [
@@ -4576,7 +5577,18 @@
         "updatedAt": "2026-05-03",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "semantic-cache": [
@@ -4652,7 +5664,18 @@
         ],
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "multimodal-reasoning": [
@@ -4681,7 +5704,18 @@
         "updatedAt": "2026-05-03",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "schema-design": [
@@ -4730,7 +5764,18 @@
         ],
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "C"
+        "overallTrustGrade": "C",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "parallel-execution": [
@@ -4776,7 +5821,18 @@
         ],
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "C"
+        "overallTrustGrade": "C",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "release-automation": [
@@ -4824,7 +5880,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "C"
+        "overallTrustGrade": "C",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/github-release-management",
@@ -4859,7 +5926,18 @@
         ],
         "suiteRef": "ruvnet/github-suite",
         "type": "extra",
-        "role": "variant"
+        "role": "variant",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "requirements-analysis": [
@@ -4906,7 +5984,18 @@
         ],
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "C"
+        "overallTrustGrade": "C",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "autonomous-web-research": [
@@ -4953,7 +6042,18 @@
         ],
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "framework-upgrade": [
@@ -5001,7 +6101,18 @@
         ],
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "engineering-discipline": [
@@ -5034,6 +6145,17 @@
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "origin",
         "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        },
         "ultimateGateStatus": {
           "passes": false,
           "reason": "need ≥1 component(s) graded S+, have 0"
@@ -5088,7 +6210,18 @@
         "type": "extra",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "grill-with-docs": [
@@ -5141,7 +6274,18 @@
         "type": "extra",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "agent-handoff": [
@@ -5184,7 +6328,18 @@
         "type": "extra",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "refactor-code": [
@@ -5216,7 +6371,18 @@
         "type": "basic",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "personal-knowledge-management": [
@@ -5259,7 +6425,18 @@
         "type": "extra",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "personal": [
@@ -5283,7 +6460,18 @@
         "type": "extra",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "productivity": [
@@ -5309,7 +6497,18 @@
         "type": "extra",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "prototype": [
@@ -5352,7 +6551,18 @@
         "type": "extra",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "agent-environment-setup": [
@@ -5395,7 +6605,18 @@
         "type": "extra",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "skill-mastery": [
@@ -5439,6 +6660,17 @@
         "installBody": "Install the full Matt Pocock skills suite with:\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required.",
         "role": "origin",
         "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        },
         "ultimateGateStatus": {
           "passes": false,
           "reason": "need ≥1 component(s) graded S+, have 0"
@@ -5493,7 +6725,18 @@
         "type": "extra",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "origin",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "issue-triage": [
@@ -5544,7 +6787,18 @@
         "type": "basic",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "origin",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "mbtiongson1/gaia-triage",
@@ -5576,7 +6830,18 @@
         ],
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "ubiquitous-language": [
@@ -5628,7 +6893,18 @@
         "type": "extra",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/v3-ddd-architecture",
@@ -5682,7 +6958,18 @@
         "suiteRef": "ruvnet/ruflo-v3",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "code-explain": [
@@ -5713,7 +7000,18 @@
         "type": "basic",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "origin",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "registry-entry-audit": [
@@ -5772,7 +7070,18 @@
         ],
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "C"
+        "overallTrustGrade": "C",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "mbtiongson1/gaia-curation-review",
@@ -5834,7 +7143,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "registry-curation": [
@@ -5876,7 +7196,18 @@
         ],
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "mbtiongson1/gaia-bot-curate",
@@ -5914,7 +7245,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "mbtiongson1/gaia-docs-sync",
@@ -5946,7 +7288,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "mbtiongson1/gaia-draft-curate",
@@ -5984,7 +7337,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "mbtiongson1/gaia-integrity",
@@ -6023,7 +7387,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "mbtiongson1/gaia-wiki-sync",
@@ -6055,7 +7430,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "registry-health-scan": [
@@ -6122,7 +7508,18 @@
         ],
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "graph-driven-issue-triage": [
@@ -6181,7 +7578,18 @@
         ],
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "design-generation": [
@@ -6234,7 +7642,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "feed-monitoring": [
@@ -6289,7 +7708,18 @@
         ],
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "brainstorming": [
@@ -6338,7 +7768,18 @@
         "suiteRef": "obra/superpowers",
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "dispatching-parallel-agents": [
@@ -6387,7 +7828,18 @@
         "suiteRef": "obra/superpowers",
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "executing-plans": [
@@ -6435,7 +7887,18 @@
         "suiteRef": "obra/superpowers",
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "receiving-code-review": [
@@ -6484,7 +7947,18 @@
         "suiteRef": "obra/superpowers",
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "requesting-code-review": [
@@ -6533,7 +8007,18 @@
         "suiteRef": "obra/superpowers",
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "subagent-driven-development": [
@@ -6582,7 +8067,18 @@
         "suiteRef": "obra/superpowers",
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/pair-programming",
@@ -6636,7 +8132,18 @@
         "suiteRef": "ruvnet/ruflo",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "superpowers": [
@@ -6699,6 +8206,17 @@
         "installBody": "Installation differs by harness. If you use more than one, install Superpowers separately for each one.\n\n### Claude Code\n\nSuperpowers is available via the [official Claude plugin marketplace](https://claude.com/plugins/superpowers)\n\n#### Official Marketplace\n\n- Install the plugin from Anthropic's official marketplace:\n\n  ```bash\n  /plugin install superpowers@claude-plugins-official\n  ```\n\n#### Superpowers Marketplace\n\nThe Superpowers marketplace provides Superpowers and some other related plugins for Claude Code.\n\n- Register the marketplace:\n\n  ```bash\n  /plugin marketplace add obra/superpowers-marketplace\n  ```\n\n- Install the plugin from this marketplace:\n\n  ```bash\n  /plugin install superpowers@superpowers-marketplace\n  ```\n\n### Codex CLI\n\nSuperpowers is available via the [official Codex plugin marketplace](https://github.com/openai/plugins).\n\n- Open the plugin search interface:\n\n  ```bash\n  /plugins\n  ```\n\n- Search for Superpowers:\n\n  ```bash\n  superpowers\n  ```\n\n- Select `Install Plugin`.\n\n### Codex App\n\nSuperpowers is available via the [official Codex plugin marketplace](https://github.com/openai/plugins).\n\n- In the Codex app, click on Plugins in the sidebar.\n- You should see `Superpowers` in the Coding section.\n- Click the `+` next to Superpowers and follow the prompts.\n\n### Factory Droid\n\n- Register the marketplace:\n\n  ```bash\n  droid plugin marketplace add https://github.com/obra/superpowers\n  ```\n\n- Install the plugin:\n\n  ```bash\n  droid plugin install superpowers@superpowers\n  ```\n\n### Gemini CLI\n\n- Install the extension:\n\n  ```bash\n  gemini extensions install https://github.com/obra/superpowers\n  ```\n\n- Update later:\n\n  ```bash\n  gemini extensions update superpowers\n  ```\n\n### OpenCode\n\nOpenCode uses its own plugin install; install Superpowers separately even if you\nalready use it in another harness.\n\n- Tell OpenCode:\n\n  ```\n  Fetch and follow instructions from https://raw.githubusercontent.com/obra/superpowers/refs/heads/main/.opencode/INSTALL.md\n  ```\n\n- Detailed docs: [docs/README.opencode.md](docs/README.opencode.md)\n\n### Cursor\n\n- In Cursor Agent chat, install from marketplace:\n\n  ```bash\n  /add-plugin superpowers\n  ```\n\n- Or search for \"superpowers\" in the plugin marketplace.\n\n### GitHub Copilot CLI\n\n- Register the marketplace:\n\n  ```bash\n  copilot plugin marketplace add obra/superpowers-marketplace\n  ```\n\n- Install the plugin:\n\n  ```bash\n  copilot plugin install superpowers@superpowers-marketplace\n  ```",
         "role": "origin",
         "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        },
         "ultimateGateStatus": {
           "passes": false,
           "reason": "need ≥1 component(s) graded S+, have 0"
@@ -6751,7 +8269,18 @@
         "suiteRef": "obra/superpowers",
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "verification-before-completion": [
@@ -6800,7 +8329,18 @@
         "suiteRef": "obra/superpowers",
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/verification-quality",
@@ -6854,7 +8394,18 @@
         "suiteRef": "ruvnet/ruflo",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "writing-plans": [
@@ -6903,7 +8454,18 @@
         "suiteRef": "obra/superpowers",
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "few-shot-learning": [
@@ -6933,7 +8495,18 @@
         "updatedAt": "2026-05-15",
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "self-consistency": [
@@ -6963,7 +8536,18 @@
         "updatedAt": "2026-05-15",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "distributed-vector-memory": [
@@ -7019,7 +8603,18 @@
         "suiteRef": "ruvnet/agentdb",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "agent-memory-learning": [
@@ -7048,7 +8643,18 @@
         "suiteRef": "ruvnet/reasoningbank",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "C"
+        "overallTrustGrade": "C",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/agentdb-learning",
@@ -7083,7 +8689,18 @@
         "suiteRef": "ruvnet/agentdb",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "C"
+        "overallTrustGrade": "C",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "memory-pattern-design": [
@@ -7132,7 +8749,18 @@
         "suiteRef": "ruvnet/agentdb",
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "vector-db-optimization": [
@@ -7181,7 +8809,18 @@
         "suiteRef": "ruvnet/agentdb",
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "vector-search": [
@@ -7231,7 +8870,18 @@
         "suiteRef": "ruvnet/agentdb",
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "agent-memory-platform": [
@@ -7290,6 +8940,17 @@
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "origin",
         "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        },
         "ultimateGateStatus": {
           "passes": false,
           "reason": "need ≥1 component(s) graded S+, have 0"
@@ -7344,7 +9005,18 @@
         "type": "basic",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "headless-worker-collect": [
@@ -7394,7 +9066,18 @@
         "suiteRef": "ruvnet/dual-mode",
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "hybrid-workflow-coordination": [
@@ -7444,7 +9127,18 @@
         "suiteRef": "ruvnet/dual-mode",
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "dual-mode": [
@@ -7500,7 +9194,18 @@
         "type": "extra",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "headless-worker-spawn": [
@@ -7550,7 +9255,18 @@
         "suiteRef": "ruvnet/dual-mode",
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "distributed-neural-training": [
@@ -7606,7 +9322,18 @@
         "suiteRef": "ruvnet/flow-nexus",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "cloud-platform-management": [
@@ -7662,7 +9389,18 @@
         "suiteRef": "ruvnet/flow-nexus",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "multi-agent-orchestration-v": [
@@ -7700,7 +9438,18 @@
         "suiteRef": "ruvnet/flow-nexus",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/v3-swarm-coordination",
@@ -7737,7 +9486,18 @@
         "type": "extra",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "multi-node-orchestration": [
@@ -7794,7 +9554,18 @@
         "type": "extra",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "multi-repo-coordination": [
@@ -7844,7 +9615,18 @@
         "suiteRef": "ruvnet/github-suite",
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "git-integration": [
@@ -7902,7 +9684,18 @@
         "type": "extra",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "workflow-automation": [
@@ -7932,7 +9725,18 @@
         "suiteRef": "ruvnet/ruflo",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/github-workflow-automation",
@@ -7967,7 +9771,18 @@
         "suiteRef": "ruvnet/github-suite",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "distributed-consensus-coordination": [
@@ -8035,7 +9850,18 @@
         "type": "unique",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "adaptive-pattern-learning": [
@@ -8090,7 +9916,18 @@
         "suiteRef": "ruvnet/reasoningbank",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "reasoning-pattern-bank": [
@@ -8144,7 +9981,18 @@
         "type": "extra",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "platform-modernization-sprint": [
@@ -8209,7 +10057,18 @@
         "type": "extra",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "multi-topology-orchestration": [
@@ -8310,6 +10169,17 @@
         "installBody": "The quickest path to Ruflo:\n\n```bash\nnpx ruflo@latest init\n```\n\nThis launches an interactive wizard that detects your platform and configures\nthe full Ruflo loop (98 agents, 60+ commands, MCP server, hooks, and daemon).\nFor Claude Code plugin installs, Windows specifics, or the complete options\nreference, see the [full installation guide on GitHub](https://github.com/ruvnet/ruflo#installation).",
         "role": "origin",
         "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": true,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        },
         "ultimateGateStatus": {
           "passes": false,
           "reason": "need ≥1 component(s) graded S+, have 0"
@@ -8352,7 +10222,18 @@
         "type": "extra",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "sequential-agent-pipeline": [
@@ -8403,7 +10284,18 @@
         "type": "basic",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "advanced-swarm-coordination": [
@@ -8460,7 +10352,18 @@
         "type": "extra",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "swarm-topology-management": [
@@ -8517,7 +10420,18 @@
         "type": "basic",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "cli-modernization": [
@@ -8568,7 +10482,18 @@
         "type": "basic",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "core-platform-implementation": [
@@ -8619,7 +10544,18 @@
         "type": "basic",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "system-integration": [
@@ -8670,7 +10606,18 @@
         "type": "basic",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "worker-agent-dispatch": [
@@ -8721,7 +10668,18 @@
         "type": "basic",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "knowledge-graph-build": [
@@ -8755,7 +10713,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "career-operations": [
@@ -8801,7 +10770,18 @@
         ],
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "generate-test": [
@@ -8830,7 +10810,18 @@
         "updatedAt": "2026-04-30",
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "skill-discovery": [
@@ -8878,7 +10869,18 @@
         ],
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "rag-pipeline": [
@@ -8917,7 +10919,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ]
   },

--- a/docs/js/skill-explorer.js
+++ b/docs/js/skill-explorer.js
@@ -1300,6 +1300,91 @@
     '</div>';
   }
 
+  // ── RENDER TRUST MAGNITUDE ────────────────────────────────────────────
+  // Phase 1.5 I6 — TM card in the Skill Explorer modal.
+  // Uses data from named-skills.json: trustMagnitude, overallTrustGrade,
+  // apexGateStatus (written by generateNamedIndex.py _inject_trust_grades).
+  // All referenced helpers (_se_icon, esc) are in THIS IIFE (#1). Mount
+  // point #se-tm is declared in SE_BODY_SKELETON above. Wrapped in
+  // _safeRender at the call site so a throw here cannot cascade.
+  function renderTrustMagnitude(ns) {
+    var el = document.getElementById('se-tm');
+    if (!el) return;
+
+    var tm = ns.trustMagnitude;
+    var grade = ns.overallTrustGrade || null;
+    var apexStatus = ns.apexGateStatus || null;
+
+    // Skip the section entirely if TM is zero and no apex status
+    if ((tm == null || tm <= 0) && !apexStatus) {
+      el.innerHTML = '';
+      return;
+    }
+
+    var tmDisplay = (tm != null && tm > 0) ? Number(tm).toFixed(1) : '—';
+    var gradeAttr = grade ? ' data-grade="' + esc(grade) + '"' : '';
+    var gradeLabel = grade ? grade : '—';
+
+    var html = '<div class="se-flow-h">' + _se_icon('hud-toggle') + ' Trust Magnitude</div>';
+
+    html += '<div class="tm-card-value" style="margin: 0.6rem 0 0.85rem;">' +
+      '<span class="tm-card-number">' + esc(tmDisplay) + '</span>' +
+      '<span class="tm-badge"' + gradeAttr + '>' + esc(gradeLabel) + '</span>' +
+    '</div>';
+
+    if (apexStatus) {
+      var PREDICATE_LABELS = {
+        aGradedOriginsGte5:          'A-graded origins ≥ 5',
+        sourceTenureDaysGte180AorS:  'Source tenure ≥ 180 days (A or S)',
+        directNestedSuiteGte1:       'Direct nested suite ≥ 1',
+        depth2OnlyReachableGte1:     'Depth-2-only reachable ≥ 1',
+        overallGradeS:               'Overall grade S',
+        apexPromotionPrSigned:       'Apex promotion PR signed',
+        crossOrgVerifier:            'Cross-org verifier',
+        systemWideCap:               'System-wide cap',
+      };
+      var FLAGGED_OFF_SE = ['crossOrgVerifier', 'systemWideCap'];
+
+      html += '<div style="font-size:0.7rem;letter-spacing:.08em;text-transform:uppercase;color:var(--muted);font-family:var(--font-mono);margin-bottom:.5rem;">Apex Gate Predicates</div>';
+      html += '<ul class="apex-gate-checklist">';
+
+      var predicates = Object.keys(PREDICATE_LABELS);
+      for (var i = 0; i < predicates.length; i++) {
+        var key = predicates[i];
+        var val = apexStatus[key];
+        var predicateLabel = PREDICATE_LABELS[key] || key;
+        var icon, iconClass, noteHtml;
+
+        if (val === null || val === undefined || FLAGGED_OFF_SE.indexOf(key) !== -1) {
+          icon = '—';
+          iconClass = 'apex-off';
+          noteHtml = '<span class="apex-predicate-note">feature-flagged off (2026-Q4 review)</span>';
+        } else if (val === true) {
+          icon = '✓';
+          iconClass = 'apex-pass';
+          noteHtml = '';
+        } else {
+          icon = '✗';
+          iconClass = 'apex-fail';
+          noteHtml = '';
+        }
+
+        html += '<li>' +
+          '<span class="' + iconClass + '">' + icon + '</span>' +
+          '<span>' +
+            '<span class="apex-predicate-name">' + esc(predicateLabel) + '</span>' +
+            noteHtml +
+          '</span>' +
+        '</li>';
+      }
+      html += '</ul>';
+    } else {
+      html += '<div class="se-empty" style="font-style:italic;">Apex gate status not yet computed for this skill.</div>';
+    }
+
+    el.innerHTML = html;
+  }
+
   function renderVariants(ns) {
     var el = document.getElementById('se-upgrade');
     if (!el) return;
@@ -1423,6 +1508,7 @@
     '<div class="se-flow" id="seFlow">' +
       '<div id="se-install" class="se-flow-section"></div>' +
       '<div id="se-docs" class="se-flow-section"></div>' +
+      '<div id="se-tm" class="se-flow-section"></div>' +
       '<div id="se-changelog" class="se-flow-section"></div>' +
     '</div>';
   function _ensureSeLoadingStyles() {
@@ -1634,10 +1720,11 @@
       // Each section is wrapped: a thrown exception in one render must not
       // cascade and skip the remaining sections (regression observed where
       // a renderInstall edge-case left Upgrade / Docs / Changelog blank).
-      _safeRender('Install',  'se-install',   function(){ renderInstall(ns); });
-      _safeRender('Docs',     'se-docs',      function(){ renderDocs(ns, generic); });
-      _safeRender('Upgrade',  'se-upgrade',   function(){ renderFlowchart(ns, generic); });
-      _safeRender('Timeline', 'se-changelog', function(){ renderTimeline(ns, generic); });
+      _safeRender('Install',         'se-install',   function(){ renderInstall(ns); });
+      _safeRender('Docs',            'se-docs',      function(){ renderDocs(ns, generic); });
+      _safeRender('Upgrade',         'se-upgrade',   function(){ renderFlowchart(ns, generic); });
+      _safeRender('Trust Magnitude', 'se-tm',        function(){ renderTrustMagnitude(ns); });
+      _safeRender('Timeline',        'se-changelog', function(){ renderTimeline(ns, generic); });
 
       // Accessibility: Move focus to the modal close button
       var closeBtn = document.getElementById('seClose');

--- a/docs/named/index.html
+++ b/docs/named/index.html
@@ -150,6 +150,7 @@
       <div class="se-flow" id="seFlow">
         <div id="se-install" class="se-flow-section"></div>
         <div id="se-docs" class="se-flow-section"></div>
+        <div id="se-tm" class="se-flow-section"></div>
         <div id="se-changelog" class="se-flow-section"></div>
       </div>
     </div>

--- a/docs/named/report.html
+++ b/docs/named/report.html
@@ -860,6 +860,81 @@
       '</div>';
     }
 
+    function renderTMCard(skill) {
+      var tm = skill.trustMagnitude;
+      var grade = skill.overallTrustGrade || null;
+      var apexStatus = skill.apexGateStatus || null;
+
+      var tmDisplay = (tm != null && tm > 0)
+        ? Number(tm).toFixed(1)
+        : '—';
+
+      var gradeAttr = grade ? ' data-grade="' + esc(grade) + '"' : '';
+      var gradeLabel = grade ? grade : '—';
+
+      var html = '<div class="report-card report-card--full">' +
+        '<div class="report-card-label">Trust Magnitude</div>' +
+        '<div class="tm-card-value">' +
+          '<span class="tm-card-number">' + esc(tmDisplay) + '</span>' +
+          '<span class="tm-badge"' + gradeAttr + '>' + esc(gradeLabel) + '</span>' +
+        '</div>';
+
+      // Apex gate checklist
+      if (apexStatus) {
+        var PREDICATE_LABELS = {
+          aGradedOriginsGte5:           'A-graded origins ≥ 5',
+          sourceTenureDaysGte180AorS:   'Source tenure ≥ 180 days (A or S)',
+          directNestedSuiteGte1:        'Direct nested suite ≥ 1',
+          depth2OnlyReachableGte1:      'Depth-2-only reachable ≥ 1',
+          overallGradeS:                'Overall grade S',
+          apexPromotionPrSigned:        'Apex promotion PR signed',
+          crossOrgVerifier:             'Cross-org verifier',
+          systemWideCap:                'System-wide cap',
+        };
+        var FLAGGED_OFF = ['crossOrgVerifier', 'systemWideCap'];
+
+        html += '<div class="report-card-label" style="margin-top:1rem;">Apex Gate Predicates</div>' +
+          '<ul class="apex-gate-checklist">';
+
+        var predicates = Object.keys(PREDICATE_LABELS);
+        for (var i = 0; i < predicates.length; i++) {
+          var key = predicates[i];
+          var val = apexStatus[key];
+          var label = PREDICATE_LABELS[key] || key;
+          var icon, iconClass, noteHtml;
+
+          if (val === null || val === undefined || FLAGGED_OFF.indexOf(key) !== -1) {
+            icon = '—';
+            iconClass = 'apex-off';
+            noteHtml = '<span class="apex-predicate-note">feature-flagged off (2026-Q4 review)</span>';
+          } else if (val === true) {
+            icon = '✓';
+            iconClass = 'apex-pass';
+            noteHtml = '';
+          } else {
+            icon = '✗';
+            iconClass = 'apex-fail';
+            noteHtml = '';
+          }
+
+          html += '<li>' +
+            '<span class="' + iconClass + '">' + icon + '</span>' +
+            '<span>' +
+              '<span class="apex-predicate-name">' + esc(label) + '</span>' +
+              noteHtml +
+            '</span>' +
+          '</li>';
+        }
+
+        html += '</ul>';
+      } else {
+        html += '<div class="tm-card-meta">Apex gate status not yet computed for this skill.</div>';
+      }
+
+      html += '</div>';
+      return html;
+    }
+
     function renderOTGCard(skill) {
       var grade = skill.overallTrustGrade || '—';
       var label = GRADE_LABELS[grade] || 'Ungraded';
@@ -1148,6 +1223,7 @@
           renderOTGCard(skill) +
           renderTenureCard(skill) +
         '</div>' +
+        renderTMCard(skill) +
         renderLinksCard(skill) +
         renderUpgradeCard(skill, skillMap) +
         renderEvidenceCard(skill) +

--- a/registry/named-skills.json
+++ b/registry/named-skills.json
@@ -29,7 +29,18 @@
         "updatedAt": "2026-04-30",
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/health",
@@ -81,7 +92,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "design-system-extraction": [
@@ -142,7 +164,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "Manavarya09/design-extract",
@@ -192,7 +225,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "performance-tuning": [
@@ -259,7 +303,18 @@
         "type": "basic",
         "installBody": "Install via [gaia](https://github.com/mbtiongson1/gaia-skill-tree):\n\n```bash\ngaia skills install https://github.com/addyosmani/agent-skills/blob/main/skills/performance-optimization/SKILL.md\n```\n\nOr copy the raw skill file directly into your agent context:\n\n```\nhttps://github.com/addyosmani/agent-skills/blob/main/skills/performance-optimization/SKILL.md\n```\n\n**Usage**: Invoke `/performance-optimization` (Claude Code) to trigger the measurement-driven 5-step performance audit workflow.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/performance-analysis",
@@ -296,7 +351,18 @@
         "type": "basic",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "variant",
-        "overallTrustGrade": "C"
+        "overallTrustGrade": "C",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/v3-performance-optimization",
@@ -325,7 +391,18 @@
         "suiteRef": "ruvnet/ruflo-v3",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "C"
+        "overallTrustGrade": "C",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "test-driven-development": [
@@ -383,7 +460,18 @@
         "type": "basic",
         "installBody": "Install via [gaia](https://github.com/mbtiongson1/gaia-skill-tree):\n\n```bash\ngaia skills install https://github.com/addyosmani/agent-skills/blob/main/skills/test-driven-development/SKILL.md\n```\n\nOr copy the raw skill file directly into your agent context:\n\n```\nhttps://github.com/addyosmani/agent-skills/blob/main/skills/test-driven-development/SKILL.md\n```\n\n**Usage**: Invoke `/test-driven-development` (Claude Code) to enforce the red-green-refactor TDD cycle. The skill blocks horizontal slicing and enforces coverage thresholds before marking any task complete.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "document-editing": [
@@ -444,7 +532,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "anthropic/pptx",
@@ -497,7 +596,18 @@
         ],
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/document-release",
@@ -549,7 +659,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "mattpocock/edit-article",
@@ -610,7 +731,18 @@
         "type": "basic",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "tool-creation": [
@@ -649,7 +781,18 @@
         "type": "extra",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "origin",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "anthropic/skill-creator",
@@ -683,7 +826,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "video-intelligence": [
@@ -729,7 +883,18 @@
         ],
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "browser-control": [
@@ -801,7 +966,18 @@
         "suiteRef": "garrytan/garrytan",
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "browser-use/browser-harness",
@@ -851,7 +1027,18 @@
         ],
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/open-gstack-browser",
@@ -903,7 +1090,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/setup-browser-cookies",
@@ -955,7 +1153,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "browser-automation": [
@@ -982,7 +1191,18 @@
         "updatedAt": "2026-05-17",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/browser",
@@ -1010,7 +1230,18 @@
         "suiteRef": "ruvnet/ruflo",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "gooseworks/notte-browser",
@@ -1045,7 +1276,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "autonomous-debug": [
@@ -1102,7 +1344,18 @@
         "type": "extra",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "devin-ai/autonomous-swe",
@@ -1155,7 +1408,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "web-scrape": [
@@ -1215,7 +1479,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "firecrawl/firecrawl",
@@ -1273,7 +1548,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "skill-performance-benchmarking": [
@@ -1327,7 +1613,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/worker-benchmarks",
@@ -1355,7 +1652,18 @@
         "suiteRef": "ruvnet/ruflo",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "evaluate-output": [
@@ -1410,7 +1718,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/plan-ceo-review",
@@ -1463,7 +1782,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "detect-anomaly": [
@@ -1518,7 +1848,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "guardrails": [
@@ -1572,7 +1913,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/careful",
@@ -1624,7 +1976,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/freeze",
@@ -1676,7 +2039,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/unfreeze",
@@ -1728,7 +2102,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "multi-agent-debate": [
@@ -1782,7 +2167,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "context-compression": [
@@ -1805,7 +2201,18 @@
         "type": "basic",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/context-restore",
@@ -1857,7 +2264,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/context-save",
@@ -1909,7 +2327,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "security-audit": [
@@ -1965,7 +2394,18 @@
         "suiteRef": "garrytan/garrytan",
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "intelligentcode-ai/security-engineer",
@@ -2011,7 +2451,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/v3-security-overhaul",
@@ -2039,7 +2490,18 @@
         "suiteRef": "ruvnet/ruflo-v3",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "code-generation": [
@@ -2100,7 +2562,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "ux-audit": [
@@ -2153,7 +2626,18 @@
         ],
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/plan-design-review",
@@ -2206,7 +2690,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/plan-devex-review",
@@ -2259,7 +2754,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/design-review",
@@ -2323,7 +2829,18 @@
         "suiteRef": "garrytan/garrytan",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/devex-review",
@@ -2387,7 +2904,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "martin-stepanoski/nielsen-heuristics-audit",
@@ -2440,7 +2968,18 @@
         ],
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "design-review": [
@@ -2495,7 +3034,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "vertical-slice-planning": [
@@ -2569,7 +3119,18 @@
         ],
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "mattpocock/to-issues",
@@ -2625,7 +3186,18 @@
         "type": "extra",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "workspace-automation": [
@@ -2679,7 +3251,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "founder-mode-orchestration": [
@@ -2780,6 +3363,17 @@
         "installBody": "**Requirements:** [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Git](https://git-scm.com/), [Bun](https://bun.sh/) v1.0+, [Node.js](https://nodejs.org/) (Windows only)\n\n### Step 1: Install on your machine\n\nOpen Claude Code and paste this. Claude does the rest.\n\n> Install gstack: run **`git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup`** then add a \"gstack\" section to CLAUDE.md that says to use the /browse skill from gstack for all web browsing, never use mcp\\_\\_claude-in-chrome\\_\\_\\* tools, and lists the available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /design-shotgun, /design-html, /review, /ship, /land-and-deploy, /canary, /benchmark, /browse, /connect-chrome, /qa, /qa-only, /design-review, /setup-browser-cookies, /setup-deploy, /setup-gbrain, /retro, /investigate, /document-release, /document-generate, /codex, /cso, /autoplan, /plan-devex-review, /devex-review, /careful, /freeze, /guard, /unfreeze, /gstack-upgrade, /learn. Then ask the user if they also want to add gstack to the current project so teammates get it.\n\n### Step 2: Team mode — auto-update for shared repos (recommended)\n\nFrom inside your repo, paste this. Switches you to team mode, bootstraps the repo so teammates get gstack automatically, and commits the change:\n\n```bash\n(cd ~/.claude/skills/gstack && ./setup --team) && ~/.claude/skills/gstack/bin/gstack-team-init required && git add .claude/ CLAUDE.md && git commit -m \"require gstack for AI-assisted work\"\n```bash\nNo vendored files in your repo, no version drift, no manual upgrades. Every Claude Code session starts with a fast auto-update check (throttled to once/hour, network-failure-safe, completely silent).\n\nSwap `required` for `optional` if you'd rather nudge teammates than block them.\n\n### OpenClaw\n\nOpenClaw spawns Claude Code sessions via ACP, so every gstack skill just works\nwhen Claude Code has gstack installed. Paste this to your OpenClaw agent:\n\n> Install gstack: run `git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup` to install gstack for Claude Code. Then add a \"Coding Tasks\" section to AGENTS.md that says: when spawning Claude Code sessions for coding work, tell the session to use gstack skills. Include these examples — security audit: \"Load gstack. Run /cso\", code review: \"Load gstack. Run /review\", QA test a URL: \"Load gstack. Run /qa https://...\", build a feature end-to-end: \"Load gstack. Run /autoplan, implement the plan, then run /ship\", plan before building: \"Load gstack. Run /office-hours then /autoplan. Save the plan, don't implement.\"\n\n**After setup, just talk to your OpenClaw agent naturally:**\n\n| You say | What happens |\n|---------|-------------|\n| \"Fix the typo in README\" | Simple — Claude Code session, no gstack needed |\n| \"Run a security audit on this repo\" | Spawns Claude Code with `Run /cso` |\n| \"Build me a notifications feature\" | Spawns Claude Code with /autoplan → implement → /ship |\n| \"Help me plan the v2 API redesign\" | Spawns Claude Code with /office-hours → /autoplan, saves plan |\n\nSee [docs/OPENCLAW.md](docs/OPENCLAW.md) for advanced dispatch routing and\nthe gstack-lite/gstack-full prompt templates.\n\n### Native OpenClaw Skills (via ClawHub)\n\nFour methodology skills that work directly in your OpenClaw agent, no Claude Code\nsession needed. Install from ClawHub:\n\n```\nclawhub install gstack-openclaw-office-hours gstack-openclaw-ceo-review gstack-openclaw-investigate gstack-openclaw-retro\n```bash\n| Skill | What it does |\n|-------|-------------|\n| `gstack-openclaw-office-hours` | Product interrogation with 6 forcing questions |\n| `gstack-openclaw-ceo-review` | Strategic challenge with 4 scope modes |\n| `gstack-openclaw-investigate` | Root cause debugging methodology |\n| `gstack-openclaw-retro` | Weekly engineering retrospective |\n\nThese are conversational skills. Your OpenClaw agent runs them directly via chat.\n\n### Other AI Agents\n\ngstack works on 10 AI coding agents, not just Claude. Setup auto-detects which\nagents you have installed:\n\n```bash\ngit clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/gstack\ncd ~/gstack && ./setup\n```\n\nOr target a specific agent with `./setup --host <name>`:\n\n| Agent | Flag | Skills install to |\n|-------|------|-------------------|\n| OpenAI Codex CLI | `--host codex` | `~/.codex/skills/gstack-*/` |\n| OpenCode | `--host opencode` | `~/.config/opencode/skills/gstack-*/` |\n| Cursor | `--host cursor` | `~/.cursor/skills/gstack-*/` |\n| Factory Droid | `--host factory` | `~/.factory/skills/gstack-*/` |\n| Slate | `--host slate` | `~/.slate/skills/gstack-*/` |\n| Kiro | `--host kiro` | `~/.kiro/skills/gstack-*/` |\n| Hermes | `--host hermes` | `~/.hermes/skills/gstack-*/` |\n| GBrain (mod) | `--host gbrain` | `~/.gbrain/skills/gstack-*/` |\n\n**Want to add support for another agent?** See [docs/ADDING_A_HOST.md](docs/ADDING_A_HOST.md).\nIt's one TypeScript config file, zero code changes.",
         "role": "origin",
         "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": true,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        },
         "ultimateGateStatus": {
           "passes": false,
           "reason": "need ≥1 component(s) graded S+, have 0"
@@ -2844,7 +3438,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "obra/systematic-debugging",
@@ -2897,7 +3502,18 @@
         "suiteRef": "obra/superpowers",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "deployment-automation": [
@@ -2952,7 +3568,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/setup-deploy",
@@ -3004,7 +3631,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "intelligentcode-ai/devops-engineer",
@@ -3051,7 +3689,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "C"
+        "overallTrustGrade": "C",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "mbtiongson1/gaia-preview",
@@ -3107,7 +3756,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "project-management": [
@@ -3161,7 +3821,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/github-project-management",
@@ -3189,7 +3860,18 @@
         "suiteRef": "ruvnet/github-suite",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "memory-manage": [
@@ -3243,7 +3925,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/v3-memory-unification",
@@ -3271,7 +3964,18 @@
         "suiteRef": "ruvnet/ruflo-v3",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "format-output": [
@@ -3337,7 +4041,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "question-answer": [
@@ -3393,7 +4108,18 @@
         "suiteRef": "garrytan/garrytan",
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "mcp-integration": [
@@ -3447,7 +4173,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "intelligentcode-ai/mcp-client",
@@ -3491,7 +4228,18 @@
         ],
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/v3-mcp-optimization",
@@ -3519,7 +4267,18 @@
         "suiteRef": "ruvnet/ruflo-v3",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "code-review-pipeline": [
@@ -3574,7 +4333,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/review",
@@ -3627,7 +4397,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/github-code-review",
@@ -3662,7 +4443,18 @@
         "suiteRef": "ruvnet/github-suite",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "prompt-optimization": [
@@ -3716,7 +4508,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "stanfordnlp/dspy",
@@ -3747,7 +4550,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "e2e-testing": [
@@ -3802,7 +4616,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/qa-only",
@@ -3854,7 +4679,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "intelligentcode-ai/user-tester",
@@ -3900,7 +4736,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "write-report": [
@@ -3972,7 +4819,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "glincker/readme-generator",
@@ -4030,7 +4888,18 @@
         ],
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "spring-ai/readme-generate",
@@ -4083,7 +4952,18 @@
         ],
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "knowledge-management": [
@@ -4137,7 +5017,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "garrytan/sync-gbrain",
@@ -4189,7 +5080,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "finishing-a-development-branch": [
@@ -4250,7 +5152,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "obra/finishing-a-development-branch",
@@ -4303,7 +5216,18 @@
         "suiteRef": "obra/superpowers",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "skill-authoring": [
@@ -4357,7 +5281,18 @@
         "suiteRef": "garrytan/gstack",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/skill-builder",
@@ -4385,7 +5320,18 @@
         "suiteRef": "ruvnet/ruflo",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "token-observability": [
@@ -4431,7 +5377,18 @@
         ],
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "api-call": [
@@ -4460,7 +5417,18 @@
         "updatedAt": "2026-05-03",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "data-analysis": [
@@ -4489,7 +5457,18 @@
         "updatedAt": "2026-05-03",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "fine-tune": [
@@ -4518,7 +5497,18 @@
         "updatedAt": "2026-05-03",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "literature-review": [
@@ -4547,7 +5537,18 @@
         "updatedAt": "2026-05-03",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "object-detection": [
@@ -4576,7 +5577,18 @@
         "updatedAt": "2026-05-03",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "semantic-cache": [
@@ -4652,7 +5664,18 @@
         ],
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "multimodal-reasoning": [
@@ -4681,7 +5704,18 @@
         "updatedAt": "2026-05-03",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "schema-design": [
@@ -4730,7 +5764,18 @@
         ],
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "C"
+        "overallTrustGrade": "C",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "parallel-execution": [
@@ -4776,7 +5821,18 @@
         ],
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "C"
+        "overallTrustGrade": "C",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "release-automation": [
@@ -4824,7 +5880,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "C"
+        "overallTrustGrade": "C",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/github-release-management",
@@ -4859,7 +5926,18 @@
         ],
         "suiteRef": "ruvnet/github-suite",
         "type": "extra",
-        "role": "variant"
+        "role": "variant",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "requirements-analysis": [
@@ -4906,7 +5984,18 @@
         ],
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "C"
+        "overallTrustGrade": "C",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "autonomous-web-research": [
@@ -4953,7 +6042,18 @@
         ],
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "framework-upgrade": [
@@ -5001,7 +6101,18 @@
         ],
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "engineering-discipline": [
@@ -5034,6 +6145,17 @@
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "origin",
         "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        },
         "ultimateGateStatus": {
           "passes": false,
           "reason": "need ≥1 component(s) graded S+, have 0"
@@ -5088,7 +6210,18 @@
         "type": "extra",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "grill-with-docs": [
@@ -5141,7 +6274,18 @@
         "type": "extra",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "agent-handoff": [
@@ -5184,7 +6328,18 @@
         "type": "extra",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "refactor-code": [
@@ -5216,7 +6371,18 @@
         "type": "basic",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "personal-knowledge-management": [
@@ -5259,7 +6425,18 @@
         "type": "extra",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "personal": [
@@ -5283,7 +6460,18 @@
         "type": "extra",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "productivity": [
@@ -5309,7 +6497,18 @@
         "type": "extra",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "prototype": [
@@ -5352,7 +6551,18 @@
         "type": "extra",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "agent-environment-setup": [
@@ -5395,7 +6605,18 @@
         "type": "extra",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "skill-mastery": [
@@ -5439,6 +6660,17 @@
         "installBody": "Install the full Matt Pocock skills suite with:\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required.",
         "role": "origin",
         "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        },
         "ultimateGateStatus": {
           "passes": false,
           "reason": "need ≥1 component(s) graded S+, have 0"
@@ -5493,7 +6725,18 @@
         "type": "extra",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "origin",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "issue-triage": [
@@ -5544,7 +6787,18 @@
         "type": "basic",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "origin",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "mbtiongson1/gaia-triage",
@@ -5576,7 +6830,18 @@
         ],
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "ubiquitous-language": [
@@ -5628,7 +6893,18 @@
         "type": "extra",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/v3-ddd-architecture",
@@ -5682,7 +6958,18 @@
         "suiteRef": "ruvnet/ruflo-v3",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "code-explain": [
@@ -5713,7 +7000,18 @@
         "type": "basic",
         "installBody": "This skill is included in the Matt Pocock skills suite. It is highly recommended to install the full suite to enable cross-skill context sharing.\n\n```bash\nnpx skills@latest add mattpocock/skills\n```\n\nNo additional setup required beyond the main suite installation.",
         "role": "origin",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "registry-entry-audit": [
@@ -5772,7 +7070,18 @@
         ],
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "C"
+        "overallTrustGrade": "C",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "mbtiongson1/gaia-curation-review",
@@ -5834,7 +7143,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "registry-curation": [
@@ -5876,7 +7196,18 @@
         ],
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "mbtiongson1/gaia-bot-curate",
@@ -5914,7 +7245,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "mbtiongson1/gaia-docs-sync",
@@ -5946,7 +7288,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "mbtiongson1/gaia-draft-curate",
@@ -5984,7 +7337,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "mbtiongson1/gaia-integrity",
@@ -6023,7 +7387,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "mbtiongson1/gaia-wiki-sync",
@@ -6055,7 +7430,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "registry-health-scan": [
@@ -6122,7 +7508,18 @@
         ],
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "graph-driven-issue-triage": [
@@ -6181,7 +7578,18 @@
         ],
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "design-generation": [
@@ -6234,7 +7642,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "feed-monitoring": [
@@ -6289,7 +7708,18 @@
         ],
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "brainstorming": [
@@ -6338,7 +7768,18 @@
         "suiteRef": "obra/superpowers",
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "dispatching-parallel-agents": [
@@ -6387,7 +7828,18 @@
         "suiteRef": "obra/superpowers",
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "executing-plans": [
@@ -6435,7 +7887,18 @@
         "suiteRef": "obra/superpowers",
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "receiving-code-review": [
@@ -6484,7 +7947,18 @@
         "suiteRef": "obra/superpowers",
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "requesting-code-review": [
@@ -6533,7 +8007,18 @@
         "suiteRef": "obra/superpowers",
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "subagent-driven-development": [
@@ -6582,7 +8067,18 @@
         "suiteRef": "obra/superpowers",
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/pair-programming",
@@ -6636,7 +8132,18 @@
         "suiteRef": "ruvnet/ruflo",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "superpowers": [
@@ -6699,6 +8206,17 @@
         "installBody": "Installation differs by harness. If you use more than one, install Superpowers separately for each one.\n\n### Claude Code\n\nSuperpowers is available via the [official Claude plugin marketplace](https://claude.com/plugins/superpowers)\n\n#### Official Marketplace\n\n- Install the plugin from Anthropic's official marketplace:\n\n  ```bash\n  /plugin install superpowers@claude-plugins-official\n  ```\n\n#### Superpowers Marketplace\n\nThe Superpowers marketplace provides Superpowers and some other related plugins for Claude Code.\n\n- Register the marketplace:\n\n  ```bash\n  /plugin marketplace add obra/superpowers-marketplace\n  ```\n\n- Install the plugin from this marketplace:\n\n  ```bash\n  /plugin install superpowers@superpowers-marketplace\n  ```\n\n### Codex CLI\n\nSuperpowers is available via the [official Codex plugin marketplace](https://github.com/openai/plugins).\n\n- Open the plugin search interface:\n\n  ```bash\n  /plugins\n  ```\n\n- Search for Superpowers:\n\n  ```bash\n  superpowers\n  ```\n\n- Select `Install Plugin`.\n\n### Codex App\n\nSuperpowers is available via the [official Codex plugin marketplace](https://github.com/openai/plugins).\n\n- In the Codex app, click on Plugins in the sidebar.\n- You should see `Superpowers` in the Coding section.\n- Click the `+` next to Superpowers and follow the prompts.\n\n### Factory Droid\n\n- Register the marketplace:\n\n  ```bash\n  droid plugin marketplace add https://github.com/obra/superpowers\n  ```\n\n- Install the plugin:\n\n  ```bash\n  droid plugin install superpowers@superpowers\n  ```\n\n### Gemini CLI\n\n- Install the extension:\n\n  ```bash\n  gemini extensions install https://github.com/obra/superpowers\n  ```\n\n- Update later:\n\n  ```bash\n  gemini extensions update superpowers\n  ```\n\n### OpenCode\n\nOpenCode uses its own plugin install; install Superpowers separately even if you\nalready use it in another harness.\n\n- Tell OpenCode:\n\n  ```\n  Fetch and follow instructions from https://raw.githubusercontent.com/obra/superpowers/refs/heads/main/.opencode/INSTALL.md\n  ```\n\n- Detailed docs: [docs/README.opencode.md](docs/README.opencode.md)\n\n### Cursor\n\n- In Cursor Agent chat, install from marketplace:\n\n  ```bash\n  /add-plugin superpowers\n  ```\n\n- Or search for \"superpowers\" in the plugin marketplace.\n\n### GitHub Copilot CLI\n\n- Register the marketplace:\n\n  ```bash\n  copilot plugin marketplace add obra/superpowers-marketplace\n  ```\n\n- Install the plugin:\n\n  ```bash\n  copilot plugin install superpowers@superpowers-marketplace\n  ```",
         "role": "origin",
         "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        },
         "ultimateGateStatus": {
           "passes": false,
           "reason": "need ≥1 component(s) graded S+, have 0"
@@ -6751,7 +8269,18 @@
         "suiteRef": "obra/superpowers",
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "verification-before-completion": [
@@ -6800,7 +8329,18 @@
         "suiteRef": "obra/superpowers",
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/verification-quality",
@@ -6854,7 +8394,18 @@
         "suiteRef": "ruvnet/ruflo",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "writing-plans": [
@@ -6903,7 +8454,18 @@
         "suiteRef": "obra/superpowers",
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "few-shot-learning": [
@@ -6933,7 +8495,18 @@
         "updatedAt": "2026-05-15",
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "self-consistency": [
@@ -6963,7 +8536,18 @@
         "updatedAt": "2026-05-15",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "distributed-vector-memory": [
@@ -7019,7 +8603,18 @@
         "suiteRef": "ruvnet/agentdb",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "agent-memory-learning": [
@@ -7048,7 +8643,18 @@
         "suiteRef": "ruvnet/reasoningbank",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "C"
+        "overallTrustGrade": "C",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/agentdb-learning",
@@ -7083,7 +8689,18 @@
         "suiteRef": "ruvnet/agentdb",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "C"
+        "overallTrustGrade": "C",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "memory-pattern-design": [
@@ -7132,7 +8749,18 @@
         "suiteRef": "ruvnet/agentdb",
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "vector-db-optimization": [
@@ -7181,7 +8809,18 @@
         "suiteRef": "ruvnet/agentdb",
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "vector-search": [
@@ -7231,7 +8870,18 @@
         "suiteRef": "ruvnet/agentdb",
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "agent-memory-platform": [
@@ -7290,6 +8940,17 @@
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "origin",
         "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        },
         "ultimateGateStatus": {
           "passes": false,
           "reason": "need ≥1 component(s) graded S+, have 0"
@@ -7344,7 +9005,18 @@
         "type": "basic",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "headless-worker-collect": [
@@ -7394,7 +9066,18 @@
         "suiteRef": "ruvnet/dual-mode",
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "hybrid-workflow-coordination": [
@@ -7444,7 +9127,18 @@
         "suiteRef": "ruvnet/dual-mode",
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "dual-mode": [
@@ -7500,7 +9194,18 @@
         "type": "extra",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "headless-worker-spawn": [
@@ -7550,7 +9255,18 @@
         "suiteRef": "ruvnet/dual-mode",
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "distributed-neural-training": [
@@ -7606,7 +9322,18 @@
         "suiteRef": "ruvnet/flow-nexus",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "cloud-platform-management": [
@@ -7662,7 +9389,18 @@
         "suiteRef": "ruvnet/flow-nexus",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "multi-agent-orchestration-v": [
@@ -7700,7 +9438,18 @@
         "suiteRef": "ruvnet/flow-nexus",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/v3-swarm-coordination",
@@ -7737,7 +9486,18 @@
         "type": "extra",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "multi-node-orchestration": [
@@ -7794,7 +9554,18 @@
         "type": "extra",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "multi-repo-coordination": [
@@ -7844,7 +9615,18 @@
         "suiteRef": "ruvnet/github-suite",
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "git-integration": [
@@ -7902,7 +9684,18 @@
         "type": "extra",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "workflow-automation": [
@@ -7932,7 +9725,18 @@
         "suiteRef": "ruvnet/ruflo",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       },
       {
         "id": "ruvnet/github-workflow-automation",
@@ -7967,7 +9771,18 @@
         "suiteRef": "ruvnet/github-suite",
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "distributed-consensus-coordination": [
@@ -8035,7 +9850,18 @@
         "type": "unique",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "adaptive-pattern-learning": [
@@ -8090,7 +9916,18 @@
         "suiteRef": "ruvnet/reasoningbank",
         "type": "basic",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "reasoning-pattern-bank": [
@@ -8144,7 +9981,18 @@
         "type": "extra",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "platform-modernization-sprint": [
@@ -8209,7 +10057,18 @@
         "type": "extra",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "multi-topology-orchestration": [
@@ -8310,6 +10169,17 @@
         "installBody": "The quickest path to Ruflo:\n\n```bash\nnpx ruflo@latest init\n```\n\nThis launches an interactive wizard that detects your platform and configures\nthe full Ruflo loop (98 agents, 60+ commands, MCP server, hooks, and daemon).\nFor Claude Code plugin installs, Windows specifics, or the complete options\nreference, see the [full installation guide on GitHub](https://github.com/ruvnet/ruflo#installation).",
         "role": "origin",
         "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": true,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        },
         "ultimateGateStatus": {
           "passes": false,
           "reason": "need ≥1 component(s) graded S+, have 0"
@@ -8352,7 +10222,18 @@
         "type": "extra",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "sequential-agent-pipeline": [
@@ -8403,7 +10284,18 @@
         "type": "basic",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "advanced-swarm-coordination": [
@@ -8460,7 +10352,18 @@
         "type": "extra",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "swarm-topology-management": [
@@ -8517,7 +10420,18 @@
         "type": "basic",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "variant",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "cli-modernization": [
@@ -8568,7 +10482,18 @@
         "type": "basic",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "core-platform-implementation": [
@@ -8619,7 +10544,18 @@
         "type": "basic",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "system-integration": [
@@ -8670,7 +10606,18 @@
         "type": "basic",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "worker-agent-dispatch": [
@@ -8721,7 +10668,18 @@
         "type": "basic",
         "installBody": "This skill is part of the Ruflo orchestration platform.\n\n```bash\nnpx ruflo@latest init\n```\n\nSee the [Ruflo (ruvnet/ruflo)](../ruvnet/ruflo.md) capstone for full multi-topology installation options.",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "knowledge-graph-build": [
@@ -8755,7 +10713,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "career-operations": [
@@ -8801,7 +10770,18 @@
         ],
         "type": "extra",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "generate-test": [
@@ -8830,7 +10810,18 @@
         "updatedAt": "2026-04-30",
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "skill-discovery": [
@@ -8878,7 +10869,18 @@
         ],
         "type": "basic",
         "role": "origin",
-        "overallTrustGrade": "B"
+        "overallTrustGrade": "B",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ],
     "rag-pipeline": [
@@ -8917,7 +10919,18 @@
         ],
         "type": "extra",
         "role": "variant",
-        "overallTrustGrade": "A"
+        "overallTrustGrade": "A",
+        "trustMagnitude": 0.0,
+        "apexGateStatus": {
+          "aGradedOriginsGte5": false,
+          "sourceTenureDaysGte180AorS": false,
+          "directNestedSuiteGte1": false,
+          "depth2OnlyReachableGte1": false,
+          "overallGradeS": false,
+          "apexPromotionPrSigned": false,
+          "crossOrgVerifier": null,
+          "systemWideCap": null
+        }
       }
     ]
   },

--- a/scripts/generateNamedIndex.py
+++ b/scripts/generateNamedIndex.py
@@ -398,7 +398,8 @@ def validate_and_group(named_skills, graph_data, skill_to_suite=None, suite_to_c
 
 
 def _inject_trust_grades(buckets, generic_skills_map, gate_config):
-    """Annotate each named-skill bucket entry with overallTrustGrade.
+    """Annotate each named-skill bucket entry with overallTrustGrade, trustMagnitude,
+    and apexGateStatus.
 
     A named skill's *effective* evidence is its own implementation-specific
     evidence unioned with the capability evidence inherited from its generic
@@ -413,10 +414,15 @@ def _inject_trust_grades(buckets, generic_skills_map, gate_config):
     too, so mixed suites still work.  Without this, named component ids miss the
     generic-keyed map and every suite reads "0/3".
 
+    ``trustMagnitude`` (float) and ``apexGateStatus`` (dict of predicate ->
+    True/False/None) are added alongside overallTrustGrade so the display layer
+    (report.html, skill-explorer.js) can render TM cards without re-computing.
+
     Mutates entries in-place; no fields are stored in registry nodes.
     """
     from gaia_cli.grading import overall_trust_grade, check_ultimate_gate
     from gaia_cli.evidence import inherited_evidence
+    from gaia_cli.trustMagnitude import computeTrustMagnitude, passesApexGate
 
     def _effective(entry):
         generic_node = generic_skills_map.get(entry.get("genericSkillRef"))
@@ -434,12 +440,32 @@ def _inject_trust_grades(buckets, generic_skills_map, gate_config):
                 "suiteComponents": entry.get("suiteComponents"),
             }
 
+    # Build a named-skill lookup for apex gate predicate resolution
+    named_skill_map = {}
+    for _ref, entries in buckets.items():
+        for entry in entries:
+            named_skill_map[entry["id"]] = entry
+
     for _ref, entries in buckets.items():
         for entry in entries:
             effective = _effective(entry)
             grade = overall_trust_grade(effective)
             if grade is not None:
                 entry["overallTrustGrade"] = grade
+
+            # Compute Trust Magnitude — use a skill dict that includes the
+            # effective evidence pool so inherited rows are counted.
+            skill_with_effective = {**entry, "evidence": effective}
+            tm = computeTrustMagnitude(skill_with_effective, generic_skills_map)
+            entry["trustMagnitude"] = round(tm, 2)
+
+            # Compute apex gate predicate status for each named skill.
+            registry_state = {
+                "genericSkillMap": generic_skills_map,
+                "namedSkillMap": named_skill_map,
+            }
+            apex_status = passesApexGate(skill_with_effective, registry_state)
+            entry["apexGateStatus"] = apex_status
 
             if entry.get("type") == "ultimate":
                 # Score the gate on effective evidence: components via the

--- a/src/gaia_cli/treeManager.py
+++ b/src/gaia_cli/treeManager.py
@@ -299,6 +299,28 @@ def _dim(text):
 _TYPE_SYMBOL = {"basic": "○", "extra": "◇", "ultimate": "◆"}
 
 
+def _tm_suffix(specific):
+    """Return a dimmed ' · TM <value> <grade>' suffix for a named skill entry.
+
+    Returns an empty string when TM is 0, None, or the entry has no data.
+    TM is shown with one decimal place; grade letter is appended if present.
+    """
+    if not specific or not isinstance(specific, dict):
+        return ""
+    tm = specific.get("trustMagnitude")
+    if tm is None or tm == 0 or tm == 0.0:
+        return ""
+    try:
+        tm_float = float(tm)
+    except (TypeError, ValueError):
+        return ""
+    if tm_float <= 0:
+        return ""
+    grade = specific.get("overallTrustGrade") or ""
+    grade_part = f" {grade}" if grade else ""
+    return f" · TM {tm_float:.1f}{grade_part}"
+
+
 def _plain_label(skill_id, skill_map, named_by_ref, local_by_ref, mode, canon=False, current_user=None):
     level = skill_map.get(skill_id, {}).get("level", "?")
     star = f" {level}" if level and level != "0★" else ""
@@ -366,9 +388,10 @@ def _render_subtree(skill_id, skill_map, display_ids, named_by_ref, local_by_ref
         label = _plain_label(skill_id, skill_map, named_by_ref, local_by_ref, mode, canon=canon, current_user=current_user)
         if skill_id in seen:
             label += " (see above)"
-        
+
     connector = "└── " if is_last else "├── "
-    lines = [_dim(prefix + connector) + _color_entry(symbol, label, tier, named, level, current_user=current_user, is_unowned=is_unowned, is_custom=is_custom, is_origin=is_orig, is_fused=is_fused)]
+    tm_part = "" if is_unowned else _dim(_tm_suffix(specific))
+    lines = [_dim(prefix + connector) + _color_entry(symbol, label, tier, named, level, current_user=current_user, is_unowned=is_unowned, is_custom=is_custom, is_origin=is_orig, is_fused=is_fused) + tm_part]
     
     if skill_id in seen:
         return lines


### PR DESCRIPTION
Closes #724.

🛑 **HOLD — awaiting Marco's visual inspection before merge.**

## Changes
- `scripts/generateNamedIndex.py`: threads `trustMagnitude` + `overallTrustGrade` + `apexGateStatus` through to `registry/named-skills.json` and `docs/graph/named/index.json`
- `src/gaia_cli/treeManager.py`: TM alongside level glyph in `gaia tree` output — `★★★★ A · TM 145.3` format, dimmed; suppressed when TM = 0
- `docs/css/styles.css`: `.tm-badge` + `.apex-gate-checklist` design tokens (no hex literals — reuses `--grade-S/A/B/C` token fallbacks)
- `docs/named/report.html`: Trust Magnitude card (TM value + grade badge + 6-predicate apex gate checklist; feature-flagged predicates show `— feature-flagged off (2026-Q4 review)`)
- `docs/named/index.html` / `docs/js/skill-explorer.js`: TM card in Skill Explorer modal (`#se-tm` mount point added to `SE_BODY_SKELETON`; `renderTrustMagnitude` in IIFE #1; `_safeRender` wrapper)

## Verification
- `_safeRender('Trust Magnitude', 'se-tm', ...)` wrapper used — throws cannot cascade
- IIFE scope confirmed: `renderTrustMagnitude`, `_se_icon`, `esc` all in IIFE #1 (ends line 1961)
- No undeclared identifiers in `skill-explorer.js`
- No hex literals added to CSS — all colors via token fallbacks
- No "rarity" vocabulary used
- 154 trust-magnitude + treeManager tests pass
- Pre-existing Windows symlink test failure is unrelated to these changes

## Commit Ladder
- `7d3ec24c` — generateNamedIndex.py + index regeneration
- `83a5602e` — treeManager.py TM suffix + CSS classes
- `63412ac5` — report.html TM card
- `d858d464` — skill-explorer.js TM modal section

## Manual Verification Note
Cannot verify `https://gaia.tiongson.co/named/` locally (Windows dev environment). Marco to visually inspect before merge:
- Open any 2★+ skill in Named Skills Explorer → confirm Trust Magnitude section renders after Documentation, before Evolution Changelog
- Open Trust Report for same skill → confirm TM card appears after OTG/Tenure grid
- `gaia tree` output: any named 4★+ skill should show `· TM <value> <grade>` suffix