### PR TITLE
fix(trust): I12 — apex gate predicates (#746) — depth2 + sourceStartedAt + PR sign

### DIFF
--- a/registry/named/garrytan/gstack.md
+++ b/registry/named/garrytan/gstack.md
@@ -137,6 +137,11 @@ timeline:
 - action: migrate_trust_magnitude
   timestamp: '2026-06-19T13:26:37Z'
   details: TM 0.0 -> 589.32, grade ungraded -> S (direct edit -- CLI gap)
+- timestamp: '2026-06-19T16:27:29Z'
+  action: verified
+  contributor: unknown
+  details: 'Apex promotion PR stamped by Marco (founder/mbtiongson1) per #746 directive
+    — gstack qualifies for §11.12.8 (apexPromotionPrSigned)'
 trustMagnitude: 589.32
 overallTrustGrade: S
 apexGateStatus:
@@ -145,7 +150,9 @@ apexGateStatus:
   directNestedSuiteGte1: true
   depth2OnlyReachableGte1: false
   overallGradeS: true
-  apexPromotionPrSigned: false
+  apexPromotionPrSigned: true
+  apexPromotionPrSignedBy: mbtiongson1
+  apexPromotionPrSignedAt: '2026-06-20'
   crossOrgVerifier: null
   systemWideCap: null
 verification:

--- a/registry/named/mattpocock/skills.md
+++ b/registry/named/mattpocock/skills.md
@@ -22,7 +22,9 @@ apexGateStatus:
   directNestedSuiteGte1: true
   depth2OnlyReachableGte1: false
   overallGradeS: true
-  apexPromotionPrSigned: false
+  apexPromotionPrSigned: true
+  apexPromotionPrSignedBy: mbtiongson1
+  apexPromotionPrSignedAt: '2026-06-20'
   crossOrgVerifier: null
   systemWideCap: null
 timeline:
@@ -73,6 +75,11 @@ timeline:
 - action: migrate_trust_magnitude
   timestamp: '2026-06-19T14:32:18Z'
   details: TM 480.29 -> 480.29, grade S -> S (direct edit -- CLI gap)
+- timestamp: '2026-06-19T16:27:39Z'
+  action: verified
+  contributor: unknown
+  details: 'Apex promotion PR stamped by Marco (founder/mbtiongson1) per #746 directive
+    — mattpocock/skills qualifies for §11.12.8 (apexPromotionPrSigned)'
 evidence:
 - source: https://github.com/mattpocock/skills/stargazers
   evaluator: mbtiongson1

--- a/registry/named/obra/superpowers.md
+++ b/registry/named/obra/superpowers.md
@@ -117,6 +117,11 @@ timeline:
 - action: migrate_trust_magnitude
   timestamp: '2026-06-19T14:32:19Z'
   details: TM 445.15 -> 445.15, grade S -> S (direct edit -- CLI gap)
+- timestamp: '2026-06-19T16:27:40Z'
+  action: verified
+  contributor: unknown
+  details: 'Apex promotion PR stamped by Marco (founder/mbtiongson1) per #746 directive
+    — superpowers qualifies for §11.12.8 (apexPromotionPrSigned)'
 trustMagnitude: 445.15
 overallTrustGrade: S
 apexGateStatus:
@@ -125,7 +130,9 @@ apexGateStatus:
   directNestedSuiteGte1: false
   depth2OnlyReachableGte1: false
   overallGradeS: true
-  apexPromotionPrSigned: false
+  apexPromotionPrSigned: true
+  apexPromotionPrSignedBy: mbtiongson1
+  apexPromotionPrSignedAt: '2026-06-20'
   crossOrgVerifier: null
   systemWideCap: null
 verification:

--- a/registry/named/ruvnet/ruflo.md
+++ b/registry/named/ruvnet/ruflo.md
@@ -162,6 +162,11 @@ timeline:
 - action: migrate_trust_magnitude
   timestamp: '2026-06-19T13:26:44Z'
   details: TM 0.0 -> 482.27, grade ungraded -> S (direct edit -- CLI gap)
+- timestamp: '2026-06-19T16:27:39Z'
+  action: verified
+  contributor: unknown
+  details: 'Apex promotion PR stamped by Marco (founder/mbtiongson1) per #746 directive
+    — ruflo qualifies for §11.12.8 (apexPromotionPrSigned)'
 trustMagnitude: 482.27
 overallTrustGrade: S
 apexGateStatus:
@@ -170,7 +175,9 @@ apexGateStatus:
   directNestedSuiteGte1: true
   depth2OnlyReachableGte1: false
   overallGradeS: true
-  apexPromotionPrSigned: false
+  apexPromotionPrSigned: true
+  apexPromotionPrSignedBy: mbtiongson1
+  apexPromotionPrSignedAt: '2026-06-20'
   crossOrgVerifier: null
   systemWideCap: null
 verification:

--- a/src/gaia_cli/commands/dev.py
+++ b/src/gaia_cli/commands/dev.py
@@ -1138,6 +1138,18 @@ def meta_evidence_command(args):
             )
             sys.exit(1)
 
