### PR TITLE
feat(design): I8 — Trust Grade notch on all .plaque variants

### DIFF
--- a/docs/css/plaque.css
+++ b/docs/css/plaque.css
@@ -3727,3 +3727,138 @@ button.plaque__slug:focus-visible {
   outline: 2px solid var(--tier-extra);
   outline-offset: 2px;
 }
+
+
+/* ============================================================
+   Trust Grade notch — I8
+   A small rectangular metallic corner stamp at the bottom-right
+   of every .plaque variant, showing the skill's overallTrustGrade
+   (S=Platinum / A=Gold / B=Silver / C=Bronze). Ungraded skills
+   emit no element at all — zero markup cost when absent.
+
+   Design rules:
+   - position:absolute on the notch, resolved against .plaque's
+     existing position:relative (set in base .plaque rule).
+   - Card's border-radius clips the corner naturally; DO NOT add
+     border-radius on .plaque__trust-notch itself.
+   - WCAG AA: all grade text has ≥4.5:1 contrast on its fill.
+   - No border-left >1px colored accent (DESIGN.md absolute ban).
+   - Platinum earns a shimmer animation; reduced-motion fallback
+     converts it to a static linear-gradient.
+   ============================================================ */
+
+/* ── Notch base ──────────────────────────────────────────────── */
+.plaque__trust-notch {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  height: var(--trust-notch-h, 18px);
+  padding: 0 var(--trust-notch-pad-x, 6px);
+  font-family: var(--trust-notch-font, var(--font-mono, 'Departure Mono', 'JetBrains Mono', ui-monospace, monospace));
+  font-size: var(--trust-notch-font-size, 0.68rem);
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  line-height: 1;
+  letter-spacing: 0.04em;
+  /* No border-radius — card's existing radius clips this corner. */
+  /* z-index above the card surface but below absolute overlays. */
+  z-index: 2;
+  pointer-events: none; /* decorative — not interactive */
+}
+
+/* ── Grade S — Platinum ──────────────────────────────────────── */
+/* Text: #0b2545 (deep navy) on iridescent blue-silver fill.
+   Contrast: #0b2545 on --evidence-platinum (#e2e8f0) ≈ 10.8:1 ✓ */
+.plaque__trust-notch[data-trust-grade="S"] {
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--grade-S) 60%, #c8d8f0) 0%,
+    var(--grade-S) 45%,
+    color-mix(in srgb, var(--grade-S) 70%, #8899bb) 100%
+  );
+  color: #0b2545;
+  animation: trust-notch-shimmer 3.5s linear infinite;
+  background-size: 200% 200%;
+}
+
+@keyframes trust-notch-shimmer {
+  0%   { background-position: 0%   50%; }
+  50%  { background-position: 100% 50%; }
+  100% { background-position: 0%   50%; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .plaque__trust-notch[data-trust-grade="S"] {
+    animation: none;
+    background: linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--grade-S) 80%, #fff) 0%,
+      var(--grade-S) 100%
+    );
+  }
+}
+
+/* ── Grade A — Gold ──────────────────────────────────────────── */
+/* Text: #451a03 (deep brown) on gold fill.
+   Contrast: #451a03 on --evidence-gold (#d4af37) ≈ 7.2:1 ✓ */
+.plaque__trust-notch[data-trust-grade="A"] {
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--grade-A) 65%, #fff) 0%,
+    var(--grade-A) 55%,
+    color-mix(in srgb, var(--grade-A) 75%, #7a5c00) 100%
+  );
+  color: #451a03;
+}
+
+/* ── Grade B — Silver ────────────────────────────────────────── */
+/* Text: #0f172a (dark slate) on silver fill.
+   Contrast: #0f172a on --evidence-silver (#cbd5e1) ≈ 11.4:1 ✓ */
+.plaque__trust-notch[data-trust-grade="B"] {
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--grade-B) 55%, #8a99ad) 0%,
+    var(--grade-B) 50%,
+    color-mix(in srgb, var(--grade-B) 60%, #475569) 100%
+  );
+  color: #0f172a;
+}
+
+/* ── Grade C — Bronze ────────────────────────────────────────── */
+/* Text: #fffbeb (light warm) on bronze/tarnished fill.
+   Contrast: #fffbeb on --evidence-bronze (#b45309) ≈ 4.8:1 ✓ */
+.plaque__trust-notch[data-trust-grade="C"] {
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--grade-C) 70%, #d97706) 0%,
+    var(--grade-C) 50%,
+    color-mix(in srgb, var(--grade-C) 80%, #7c5a2a) 100%
+  );
+  color: #fffbeb;
+}
+
+/* ── Variant overrides: mini + row = letter only ─────────────── */
+/* These variants are too dense to show the grade name label.
+   The .trust-notch-name span is hidden via CSS so the DOM slot
+   stays consistent and screen readers still get the aria-label. */
+.plaque--mini .plaque__trust-notch .trust-notch-name,
+.plaque--row  .plaque__trust-notch .trust-notch-name {
+  display: none;
+}
+
+/* ── OG card: notch at print scale ──────────────────────────── */
+/* The OG variant is scaled to 1200×630 — bump the notch
+   proportionally so it reads at the social-card preview size. */
+.plaque--og .plaque__trust-notch {
+  height: 40px;
+  padding: 0 14px;
+  font-size: 1.1rem;
+  gap: 6px;
+}
+
+/* ── Settled: notch z-index above the gold corner ornament ───── */
+/* .plaque--settled has ::before / ::after corner ornaments at
+   z-index auto. The notch sits at z-index 2 (base rule) which
+   already clears them; no override needed. */

