### PR TITLE
fix(cli): timeline --user routes to named skill file not user tree (#737)

### DIFF
--- a/src/gaia_cli/commands/dev.py
+++ b/src/gaia_cli/commands/dev.py
@@ -2035,17 +2035,25 @@ def meta_timeline_command(args):
     timestamp = getattr(args, "timestamp", None)
 
     if user:
-        from gaia_cli.timeline import append_skill_tree_event
-        append_skill_tree_event(
-            user,
-            skill_id,
-            action,
-            notes,
-            registry_path=registry_path,
-            timestamp=timestamp,
-        )
-        marker = f" (at {timestamp})" if timestamp else ""
-        print(f"Appended '{action}' event for '{skill_id}' to skill-trees/{user}/skill-tree.json{marker}.")
+        # Check if skill_id refers to a named skill first; if so write there.
+        from gaia_cli.timeline import _named_skill_file
+        named_file = _named_skill_file(skill_id, registry_path)
+        if named_file:
+            from gaia_cli.timeline import append_skill_event
+            append_skill_event(skill_id, action, user, notes, registry_path=registry_path)
+            print(f"Appended '{action}' event for '{skill_id}' to named skill file.")
+        else:
+            from gaia_cli.timeline import append_skill_tree_event
+            append_skill_tree_event(
+                user,
+                skill_id,
+                action,
+                notes,
+                registry_path=registry_path,
+                timestamp=timestamp,
+            )
+            marker = f" (at {timestamp})" if timestamp else ""
+            print(f"Appended '{action}' event for '{skill_id}' to skill-trees/{user}/skill-tree.json{marker}.")
     else:
         from gaia_cli.timeline import append_skill_event
         append_skill_event(

--- a/src/gaia_cli/timeline.py
+++ b/src/gaia_cli/timeline.py
@@ -44,6 +44,20 @@ def _write_md(path, meta, body) -> None:
         encoding="utf-8",
     )
 
+def _named_skill_file(skill_id, registry_path="."):
+    """Return the Path to the named skill .md file for skill_id, or None."""
+    from gaia_cli.registry import named_skills_dir
+    named_base = Path(named_skills_dir(registry_path)).resolve()
+    if "/" in skill_id:
+        guess = (named_base / f"{skill_id}.md").resolve()
+        if guess.exists() and guess.is_relative_to(named_base):
+            return guess
+    for p in named_base.glob("**/*.md"):
+        content = p.read_text(encoding="utf-8")
+        if f"id: {skill_id}" in content or f'id: "{skill_id}"' in content:
+            return p
+    return None
+
 def append_skill_event(skill_id, action, contributor, details, registry_path="."):
     from gaia_cli.registry import registry_nodes_dir, named_skills_dir
     nodes_dir = Path(registry_nodes_dir(registry_path))

--- a/tests/test_timeline_routing.py
+++ b/tests/test_timeline_routing.py
@@ -1,0 +1,213 @@
+"""Tests for timeline routing: gaia dev timeline with --user should write to named skill
+file (not user tree) when the skill_id resolves to a named skill.
+
+Regression guard for the bug where meta_timeline_command unconditionally called
+append_skill_tree_event when --user was supplied, even for named skill IDs like
+'mattpocock/skills' that live in registry/named/.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure src is importable
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build minimal fixture registries
+# ---------------------------------------------------------------------------
+
+def _make_registry(tmp_path: Path, *, with_named: bool = True) -> Path:
+    """Create a minimal registry fixture under tmp_path/registry."""
+    registry = tmp_path / "registry"
+    nodes = registry / "nodes" / "basic"
+    nodes.mkdir(parents=True)
+    named = registry / "named" / "testuser"
+    named.mkdir(parents=True)
+
+    # Generic node (simple ID, no slash)
+    (nodes / "generic-skill.json").write_text(
+        json.dumps({
+            "id": "generic-skill",
+            "name": "Generic Skill",
+            "type": "basic",
+            "level": "1★",
+            "description": "A generic skill",
+            "status": "provisional",
+            "prerequisites": [],
+            "derivatives": [],
+            "evidence": [],
+            "knownAgents": [],
+            "createdAt": "2026-06-01",
+            "updatedAt": "2026-06-01",
+            "version": "0.1.0",
+        }),
+        encoding="utf-8",
+    )
+
+    if with_named:
+        # Named skill with composite id (slash-separated)
+        (named / "myskill.md").write_text(
+            "---\n"
+            "id: testuser/myskill\n"
+            "name: My Named Skill\n"
+            "contributor: testuser\n"
+            "origin: true\n"
+            "genericSkillRef: generic-skill\n"
+            "status: named\n"
+            "level: 2★\n"
+            "description: A named skill for testing\n"
+            "---\n"
+            "\n# Testuser / My Skill\n",
+            encoding="utf-8",
+        )
+
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Tests for _named_skill_file helper
+# ---------------------------------------------------------------------------
+
+class TestNamedSkillFile:
+    def test_returns_path_for_slash_id(self, tmp_path):
+        from gaia_cli.timeline import _named_skill_file
+
+        root = _make_registry(tmp_path)
+        result = _named_skill_file("testuser/myskill", registry_path=str(root))
+        assert result is not None
+        assert result.name == "myskill.md"
+
+    def test_returns_none_for_unknown_id(self, tmp_path):
+        from gaia_cli.timeline import _named_skill_file
+
+        root = _make_registry(tmp_path)
+        result = _named_skill_file("nonexistent/skill", registry_path=str(root))
+        assert result is None
+
+    def test_returns_none_for_generic_node_id(self, tmp_path):
+        from gaia_cli.timeline import _named_skill_file
+
+        root = _make_registry(tmp_path)
+        # 'generic-skill' has no slash so no direct guess; won't match frontmatter
+        result = _named_skill_file("generic-skill", registry_path=str(root))
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Test: append_skill_event writes to named skill .md, not node JSON
+# ---------------------------------------------------------------------------
+
+class TestAppendSkillEventRouting:
+    def test_timeline_named_skill_routes_to_named_file(self, tmp_path):
+        """append_skill_event with a named skill ID must write to the .md file."""
+        from gaia_cli.timeline import append_skill_event
+
+        root = _make_registry(tmp_path)
+        named_md = root / "registry" / "named" / "testuser" / "myskill.md"
+        original_content = named_md.read_text(encoding="utf-8")
+
+        # The named skill file should not contain a timeline yet
+        assert "timeline:" not in original_content
+
+        append_skill_event(
+            "testuser/myskill",
+            "demote",
+            "testuser",
+            "Test demote event",
+            registry_path=str(root),
+        )
+
+        updated_content = named_md.read_text(encoding="utf-8")
+        assert "timeline:" in updated_content
+        assert "demote" in updated_content
+
+        # Generic node must NOT be touched
+        node_json = root / "registry" / "nodes" / "basic" / "generic-skill.json"
+        node_data = json.loads(node_json.read_text(encoding="utf-8"))
+        assert "timeline" not in node_data
+
+
+# ---------------------------------------------------------------------------
+# Test: meta_timeline_command with --user routes to named file for named skill
+# ---------------------------------------------------------------------------
+
+class TestMetaTimelineCommandRouting:
+    def _make_args(self, skill_id, action, notes, user, registry, timestamp=None, no_build=True):
+        args = MagicMock()
+        args.skill_id = skill_id
+        args.action = action
+        args.notes = notes
+        args.user = user
+        args.registry = registry
+        args.timestamp = timestamp
+        args.no_build = no_build
+        return args
+
+    def test_timeline_with_user_routes_to_named_file_when_named_skill(self, tmp_path):
+        """meta_timeline_command with --user must write to named .md when skill is named."""
+        from gaia_cli.commands.dev import meta_timeline_command
+
+        root = _make_registry(tmp_path)
+        named_md = root / "registry" / "named" / "testuser" / "myskill.md"
+
+        args = self._make_args(
+            skill_id="testuser/myskill",
+            action="demote",
+            notes="apex gate failed",
+            user="mbtiongson1",
+            registry=str(root),
+            no_build=True,
+        )
+
+        meta_timeline_command(args)
+
+        updated_content = named_md.read_text(encoding="utf-8")
+        assert "timeline:" in updated_content
+        assert "demote" in updated_content
+
+        # User tree must NOT be created/touched
+        user_tree = root / "skill-trees" / "mbtiongson1" / "skill-tree.json"
+        assert not user_tree.exists()
+
+    def test_timeline_with_user_routes_to_user_tree_for_generic_skill(self, tmp_path):
+        """meta_timeline_command with --user must write to user tree for generic skill IDs."""
+        from gaia_cli.commands.dev import meta_timeline_command
+
+        root = _make_registry(tmp_path)
+
+        # Create a user tree for mbtiongson1
+        user_tree_dir = root / "skill-trees" / "mbtiongson1"
+        user_tree_dir.mkdir(parents=True)
+        user_tree_file = user_tree_dir / "skill-tree.json"
+        user_tree_file.write_text(
+            json.dumps({
+                "username": "mbtiongson1",
+                "unlockedSkills": [],
+                "timeline": [],
+            }),
+            encoding="utf-8",
+        )
+
+        args = self._make_args(
+            skill_id="generic-skill",
+            action="note",
+            notes="Testing generic routing",
+            user="mbtiongson1",
+            registry=str(root),
+            no_build=True,
+        )
+
+        meta_timeline_command(args)
+
+        tree_data = json.loads(user_tree_file.read_text(encoding="utf-8"))
+        timeline = tree_data.get("timeline", [])
+        assert any(ev.get("action") == "note" and ev.get("skillId") == "generic-skill" for ev in timeline)


### PR DESCRIPTION
Closes #737. Follow-up to PR #728 (I2).

## Root cause
`meta_timeline_command` unconditionally called `append_skill_tree_event` when `--user` was supplied, writing to `skill-trees/<user>/skill-tree.json` even when the skill ID resolved to a named skill in `registry/named/`.

## Fix
- Added `_named_skill_file(skill_id, registry_path)` helper to `timeline.py`
- `meta_timeline_command`: when `--user` is supplied, check named skill first; fall through to user tree only if skill ID is not a named skill
- Tests added for both routing paths

## Impact
`gaia dev timeline mattpocock/skills --user mbtiongson1 --action demote --notes "..."` now correctly writes to `registry/named/mattpocock/skills.md`.