+    # Validate --source-started-at as ISO YYYY-MM-DD; reject bad input loudly.
+    source_started_at = getattr(args, "source_started_at", None)
+    if source_started_at is not None:
+        try:
+            datetime.date.fromisoformat(source_started_at)
+        except ValueError:
+            print(
+                f"Error: --source-started-at must be ISO YYYY-MM-DD; got '{source_started_at}'.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
     # Derive grade from trust number
     derived_grade: str | None = None
     if trust_number is not None:
@@ -1150,10 +1162,10 @@ def meta_evidence_command(args):
 
     if index is not None and trust_number is None and evidence_type is None and (
         not getattr(args, "notes", None)
-    ):
+    ) and source_started_at is None:
         print(
-            "Error: --index requires at least one of --trust, --type, or --notes "
-            "to update on the existing entry.",
+            "Error: --index requires at least one of --trust, --type, --notes, "
+            "or --source-started-at to update on the existing entry.",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -1190,6 +1202,8 @@ def meta_evidence_command(args):
         evidence["contributors"] = args.contributors
     if getattr(args, "skill_count_in_repo", None) is not None:
         evidence["skillCountInRepo"] = args.skill_count_in_repo
+    if source_started_at is not None:
+        evidence["sourceStartedAt"] = source_started_at
 
     def _apply(ev_list: list) -> dict:
         """Append the new entry, or update the entry at ``index`` in place.
@@ -1241,6 +1255,8 @@ def meta_evidence_command(args):
             entry["contributors"] = args.contributors
         if getattr(args, "skill_count_in_repo", None) is not None:
             entry["skillCountInRepo"] = args.skill_count_in_repo
+        if source_started_at is not None:
+            entry["sourceStartedAt"] = source_started_at
         return entry
 
     if "/" in skill_id:

--- a/src/gaia_cli/main.py
+++ b/src/gaia_cli/main.py
@@ -3663,6 +3663,12 @@ def get_parser():
         help="Number of skills in the repo (mothership discount divisor for github-stars-own)",
     )
     dev_evidence.add_argument(
+        "--source-started-at",
+        dest="source_started_at",
+        metavar="YYYY-MM-DD",
+        help="ISO date the source content first existed (for tenure decay; populates evidence[].sourceStartedAt)",
+    )
+    dev_evidence.add_argument(
         "--no-build",
         action="store_true",
         help="Skip rebuilding docs and graph assets after adding evidence",

--- a/src/gaia_cli/trustMagnitude.py
+++ b/src/gaia_cli/trustMagnitude.py
@@ -939,35 +939,54 @@ def checkDepth2OnlyReachableGte1(
     skill: dict,
     registryState: Optional[dict] = None,
 ) -> bool:
-    """Walks fusion graph (role='origin' edges only); excludes suite components.
+    """Walks fusion graph (role='origin' edges + suiteComponents).
 
-    Counts skills reachable only at depth-2 (not at depth-1). Must be >= 1.
+    Counts skills reachable at depth-2 via fusion-recipe origins or
+    suiteComponents. Must be >= 1.
 
-    `registryState` carries a `genericSkillMap`.
+    `registryState` carries `genericSkillMap` and (optionally) `namedSkillMap`.
+    Suite-based ultimates have no `fusion-recipe` rows; their fusion graph IS
+    the `suiteComponents` array, so we walk both fusion-recipe origins AND
+    suiteComponents at every depth (RFC §11.12.3, founder ruling per #746).
+
+    A node is counted as "depth-2 reachable" if it sits two hops from `skill`
+    via the union graph; nodes at depth-1 are excluded only when `skill` itself
+    appears among them (cycle guard). Per Marco's #746 ruling, suite ultimates
+    whose nested components also appear at depth-1 (a flat redundancy that
+    suite authors typically include) still qualify on the basis of nested
+    structural depth.
     """
     if registryState is None:
         return False
     genericSkillMap = registryState.get("genericSkillMap") or {}
+    namedSkillMap = registryState.get("namedSkillMap") or {}
     skillId = skill.get("id") or skill.get("skillId")
     if not skillId:
         return False
 
-    # Depth-1 set: direct fusion-recipe origins (NOT suite components).
-    depth1 = set(_fusionOriginIds(skill, genericSkillMap))
+    # Depth-1 set: direct fusion-recipe origins UNION suiteComponents.
+    depth1 = set(
+        _fusionAndSuiteOriginIds(skill, genericSkillMap, namedSkillMap)
+    )
     if not depth1:
         return False
 
-    depth2Only: set[str] = set()
+    depth2: set[str] = set()
     for d1id in depth1:
-        d1node = genericSkillMap.get(d1id) or {}
-        d2 = _fusionOriginIds(d1node, genericSkillMap)
+        # Look up depth-1 node in named map first (suiteComponent IDs like
+        # "garrytan/garrytan" live there), then fall back to the generic map
+        # for fusion-recipe origins.
+        d1node = (
+            namedSkillMap.get(d1id)
+            or genericSkillMap.get(d1id)
+            or {}
+        )
+        d2 = _fusionAndSuiteOriginIds(d1node, genericSkillMap, namedSkillMap)
         for d2id in d2:
             if d2id == skillId:
                 continue
-            if d2id in depth1:
-                continue
-            depth2Only.add(d2id)
-    return len(depth2Only) >= 1
+            depth2.add(d2id)
+    return len(depth2) >= 1
 
 
 def _fusionOriginIds(skill: dict, genericSkillMap: dict) -> list[str]:
@@ -993,6 +1012,28 @@ def _fusionOriginIds(skill: dict, genericSkillMap: dict) -> list[str]:
             if role == "variant":
                 continue
             out.append(originId)
+    return out
+
+
+def _fusionAndSuiteOriginIds(
+    skill: dict,
+    genericSkillMap: dict,
+    namedSkillMap: Optional[dict] = None,
+) -> list[str]:
+    """Union of fusion-recipe origins and suiteComponents.
+
+    Suite-based ultimates (e.g. `garrytan/gstack`) carry no `fusion-recipe`
+    evidence row; their fusion graph IS the `suiteComponents` array. Per
+    RFC §11.12.3 founder ruling (#746), apex depth walks must include both.
+    """
+    del namedSkillMap  # reserved — suiteComponent IDs are looked up by caller
+    out: list[str] = list(_fusionOriginIds(skill, genericSkillMap))
+    seen = set(out)
+    for cid in skill.get("suiteComponents") or []:
+        if not cid or cid in seen:
+            continue
+        seen.add(cid)
+        out.append(cid)
     return out
 
 

--- a/tests/test_evidence_regrade.py
+++ b/tests/test_evidence_regrade.py
@@ -135,3 +135,50 @@ def test_index_requires_update_field(tmp_path):
     root = _build_registry(tmp_path, [{"source": "https://a", "class": "A"}])
     with pytest.raises(SystemExit):
         meta_evidence_command(_args(root, index=0))
+
+
+def test_source_started_at_appended(tmp_path):
+    """`gaia dev evidence ... --source-started-at YYYY-MM-DD` writes sourceStartedAt."""
+    root = _build_registry(tmp_path, [])
+    meta_evidence_command(
+        _args(
+            root,
+            source="https://example.com/evidence",
+            evidence_type="repo",
+            trust=80,
+            source_started_at="2024-01-15",
+        )
+    )
+    ev = _load_node(root)["evidence"]
+    assert len(ev) == 1
+    assert ev[0]["sourceStartedAt"] == "2024-01-15"
+
+
+def test_source_started_at_in_place_update(tmp_path):
+    """--index can also patch sourceStartedAt on an existing entry."""
+    root = _build_registry(
+        tmp_path,
+        [{"source": "https://a", "type": "repo", "trustNumber": 80, "grade": "A"}],
+    )
+    meta_evidence_command(
+        _args(root, index=0, source_started_at="2023-06-01")
+    )
+    entry = _load_node(root)["evidence"][0]
+    assert entry["sourceStartedAt"] == "2023-06-01"
+    # untouched fields preserved
+    assert entry["trustNumber"] == 80
+
+
+def test_source_started_at_invalid_iso_exits(tmp_path):
+    """Bad ISO date is rejected loudly (not silently coerced)."""
+    root = _build_registry(tmp_path, [])
+    with pytest.raises(SystemExit):
+        meta_evidence_command(
+            _args(
+                root,
+                source="https://example.com/evidence",
+                evidence_type="repo",
+                trust=80,
+                source_started_at="not-a-date",
+            )
+        )

--- a/tests/test_trust_magnitude.py
+++ b/tests/test_trust_magnitude.py
@@ -517,35 +517,38 @@ def test_apex_gate_source_tenure_absent_treats_as_age_zero():
     assert gate["sourceTenureDaysGte180AorS"] is False
 
 
-def test_apex_gate_depth2_suite_exclusion():
-    """Delta §B: suiteComponents edges are NOT fusion edges — depth2 check ignores them."""
-    # The skill has suiteComponents, which would reach "suiteChild" at depth-1
-    # if suite edges counted. But _fusionOriginIds only reads fusion-recipe evidence,
-    # not suiteComponents. So depth-1 set is empty -> depth2OnlyReachableGte1=False.
+def test_apex_gate_depth2_suite_inclusion():
+    """Founder ruling #746: suiteComponents edges DO count in the fusion graph.
+
+    Suite-based ultimates (e.g. garrytan/gstack) carry no fusion-recipe rows;
+    their fusion graph IS the suiteComponents array. Per RFC §11.12.3 founder
+    ruling, the apex depth walker must include both fusion-recipe origins AND
+    suiteComponents at every depth.
+    """
     skill = {
         "id": "suite-host",
         "suiteComponents": ["suiteChild"],
-        # No fusion-recipe evidence row — only suite structure
+        # No fusion-recipe evidence row — depth-1 must come from suiteComponents.
         "evidence": [],
     }
     suiteChildNode = {
         "id": "suiteChild",
         "suiteComponents": ["grandchild"],
-        "evidence": [
-            {"type": "fusion-recipe", "origins": ["grandchild"]},
-        ],
     }
     state = {
         "genericSkillMap": {
             "suiteChild": suiteChildNode,
             "grandchild": {"id": "grandchild"},
-        }
+        },
+        "namedSkillMap": {
+            "suiteChild": suiteChildNode,
+        },
     }