--- a/docs/css/plaque.css
+++ b/docs/css/plaque.css
@@ -3731,16 +3731,16 @@ button.plaque__slug:focus-visible {
 
 /* ============================================================
    Trust Grade notch — I8
-   A small rectangular metallic corner stamp at the bottom-right
-   of every .plaque variant, showing the skill's overallTrustGrade
-   (S=Platinum / A=Gold / B=Silver / C=Bronze). Ungraded skills
-   emit no element at all — zero markup cost when absent.
+   A full-width centered footer row at the bottom of every
+   .plaque variant, showing the skill's overallTrustGrade letter
+   + TM number (e.g. "A · 47"). Grade name labels are never shown.
+   Ungraded skills emit no element at all — zero markup cost.
 
    Design rules:
-   - position:absolute on the notch, resolved against .plaque's
-     existing position:relative (set in base .plaque rule).
-   - Card's border-radius clips the corner naturally; DO NOT add
-     border-radius on .plaque__trust-notch itself.
+   - Centered footer via display:flex + justify-content:center.
+     Uses margin-top:auto so it pins to the card bottom inside
+     the flex column layout of .plaque.
+   - DO NOT add border-radius on .plaque__trust-notch itself.
    - WCAG AA: all grade text has ≥4.5:1 contrast on its fill.
    - No border-left >1px colored accent (DESIGN.md absolute ban).
    - Platinum earns a shimmer animation; reduced-motion fallback
@@ -3749,32 +3749,29 @@ button.plaque__slug:focus-visible {
 
 /* ── Notch base ──────────────────────────────────────────────── */
 .plaque__trust-notch {
-  position: absolute;
-  bottom: 0;
-  right: 0;
-  height: var(--trust-notch-h, 18px);
-  padding: 0 var(--trust-notch-pad-x, 6px);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  padding: 4px 0 6px;
+  margin-top: auto;
   font-family: var(--trust-notch-font, var(--font-mono, 'Departure Mono', 'JetBrains Mono', ui-monospace, monospace));
   font-size: var(--trust-notch-font-size, 0.68rem);
   font-weight: 700;
-  display: flex;
-  align-items: center;
   gap: 3px;
   line-height: 1;
   letter-spacing: 0.04em;
-  /* No border-radius — card's existing radius clips this corner. */
-  /* z-index above the card surface but below absolute overlays. */
-  z-index: 2;
   pointer-events: none; /* decorative — not interactive */
 }
 
-/* ── Grade S — Platinum ──────────────────────────────────────── */
+/* ── Grade S — Platinum (iridescent titanium) ────────────────── */
 .plaque__trust-notch[data-trust-grade="S"] {
   background: linear-gradient(
     135deg,
-    color-mix(in srgb, var(--grade-S) 60%, var(--trust-notch-S-hi)) 0%,
-    var(--grade-S) 45%,
-    color-mix(in srgb, var(--grade-S) 70%, var(--trust-notch-S-lo)) 100%
+    var(--trust-notch-S-hi2) 0%,
+    color-mix(in srgb, var(--trust-notch-S-mid) 80%, var(--trust-notch-S-violet)) 35%,
+    var(--trust-notch-S-mid) 65%,
+    color-mix(in srgb, var(--trust-notch-S-violet) 60%, var(--trust-notch-S-mid)) 100%
   );
   color: var(--trust-notch-text-S);
   animation: trust-notch-shimmer 3.5s linear infinite;
@@ -3792,8 +3789,8 @@ button.plaque__slug:focus-visible {
     animation: none;
     background: linear-gradient(
       135deg,
-      color-mix(in srgb, var(--grade-S) 80%, var(--trust-notch-S-hi-rm)) 0%,
-      var(--grade-S) 100%
+      color-mix(in srgb, var(--trust-notch-S-hi2) 80%, var(--trust-notch-S-hi-rm)) 0%,
+      var(--trust-notch-S-mid) 100%
     );
   }
 }
@@ -3809,13 +3806,13 @@ button.plaque__slug:focus-visible {
   color: var(--trust-notch-text-A);
 }
 
-/* ── Grade B — Silver ────────────────────────────────────────── */
+/* ── Grade B — Silver (dark steel) ──────────────────────────── */
 .plaque__trust-notch[data-trust-grade="B"] {
   background: linear-gradient(
     135deg,
-    color-mix(in srgb, var(--grade-B) 55%, var(--trust-notch-B-hi)) 0%,
-    var(--grade-B) 50%,
-    color-mix(in srgb, var(--grade-B) 60%, var(--trust-notch-B-lo)) 100%
+    var(--trust-notch-B-hi) 0%,
+    color-mix(in srgb, var(--trust-notch-B-hi) 55%, var(--trust-notch-B-lo)) 50%,
+    var(--trust-notch-B-lo) 100%
   );
   color: var(--trust-notch-text-B);
 }
@@ -3831,26 +3828,15 @@ button.plaque__slug:focus-visible {
   color: var(--trust-notch-text-C);
 }
 
-/* ── Variant overrides: mini + row = letter only ─────────────── */
-/* These variants are too dense to show the grade name label.
-   The .trust-notch-name span is hidden via CSS so the DOM slot
-   stays consistent and screen readers still get the aria-label. */
-.plaque--mini .plaque__trust-notch .trust-notch-name,
-.plaque--row  .plaque__trust-notch .trust-notch-name {
-  display: none;
-}
-
 /* ── OG card: notch at print scale ──────────────────────────── */
-/* The OG variant is scaled to 1200×630 — bump the notch
-   proportionally so it reads at the social-card preview size. */
+/* The OG variant is scaled to 1200×630 — bump the font size
+   proportionally so it reads at the social-card preview size.
+   No absolute positioning needed — inherits footer-row layout. */
 .plaque--og .plaque__trust-notch {
-  height: 40px;
-  padding: 0 14px;
   font-size: 1.1rem;
-  gap: 6px;
+  padding: 6px 0 10px;
 }
 
-/* ── Settled: notch z-index above the gold corner ornament ───── */
-/* .plaque--settled has ::before / ::after corner ornaments at
-   z-index auto. The notch sits at z-index 2 (base rule) which
-   already clears them; no override needed. */
+/* ── Settled: notch already clear of corner ornaments ────────── */
+/* .plaque--settled corner ornaments are at z-index auto;
+   the notch is in normal flow so no z-index override needed. */

--- a/docs/css/plaque.css
+++ b/docs/css/plaque.css
@@ -3769,16 +3769,14 @@ button.plaque__slug:focus-visible {
 }
 
 /* ── Grade S — Platinum ──────────────────────────────────────── */
-/* Text: #0b2545 (deep navy) on iridescent blue-silver fill.
-   Contrast: #0b2545 on --evidence-platinum (#e2e8f0) ≈ 10.8:1 ✓ */
 .plaque__trust-notch[data-trust-grade="S"] {
   background: linear-gradient(
     135deg,
-    color-mix(in srgb, var(--grade-S) 60%, #c8d8f0) 0%,
+    color-mix(in srgb, var(--grade-S) 60%, var(--trust-notch-S-hi)) 0%,
     var(--grade-S) 45%,
-    color-mix(in srgb, var(--grade-S) 70%, #8899bb) 100%
+    color-mix(in srgb, var(--grade-S) 70%, var(--trust-notch-S-lo)) 100%
   );
-  color: #0b2545;
+  color: var(--trust-notch-text-S);
   animation: trust-notch-shimmer 3.5s linear infinite;
   background-size: 200% 200%;
 }
@@ -3794,49 +3792,43 @@ button.plaque__slug:focus-visible {
     animation: none;
     background: linear-gradient(
       135deg,
-      color-mix(in srgb, var(--grade-S) 80%, #fff) 0%,
+      color-mix(in srgb, var(--grade-S) 80%, var(--trust-notch-S-hi-rm)) 0%,
       var(--grade-S) 100%
     );
   }
 }
 
 /* ── Grade A — Gold ──────────────────────────────────────────── */
-/* Text: #451a03 (deep brown) on gold fill.
-   Contrast: #451a03 on --evidence-gold (#d4af37) ≈ 7.2:1 ✓ */
 .plaque__trust-notch[data-trust-grade="A"] {
   background: linear-gradient(
     135deg,
-    color-mix(in srgb, var(--grade-A) 65%, #fff) 0%,
+    color-mix(in srgb, var(--grade-A) 65%, var(--trust-notch-A-hi)) 0%,
     var(--grade-A) 55%,
-    color-mix(in srgb, var(--grade-A) 75%, #7a5c00) 100%
+    color-mix(in srgb, var(--grade-A) 75%, var(--trust-notch-A-lo)) 100%
   );
-  color: #451a03;
+  color: var(--trust-notch-text-A);
 }
 
 /* ── Grade B — Silver ────────────────────────────────────────── */
-/* Text: #0f172a (dark slate) on silver fill.
-   Contrast: #0f172a on --evidence-silver (#cbd5e1) ≈ 11.4:1 ✓ */
 .plaque__trust-notch[data-trust-grade="B"] {
   background: linear-gradient(
     135deg,
-    color-mix(in srgb, var(--grade-B) 55%, #8a99ad) 0%,
+    color-mix(in srgb, var(--grade-B) 55%, var(--trust-notch-B-hi)) 0%,
     var(--grade-B) 50%,
-    color-mix(in srgb, var(--grade-B) 60%, #475569) 100%
+    color-mix(in srgb, var(--grade-B) 60%, var(--trust-notch-B-lo)) 100%
   );
-  color: #0f172a;
+  color: var(--trust-notch-text-B);
 }
 
 /* ── Grade C — Bronze ────────────────────────────────────────── */
-/* Text: #fffbeb (light warm) on bronze/tarnished fill.
-   Contrast: #fffbeb on --evidence-bronze (#b45309) ≈ 4.8:1 ✓ */
 .plaque__trust-notch[data-trust-grade="C"] {
   background: linear-gradient(
     135deg,
-    color-mix(in srgb, var(--grade-C) 70%, #d97706) 0%,
+    color-mix(in srgb, var(--grade-C) 70%, var(--trust-notch-C-hi)) 0%,
     var(--grade-C) 50%,
-    color-mix(in srgb, var(--grade-C) 80%, #7c5a2a) 100%
+    color-mix(in srgb, var(--grade-C) 80%, var(--trust-notch-C-lo)) 100%
   );
-  color: #fffbeb;
+  color: var(--trust-notch-text-C);
 }
 
 /* ── Variant overrides: mini + row = letter only ─────────────── */

--- a/docs/css/plaque.css
+++ b/docs/css/plaque.css
@@ -3730,190 +3730,129 @@ button.plaque__slug:focus-visible {
 
 
 /* ============================================================
-   Trust Grade notch — I8
-   A small centered pill pinned to the very bottom of the plaque card.
-   Default: TM number visible. Hover: shine sweep reveals grade letter.
-   Ungraded skills emit no element at all — zero markup cost.
+   Trust Grade notch — I8 (redesign: pixel-thin bar → expand on hover)
 
-   Design rules:
-   - width: fit-content, centered via margin auto. NOT full-width.
-   - Bottom corners match card radius (top corners flush with card edge).
-   - Hover reveal: .trust-notch-default fades out, .trust-notch-reveal
-     appears with shine sweep animation.
-   - WCAG AA: all grade text has ≥4.5:1 contrast on its fill.
-   - No border-left >1px colored accent (DESIGN.md absolute ban).
-   - Platinum earns a shimmer animation; reduced-motion fallback
-     converts it to a static linear-gradient.
+   Default: 3px colored bar flush at the very card bottom (full-width,
+   boxy — no radius). Grade color is always visible as a thin stripe.
+
+   Hover (whole plaque): bar expands to 24px, "MAG X.X" counts up from
+   0 to the real TM in <0.4s via JS (_wireTrustNotches). The label fades
+   in as the bar opens. Transition ≤0.35s so the whole motion is snappy.
+
+   Ungraded skills emit no element — zero markup cost.
    ============================================================ */
 
-/* ── Grade S — Platinum (iridescent titanium) ────────────────── */
+/* ── Base bar ────────────────────────────────────────────────── */
+.plaque__trust-notch {
+  /* Push to very bottom of the flex column card */
+  margin-top: auto;
+  /* Full width, boxy — no radius, no gap */
+  width: 100%;
+  margin-bottom: calc(-1 * var(--plaque-pad, 20px));
+  margin-left: calc(-1 * var(--plaque-pad, 20px));
+  /* Compensate for card padding on both sides */
+  width: calc(100% + 2 * var(--plaque-pad, 20px));
+  /* Thin bar by default */
+  height: 3px;
+  overflow: hidden;
+  transition: height 0.28s cubic-bezier(0.22, 1, 0.36, 1);
+  /* Label hidden at 3px height, revealed as bar expands */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+
+/* ── Expand on plaque hover ──────────────────────────────────── */
+.plaque:hover .plaque__trust-notch {
+  height: 24px;
+}
+
+/* ── Label: invisible at rest, fades in as bar opens ─────────── */
+.trust-notch-label {
+  font-family: var(--font-mono, 'Departure Mono', 'JetBrains Mono', ui-monospace, monospace);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  opacity: 0;
+  transition: opacity 0.18s ease 0.12s;
+  line-height: 1;
+  pointer-events: none;
+  user-select: none;
+}
+.plaque:hover .trust-notch-label {
+  opacity: 1;
+}
+
+/* ── Grade fills ─────────────────────────────────────────────── */
+/* S — Platinum: animated iridescent sweep */
 .plaque__trust-notch[data-trust-grade="S"] {
   background: linear-gradient(
-    135deg,
-    var(--trust-notch-S-hi2, rgba(226,232,240,0.28)) 0%,
-    color-mix(in srgb, var(--trust-notch-S-mid, rgba(226,232,240,0.18)) 80%, var(--trust-notch-S-violet, rgba(180,160,220,0.2))) 35%,
-    var(--trust-notch-S-mid, rgba(226,232,240,0.18)) 65%,
-    color-mix(in srgb, var(--trust-notch-S-violet, rgba(180,160,220,0.2)) 60%, var(--trust-notch-S-mid, rgba(226,232,240,0.18))) 100%
+    90deg,
+    var(--trust-notch-S-hi2, #d1e8ff) 0%,
+    color-mix(in srgb, var(--trust-notch-S-mid, #a5c7eb) 80%, var(--trust-notch-S-violet, #c8d8ff)) 30%,
+    var(--trust-notch-S-mid, #a5c7eb) 60%,
+    var(--trust-notch-S-hi2, #d1e8ff) 100%
   );
-  color: var(--trust-notch-text-S, var(--evidence-platinum, #e2e8f0));
-  --trust-notch-shine: rgba(255, 255, 255, 0.65);
-  animation: trust-notch-shimmer 3.5s linear infinite;
-  background-size: 200% 200%;
+  background-size: 200% 100%;
+  animation: trust-notch-shimmer 2.8s linear infinite;
+  color: var(--trust-notch-text-S, #0f172a);
 }
 
 @keyframes trust-notch-shimmer {
-  0%   { background-position: 0%   50%; }
-  50%  { background-position: 100% 50%; }
-  100% { background-position: 0%   50%; }
+  0%   { background-position: 0%   0%; }
+  100% { background-position: 200% 0%; }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .plaque__trust-notch[data-trust-grade="S"] {
     animation: none;
-    background: linear-gradient(
-      135deg,
-      color-mix(in srgb, var(--trust-notch-S-hi2, rgba(226,232,240,0.28)) 80%, var(--trust-notch-S-hi-rm, rgba(226,232,240,0.20))) 0%,
-      var(--trust-notch-S-mid, rgba(226,232,240,0.18)) 100%
-    );
+    background: var(--trust-notch-S-mid, #a5c7eb);
   }
 }
 
-/* ── Grade A — Gold ──────────────────────────────────────────── */
+/* A — Gold */
 .plaque__trust-notch[data-trust-grade="A"] {
-  background: linear-gradient(
-    135deg,
-    color-mix(in srgb, var(--grade-A, #d4af37) 65%, var(--trust-notch-A-hi, #fff)) 0%,
-    var(--grade-A, #d4af37) 55%,
-    color-mix(in srgb, var(--grade-A, #d4af37) 75%, var(--trust-notch-A-lo, #000)) 100%
-  );
-  color: var(--trust-notch-text-A, #030712);
-  --trust-notch-shine: rgba(255, 223, 120, 0.55);
+  background: var(--grade-A, #d4af37);
+  color: #030712;
 }
 
-/* ── Grade B — Silver (dark steel) ──────────────────────────── */
+/* B — Silver (steel) */
 .plaque__trust-notch[data-trust-grade="B"] {
-  background: linear-gradient(
-    135deg,
-    var(--trust-notch-B-hi, rgba(203,213,225,0.35)) 0%,
-    color-mix(in srgb, var(--trust-notch-B-hi, rgba(203,213,225,0.35)) 55%, var(--trust-notch-B-lo, rgba(203,213,225,0.18))) 50%,
-    var(--trust-notch-B-lo, rgba(203,213,225,0.18)) 100%
-  );
-  color: var(--trust-notch-text-B, var(--evidence-silver, #cbd5e1));
-  --trust-notch-shine: rgba(220, 230, 240, 0.55);
+  background: var(--trust-notch-B-hi, rgba(148,163,184,0.55));
+  color: var(--text, #e2e8f0);
 }
 
-/* ── Grade C — Bronze ────────────────────────────────────────── */
+/* C — Bronze */
 .plaque__trust-notch[data-trust-grade="C"] {
-  background: linear-gradient(
-    135deg,
-    color-mix(in srgb, var(--grade-C, #b45309) 70%, var(--trust-notch-C-hi, #fff)) 0%,
-    var(--grade-C, #b45309) 50%,
-    color-mix(in srgb, var(--grade-C, #b45309) 80%, var(--trust-notch-C-lo, #000)) 100%
-  );
-  color: var(--trust-notch-text-C, #fff8f0);
-  --trust-notch-shine: rgba(220, 160, 80, 0.55);
+  background: var(--grade-C, #b45309);
+  color: #fff8f0;
 }
 
-/* ── Notch base ──────────────────────────────────────────────────
-   Sits flush at the card bottom via margin-top: auto (the .plaque
-   base is already display:flex flex-direction:column so this works).
-   width: fit-content + auto side margins centers it without spanning
-   the full card width. Bottom corners match the card radius. */
-.plaque__trust-notch {
-  position: relative;
-  overflow: hidden;
-  width: fit-content;
-  min-width: 48px;
-  max-width: 120px;
-  margin-top: auto;
-  margin-left: auto;
-  margin-right: auto;
-  padding: 3px 10px 5px;
-  border-radius: 0 0 var(--plaque-radius, 8px) var(--plaque-radius, 8px);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-top: none;
-  font-family: var(--trust-notch-font, var(--font-mono, 'Departure Mono', 'JetBrains Mono', ui-monospace, monospace));
-  font-size: var(--trust-notch-font-size, 11px);
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-align: center;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  /* Negative margin-bottom pulls it flush with the card's inner bottom edge
-     so there's no gap between the notch pill and the card border. */
-  margin-bottom: calc(-1 * var(--plaque-pad, 20px));
-}
-
-/* ── Span states ─────────────────────────────────────────────────
-   .trust-notch-default  → TM number, visible by default
-   .trust-notch-reveal   → grade letter, hidden by default          */
-.trust-notch-default {
-  opacity: 1;
-  transition: opacity 0.2s ease;
-}
-.trust-notch-reveal {
-  position: absolute;
-  opacity: 0;
-  font-size: 13px;
-  transition: opacity 0.2s ease 0.15s;
-}
-
-/* On plaque or notch hover: swap default ↔ reveal */
-.plaque:hover .trust-notch-default,
-.plaque__trust-notch:hover .trust-notch-default {
-  opacity: 0;
-}
-.plaque:hover .trust-notch-reveal,
-.plaque__trust-notch:hover .trust-notch-reveal {
-  opacity: 1;
-}
-
-/* Shine sweep pseudo-element fires on hover */
-.plaque__trust-notch[data-trust-grade]:hover::after {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: -60%;
-  width: 40%;
-  height: 100%;
-  background: linear-gradient(
-    105deg,
-    transparent 20%,
-    var(--trust-notch-shine, rgba(255, 255, 255, 0.55)) 50%,
-    transparent 80%
-  );
-  animation: trust-notch-shine-sweep 0.45s ease-out forwards;
-  pointer-events: none;
-}
-
-@keyframes trust-notch-shine-sweep {
-  from { transform: translateX(0); }
-  to   { transform: translateX(400%); }
-}
-
-/* Reduced-motion: skip sweep, still swap text */
-@media (prefers-reduced-motion: reduce) {
-  .plaque__trust-notch[data-trust-grade]:hover::after {
-    display: none;
-  }
-  .plaque:hover .trust-notch-reveal,
-  .plaque__trust-notch:hover .trust-notch-reveal {
-    transition-delay: 0s;
-  }
-  @keyframes trust-notch-shine-sweep { from {} to {} }
-}
-
-/* ── OG card: notch at print scale ──────────────────────────── */
+/* ── OG card: proportional bar at social-card scale ─────────── */
 .plaque--og .plaque__trust-notch {
-  font-size: 1.1rem;
-  padding: 6px 12px 10px;
-  max-width: 200px;
+  height: 5px;
+}
+.plaque--og:hover .plaque__trust-notch {
+  height: 32px;
+}
+.plaque--og .trust-notch-label {
+  font-size: 13px;
 }
 
-/* ── Settled: notch already clear of corner ornaments ────────── */
-/* .plaque--settled corner ornaments are at z-index auto;
-   the notch is in normal flow so no z-index override needed. */
+/* ── Reduced-motion: skip height transition, show label always ── */
+@media (prefers-reduced-motion: reduce) {
+  .plaque__trust-notch {
+    height: 24px;
+    transition: none;
+  }
+  .trust-notch-label {
+    opacity: 1;
+    transition: none;
+  }
+}
 
 
 /* ── Row variant: evidence badge ─────────────────────────────────

--- a/docs/css/plaque.css
+++ b/docs/css/plaque.css
@@ -3731,49 +3731,32 @@ button.plaque__slug:focus-visible {
 
 /* ============================================================
    Trust Grade notch — I8
-   A full-width centered footer row at the bottom of every
-   .plaque variant, showing the skill's overallTrustGrade letter
-   + TM number (e.g. "A · 47"). Grade name labels are never shown.
+   A small centered pill pinned to the very bottom of the plaque card.
+   Default: TM number visible. Hover: shine sweep reveals grade letter.
    Ungraded skills emit no element at all — zero markup cost.
 
    Design rules:
-   - Centered footer via display:flex + justify-content:center.
-     Uses margin-top:auto so it pins to the card bottom inside
-     the flex column layout of .plaque.
-   - DO NOT add border-radius on .plaque__trust-notch itself.
+   - width: fit-content, centered via margin auto. NOT full-width.
+   - Bottom corners match card radius (top corners flush with card edge).
+   - Hover reveal: .trust-notch-default fades out, .trust-notch-reveal
+     appears with shine sweep animation.
    - WCAG AA: all grade text has ≥4.5:1 contrast on its fill.
    - No border-left >1px colored accent (DESIGN.md absolute ban).
    - Platinum earns a shimmer animation; reduced-motion fallback
      converts it to a static linear-gradient.
    ============================================================ */
 
-/* ── Notch base ──────────────────────────────────────────────── */
-.plaque__trust-notch {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 100%;
-  padding: 4px 0 6px;
-  margin-top: auto;
-  font-family: var(--trust-notch-font, var(--font-mono, 'Departure Mono', 'JetBrains Mono', ui-monospace, monospace));
-  font-size: var(--trust-notch-font-size, 0.68rem);
-  font-weight: 700;
-  gap: 3px;
-  line-height: 1;
-  letter-spacing: 0.04em;
-  pointer-events: none; /* decorative — not interactive */
-}
-
 /* ── Grade S — Platinum (iridescent titanium) ────────────────── */
 .plaque__trust-notch[data-trust-grade="S"] {
   background: linear-gradient(
     135deg,
-    var(--trust-notch-S-hi2) 0%,
-    color-mix(in srgb, var(--trust-notch-S-mid) 80%, var(--trust-notch-S-violet)) 35%,
-    var(--trust-notch-S-mid) 65%,
-    color-mix(in srgb, var(--trust-notch-S-violet) 60%, var(--trust-notch-S-mid)) 100%
+    var(--trust-notch-S-hi2, rgba(226,232,240,0.28)) 0%,
+    color-mix(in srgb, var(--trust-notch-S-mid, rgba(226,232,240,0.18)) 80%, var(--trust-notch-S-violet, rgba(180,160,220,0.2))) 35%,
+    var(--trust-notch-S-mid, rgba(226,232,240,0.18)) 65%,
+    color-mix(in srgb, var(--trust-notch-S-violet, rgba(180,160,220,0.2)) 60%, var(--trust-notch-S-mid, rgba(226,232,240,0.18))) 100%
   );
-  color: var(--trust-notch-text-S);
+  color: var(--trust-notch-text-S, var(--evidence-platinum, #e2e8f0));
+  --trust-notch-shine: rgba(255, 255, 255, 0.65);
   animation: trust-notch-shimmer 3.5s linear infinite;
   background-size: 200% 200%;
 }
@@ -3789,8 +3772,8 @@ button.plaque__slug:focus-visible {
     animation: none;
     background: linear-gradient(
       135deg,
-      color-mix(in srgb, var(--trust-notch-S-hi2) 80%, var(--trust-notch-S-hi-rm)) 0%,
-      var(--trust-notch-S-mid) 100%
+      color-mix(in srgb, var(--trust-notch-S-hi2, rgba(226,232,240,0.28)) 80%, var(--trust-notch-S-hi-rm, rgba(226,232,240,0.20))) 0%,
+      var(--trust-notch-S-mid, rgba(226,232,240,0.18)) 100%
     );
   }
 }
@@ -3799,44 +3782,153 @@ button.plaque__slug:focus-visible {
 .plaque__trust-notch[data-trust-grade="A"] {
   background: linear-gradient(
     135deg,
-    color-mix(in srgb, var(--grade-A) 65%, var(--trust-notch-A-hi)) 0%,
-    var(--grade-A) 55%,
-    color-mix(in srgb, var(--grade-A) 75%, var(--trust-notch-A-lo)) 100%
+    color-mix(in srgb, var(--grade-A, #d4af37) 65%, var(--trust-notch-A-hi, #fff)) 0%,
+    var(--grade-A, #d4af37) 55%,
+    color-mix(in srgb, var(--grade-A, #d4af37) 75%, var(--trust-notch-A-lo, #000)) 100%
   );
-  color: var(--trust-notch-text-A);
+  color: var(--trust-notch-text-A, #030712);
+  --trust-notch-shine: rgba(255, 223, 120, 0.55);
 }
 
 /* ── Grade B — Silver (dark steel) ──────────────────────────── */
 .plaque__trust-notch[data-trust-grade="B"] {
   background: linear-gradient(
     135deg,
-    var(--trust-notch-B-hi) 0%,
-    color-mix(in srgb, var(--trust-notch-B-hi) 55%, var(--trust-notch-B-lo)) 50%,
-    var(--trust-notch-B-lo) 100%
+    var(--trust-notch-B-hi, rgba(203,213,225,0.35)) 0%,
+    color-mix(in srgb, var(--trust-notch-B-hi, rgba(203,213,225,0.35)) 55%, var(--trust-notch-B-lo, rgba(203,213,225,0.18))) 50%,
+    var(--trust-notch-B-lo, rgba(203,213,225,0.18)) 100%
   );
-  color: var(--trust-notch-text-B);
+  color: var(--trust-notch-text-B, var(--evidence-silver, #cbd5e1));
+  --trust-notch-shine: rgba(220, 230, 240, 0.55);
 }
 
 /* ── Grade C — Bronze ────────────────────────────────────────── */
 .plaque__trust-notch[data-trust-grade="C"] {
   background: linear-gradient(
     135deg,
-    color-mix(in srgb, var(--grade-C) 70%, var(--trust-notch-C-hi)) 0%,
-    var(--grade-C) 50%,
-    color-mix(in srgb, var(--grade-C) 80%, var(--trust-notch-C-lo)) 100%
+    color-mix(in srgb, var(--grade-C, #b45309) 70%, var(--trust-notch-C-hi, #fff)) 0%,
+    var(--grade-C, #b45309) 50%,
+    color-mix(in srgb, var(--grade-C, #b45309) 80%, var(--trust-notch-C-lo, #000)) 100%
   );
-  color: var(--trust-notch-text-C);
+  color: var(--trust-notch-text-C, #fff8f0);
+  --trust-notch-shine: rgba(220, 160, 80, 0.55);
+}
+
+/* ── Notch base ──────────────────────────────────────────────────
+   Sits flush at the card bottom via margin-top: auto (the .plaque
+   base is already display:flex flex-direction:column so this works).
+   width: fit-content + auto side margins centers it without spanning
+   the full card width. Bottom corners match the card radius. */
+.plaque__trust-notch {
+  position: relative;
+  overflow: hidden;
+  width: fit-content;
+  min-width: 48px;
+  max-width: 120px;
+  margin-top: auto;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 3px 10px 5px;
+  border-radius: 0 0 var(--plaque-radius, 8px) var(--plaque-radius, 8px);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-top: none;
+  font-family: var(--trust-notch-font, var(--font-mono, 'Departure Mono', 'JetBrains Mono', ui-monospace, monospace));
+  font-size: var(--trust-notch-font-size, 11px);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  /* Negative margin-bottom pulls it flush with the card's inner bottom edge
+     so there's no gap between the notch pill and the card border. */
+  margin-bottom: calc(-1 * var(--plaque-pad, 20px));
+}
+
+/* ── Span states ─────────────────────────────────────────────────
+   .trust-notch-default  → TM number, visible by default
+   .trust-notch-reveal   → grade letter, hidden by default          */
+.trust-notch-default {
+  opacity: 1;
+  transition: opacity 0.2s ease;
+}
+.trust-notch-reveal {
+  position: absolute;
+  opacity: 0;
+  font-size: 13px;
+  transition: opacity 0.2s ease 0.15s;
+}
+
+/* On plaque or notch hover: swap default ↔ reveal */
+.plaque:hover .trust-notch-default,
+.plaque__trust-notch:hover .trust-notch-default {
+  opacity: 0;
+}
+.plaque:hover .trust-notch-reveal,
+.plaque__trust-notch:hover .trust-notch-reveal {
+  opacity: 1;
+}
+
+/* Shine sweep pseudo-element fires on hover */
+.plaque__trust-notch[data-trust-grade]:hover::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -60%;
+  width: 40%;
+  height: 100%;
+  background: linear-gradient(
+    105deg,
+    transparent 20%,
+    var(--trust-notch-shine, rgba(255, 255, 255, 0.55)) 50%,
+    transparent 80%
+  );
+  animation: trust-notch-shine-sweep 0.45s ease-out forwards;
+  pointer-events: none;
+}
+
+@keyframes trust-notch-shine-sweep {
+  from { transform: translateX(0); }
+  to   { transform: translateX(400%); }
+}
+
+/* Reduced-motion: skip sweep, still swap text */
+@media (prefers-reduced-motion: reduce) {
+  .plaque__trust-notch[data-trust-grade]:hover::after {
+    display: none;
+  }
+  .plaque:hover .trust-notch-reveal,
+  .plaque__trust-notch:hover .trust-notch-reveal {
+    transition-delay: 0s;
+  }
+  @keyframes trust-notch-shine-sweep { from {} to {} }
 }
 
 /* ── OG card: notch at print scale ──────────────────────────── */
-/* The OG variant is scaled to 1200×630 — bump the font size
-   proportionally so it reads at the social-card preview size.
-   No absolute positioning needed — inherits footer-row layout. */
 .plaque--og .plaque__trust-notch {
   font-size: 1.1rem;
-  padding: 6px 0 10px;
+  padding: 6px 12px 10px;
+  max-width: 200px;
 }
 
 /* ── Settled: notch already clear of corner ornaments ────────── */
 /* .plaque--settled corner ornaments are at z-index auto;
    the notch is in normal flow so no z-index override needed. */
+
+
+/* ── Row variant: evidence badge ─────────────────────────────────
+   Shown at the end of list-view rows as a small muted label.
+   Positioned just before the › arrow. */
+.plaque--row .plaque__ev-badge {
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  opacity: 0.55;
+  margin-left: auto;
+  align-self: center;
+  padding: 1px 4px;
+  text-transform: uppercase;
+  font-family: var(--font-mono, 'Departure Mono', 'JetBrains Mono', ui-monospace, monospace);
+  white-space: nowrap;
+  flex-shrink: 0;
+}

--- a/docs/css/tokens.css
+++ b/docs/css/tokens.css
@@ -107,4 +107,21 @@
   --trust-notch-pad-x: 6px;
   --trust-notch-font: var(--font-mono);
   --trust-notch-font-size: 0.68rem;
+
+  /* Text colors — WCAG AA verified against each metallic fill */
+  --trust-notch-text-S: #0b2545; /* deep navy on platinum ≈ 10.8:1 */
+  --trust-notch-text-A: #451a03; /* deep brown on gold ≈ 7.2:1 */
+  --trust-notch-text-B: #0f172a; /* dark slate on silver ≈ 11.4:1 */
+  --trust-notch-text-C: #fffbeb; /* warm white on bronze ≈ 4.8:1 */
+
+  /* Metallic highlight and shadow stops for color-mix() gradients */
+  --trust-notch-S-hi: #c8d8f0;
+  --trust-notch-S-lo: #8899bb;
+  --trust-notch-S-hi-rm: #ffffff; /* reduced-motion highlight */
+  --trust-notch-A-hi: #ffffff;
+  --trust-notch-A-lo: #7a5c00;
+  --trust-notch-B-hi: #8a99ad;
+  --trust-notch-B-lo: #475569;
+  --trust-notch-C-hi: #d97706;
+  --trust-notch-C-lo: #7c5a2a;
 }

--- a/docs/css/tokens.css
+++ b/docs/css/tokens.css
@@ -100,4 +100,11 @@
   --grade-B-rgb: var(--evidence-silver-rgb);
   --grade-C: var(--evidence-bronze);
   --grade-C-rgb: var(--evidence-bronze-rgb);
+
+  /* ── Trust Grade notch tokens ────────────────────────────────── */
+  /* Used by .plaque__trust-notch in plaque.css */
+  --trust-notch-h: 18px;
+  --trust-notch-pad-x: 6px;
+  --trust-notch-font: var(--font-mono);
+  --trust-notch-font-size: 0.68rem;
 }

--- a/docs/css/tokens.css
+++ b/docs/css/tokens.css
@@ -111,13 +111,16 @@
   /* Text colors — WCAG AA verified against each metallic fill */
   --trust-notch-text-S: #0b2545; /* deep navy on platinum ≈ 10.8:1 */
   --trust-notch-text-A: #451a03; /* deep brown on gold ≈ 7.2:1 */
-  --trust-notch-text-B: #0f172a; /* dark slate on silver ≈ 11.4:1 */
+  --trust-notch-text-B: var(--text, #e2e8f0); /* light on dark steel ≈ 6.2:1 (was #0f172a → ~2.3:1, fails AA on #475569) */
   --trust-notch-text-C: #fffbeb; /* warm white on bronze ≈ 4.8:1 */
 
   /* Metallic highlight and shadow stops for color-mix() gradients */
   --trust-notch-S-hi: #c8d8f0;
   --trust-notch-S-lo: #8899bb;
   --trust-notch-S-hi-rm: #ffffff; /* reduced-motion highlight */
+  --trust-notch-S-hi2: #ecf4ff;   /* icy titanium highlight */
+  --trust-notch-S-mid: #a5c7eb;   /* steel blue mid */
+  --trust-notch-S-violet: #c8d8ff; /* violet iridescent edge */
   --trust-notch-A-hi: #ffffff;
   --trust-notch-A-lo: #7a5c00;
   --trust-notch-B-hi: #8a99ad;

--- a/docs/js/plaque.js
+++ b/docs/js/plaque.js
@@ -240,39 +240,78 @@
   }
 
   // ── Trust Grade notch field helper (I8) ─────────────────────────
-  // Returns the .plaque__trust-notch HTML when skill.overallTrustGrade
-  // is a real grade (S/A/B/C), or an empty string when absent/ungraded.
-  // The notch is injected via _shell so every variant gets it automatically.
+  // ── Trust Grade notch field helper (I8) ─────────────────────────
+  // Pixel-thin colored bar flush at the card bottom.
+  // On plaque hover: bar expands to full label height, "MAG X.X" counts up
+  // from 0 to the real TM in <0.4s.
   //
-  // Source fields checked in priority order:
-  //   1. ns.overallTrustGrade  (named-skills.json + docs/graph/named/index.json)
-  //   2. ns.trustGrade         (legacy alias, if present)
+  // DOM structure:
+  //   <div class="plaque__trust-notch" data-trust-grade="A" data-tm="122.8">
+  //     <span class="trust-notch-label">MAG <span class="trust-notch-num">0</span></span>
+  //   </div>
   //
-  // Hover reveal:
-  //   Default (no hover): shows TM number (.trust-notch-default).
-  //   Hover: shine sweep animation reveals grade letter S/A/B/C
-  //          (.trust-notch-reveal) while TM number fades out.
+  // The counter is wired in _wireTrustNotches(), called once per render cycle.
   var GRADE_NAMES = { S: 'Platinum', A: 'Gold', B: 'Silver', C: 'Bronze' };
 
   function _fieldTrustNotch(ns) {
     var tg = (ns && (ns.overallTrustGrade || ns.trustGrade)) || '';
-    // Normalise: only accept canonical grades; ignore 'ungraded' / nullish
     if (!tg || tg === 'ungraded' || !GRADE_NAMES[tg]) return '';
-
-    var gradeName = GRADE_NAMES[tg];
     var tm = (ns && (ns.trustMagnitude || ns.overallTrustMagnitude));
-    var tmRounded = (tm != null && tm !== '') ? Math.round(Number(tm)) : 0;
-    var tmLabel = tmRounded > 0 ? String(tmRounded) : '';
-
-    var ariaLabel = 'Trust grade: ' + gradeName + (tmRounded > 0 ? ', magnitude ' + tmRounded : '');
-    // .trust-notch-default: TM number visible by default, fades on hover
-    // .trust-notch-reveal: grade letter hidden by default, reveals on hover
+    var tmVal = (tm != null && tm !== '') ? parseFloat(Number(tm).toFixed(1)) : 0;
+    var gradeName = GRADE_NAMES[tg];
+    var ariaLabel = 'Trust grade: ' + gradeName + (tmVal > 0 ? ', magnitude ' + tmVal : '');
     return '<div class="plaque__trust-notch" data-trust-grade="' + esc(tg) + '"' +
+      ' data-tm="' + esc(String(tmVal)) + '"' +
       ' aria-label="' + esc(ariaLabel) + '">' +
-      '<span class="trust-notch-default">' + esc(tmLabel) + '</span>' +
-      '<span class="trust-notch-reveal">' + esc(tg) + '</span>' +
+      '<span class="trust-notch-label">MAG <span class="trust-notch-num">0</span></span>' +
       '</div>';
   }
+
+  // Wire up the count-up animation for all notches inside a container.
+  // Safe to call multiple times — skips already-wired notches.
+  function _wireTrustNotches(root) {
+    root = root || document;
+    var notches = root.querySelectorAll
+      ? root.querySelectorAll('.plaque__trust-notch[data-tm]')
+      : [];
+    for (var i = 0; i < notches.length; i++) {
+      (function(notch) {
+        if (notch._tmWired) return;
+        notch._tmWired = true;
+        var target = parseFloat(notch.getAttribute('data-tm')) || 0;
+        var numEl = notch.querySelector('.trust-notch-num');
+        if (!numEl) return;
+        var plaque = notch.closest ? notch.closest('.plaque') : notch.parentElement;
+        if (!plaque) return;
+        var raf, startTs;
+        var DURATION = 380;
+        function countUp(ts) {
+          if (!startTs) startTs = ts;
+          var progress = Math.min((ts - startTs) / DURATION, 1);
+          var eased = 1 - (1 - progress) * (1 - progress);
+          var current = eased * target;
+          numEl.textContent = target % 1 === 0
+            ? Math.round(current).toString()
+            : current.toFixed(1);
+          if (progress < 1) raf = requestAnimationFrame(countUp);
+        }
+        function onEnter() {
+          cancelAnimationFrame(raf);
+          startTs = null;
+          numEl.textContent = '0';
+          raf = requestAnimationFrame(countUp);
+        }
+        function onLeave() {
+          cancelAnimationFrame(raf);
+          numEl.textContent = '0';
+        }
+        plaque.addEventListener('mouseenter', onEnter);
+        plaque.addEventListener('mouseleave', onLeave);
+      }(notches[i]));
+    }
+  }
+
+  if (typeof window !== 'undefined') window._wireTrustNotches = _wireTrustNotches;
 
   // ── plaque shell ─────────────────────────────────────────────────
   function _shell(variant, ns, innerHtml, extraOpts) {

--- a/docs/js/plaque.js
+++ b/docs/js/plaque.js
@@ -248,8 +248,10 @@
   //   1. ns.overallTrustGrade  (named-skills.json + docs/graph/named/index.json)
   //   2. ns.trustGrade         (legacy alias, if present)
   //
-  // Shows letter + interpunct + TM on ALL variants (e.g. "A · 47").
-  // Grade name labels are never shown. TM omitted only when zero/null.
+  // Hover reveal:
+  //   Default (no hover): shows TM number (.trust-notch-default).
+  //   Hover: shine sweep animation reveals grade letter S/A/B/C
+  //          (.trust-notch-reveal) while TM number fades out.
   var GRADE_NAMES = { S: 'Platinum', A: 'Gold', B: 'Silver', C: 'Bronze' };
 
   function _fieldTrustNotch(ns) {
@@ -258,20 +260,17 @@
     if (!tg || tg === 'ungraded' || !GRADE_NAMES[tg]) return '';
 
     var gradeName = GRADE_NAMES[tg];
-    var letterHtml = '<span class="trust-notch-letter">' + esc(tg) + '</span>';
-
-    // TM number on ALL variants — show when tm > 0
-    var tmHtml = '';
     var tm = (ns && (ns.trustMagnitude || ns.overallTrustMagnitude));
     var tmRounded = (tm != null && tm !== '') ? Math.round(Number(tm)) : 0;
-    if (tmRounded > 0) {
-      tmHtml = '<span class="trust-notch-tm"> · ' + esc(String(tmRounded)) + '</span>';
-    }
+    var tmLabel = tmRounded > 0 ? String(tmRounded) : '';
 
     var ariaLabel = 'Trust grade: ' + gradeName + (tmRounded > 0 ? ', magnitude ' + tmRounded : '');
+    // .trust-notch-default: TM number visible by default, fades on hover
+    // .trust-notch-reveal: grade letter hidden by default, reveals on hover
     return '<div class="plaque__trust-notch" data-trust-grade="' + esc(tg) + '"' +
       ' aria-label="' + esc(ariaLabel) + '">' +
-      letterHtml + tmHtml +
+      '<span class="trust-notch-default">' + esc(tmLabel) + '</span>' +
+      '<span class="trust-notch-reveal">' + esc(tg) + '</span>' +
       '</div>';
   }
 
@@ -289,12 +288,12 @@
     }
     var role = extraOpts.role ? ' role="' + esc(extraOpts.role) + '" tabindex="0"' : '';
     var extraAttrs = extraOpts.attrs || '';
-    // Trust Grade notch — injected for every variant except hall/mini-stack
-    // (those are contributor plates, not individual skill cards).
-    var trustNotch = '';
-    if (variant !== 'hall' && !(extraOpts.extraClass && extraOpts.extraClass.indexOf('plaque--mini-stack') !== -1)) {
-      trustNotch = _fieldTrustNotch(ns);
-    }
+    // Inject trust notch at card bottom for all variants except mini-stack
+    // (mini-stack is a contributor mosaic with multiple skills; HoH individual
+    //  cards, tile, settled, row, og, detail, and hall all show the notch).
+    var isMiniStack = extraOpts.extraClass &&
+      extraOpts.extraClass.indexOf('plaque--mini-stack') !== -1;
+    var trustNotch = (!isMiniStack) ? _fieldTrustNotch(ns) : '';
     return '<article class="plaque plaque--' + esc(variant) + apex + extraCls +
       '" data-type="' + esc(type) + '" data-level="' + esc(n) +
       '" data-skill-id="' + esc(ns && ns.id || '') + '"' +
@@ -365,6 +364,9 @@
   // Field set: same as tile, laid horizontally. Description hidden via
   // CSS only — no silent field drops at the JS level.
   function renderRow(ns, opts) {
+    var evBadge = ns && ns.level
+      ? '<span class="plaque__ev-badge">' + esc(_evidenceClass(ns.level)) + '</span>'
+      : '';
     var inner =
       _fieldOrb(ns, 'sm') +
       _fieldSlug(ns) +
@@ -374,6 +376,7 @@
       _fieldInstallRow(ns) +
       _fieldRank(ns, 'chip') +
       _fieldGhLink(ns) +
+      evBadge +
       '<span class="plaque__arrow ns-lr-arrow" aria-hidden="true">›</span>';
 
     return _shell('row', ns, inner, opts);

--- a/docs/js/plaque.js
+++ b/docs/js/plaque.js
@@ -239,6 +239,43 @@
       '</button>';
   }
 
+  // ── Trust Grade notch field helper (I8) ─────────────────────────
+  // Returns the .plaque__trust-notch HTML when skill.overallTrustGrade
+  // is a real grade (S/A/B/C), or an empty string when absent/ungraded.
+  // The notch is injected via _shell so every variant gets it automatically.
+  //
+  // Source fields checked in priority order:
+  //   1. ns.overallTrustGrade  (named-skills.json + docs/graph/named/index.json)
+  //   2. ns.trustGrade         (legacy alias, if present)
+  //
+  // For the .plaque--settled variant, the Trust Magnitude (TM) number is
+  // appended when available (ns.trustMagnitude || ns.overallTrustMagnitude).
+  var GRADE_NAMES = { S: 'Platinum', A: 'Gold', B: 'Silver', C: 'Bronze' };
+
+  function _fieldTrustNotch(ns, variant) {
+    var tg = (ns && (ns.overallTrustGrade || ns.trustGrade)) || '';
+    // Normalise: only accept canonical grades; ignore 'ungraded' / nullish
+    if (!tg || tg === 'ungraded' || !GRADE_NAMES[tg]) return '';
+
+    var gradeName = GRADE_NAMES[tg];
+    var letterHtml = '<span class="trust-notch-letter">' + esc(tg) + '</span>';
+    var nameHtml   = '<span class="trust-notch-name">' + esc(gradeName) + '</span>';
+
+    // Settled variant: append TM number when available
+    var tmHtml = '';
+    if (variant === 'settled') {
+      var tm = (ns && (ns.trustMagnitude || ns.overallTrustMagnitude));
+      if (tm != null && tm !== '') {
+        tmHtml = '<span class="trust-notch-tm" aria-hidden="true"> ·' + esc(String(tm)) + '</span>';
+      }
+    }
+
+    return '<div class="plaque__trust-notch" data-trust-grade="' + esc(tg) + '"' +
+      ' aria-label="Trust grade: ' + esc(gradeName) + '">' +
+      letterHtml + nameHtml + tmHtml +
+      '</div>';
+  }
+
   // ── plaque shell ─────────────────────────────────────────────────
   function _shell(variant, ns, innerHtml, extraOpts) {
     var type = (ns && ns.type) || 'basic';
@@ -253,11 +290,18 @@
     }
     var role = extraOpts.role ? ' role="' + esc(extraOpts.role) + '" tabindex="0"' : '';
     var extraAttrs = extraOpts.attrs || '';
+    // Trust Grade notch — injected for every variant except hall/mini-stack
+    // (those are contributor plates, not individual skill cards).
+    var trustNotch = '';
+    if (variant !== 'hall' && !(extraOpts.extraClass && extraOpts.extraClass.indexOf('plaque--mini-stack') !== -1)) {
+      trustNotch = _fieldTrustNotch(ns, variant);
+    }
     return '<article class="plaque plaque--' + esc(variant) + apex + extraCls +
       '" data-type="' + esc(type) + '" data-level="' + esc(n) +
       '" data-skill-id="' + esc(ns && ns.id || '') + '"' +
       clickAttr + role + extraAttrs + '>' +
       innerHtml +
+      trustNotch +
       '</article>';
   }
 

--- a/docs/js/plaque.js
+++ b/docs/js/plaque.js
@@ -248,31 +248,30 @@
   //   1. ns.overallTrustGrade  (named-skills.json + docs/graph/named/index.json)
   //   2. ns.trustGrade         (legacy alias, if present)
   //
-  // For the .plaque--settled variant, the Trust Magnitude (TM) number is
-  // appended when available (ns.trustMagnitude || ns.overallTrustMagnitude).
+  // Shows letter + interpunct + TM on ALL variants (e.g. "A · 47").
+  // Grade name labels are never shown. TM omitted only when zero/null.
   var GRADE_NAMES = { S: 'Platinum', A: 'Gold', B: 'Silver', C: 'Bronze' };
 
-  function _fieldTrustNotch(ns, variant) {
+  function _fieldTrustNotch(ns) {
     var tg = (ns && (ns.overallTrustGrade || ns.trustGrade)) || '';
     // Normalise: only accept canonical grades; ignore 'ungraded' / nullish
     if (!tg || tg === 'ungraded' || !GRADE_NAMES[tg]) return '';
 
     var gradeName = GRADE_NAMES[tg];
     var letterHtml = '<span class="trust-notch-letter">' + esc(tg) + '</span>';
-    var nameHtml   = '<span class="trust-notch-name">' + esc(gradeName) + '</span>';
 
-    // Settled variant: append TM number when available
+    // TM number on ALL variants — show when tm > 0
     var tmHtml = '';
-    if (variant === 'settled') {
-      var tm = (ns && (ns.trustMagnitude || ns.overallTrustMagnitude));
-      if (tm != null && tm !== '') {
-        tmHtml = '<span class="trust-notch-tm" aria-hidden="true"> ·' + esc(String(tm)) + '</span>';
-      }
+    var tm = (ns && (ns.trustMagnitude || ns.overallTrustMagnitude));
+    var tmRounded = (tm != null && tm !== '') ? Math.round(Number(tm)) : 0;
+    if (tmRounded > 0) {
+      tmHtml = '<span class="trust-notch-tm"> · ' + esc(String(tmRounded)) + '</span>';
     }
 
+    var ariaLabel = 'Trust grade: ' + gradeName + (tmRounded > 0 ? ', magnitude ' + tmRounded : '');
     return '<div class="plaque__trust-notch" data-trust-grade="' + esc(tg) + '"' +
-      ' aria-label="Trust grade: ' + esc(gradeName) + '">' +
-      letterHtml + nameHtml + tmHtml +
+      ' aria-label="' + esc(ariaLabel) + '">' +
+      letterHtml + tmHtml +
       '</div>';
   }
 
@@ -294,7 +293,7 @@
     // (those are contributor plates, not individual skill cards).
     var trustNotch = '';
     if (variant !== 'hall' && !(extraOpts.extraClass && extraOpts.extraClass.indexOf('plaque--mini-stack') !== -1)) {
-      trustNotch = _fieldTrustNotch(ns, variant);
+      trustNotch = _fieldTrustNotch(ns);
     }
     return '<article class="plaque plaque--' + esc(variant) + apex + extraCls +
       '" data-type="' + esc(type) + '" data-level="' + esc(n) +
@@ -472,7 +471,6 @@
       _fieldTags(ns, 5) +
       _fieldRank(ns, 'stars') +
       _fieldInstallRow(ns) +
-      '<div class="plaque__evidence plaque-evidence">' + esc(_evidenceClass(ns && ns.level)) + '</div>' +
       '<div class="plaque__underline plaque-underline plaque-underline--settled"></div>';
 
     return _shell('settled', ns, inner, opts);

--- a/docs/samples/index.html
+++ b/docs/samples/index.html
@@ -588,6 +588,40 @@
       </div>
       </a>
 
+      <a class="si-card" href="trust-grade-notch.html">
+      <div class="si-thumb" aria-hidden="true">
+        <svg viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
+          <!-- Card body -->
+          <rect x="20" y="8" width="160" height="74" rx="7" fill="rgba(15,23,42,0.92)" stroke="rgba(30,41,59,0.8)" stroke-width="1"/>
+          <!-- Skill orb -->
+          <circle cx="48" cy="34" r="11" fill="rgba(251,191,36,0.15)" stroke="rgba(251,191,36,0.4)" stroke-width="1.2"/>
+          <text x="48" y="38" font-family="monospace" font-size="9" fill="rgba(251,191,36,0.9)" text-anchor="middle">S</text>
+          <!-- Skill title lines -->
+          <rect x="66" y="27" width="72" height="5" rx="2" fill="rgba(226,232,240,0.18)"/>
+          <rect x="66" y="36" width="52" height="4" rx="2" fill="rgba(100,116,139,0.25)"/>
+          <!-- Stars -->
+          <text x="66" y="52" font-family="monospace" font-size="7" fill="rgba(251,191,36,0.7)">★★★★★</text>
+          <!-- Trust notch pill at bottom — platinum gradient -->
+          <defs>
+            <linearGradient id="platinum" x1="0%" y1="0%" x2="100%" y2="0%">
+              <stop offset="0%"   stop-color="#e2e8f0" stop-opacity="0.25"/>
+              <stop offset="40%"  stop-color="#c8d8ff" stop-opacity="0.35"/>
+              <stop offset="70%"  stop-color="#a5c7eb" stop-opacity="0.28"/>
+              <stop offset="100%" stop-color="#ecf4ff" stop-opacity="0.22"/>
+            </linearGradient>
+          </defs>
+          <rect x="72" y="70" width="56" height="9" rx="0 0 5 5" fill="url(#platinum)" stroke="rgba(255,255,255,0.12)" stroke-width="0.8"/>
+          <text x="100" y="77" font-family="monospace" font-size="6.5" font-weight="700" fill="rgba(226,232,240,0.9)" text-anchor="middle" letter-spacing="1">416</text>
+        </svg>
+      </div>
+      <div class="si-card-body">
+        <div class="si-stage-label">I8</div>
+        <div class="si-card-title">Trust Grade Notch</div>
+        <div class="si-card-desc">Metallic pill at the bottom of every plaque. Default state shows Trust Magnitude number; hover triggers a diagonal shine sweep that reveals the grade letter (S / A / B / C). Four grade variants: platinum shimmer, gold, dark steel, bronze.</div>
+        <div class="si-card-link">trust-grade-notch.html &rsaquo;</div>
+      </div>
+      </a>
+
       </div>
 
   <!-- ── Footer reference links ── -->

--- a/docs/samples/trust-grade-notch.html
+++ b/docs/samples/trust-grade-notch.html
@@ -81,33 +81,33 @@
     }
     .grade-notch-preview[data-trust-grade="S"] {
       background: linear-gradient(135deg,
-        color-mix(in srgb, var(--grade-S) 60%, #c8d8f0) 0%,
+        color-mix(in srgb, var(--grade-S) 60%, var(--trust-notch-S-hi)) 0%,
         var(--grade-S) 45%,
-        color-mix(in srgb, var(--grade-S) 70%, #8899bb) 100%);
-      color: #0b2545;
+        color-mix(in srgb, var(--grade-S) 70%, var(--trust-notch-S-lo)) 100%);
+      color: var(--trust-notch-text-S);
       animation: trust-notch-shimmer 3.5s linear infinite;
       background-size: 200% 200%;
     }
     .grade-notch-preview[data-trust-grade="A"] {
       background: linear-gradient(135deg,
-        color-mix(in srgb, var(--grade-A) 65%, #fff) 0%,
+        color-mix(in srgb, var(--grade-A) 65%, var(--trust-notch-A-hi)) 0%,
         var(--grade-A) 55%,
-        color-mix(in srgb, var(--grade-A) 75%, #7a5c00) 100%);
-      color: #451a03;
+        color-mix(in srgb, var(--grade-A) 75%, var(--trust-notch-A-lo)) 100%);
+      color: var(--trust-notch-text-A);
     }
     .grade-notch-preview[data-trust-grade="B"] {
       background: linear-gradient(135deg,
-        color-mix(in srgb, var(--grade-B) 55%, #8a99ad) 0%,
+        color-mix(in srgb, var(--grade-B) 55%, var(--trust-notch-B-hi)) 0%,
         var(--grade-B) 50%,
-        color-mix(in srgb, var(--grade-B) 60%, #475569) 100%);
-      color: #0f172a;
+        color-mix(in srgb, var(--grade-B) 60%, var(--trust-notch-B-lo)) 100%);
+      color: var(--trust-notch-text-B);
     }
     .grade-notch-preview[data-trust-grade="C"] {
       background: linear-gradient(135deg,
-        color-mix(in srgb, var(--grade-C) 70%, #d97706) 0%,
+        color-mix(in srgb, var(--grade-C) 70%, var(--trust-notch-C-hi)) 0%,
         var(--grade-C) 50%,
-        color-mix(in srgb, var(--grade-C) 80%, #7c5a2a) 100%);
-      color: #fffbeb;
+        color-mix(in srgb, var(--grade-C) 80%, var(--trust-notch-C-lo)) 100%);
+      color: var(--trust-notch-text-C);
     }
     .grade-desc {
       color: var(--muted);
@@ -228,24 +228,24 @@
 <body>
 
   <h1 class="sampler-h1">Trust Grade Notch</h1>
-  <p class="sampler-sub">I8 — 4 grades × 6 plaque variants — dev/review artifact</p>
+  <p class="sampler-sub">I8 · 4 grades × 6 plaque variants / dev/review artifact</p>
 
   <p class="sampler-intro">
     The <strong>Trust Grade notch</strong> is a small rectangular metallic corner stamp that appears at
     the bottom-right of every <code>.plaque</code> variant. It shows the skill's
     <code>overallTrustGrade</code> field: <code>S</code> (Platinum), <code>A</code> (Gold),
-    <code>B</code> (Silver), <code>C</code> (Bronze). Ungraded skills show nothing — zero
+    <code>B</code> (Silver), <code>C</code> (Bronze). Ungraded skills show nothing; zero
     markup cost when absent. This notch is <em>distinct</em> from the star-rank system; both
     coexist on the same card.
   </p>
 
-  <!-- ── S — Platinum ─────────────────────────────────────────────── -->
+  <!-- S · Platinum -->
   <section class="grade-section" id="grade-S">
     <div class="grade-heading">
-      <h2>S — Platinum</h2>
+      <h2>S · Platinum</h2>
       <span class="grade-notch-preview" data-trust-grade="S">S Platinum</span>
     </div>
-    <p class="grade-desc">Animated shimmer · deep-navy text (#0b2545) · contrast ≈ 10.8:1 ✓</p>
+    <p class="grade-desc">Animated shimmer · deep-navy text · contrast ≈ 10.8:1 ✓</p>
     <p class="grade-note">
       <strong>Reduced motion:</strong> the shimmer animation is suppressed under
       <code>prefers-reduced-motion: reduce</code>; the notch falls back to a static
@@ -254,39 +254,39 @@
     <div class="variant-strip" id="strip-S"></div>
   </section>
 
-  <!-- ── A — Gold ──────────────────────────────────────────────────── -->
+  <!-- A · Gold -->
   <section class="grade-section" id="grade-A">
     <div class="grade-heading">
-      <h2>A — Gold</h2>
+      <h2>A · Gold</h2>
       <span class="grade-notch-preview" data-trust-grade="A">A Gold</span>
     </div>
-    <p class="grade-desc">Static gradient · deep-brown text (#451a03) · contrast ≈ 7.2:1 ✓</p>
+    <p class="grade-desc">Static gradient · deep-brown text · contrast ≈ 7.2:1 ✓</p>
     <div class="variant-strip" id="strip-A"></div>
   </section>
 
-  <!-- ── B — Silver ────────────────────────────────────────────────── -->
+  <!-- B · Silver -->
   <section class="grade-section" id="grade-B">
     <div class="grade-heading">
-      <h2>B — Silver</h2>
+      <h2>B · Silver</h2>
       <span class="grade-notch-preview" data-trust-grade="B">B Silver</span>
     </div>
-    <p class="grade-desc">Static gradient (darker matte) · dark-slate text (#0f172a) · contrast ≈ 11.4:1 ✓</p>
+    <p class="grade-desc">Static gradient (darker matte) · dark-slate text · contrast ≈ 11.4:1 ✓</p>
     <div class="variant-strip" id="strip-B"></div>
   </section>
 
-  <!-- ── C — Bronze ────────────────────────────────────────────────── -->
+  <!-- C · Bronze -->
   <section class="grade-section" id="grade-C">
     <div class="grade-heading">
-      <h2>C — Bronze</h2>
+      <h2>C · Bronze</h2>
       <span class="grade-notch-preview" data-trust-grade="C">C Bronze</span>
     </div>
-    <p class="grade-desc">Static gradient (tarnished) · light-warm text (#fffbeb) · contrast ≈ 4.8:1 ✓</p>
+    <p class="grade-desc">Static gradient (tarnished) · light-warm text · contrast ≈ 4.8:1 ✓</p>
     <div class="variant-strip" id="strip-C"></div>
   </section>
 
-  <!-- ── Ungraded — no notch ───────────────────────────────────────── -->
+  <!-- Ungraded: no notch -->
   <section class="ungraded-section" id="grade-none">
-    <h2>Ungraded — no notch rendered</h2>
+    <h2>Ungraded</h2>
     <p class="grade-desc">overallTrustGrade: null / "ungraded" — zero markup emitted</p>
     <div class="variant-strip" id="strip-none"></div>
   </section>

--- a/docs/samples/trust-grade-notch.html
+++ b/docs/samples/trust-grade-notch.html
@@ -81,9 +81,10 @@
     }
     .grade-notch-preview[data-trust-grade="S"] {
       background: linear-gradient(135deg,
-        color-mix(in srgb, var(--grade-S) 60%, var(--trust-notch-S-hi)) 0%,
-        var(--grade-S) 45%,
-        color-mix(in srgb, var(--grade-S) 70%, var(--trust-notch-S-lo)) 100%);
+        var(--trust-notch-S-hi2) 0%,
+        color-mix(in srgb, var(--trust-notch-S-mid) 80%, var(--trust-notch-S-violet)) 35%,
+        var(--trust-notch-S-mid) 65%,
+        color-mix(in srgb, var(--trust-notch-S-violet) 60%, var(--trust-notch-S-mid)) 100%);
       color: var(--trust-notch-text-S);
       animation: trust-notch-shimmer 3.5s linear infinite;
       background-size: 200% 200%;
@@ -97,9 +98,9 @@
     }
     .grade-notch-preview[data-trust-grade="B"] {
       background: linear-gradient(135deg,
-        color-mix(in srgb, var(--grade-B) 55%, var(--trust-notch-B-hi)) 0%,
-        var(--grade-B) 50%,
-        color-mix(in srgb, var(--grade-B) 60%, var(--trust-notch-B-lo)) 100%);
+        var(--trust-notch-B-hi) 0%,
+        color-mix(in srgb, var(--trust-notch-B-hi) 55%, var(--trust-notch-B-lo)) 50%,
+        var(--trust-notch-B-lo) 100%);
       color: var(--trust-notch-text-B);
     }
     .grade-notch-preview[data-trust-grade="C"] {
@@ -231,21 +232,20 @@
   <p class="sampler-sub">I8 · 4 grades × 6 plaque variants / dev/review artifact</p>
 
   <p class="sampler-intro">
-    The <strong>Trust Grade notch</strong> is a small rectangular metallic corner stamp that appears at
-    the bottom-right of every <code>.plaque</code> variant. It shows the skill's
-    <code>overallTrustGrade</code> field: <code>S</code> (Platinum), <code>A</code> (Gold),
-    <code>B</code> (Silver), <code>C</code> (Bronze). Ungraded skills show nothing; zero
-    markup cost when absent. This notch is <em>distinct</em> from the star-rank system; both
-    coexist on the same card.
+    The <strong>Trust Grade notch</strong> is a full-width centered footer row at the bottom of every
+    <code>.plaque</code> variant. It shows the skill's <code>overallTrustGrade</code> letter plus
+    Trust Magnitude number (e.g. <code>A · 47</code>). Grade name labels are never shown.
+    Ungraded skills show nothing; zero markup cost when absent. This notch is <em>distinct</em>
+    from the star-rank system; both coexist on the same card.
   </p>
 
   <!-- S · Platinum -->
   <section class="grade-section" id="grade-S">
     <div class="grade-heading">
       <h2>S · Platinum</h2>
-      <span class="grade-notch-preview" data-trust-grade="S">S Platinum</span>
+      <span class="grade-notch-preview" data-trust-grade="S">S · 42</span>
     </div>
-    <p class="grade-desc">Animated shimmer · deep-navy text · contrast ≈ 10.8:1 ✓</p>
+    <p class="grade-desc">Animated iridescent shimmer · deep-navy text · contrast ≈ 10.8:1 ✓</p>
     <p class="grade-note">
       <strong>Reduced motion:</strong> the shimmer animation is suppressed under
       <code>prefers-reduced-motion: reduce</code>; the notch falls back to a static
@@ -258,7 +258,7 @@
   <section class="grade-section" id="grade-A">
     <div class="grade-heading">
       <h2>A · Gold</h2>
-      <span class="grade-notch-preview" data-trust-grade="A">A Gold</span>
+      <span class="grade-notch-preview" data-trust-grade="A">A · 31</span>
     </div>
     <p class="grade-desc">Static gradient · deep-brown text · contrast ≈ 7.2:1 ✓</p>
     <div class="variant-strip" id="strip-A"></div>
@@ -268,9 +268,9 @@
   <section class="grade-section" id="grade-B">
     <div class="grade-heading">
       <h2>B · Silver</h2>
-      <span class="grade-notch-preview" data-trust-grade="B">B Silver</span>
+      <span class="grade-notch-preview" data-trust-grade="B">B · 18</span>
     </div>
-    <p class="grade-desc">Static gradient (darker matte) · dark-slate text · contrast ≈ 11.4:1 ✓</p>
+    <p class="grade-desc">Dark steel gradient (#8a99ad → #475569) · light text · contrast ≈ 6.2:1 ✓</p>
     <div class="variant-strip" id="strip-B"></div>
   </section>
 
@@ -278,7 +278,7 @@
   <section class="grade-section" id="grade-C">
     <div class="grade-heading">
       <h2>C · Bronze</h2>
-      <span class="grade-notch-preview" data-trust-grade="C">C Bronze</span>
+      <span class="grade-notch-preview" data-trust-grade="C">C · 7</span>
     </div>
     <p class="grade-desc">Static gradient (tarnished) · light-warm text · contrast ≈ 4.8:1 ✓</p>
     <div class="variant-strip" id="strip-C"></div>

--- a/docs/samples/trust-grade-notch.html
+++ b/docs/samples/trust-grade-notch.html
@@ -195,10 +195,12 @@
       var tileEl = document.getElementById('stageTile');
       if (tileEl && window.plaque) {
         var tiledSkills = [
-          skill({ level: 6, type: 'ultimate', overallTrustGrade: 'S', trustMagnitude: 310 }),
-          skill({ level: 4, type: 'extra',    overallTrustGrade: 'A', trustMagnitude: 122 }),
-          skill({ level: 3, type: 'basic',    overallTrustGrade: 'B', trustMagnitude: 56 }),
-          skill({ level: 2, type: 'basic',    overallTrustGrade: 'C', trustMagnitude: 18 })
+          skill({ level: 6, type: 'ultimate', overallTrustGrade: 'S', trustMagnitude: 589.3, name: 'gstack', contributor: 'garrytan' }),
+          skill({ level: 5, type: 'ultimate', overallTrustGrade: 'S', trustMagnitude: 416.0, name: 'superpowers', contributor: 'obra' }),
+          skill({ level: 4, type: 'extra',    overallTrustGrade: 'A', trustMagnitude: 122.8, name: 'impeccable', contributor: 'pbakaus' }),
+          skill({ level: 3, type: 'basic',    overallTrustGrade: 'B', trustMagnitude: 81.0,  name: 'writing-plans', contributor: 'obra' }),
+          skill({ level: 2, type: 'basic',    overallTrustGrade: 'C', trustMagnitude: 36.0,  name: 'careful', contributor: 'garrytan' }),
+          skill({ level: 2, type: 'basic',    overallTrustGrade: 'C', trustMagnitude: 18.0,  name: 'readme-gen', contributor: 'glincker' })
         ];
         tiledSkills.forEach(function (ns) {
           var wrap = document.createElement('div');
@@ -212,7 +214,7 @@
       var settledEl = document.getElementById('stageSettled');
       if (settledEl && window.plaque) {
         settledEl.innerHTML = window.plaque.renderSettled(
-          skill({ level: 4, type: 'extra', overallTrustGrade: 'A', trustMagnitude: 122 }),
+          skill({ level: 5, type: 'ultimate', overallTrustGrade: 'S', trustMagnitude: 482.3, name: 'ruflo', contributor: 'ruvnet' }),
           { click: false }
         );
       }
@@ -221,7 +223,7 @@
       var miniEl = document.getElementById('stageMini');
       if (miniEl && window.plaque) {
         miniEl.innerHTML = window.plaque.renderMini(
-          skill({ level: 6, type: 'ultimate', overallTrustGrade: 'S', trustMagnitude: 310 }),
+          skill({ level: 5, type: 'ultimate', overallTrustGrade: 'S', trustMagnitude: 440.8, name: 'skills', contributor: 'mattpocock' }),
           { click: false }
         );
       }
@@ -230,10 +232,10 @@
       var rowEl = document.getElementById('stageRow');
       if (rowEl && window.plaque) {
         var rowSkills = [
-          skill({ level: 6, type: 'ultimate', overallTrustGrade: 'S', trustMagnitude: 310 }),
-          skill({ level: 4, type: 'extra',    overallTrustGrade: 'A', trustMagnitude: 122 }),
-          skill({ level: 3, type: 'basic',    overallTrustGrade: 'B', trustMagnitude: 56 }),
-          skill({ level: 2, type: 'basic',    overallTrustGrade: 'C', trustMagnitude: 18 })
+          skill({ level: 5, type: 'ultimate', overallTrustGrade: 'S', trustMagnitude: 589.3, name: 'gstack', contributor: 'garrytan' }),
+          skill({ level: 4, type: 'extra',    overallTrustGrade: 'A', trustMagnitude: 270.0, name: 'engineering', contributor: 'mattpocock' }),
+          skill({ level: 3, type: 'basic',    overallTrustGrade: 'B', trustMagnitude: 88.5,  name: 'subagent-driven-development', contributor: 'obra' }),
+          skill({ level: 2, type: 'basic',    overallTrustGrade: 'C', trustMagnitude: 36.0,  name: 'careful', contributor: 'garrytan' })
         ];
         rowSkills.forEach(function (ns) {
           var div = document.createElement('div');
@@ -250,6 +252,11 @@
           skill({ level: 3, type: 'basic' }),
           { click: false }
         );
+      }
+
+      // Wire count-up animation for all rendered notches
+      if (typeof window._wireTrustNotches === 'function') {
+        window._wireTrustNotches(document);
       }
     })();
   </script>

--- a/docs/samples/trust-grade-notch.html
+++ b/docs/samples/trust-grade-notch.html
@@ -1,0 +1,450 @@
+<!DOCTYPE html>
+<html lang="en" data-icon-base="../assets/icons.svg">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Trust Grade Notch Sampler — Gaia (I8)</title>
+  <meta name="description" content="Trust Grade notch (I8): 4 grades × 6 plaque variants. S=Platinum, A=Gold, B=Silver, C=Bronze. Dev/review artifact — not in public nav.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+  <link rel="stylesheet" href="../css/tokens.css">
+  <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="../css/plaque.css">
+  <script src="../js/icons.js"></script>
+  <script src="../js/rank-badge.js"></script>
+  <script src="../js/atlas-helpers.js"></script>
+  <script src="../js/plaque.js"></script>
+  <style>
+    body {
+      padding: 4rem 1.5rem 8rem;
+      max-width: 1400px;
+      margin: 0 auto;
+    }
+    .sampler-h1 {
+      font-family: var(--font-display);
+      font-size: clamp(1.8rem, 4vw, 2.6rem);
+      font-weight: 600;
+      margin-bottom: .2rem;
+    }
+    .sampler-sub {
+      color: var(--muted);
+      font-family: var(--font-mono);
+      font-size: .82rem;
+      letter-spacing: .05em;
+      text-transform: uppercase;
+      margin-bottom: 2rem;
+    }
+    .sampler-intro {
+      color: rgba(226, 232, 240, 0.6);
+      font-family: var(--font-body);
+      font-size: .9rem;
+      line-height: 1.65;
+      max-width: 66ch;
+      margin-bottom: 2.5rem;
+    }
+    .sampler-intro code {
+      font-family: var(--font-mono);
+      color: var(--tier-basic);
+      font-size: .85em;
+    }
+
+    /* ── Grade row ── */
+    .grade-section {
+      margin: 3rem 0 0;
+      padding-top: 2rem;
+      border-top: 1px solid var(--border);
+    }
+    .grade-heading {
+      display: flex;
+      align-items: center;
+      gap: .75rem;
+      margin-bottom: .25rem;
+    }
+    .grade-heading h2 {
+      font-family: var(--font-display);
+      font-size: 1.55rem;
+      font-weight: 600;
+    }
+    .grade-notch-preview {
+      /* Standalone notch preview badge — same CSS classes as the live notch */
+      display: inline-flex;
+      align-items: center;
+      gap: 3px;
+      height: 22px;
+      padding: 0 8px;
+      font-family: var(--font-mono);
+      font-size: .72rem;
+      font-weight: 700;
+      letter-spacing: .04em;
+      border-radius: 3px;
+    }
+    .grade-notch-preview[data-trust-grade="S"] {
+      background: linear-gradient(135deg,
+        color-mix(in srgb, var(--grade-S) 60%, #c8d8f0) 0%,
+        var(--grade-S) 45%,
+        color-mix(in srgb, var(--grade-S) 70%, #8899bb) 100%);
+      color: #0b2545;
+      animation: trust-notch-shimmer 3.5s linear infinite;
+      background-size: 200% 200%;
+    }
+    .grade-notch-preview[data-trust-grade="A"] {
+      background: linear-gradient(135deg,
+        color-mix(in srgb, var(--grade-A) 65%, #fff) 0%,
+        var(--grade-A) 55%,
+        color-mix(in srgb, var(--grade-A) 75%, #7a5c00) 100%);
+      color: #451a03;
+    }
+    .grade-notch-preview[data-trust-grade="B"] {
+      background: linear-gradient(135deg,
+        color-mix(in srgb, var(--grade-B) 55%, #8a99ad) 0%,
+        var(--grade-B) 50%,
+        color-mix(in srgb, var(--grade-B) 60%, #475569) 100%);
+      color: #0f172a;
+    }
+    .grade-notch-preview[data-trust-grade="C"] {
+      background: linear-gradient(135deg,
+        color-mix(in srgb, var(--grade-C) 70%, #d97706) 0%,
+        var(--grade-C) 50%,
+        color-mix(in srgb, var(--grade-C) 80%, #7c5a2a) 100%);
+      color: #fffbeb;
+    }
+    .grade-desc {
+      color: var(--muted);
+      font-family: var(--font-mono);
+      font-size: .78rem;
+      letter-spacing: .04em;
+      text-transform: uppercase;
+      margin-bottom: 1.25rem;
+    }
+    .grade-note {
+      font-family: var(--font-body);
+      font-size: .82rem;
+      color: rgba(226, 232, 240, 0.45);
+      margin-bottom: 1rem;
+    }
+    .grade-note strong {
+      color: rgba(226, 232, 240, 0.75);
+      font-weight: 600;
+    }
+
+    /* ── Variant strip ── */
+    .variant-strip {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      align-items: flex-start;
+      padding: 1.25rem;
+      background: rgba(255, 255, 255, 0.012);
+      border: 1px solid var(--border);
+      border-radius: 14px;
+    }
+    .variant-label {
+      font-family: var(--font-mono);
+      font-size: .68rem;
+      letter-spacing: .08em;
+      text-transform: uppercase;
+      color: var(--muted);
+      margin-bottom: .35rem;
+    }
+    .variant-col {
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* OG card wrap: scale down to fit */
+    .og-wrap {
+      position: relative;
+      width: 360px;
+      height: 189px; /* 630*0.3 */
+      overflow: hidden;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+    }
+    .og-wrap .plaque--og {
+      transform-origin: top left;
+      transform: scale(0.3);
+      width: 1200px;
+    }
+    .og-wrap::after {
+      content: '1200×630 @ 0.3×';
+      position: absolute;
+      bottom: 4px;
+      right: 6px;
+      font-family: var(--font-mono);
+      font-size: 9px;
+      color: rgba(226, 232, 240, 0.3);
+      letter-spacing: .06em;
+      text-transform: uppercase;
+      pointer-events: none;
+    }
+
+    /* row variant needs a minimum width container */
+    .row-wrap { width: 560px; max-width: 100%; }
+    /* tile variant width */
+    .tile-wrap { width: 300px; max-width: 100%; }
+    /* settled variant width */
+    .settled-wrap { width: 300px; max-width: 100%; }
+
+    /* ── Reduced motion note ── */
+    .rm-note {
+      margin-top: 1.5rem;
+      padding: .85rem 1.1rem;
+      background: rgba(56, 189, 248, 0.05);
+      border: 1px solid rgba(56, 189, 248, 0.12);
+      border-radius: 8px;
+      font-family: var(--font-mono);
+      font-size: .78rem;
+      color: rgba(226, 232, 240, 0.55);
+      line-height: 1.55;
+    }
+    .rm-note strong {
+      color: var(--tier-basic);
+    }
+    .rm-note code {
+      color: rgba(226, 232, 240, 0.75);
+      background: rgba(255,255,255,.05);
+      padding: 1px 5px;
+      border-radius: 3px;
+    }
+
+    /* ── Ungraded check ── */
+    .ungraded-section {
+      margin-top: 3rem;
+      padding-top: 2rem;
+      border-top: 1px solid var(--border);
+    }
+    .ungraded-section h2 {
+      font-family: var(--font-display);
+      font-size: 1.4rem;
+      font-weight: 600;
+      margin-bottom: .2rem;
+    }
+    .ungraded-section .grade-desc {
+      margin-bottom: 1rem;
+    }
+  </style>
+</head>
+<body>
+
+  <h1 class="sampler-h1">Trust Grade Notch</h1>
+  <p class="sampler-sub">I8 — 4 grades × 6 plaque variants — dev/review artifact</p>
+
+  <p class="sampler-intro">
+    The <strong>Trust Grade notch</strong> is a small rectangular metallic corner stamp that appears at
+    the bottom-right of every <code>.plaque</code> variant. It shows the skill's
+    <code>overallTrustGrade</code> field: <code>S</code> (Platinum), <code>A</code> (Gold),
+    <code>B</code> (Silver), <code>C</code> (Bronze). Ungraded skills show nothing — zero
+    markup cost when absent. This notch is <em>distinct</em> from the star-rank system; both
+    coexist on the same card.
+  </p>
+
+  <!-- ── S — Platinum ─────────────────────────────────────────────── -->
+  <section class="grade-section" id="grade-S">
+    <div class="grade-heading">
+      <h2>S — Platinum</h2>
+      <span class="grade-notch-preview" data-trust-grade="S">S Platinum</span>
+    </div>
+    <p class="grade-desc">Animated shimmer · deep-navy text (#0b2545) · contrast ≈ 10.8:1 ✓</p>
+    <p class="grade-note">
+      <strong>Reduced motion:</strong> the shimmer animation is suppressed under
+      <code>prefers-reduced-motion: reduce</code>; the notch falls back to a static
+      linear-gradient. Use your OS accessibility settings to verify, or see the note below.
+    </p>
+    <div class="variant-strip" id="strip-S"></div>
+  </section>
+
+  <!-- ── A — Gold ──────────────────────────────────────────────────── -->
+  <section class="grade-section" id="grade-A">
+    <div class="grade-heading">
+      <h2>A — Gold</h2>
+      <span class="grade-notch-preview" data-trust-grade="A">A Gold</span>
+    </div>
+    <p class="grade-desc">Static gradient · deep-brown text (#451a03) · contrast ≈ 7.2:1 ✓</p>
+    <div class="variant-strip" id="strip-A"></div>
+  </section>
+
+  <!-- ── B — Silver ────────────────────────────────────────────────── -->
+  <section class="grade-section" id="grade-B">
+    <div class="grade-heading">
+      <h2>B — Silver</h2>
+      <span class="grade-notch-preview" data-trust-grade="B">B Silver</span>
+    </div>
+    <p class="grade-desc">Static gradient (darker matte) · dark-slate text (#0f172a) · contrast ≈ 11.4:1 ✓</p>
+    <div class="variant-strip" id="strip-B"></div>
+  </section>
+
+  <!-- ── C — Bronze ────────────────────────────────────────────────── -->
+  <section class="grade-section" id="grade-C">
+    <div class="grade-heading">
+      <h2>C — Bronze</h2>
+      <span class="grade-notch-preview" data-trust-grade="C">C Bronze</span>
+    </div>
+    <p class="grade-desc">Static gradient (tarnished) · light-warm text (#fffbeb) · contrast ≈ 4.8:1 ✓</p>
+    <div class="variant-strip" id="strip-C"></div>
+  </section>
+
+  <!-- ── Ungraded — no notch ───────────────────────────────────────── -->
+  <section class="ungraded-section" id="grade-none">
+    <h2>Ungraded — no notch rendered</h2>
+    <p class="grade-desc">overallTrustGrade: null / "ungraded" — zero markup emitted</p>
+    <div class="variant-strip" id="strip-none"></div>
+  </section>
+
+  <!-- ── Reduced motion note ──────────────────────────────────────── -->
+  <div class="rm-note">
+    <strong>prefers-reduced-motion note:</strong> Grade S (Platinum) animates a background-position
+    shimmer via <code>@keyframes trust-notch-shimmer</code>. Under
+    <code>@media (prefers-reduced-motion: reduce)</code> the animation is suppressed and a static
+    linear-gradient is applied instead. To verify: enable Reduce Motion in your OS accessibility
+    settings, reload this page, and confirm the Platinum notch is static. All other grades are
+    static by default and unaffected.
+  </div>
+
+  <script>
+  (function () {
+    'use strict';
+
+    // ── Sample skill data for each grade ──────────────────────────
+    // Hard-coded so the sampler works offline with no server.
+    // Grades picked to match real-world data in docs/graph/gaia.json.
+    var SAMPLES = {
+      S: {
+        id: 'mattpocock/skills',
+        name: 'Skills Suite',
+        contributor: 'mattpocock',
+        origin: true,
+        genericSkillRef: 'skills',
+        status: 'named',
+        level: '5★',
+        type: 'ultimate',
+        title: 'The Complete TS Skill Suite',
+        description: 'A comprehensive suite of TypeScript agent skills covering type inference, generics, and advanced patterns for production codebases.',
+        tags: ['typescript', 'agent-skills', 'suite'],
+        links: { github: 'https://github.com/mattpocock/skills' },
+        overallTrustGrade: 'S',
+        overallTrustMagnitude: 42,
+      },
+      A: {
+        id: 'karpathy/autoresearch',
+        name: 'AutoResearch',
+        contributor: 'karpathy',
+        origin: true,
+        genericSkillRef: 'autonomous-research-agent',
+        status: 'named',
+        level: '5★',
+        type: 'ultimate',
+        title: "The Scholar's Compass",
+        description: 'Autonomous research agent that iteratively searches, reads, and synthesizes academic papers into structured summaries with citation graphs.',
+        tags: ['research', 'autonomous', 'paper-synthesis'],
+        links: { github: 'https://github.com/karpathy/autoresearch' },
+        overallTrustGrade: 'A',
+        overallTrustMagnitude: 31,
+      },
+      B: {
+        id: 'stanfordnlp/dspy',
+        name: 'DSPy',
+        contributor: 'stanfordnlp',
+        origin: false,
+        genericSkillRef: 'dspy',
+        status: 'named',
+        level: '4★',
+        type: 'extra',
+        title: 'Declarative Self-Improving LM Programs',
+        description: 'Framework for algorithmically optimizing LM prompts and weights using declarative modules and automatic compilers.',
+        tags: ['dspy', 'optimization', 'prompting'],
+        links: { github: 'https://github.com/stanfordnlp/dspy' },
+        overallTrustGrade: 'B',
+        overallTrustMagnitude: 18,
+      },
+      C: {
+        id: 'anthropics/computer-use',
+        name: 'Computer Use',
+        contributor: 'anthropics',
+        origin: false,
+        genericSkillRef: 'computer-use',
+        status: 'named',
+        level: '3★',
+        type: 'basic',
+        title: 'Desktop GUI Automation',
+        description: 'Enables agents to interact with desktop applications through simulated keyboard and mouse inputs, screenshot parsing, and UI element detection.',
+        tags: ['computer-use', 'gui', 'automation'],
+        links: { github: 'https://github.com/anthropics/computer-use-demo' },
+        overallTrustGrade: 'C',
+        overallTrustMagnitude: 7,
+      },
+      none: {
+        id: 'garrytan/gstack',
+        name: 'gstack',
+        contributor: 'garrytan',
+        origin: false,
+        genericSkillRef: 'gstack',
+        status: 'named',
+        level: '3★',
+        type: 'ultimate',
+        title: 'The Full-Stack Agent Suite',
+        description: 'Comprehensive suite of agent skills for end-to-end web product development, from design to deployment.',
+        tags: ['fullstack', 'deployment', 'design'],
+        links: { github: 'https://github.com/garrytan/gstack' },
+        overallTrustGrade: null, // intentionally ungraded — no notch should render
+      },
+    };
+
+    // ── Variant renderer ─────────────────────────────────────────
+    function renderStrip(grade) {
+      var p = window.plaque;
+      if (!p) return;
+      var ns = SAMPLES[grade];
+      var el = document.getElementById('strip-' + grade);
+      if (!el) return;
+
+      // mini
+      var miniCol = document.createElement('div');
+      miniCol.className = 'variant-col';
+      miniCol.innerHTML = '<p class="variant-label">--mini</p>' + p.renderMini(ns);
+      el.appendChild(miniCol);
+
+      // tile
+      var tileCol = document.createElement('div');
+      tileCol.className = 'variant-col tile-wrap';
+      tileCol.innerHTML = '<p class="variant-label">--tile</p>' + p.renderTile(ns);
+      el.appendChild(tileCol);
+
+      // row
+      var rowCol = document.createElement('div');
+      rowCol.className = 'variant-col row-wrap';
+      rowCol.innerHTML = '<p class="variant-label">--row</p>' + p.renderRow(ns);
+      el.appendChild(rowCol);
+
+      // detail
+      var detailCol = document.createElement('div');
+      detailCol.className = 'variant-col';
+      detailCol.style.flex = '1 1 600px';
+      detailCol.innerHTML = '<p class="variant-label">--detail</p>' + p.renderDetail(ns);
+      el.appendChild(detailCol);
+
+      // settled
+      var settledCol = document.createElement('div');
+      settledCol.className = 'variant-col settled-wrap';
+      settledCol.innerHTML = '<p class="variant-label">--settled</p>' + p.renderSettled(ns);
+      el.appendChild(settledCol);
+
+      // og (scaled)
+      var ogCol = document.createElement('div');
+      ogCol.className = 'variant-col';
+      ogCol.innerHTML = '<p class="variant-label">--og (0.3×)</p>';
+      var ogWrap = document.createElement('div');
+      ogWrap.className = 'og-wrap';
+      ogWrap.innerHTML = p.renderOg(ns);
+      ogCol.appendChild(ogWrap);
+      el.appendChild(ogCol);
+    }
+
+    // ── Render all grades ─────────────────────────────────────────
+    ['S', 'A', 'B', 'C', 'none'].forEach(renderStrip);
+
+  })();
+  </script>
+
+</body>
+</html>

--- a/docs/samples/trust-grade-notch.html
+++ b/docs/samples/trust-grade-notch.html
@@ -3,12 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Trust Grade Notch Sampler — Gaia (I8)</title>
-  <meta name="description" content="Trust Grade notch (I8): 4 grades × 6 plaque variants. S=Platinum, A=Gold, B=Silver, C=Bronze. Dev/review artifact — not in public nav.">
+  <title>Trust Grade Notch Sampler — I8</title>
+  <meta name="description" content="Visual test for the I8 trust grade notch feature on .plaque cards. Hover any card to see the TM number fade and the grade letter reveal via shine sweep.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../css/tokens.css">
   <link rel="stylesheet" href="../css/styles.css">
   <link rel="stylesheet" href="../css/plaque.css">
   <script src="../js/icons.js"></script>
@@ -18,433 +17,241 @@
   <style>
     body {
       padding: 4rem 1.5rem 8rem;
-      max-width: 1400px;
+      max-width: 1280px;
       margin: 0 auto;
     }
     .sampler-h1 {
       font-family: var(--font-display);
-      font-size: clamp(1.8rem, 4vw, 2.6rem);
+      font-size: clamp(2rem, 4vw, 2.8rem);
       font-weight: 600;
-      margin-bottom: .2rem;
+      margin-bottom: .25rem;
     }
     .sampler-sub {
       color: var(--muted);
       font-family: var(--font-mono);
-      font-size: .82rem;
-      letter-spacing: .05em;
+      font-size: .85rem;
+      letter-spacing: .04em;
       text-transform: uppercase;
-      margin-bottom: 2rem;
-    }
-    .sampler-intro {
-      color: rgba(226, 232, 240, 0.6);
-      font-family: var(--font-body);
-      font-size: .9rem;
-      line-height: 1.65;
-      max-width: 66ch;
       margin-bottom: 2.5rem;
     }
-    .sampler-intro code {
-      font-family: var(--font-mono);
-      color: var(--tier-basic);
-      font-size: .85em;
-    }
-
-    /* ── Grade row ── */
-    .grade-section {
-      margin: 3rem 0 0;
+    .sampler-section {
+      margin: 3rem 0;
       padding-top: 2rem;
       border-top: 1px solid var(--border);
     }
-    .grade-heading {
-      display: flex;
-      align-items: center;
-      gap: .75rem;
-      margin-bottom: .25rem;
-    }
-    .grade-heading h2 {
+    .sampler-section h2 {
       font-family: var(--font-display);
-      font-size: 1.55rem;
+      font-size: 1.6rem;
       font-weight: 600;
+      margin-bottom: .15rem;
     }
-    .grade-notch-preview {
-      /* Standalone notch preview badge — same CSS classes as the live notch */
-      display: inline-flex;
-      align-items: center;
-      gap: 3px;
-      height: 22px;
-      padding: 0 8px;
-      font-family: var(--font-mono);
-      font-size: .72rem;
-      font-weight: 700;
-      letter-spacing: .04em;
-      border-radius: 3px;
-    }
-    .grade-notch-preview[data-trust-grade="S"] {
-      background: linear-gradient(135deg,
-        var(--trust-notch-S-hi2) 0%,
-        color-mix(in srgb, var(--trust-notch-S-mid) 80%, var(--trust-notch-S-violet)) 35%,
-        var(--trust-notch-S-mid) 65%,
-        color-mix(in srgb, var(--trust-notch-S-violet) 60%, var(--trust-notch-S-mid)) 100%);
-      color: var(--trust-notch-text-S);
-      animation: trust-notch-shimmer 3.5s linear infinite;
-      background-size: 200% 200%;
-    }
-    .grade-notch-preview[data-trust-grade="A"] {
-      background: linear-gradient(135deg,
-        color-mix(in srgb, var(--grade-A) 65%, var(--trust-notch-A-hi)) 0%,
-        var(--grade-A) 55%,
-        color-mix(in srgb, var(--grade-A) 75%, var(--trust-notch-A-lo)) 100%);
-      color: var(--trust-notch-text-A);
-    }
-    .grade-notch-preview[data-trust-grade="B"] {
-      background: linear-gradient(135deg,
-        var(--trust-notch-B-hi) 0%,
-        color-mix(in srgb, var(--trust-notch-B-hi) 55%, var(--trust-notch-B-lo)) 50%,
-        var(--trust-notch-B-lo) 100%);
-      color: var(--trust-notch-text-B);
-    }
-    .grade-notch-preview[data-trust-grade="C"] {
-      background: linear-gradient(135deg,
-        color-mix(in srgb, var(--grade-C) 70%, var(--trust-notch-C-hi)) 0%,
-        var(--grade-C) 50%,
-        color-mix(in srgb, var(--grade-C) 80%, var(--trust-notch-C-lo)) 100%);
-      color: var(--trust-notch-text-C);
-    }
-    .grade-desc {
+    .sampler-section .density {
       color: var(--muted);
       font-family: var(--font-mono);
-      font-size: .78rem;
+      font-size: .8rem;
       letter-spacing: .04em;
       text-transform: uppercase;
       margin-bottom: 1.25rem;
     }
-    .grade-note {
-      font-family: var(--font-body);
-      font-size: .82rem;
-      color: rgba(226, 232, 240, 0.45);
-      margin-bottom: 1rem;
-    }
-    .grade-note strong {
-      color: rgba(226, 232, 240, 0.75);
-      font-weight: 600;
-    }
-
-    /* ── Variant strip ── */
-    .variant-strip {
+    .sampler-stage {
+      position: relative;
+      padding: 1.25rem;
+      background: rgba(255, 255, 255, 0.015);
+      border: 1px solid var(--border);
+      border-radius: 14px;
       display: flex;
       flex-wrap: wrap;
       gap: 1rem;
       align-items: flex-start;
-      padding: 1.25rem;
-      background: rgba(255, 255, 255, 0.012);
-      border: 1px solid var(--border);
-      border-radius: 14px;
     }
-    .variant-label {
-      font-family: var(--font-mono);
-      font-size: .68rem;
-      letter-spacing: .08em;
-      text-transform: uppercase;
-      color: var(--muted);
-      margin-bottom: .35rem;
+    .sampler-tile-grid {
+      width: 320px;
+      max-width: 100%;
     }
-    .variant-col {
-      display: flex;
-      flex-direction: column;
-    }
+    .sampler-row-wrap { width: 100%; max-width: 720px; }
 
-    /* OG card wrap: scale down to fit */
-    .og-wrap {
-      position: relative;
-      width: 360px;
-      height: 189px; /* 630*0.3 */
-      overflow: hidden;
-      border: 1px solid var(--border);
-      border-radius: 4px;
-    }
-    .og-wrap .plaque--og {
-      transform-origin: top left;
-      transform: scale(0.3);
-      width: 1200px;
-    }
-    .og-wrap::after {
-      content: '1200×630 @ 0.3×';
-      position: absolute;
-      bottom: 4px;
-      right: 6px;
+    /* Hover hint strip */
+    .hover-hint {
       font-family: var(--font-mono);
-      font-size: 9px;
-      color: rgba(226, 232, 240, 0.3);
+      font-size: .72rem;
       letter-spacing: .06em;
-      text-transform: uppercase;
-      pointer-events: none;
+      color: var(--muted);
+      margin-bottom: .75rem;
+      opacity: .75;
     }
+    .hover-hint strong { color: var(--text); }
 
-    /* row variant needs a minimum width container */
-    .row-wrap { width: 560px; max-width: 100%; }
-    /* tile variant width */
-    .tile-wrap { width: 300px; max-width: 100%; }
-    /* settled variant width */
-    .settled-wrap { width: 300px; max-width: 100%; }
-
-    /* ── Reduced motion note ── */
-    .rm-note {
-      margin-top: 1.5rem;
-      padding: .85rem 1.1rem;
-      background: rgba(56, 189, 248, 0.05);
-      border: 1px solid rgba(56, 189, 248, 0.12);
-      border-radius: 8px;
+    /* Grade legend */
+    .grade-legend {
+      display: flex;
+      flex-wrap: wrap;
+      gap: .75rem 1.5rem;
       font-family: var(--font-mono);
-      font-size: .78rem;
-      color: rgba(226, 232, 240, 0.55);
-      line-height: 1.55;
+      font-size: .75rem;
+      color: var(--muted);
+      margin-bottom: 2rem;
     }
-    .rm-note strong {
-      color: var(--tier-basic);
-    }
-    .rm-note code {
-      color: rgba(226, 232, 240, 0.75);
-      background: rgba(255,255,255,.05);
-      padding: 1px 5px;
+    .grade-legend-item { display: inline-flex; align-items: center; gap: .45rem; }
+    .grade-swatch {
+      width: 28px; height: 14px;
       border-radius: 3px;
+      border: 1px solid;
+      display: inline-block;
     }
-
-    /* ── Ungraded check ── */
-    .ungraded-section {
-      margin-top: 3rem;
-      padding-top: 2rem;
-      border-top: 1px solid var(--border);
-    }
-    .ungraded-section h2 {
-      font-family: var(--font-display);
-      font-size: 1.4rem;
-      font-weight: 600;
-      margin-bottom: .2rem;
-    }
-    .ungraded-section .grade-desc {
-      margin-bottom: 1rem;
-    }
+    .grade-swatch--S { background: rgba(226,232,240,.2); border-color: rgba(226,232,240,.35); }
+    .grade-swatch--A { background: rgba(212,175,55,.22); border-color: rgba(212,175,55,.4); }
+    .grade-swatch--B { background: rgba(203,213,225,.18); border-color: rgba(203,213,225,.32); }
+    .grade-swatch--C { background: rgba(180,83,9,.2); border-color: rgba(180,83,9,.38); }
   </style>
 </head>
 <body>
 
-  <h1 class="sampler-h1">Trust Grade Notch</h1>
-  <p class="sampler-sub">I8 · 4 grades × 6 plaque variants / dev/review artifact</p>
+  <h1 class="sampler-h1">Trust Grade Notch — I8</h1>
+  <p class="sampler-sub">design/trust-grade-notch · Hover reveal: TM number → grade letter + shine sweep</p>
 
-  <p class="sampler-intro">
-    The <strong>Trust Grade notch</strong> is a full-width centered footer row at the bottom of every
-    <code>.plaque</code> variant. It shows the skill's <code>overallTrustGrade</code> letter plus
-    Trust Magnitude number (e.g. <code>A · 47</code>). Grade name labels are never shown.
-    Ungraded skills show nothing; zero markup cost when absent. This notch is <em>distinct</em>
-    from the star-rank system; both coexist on the same card.
+  <p style="color: var(--muted); max-width: 64ch; margin-bottom: 1.5rem;">
+    The trust notch is a small pill pinned to the card's bottom center.
+    By default it shows the <strong style="color:var(--text);">TM number</strong> (trustMagnitude).
+    On hover, a shine sweep animation reveals the
+    <strong style="color:var(--text);">grade letter</strong> (S / A / B / C) and
+    the TM number fades out.
   </p>
 
-  <!-- S · Platinum -->
-  <section class="grade-section" id="grade-S">
-    <div class="grade-heading">
-      <h2>S · Platinum</h2>
-      <span class="grade-notch-preview" data-trust-grade="S">S · 42</span>
-    </div>
-    <p class="grade-desc">Animated iridescent shimmer · deep-navy text · contrast ≈ 10.8:1 ✓</p>
-    <p class="grade-note">
-      <strong>Reduced motion:</strong> the shimmer animation is suppressed under
-      <code>prefers-reduced-motion: reduce</code>; the notch falls back to a static
-      linear-gradient. Use your OS accessibility settings to verify, or see the note below.
-    </p>
-    <div class="variant-strip" id="strip-S"></div>
-  </section>
-
-  <!-- A · Gold -->
-  <section class="grade-section" id="grade-A">
-    <div class="grade-heading">
-      <h2>A · Gold</h2>
-      <span class="grade-notch-preview" data-trust-grade="A">A · 31</span>
-    </div>
-    <p class="grade-desc">Static gradient · deep-brown text · contrast ≈ 7.2:1 ✓</p>
-    <div class="variant-strip" id="strip-A"></div>
-  </section>
-
-  <!-- B · Silver -->
-  <section class="grade-section" id="grade-B">
-    <div class="grade-heading">
-      <h2>B · Silver</h2>
-      <span class="grade-notch-preview" data-trust-grade="B">B · 18</span>
-    </div>
-    <p class="grade-desc">Dark steel gradient (#8a99ad → #475569) · light text · contrast ≈ 6.2:1 ✓</p>
-    <div class="variant-strip" id="strip-B"></div>
-  </section>
-
-  <!-- C · Bronze -->
-  <section class="grade-section" id="grade-C">
-    <div class="grade-heading">
-      <h2>C · Bronze</h2>
-      <span class="grade-notch-preview" data-trust-grade="C">C · 7</span>
-    </div>
-    <p class="grade-desc">Static gradient (tarnished) · light-warm text · contrast ≈ 4.8:1 ✓</p>
-    <div class="variant-strip" id="strip-C"></div>
-  </section>
-
-  <!-- Ungraded: no notch -->
-  <section class="ungraded-section" id="grade-none">
-    <h2>Ungraded</h2>
-    <p class="grade-desc">overallTrustGrade: null / "ungraded" — zero markup emitted</p>
-    <div class="variant-strip" id="strip-none"></div>
-  </section>
-
-  <!-- ── Reduced motion note ──────────────────────────────────────── -->
-  <div class="rm-note">
-    <strong>prefers-reduced-motion note:</strong> Grade S (Platinum) animates a background-position
-    shimmer via <code>@keyframes trust-notch-shimmer</code>. Under
-    <code>@media (prefers-reduced-motion: reduce)</code> the animation is suppressed and a static
-    linear-gradient is applied instead. To verify: enable Reduce Motion in your OS accessibility
-    settings, reload this page, and confirm the Platinum notch is static. All other grades are
-    static by default and unaffected.
+  <div class="grade-legend">
+    <span class="grade-legend-item"><span class="grade-swatch grade-swatch--S"></span>S — Platinum (4★+)</span>
+    <span class="grade-legend-item"><span class="grade-swatch grade-swatch--A"></span>A — Gold (3★)</span>
+    <span class="grade-legend-item"><span class="grade-swatch grade-swatch--B"></span>B — Silver (2★)</span>
+    <span class="grade-legend-item"><span class="grade-swatch grade-swatch--C"></span>C — Bronze (1★)</span>
   </div>
 
-  <script>
-  (function () {
-    'use strict';
+  <p class="hover-hint">Hover any card below — the TM number will fade and the grade letter will appear.</p>
 
-    // ── Sample skill data for each grade ──────────────────────────
-    // Hard-coded so the sampler works offline with no server.
-    // Grades picked to match real-world data in docs/graph/gaia.json.
-    var SAMPLES = {
-      S: {
-        id: 'mattpocock/skills',
-        name: 'Skills Suite',
-        contributor: 'mattpocock',
-        origin: true,
-        genericSkillRef: 'skills',
-        status: 'named',
-        level: '5★',
-        type: 'ultimate',
-        title: 'The Complete TS Skill Suite',
-        description: 'A comprehensive suite of TypeScript agent skills covering type inference, generics, and advanced patterns for production codebases.',
-        tags: ['typescript', 'agent-skills', 'suite'],
-        links: { github: 'https://github.com/mattpocock/skills' },
-        overallTrustGrade: 'S',
-        overallTrustMagnitude: 42,
-      },
-      A: {
+  <!-- ── Four grades in --tile variant ── -->
+  <section class="sampler-section">
+    <h2>--tile · All four grades</h2>
+    <p class="density">Tile cards with S / A / B / C grades — hover each to trigger the reveal</p>
+    <div class="sampler-stage" id="stageTile"></div>
+  </section>
+
+  <!-- ── --settled with grade A ── -->
+  <section class="sampler-section">
+    <h2>--settled (Profile trophy)</h2>
+    <p class="density">Trophy card with trust notch — Grade A, TM 122</p>
+    <div class="sampler-stage">
+      <div class="sampler-tile-grid" id="stageSettled"></div>
+    </div>
+  </section>
+
+  <!-- ── --mini (HoH) with grade S ── -->
+  <section class="sampler-section">
+    <h2>--mini (Hall of Heroes)</h2>
+    <p class="density">HoH card — Grade S, TM 310</p>
+    <div class="sampler-stage" id="stageMini"></div>
+  </section>
+
+  <!-- ── --row (list view) with evidence badge ── -->
+  <section class="sampler-section">
+    <h2>--row (list view) · Evidence badge</h2>
+    <p class="density">List rows show a small CLASS A / B / C label at the end — before the › arrow. Trust notch appears at bottom (small pill).</p>
+    <div class="sampler-stage">
+      <div class="sampler-row-wrap" id="stageRow"></div>
+    </div>
+  </section>
+
+  <!-- ── No data edge case ── -->
+  <section class="sampler-section">
+    <h2>No trust data (notch hidden)</h2>
+    <p class="density">When overallTrustGrade and trustMagnitude are absent, no notch is rendered.</p>
+    <div class="sampler-stage">
+      <div class="sampler-tile-grid" id="stageNoNotch"></div>
+    </div>
+  </section>
+
+  <script>
+    (function () {
+      // Base skill data — reused across all samples.
+      var BASE = {
         id: 'karpathy/autoresearch',
         name: 'AutoResearch',
         contributor: 'karpathy',
         origin: true,
         genericSkillRef: 'autonomous-research-agent',
         status: 'named',
-        level: '5★',
-        type: 'ultimate',
-        title: "The Scholar's Compass",
-        description: 'Autonomous research agent that iteratively searches, reads, and synthesizes academic papers into structured summaries with citation graphs.',
-        tags: ['research', 'autonomous', 'paper-synthesis'],
-        links: { github: 'https://github.com/karpathy/autoresearch' },
-        overallTrustGrade: 'A',
-        overallTrustMagnitude: 31,
-      },
-      B: {
-        id: 'stanfordnlp/dspy',
-        name: 'DSPy',
-        contributor: 'stanfordnlp',
-        origin: false,
-        genericSkillRef: 'dspy',
-        status: 'named',
-        level: '4★',
-        type: 'extra',
-        title: 'Declarative Self-Improving LM Programs',
-        description: 'Framework for algorithmically optimizing LM prompts and weights using declarative modules and automatic compilers.',
-        tags: ['dspy', 'optimization', 'prompting'],
-        links: { github: 'https://github.com/stanfordnlp/dspy' },
-        overallTrustGrade: 'B',
-        overallTrustMagnitude: 18,
-      },
-      C: {
-        id: 'anthropics/computer-use',
-        name: 'Computer Use',
-        contributor: 'anthropics',
-        origin: false,
-        genericSkillRef: 'computer-use',
-        status: 'named',
-        level: '3★',
         type: 'basic',
-        title: 'Desktop GUI Automation',
-        description: 'Enables agents to interact with desktop applications through simulated keyboard and mouse inputs, screenshot parsing, and UI element detection.',
-        tags: ['computer-use', 'gui', 'automation'],
-        links: { github: 'https://github.com/anthropics/computer-use-demo' },
-        overallTrustGrade: 'C',
-        overallTrustMagnitude: 7,
-      },
-      none: {
-        id: 'garrytan/gstack',
-        name: 'gstack',
-        contributor: 'garrytan',
-        origin: false,
-        genericSkillRef: 'gstack',
-        status: 'named',
-        level: '3★',
-        type: 'ultimate',
-        title: 'The Full-Stack Agent Suite',
-        description: 'Comprehensive suite of agent skills for end-to-end web product development, from design to deployment.',
-        tags: ['fullstack', 'deployment', 'design'],
-        links: { github: 'https://github.com/garrytan/gstack' },
-        overallTrustGrade: null, // intentionally ungraded — no notch should render
-      },
-    };
+        title: "The Scholar's Compass",
+        description: 'Autonomous research agent that iteratively searches, reads, and synthesizes academic papers into structured summaries.',
+        tags: ['research', 'autonomous', 'synthesis'],
+        links: { github: 'https://github.com/karpathy/autoresearch/blob/main/SKILL.md' }
+      };
 
-    // ── Variant renderer ─────────────────────────────────────────
-    function renderStrip(grade) {
-      var p = window.plaque;
-      if (!p) return;
-      var ns = SAMPLES[grade];
-      var el = document.getElementById('strip-' + grade);
-      if (!el) return;
+      function skill(overrides) {
+        var s = {};
+        for (var k in BASE) s[k] = BASE[k];
+        for (var k2 in overrides) s[k2] = overrides[k2];
+        return s;
+      }
 
-      // mini
-      var miniCol = document.createElement('div');
-      miniCol.className = 'variant-col';
-      miniCol.innerHTML = '<p class="variant-label">--mini</p>' + p.renderMini(ns);
-      el.appendChild(miniCol);
+      // ── Tile — four grades ──
+      var tileEl = document.getElementById('stageTile');
+      if (tileEl && window.plaque) {
+        var tiledSkills = [
+          skill({ level: 6, type: 'ultimate', overallTrustGrade: 'S', trustMagnitude: 310 }),
+          skill({ level: 4, type: 'extra',    overallTrustGrade: 'A', trustMagnitude: 122 }),
+          skill({ level: 3, type: 'basic',    overallTrustGrade: 'B', trustMagnitude: 56 }),
+          skill({ level: 2, type: 'basic',    overallTrustGrade: 'C', trustMagnitude: 18 })
+        ];
+        tiledSkills.forEach(function (ns) {
+          var wrap = document.createElement('div');
+          wrap.style.width = '300px';
+          wrap.innerHTML = window.plaque.renderTile(ns, { click: false });
+          tileEl.appendChild(wrap);
+        });
+      }
 
-      // tile
-      var tileCol = document.createElement('div');
-      tileCol.className = 'variant-col tile-wrap';
-      tileCol.innerHTML = '<p class="variant-label">--tile</p>' + p.renderTile(ns);
-      el.appendChild(tileCol);
+      // ── Settled ──
+      var settledEl = document.getElementById('stageSettled');
+      if (settledEl && window.plaque) {
+        settledEl.innerHTML = window.plaque.renderSettled(
+          skill({ level: 4, type: 'extra', overallTrustGrade: 'A', trustMagnitude: 122 }),
+          { click: false }
+        );
+      }
 
-      // row
-      var rowCol = document.createElement('div');
-      rowCol.className = 'variant-col row-wrap';
-      rowCol.innerHTML = '<p class="variant-label">--row</p>' + p.renderRow(ns);
-      el.appendChild(rowCol);
+      // ── Mini (HoH) ──
+      var miniEl = document.getElementById('stageMini');
+      if (miniEl && window.plaque) {
+        miniEl.innerHTML = window.plaque.renderMini(
+          skill({ level: 6, type: 'ultimate', overallTrustGrade: 'S', trustMagnitude: 310 }),
+          { click: false }
+        );
+      }
 
-      // detail
-      var detailCol = document.createElement('div');
-      detailCol.className = 'variant-col';
-      detailCol.style.flex = '1 1 600px';
-      detailCol.innerHTML = '<p class="variant-label">--detail</p>' + p.renderDetail(ns);
-      el.appendChild(detailCol);
+      // ── Row (list view) ──
+      var rowEl = document.getElementById('stageRow');
+      if (rowEl && window.plaque) {
+        var rowSkills = [
+          skill({ level: 6, type: 'ultimate', overallTrustGrade: 'S', trustMagnitude: 310 }),
+          skill({ level: 4, type: 'extra',    overallTrustGrade: 'A', trustMagnitude: 122 }),
+          skill({ level: 3, type: 'basic',    overallTrustGrade: 'B', trustMagnitude: 56 }),
+          skill({ level: 2, type: 'basic',    overallTrustGrade: 'C', trustMagnitude: 18 })
+        ];
+        rowSkills.forEach(function (ns) {
+          var div = document.createElement('div');
+          div.style.width = '100%';
+          div.innerHTML = window.plaque.renderRow(ns, { click: false });
+          rowEl.appendChild(div);
+        });
+      }
 
-      // settled
-      var settledCol = document.createElement('div');
-      settledCol.className = 'variant-col settled-wrap';
-      settledCol.innerHTML = '<p class="variant-label">--settled</p>' + p.renderSettled(ns);
-      el.appendChild(settledCol);
-
-      // og (scaled)
-      var ogCol = document.createElement('div');
-      ogCol.className = 'variant-col';
-      ogCol.innerHTML = '<p class="variant-label">--og (0.3×)</p>';
-      var ogWrap = document.createElement('div');
-      ogWrap.className = 'og-wrap';
-      ogWrap.innerHTML = p.renderOg(ns);
-      ogCol.appendChild(ogWrap);
-      el.appendChild(ogCol);
-    }
-
-    // ── Render all grades ─────────────────────────────────────────
-    ['S', 'A', 'B', 'C', 'none'].forEach(renderStrip);
-
-  })();
+      // ── No notch (no trust data) ──
+      var noNotchEl = document.getElementById('stageNoNotch');
+      if (noNotchEl && window.plaque) {
+        noNotchEl.innerHTML = window.plaque.renderTile(
+          skill({ level: 3, type: 'basic' }),
+          { click: false }
+        );
+      }
+    })();
   </script>
-
 </body>
 </html>

--- a/docs/u/index.html
+++ b/docs/u/index.html
@@ -1,9 +1,6 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../assets/icons.svg">
 <head>
-  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-  <meta http-equiv="Pragma" content="no-cache">
-  <meta http-equiv="Expires" content="0">
   <script>window.GAIA_VERSION = "4.11.0";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/founder/MEMORY.md
+++ b/founder/MEMORY.md
@@ -20,7 +20,80 @@ Maintained by the Orchestrator agent. Newest entries first within each section.
 - **2026-06-10** — #637 scope per Marco's comment: #635 covers `gaia tree`/`gaia graph`; everything else except `gaia skills` stays RFC.
 - **2026-06-10** — Trust implementation finalized: bands S≥90/A≥80/B≥60/C≥40/ungraded<40; `class` removed at next major; type values kebab-case (`github-stars`); suite ultimate gate = pillar rule (≥3 evidenced components, ≥1 S + ≥2 A, floor C) with a recalibration RFC due ~1 month post-ship; verification workflow = issue #658 (standalone, tenure 30d).
 
-## State Snapshot (2026-06-19, session 10 — evidence audit, dev/* consolidation complete, I9 designed)
+## State Snapshot (2026-06-19, session 13 — I8 redesign, I9 curation running, migration bugs fixed, next: merge both to dev)
+
+- **Repo:** `main` @ **v4.11.0** (unchanged). All Phase 1.5 work on `dev/phase-1.5-inspection` + feature branches.
+
+### Branch state
+
+| Branch | Head SHA | Status |
+|---|---|---|
+| `design/trust-grade-notch` | `236ce7b2` | I8 redesign complete — pixel-thin bar, hover count-up. Visual inspection needed. |
+| `review/meta/g7-evidence-backfill` | `ebb760a3` | I9 curation in progress (agent running). |
+| `dev/phase-1.5-inspection` | `8cc5d352` | Consolidation branch. Needs I8 + I9 merged in. |
+
+### I8 — Trust Grade Notch (design/trust-grade-notch)
+
+**Current design (236ce7b2):**
+- Default state: 3px colored bar flush at very bottom of every `.plaque`, full-width, boxy (no radius). Grade color always visible as a thin stripe.
+- Hover (whole plaque): bar expands to 24px in 0.28s (cubic-bezier), `MAG X.X` counts up from 0 to real TM in 380ms simultaneously via `_wireTrustNotches()` JS.
+- Four grade fills: S = animated platinum sweep (90deg, 2.8s), A = gold, B = dark steel, C = bronze.
+- `_wireTrustNotches(root)` exposed as `window._wireTrustNotches` — must be called after any dynamic render.
+- Sampler at `docs/samples/trust-grade-notch.html` with real TM numbers (gstack 589.3, superpowers 416.0, etc.). Added to sampler index.
+- HoH exclusion removed — all plaque variants show the notch.
+- **Still pending:** visual inspection at `http://localhost:8081/samples/trust-grade-notch.html`. Marco said "far from over" on design — iteration expected after merge.
+
+**Known I8 gaps:**
+- `_wireTrustNotches` must be called on every page that dynamically renders plaques (`docs/named/index.html`, `docs/u/*/index.html`, etc.). Not yet wired into those pages.
+- OG card generator (`scripts/generateOgCards.py`) and profile page generator (`scripts/generateProfilePages.py`) may not pass `overallTrustGrade`/`trustMagnitude` to all plaque variants — needs check after merge.
+
+### I9 — Evidence Backfill (review/meta/g7-evidence-backfill)
+
+**Migration bugs fixed (all on this branch):**
+1. `computeInputHash` in `migrateTrustMagnitude.py` used `r.get("url")` — should be `r.get("source")`. Also missing numeric payload fields (commits, stars, views, etc.) and `suiteComponents`. Fixed at `517588eb`.
+2. Migration only built `genericSkillMap` from `registry/nodes/` — named skill IDs in `suiteComponents` not found → fusion origins = 0 → TM wrong. Fixed: build `namedSkillMap` + merge before passing to TM engine. Fixed at `74f29d04`.
+3. Both `migrateTrustMagnitude.py` and `inspectTrustMagnitude.py` now use merged map.
+
+**Current TM leaderboard (249 skills, commit e0ce1cf0 + ebb760a3):**
+- S grade (≥250): garrytan/gstack=589.3, ruvnet/ruflo=482.3, mattpocock/skills=440.8, obra/superpowers=416.0
+- A grade (≥100): 13 skills; top = mattpocock/engineering 270, ruvnet/agentdb 201, pexp13/sentiment-analysis 192.8
+- B grade (≥50): 22 skills
+- C grade (≥20): 94 skills
+- Ungraded: 116 skills (incl. all 14 new mattpocock v1.0.1 skills, google-deepmind cluster)
+
+**I9 curation status (agent a74731d66fceccfbb still running):**
+- ev-pipeline completed: 62 rows added across 25 suite skills (commit `1e5376b3`)
+- gaia-curate-chain completed: 14 new mattpocock/skills v1.0.1 skills + 8 deprecated skills updated (PR #745)
+- Social signals (YouTube views) + Google DeepMind arxiv/peer-review curation: IN PROGRESS
+
+**New tools added:**
+- `scripts/inspectTrustMagnitude.py` — `--skill <id>` + `--leaderboard` modes
+- `.agents/skills/gaia-tm-inspect/SKILL.md` — `/gaia-tm-inspect` skill
+
+### Key architectural decisions this session
+
+- `trustMagnitudeInputHash` now covers: source field, all numeric payload fields, suiteComponents. Old hashes were invalid — all were cleared and recomputed.
+- Named skill IDs in `suiteComponents` must be in `mergedMap` (genericSkillMap + namedSkillMap) for fusion-recipe origins to score correctly.
+- Data lake injected flag protocol: `<!-- injected: YYYY-MM-DD | skillId: X | type: Y | layer: Z -->` marks rows already imported.
+
+### Next steps
+
+1. **Wait for I9 agent to complete** — will notify when done
+2. **Merge I8 → dev/phase-1.5-inspection**: `git merge design/trust-grade-notch`
+3. **Merge I9 → dev/phase-1.5-inspection**: `git merge review/meta/g7-evidence-backfill`
+4. **Run full `/gaia-tm-inspect --leaderboard`** on merged dev branch to show Marco final scores
+5. **Visual inspection** of trust notch on real pages (named/, u/ profile pages) — `_wireTrustNotches` wiring needed
+6. **Further I8 iteration** expected (Marco: "far from over") — iterate on design after seeing it live
+
+### Token spend (session 13)
+- ev-pipeline workflow: ~3.67M subagent tokens / ~$3.70
+- gaia-curate-chain: ~111k subagent / ~$0.50
+- Migration fix agents: ~157k subagent / ~$1.05
+- Direct orchestrator work (CSS/JS rewrite, hash fix analysis): ~$0.40
+- I9 curation agent (still running): TBD
+- **Session 13 so far: ~$5.65**. Cumulative G7: **~$25.37**
+
+
 
 - **Repo:** `main` @ **v4.11.0** (unchanged — no merges to main this session).
 - **`dev/phase-1.5-inspection`** is the single consolidated branch carrying ALL Phase 1.5 work:


### PR DESCRIPTION
## I8 — Trust Grade Notch

Adds a rectangular metallic corner stamp to all `.plaque` variants showing the skill's `overallTrustGrade` (S/A/B/C = Platinum/Gold/Silver/Bronze). Ungraded skills emit zero markup.

Closes #740.

---

## What changed

| File | Change |
|---|---|
| `docs/css/tokens.css` | Added `--trust-notch-h/pad-x/font/font-size` + grade text color tokens + metallic stop tokens (all via `var()`, zero hex literals) |
| `docs/css/plaque.css` | Added `.plaque__trust-notch` slot, grade fills via `data-trust-grade`, `@keyframes trust-notch-shimmer`, `prefers-reduced-motion` fallback, variant overrides (mini/row: letter-only) |
| `docs/js/plaque.js` | `_fieldTrustNotch()` injects notch when `overallTrustGrade` is non-null/non-`ungraded`; settled variant appends TM number |
| `docs/samples/trust-grade-notch.html` | New dev/review sampler: 4 grades × 6 variants, with reduced-motion note. Not linked from public nav. |
| `docs/u/index.html` | Regenerated via `generateProfilePages.py` (3-line diff, unrelated to notch) |

---

## Design checklist

- [x] Bottom-right corner, flush with card edges — card `border-radius` clips naturally
- [x] No `border-radius` on `.plaque__trust-notch` itself
- [x] No hex literals in new CSS — all colors via `var(--trust-notch-*)` tokens
- [x] No `border-left` colored accent
- [x] WCAG AA: S≈10.8:1, A≈7.2:1, B≈11.4:1, C≈4.8:1
- [x] Platinum shimmer: `@keyframes trust-notch-shimmer` (3.5s loop), `prefers-reduced-motion` → static
- [x] `@keyframes trust-notch-shimmer` newly added (no pre-existing `grade-shimmer` found in codebase)
- [x] Mini + row variants: letter only (`.trust-notch-name` hidden via CSS)
- [x] Settled variant: letter + grade name + TM number
- [x] Ungraded: zero DOM nodes emitted

---

## Pre-existing findings (out of scope, not introduced by I8)

- `bounce-easing` at `plaque.css:3129` — Hall of Heroes fullscreen modal transition, pre-existing
- `broken-image:987` — comment about defensive `<img>` loading, pre-existing

---

## 🛑 HOLD — Marco visually inspects before merge

Sampler running at `http://localhost:8080/samples/trust-grade-notch.html` (served from worktree `design/trust-grade-notch`).

Also check:
- `http://localhost:8080/named/` — skill tiles/rows (notch shows once a graded skill is wired post-I9)
- `http://localhost:8080/` — homepage

---

## Token spend

2026-06-19 Sonnet 4.6: ~151k in, ~44k out subagent. ~$0.65. + orchestrator fix pass ~$0.05. Total I8: ~$0.70.