+    # depth1 = {"suiteChild"}; depth2 reaches "grandchild" via suiteComponents.
     result = checkDepth2OnlyReachableGte1(skill, state)
-    # Suite edges excluded; no fusion-recipe evidence on skill -> depth1=empty -> False.
-    assert result is False
+    assert result is True
     gate = passesApexGate(skill, state)
-    assert gate["depth2OnlyReachableGte1"] is False
+    assert gate["depth2OnlyReachableGte1"] is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes part of #746 (apex gate predicate gaps).

## Three deliverables

### 1. depth2 walker now includes suiteComponents (commit `a734beca`)

Per RFC §11.12.3 founder ruling: suite-based ultimates (gstack, ruflo, mattpocock/skills, superpowers) carry no `fusion-recipe` evidence rows; their fusion graph **is** the `suiteComponents` array. The apex depth walker now walks both fusion-recipe origins AND suiteComponents at every depth.

New helper: `_fusionAndSuiteOriginIds(skill, gMap, nMap)` — union of fusion-recipe origins + suiteComponents. `checkDepth2OnlyReachableGte1` now looks up depth-1 nodes in `namedSkillMap` (for named children like `garrytan/garrytan`) before falling back to `genericSkillMap`.

Also relaxed the strict "depth-2 only" filter per Marco's clarification ("Depth 2 will include it even if it is included in their own skill suite"): nodes reachable at depth-2 count toward the predicate even when they also appear at depth-1. Cycle guard against self-reference is preserved.

Updated `test_apex_gate_depth2_suite_exclusion` → `_suite_inclusion` to reflect the new founder ruling. Full test file passes (56/56).

### 2. `gaia dev evidence --source-started-at` flag (commit `7e0755a0`)

Adds a `--source-started-at YYYY-MM-DD` flag that populates `evidence[].sourceStartedAt`, the field consumed by `checkSourceTenureDaysGte180AorS` (§11.12.7). Without this flag, the tenure predicate could never pass for any apex skill — the field was defined in the schema but had no CLI write path.

Validates the date as ISO `YYYY-MM-DD` on the way in; bad dates exit loudly. Works in both append mode and `--index N` in-place patch mode. Three new tests in `tests/test_evidence_regrade.py` cover append, in-place patch, and bad-date rejection.

I11 (source curation) will populate this field once the data is gathered.

### 3. Marco signs apex-promotion PR for the 4 S-grade skills (commit `42e11c92`)

Per founder directive ("sign it on my stamp of approval for gstack, ruflo, skills, and superpowers only"), set on each of the four named skill files:

```yaml
apexGateStatus:
  apexPromotionPrSigned: true
  apexPromotionPrSignedBy: mbtiongson1
  apexPromotionPrSignedAt: '2026-06-20'
```

Each got a timeline event written via `gaia dev timeline ... --action verified --notes "..."` (the `verified` action was the closest enum value — see CLI gap below).

## Inspect output — `garrytan/gstack` after this branch

```
--- Apex Gate (6-star predicates, RFC §11.12) ---
  Apex gate (6-star Transcendent):  FAIL — 4/6 active predicates passed
  ────────────────────────────────────────────────────────────────
    FAIL  §11.12.5  >=8 A-graded origins in transitive closure
    FAIL  §11.12.7  Tenure >= 180 days at A-or-S
    PASS  §11.12.2  >=1 direct component with suiteComponents
    PASS  §11.12.3  >=1 node reachable only at depth >= 2
    PASS  §11.12.4  Overall Trust Grade S (strict-evidence reading)
    PASS  §11.12.8  apex-promotion PR signed by >=2 verifiers
    OFF   §11.12.6  >=2 cross-org 4-star+ verifier-attestations  [flagged OFF]
    OFF   §11.12.9  System-wide <=5 apex skills  [flagged OFF]
  ────────────────────────────────────────────────────────────────
```

Was 2/6 before this branch (only §11.12.2 + §11.12.4 passing). Now 4/6 passing — the remaining two (origins-count + tenure-days) are the I11 source-curation pass, now unblocked by deliverable 2.

## CLI gaps surfaced

- `gaia dev timeline --action` enum has no `apex_pr_signed` value (current: `propose / rank_up / demote / verified / disputed / type_change / suite_ref_set / note`). Used `verified` as the closest semantic match. Worth extending the enum in a follow-up.
- The depth-2 predicate semantics — "only at depth ≥ 2" was relaxed to "reachable at depth ≥ 2" per Marco's clarification. The G7 RFC text should be ratified to match. Tracking issue to follow.

## Tests run

- `python -m pytest tests/test_trust_magnitude.py -x -q` → 56 passed
- `python -m pytest tests/test_evidence_regrade.py -x -q` → 8 passed (5 original + 3 new)

Full suite skipped per Windows symlink limitations noted in `founder/CLAUDE.md`.
