### PR TITLE
infra(test): CI confidence + Windows-first dev (#795)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -16,3 +16,16 @@ tasks:
     desc: Build registry and generated docs
     cmds:
       - gaia dev build
+
+  release:dryrun:
+    desc: "Run all CI-equivalent gates locally before pushing (fail-fast). Usage: task release:dryrun"
+    cmds:
+      - echo "--- Gate 1/4: registry schema + integrity ---"
+      - python scripts/validate.py
+      - echo "--- Gate 2/4: smoke tests ---"
+      - python -m pytest -m smoke -x
+      - echo "--- Gate 3/4: nav mounts cohesion ---"
+      - python scripts/check_nav_mounts.py
+      - echo "--- Gate 4/4: docs build drift check ---"
+      - python -m gaia_cli docs build --check
+      - echo "✅ All CI-equivalent gates passed locally. Safe to push."

--- a/founder/handovers/CI_CONFIDENCE_REPORT.md
+++ b/founder/handovers/CI_CONFIDENCE_REPORT.md
@@ -1,0 +1,89 @@
+# CI Confidence + Windows-First Dev — Before/After Report
+
+**Issue:** #795
+**PR:** https://github.com/mbtiongson1/gaia-skill-tree/pull/796
+**Drafted:** 2026-06-22
+**Author:** Sub-agent A (Sonnet) under orchestrator session 18
+
+## Context
+
+PR #793 -> #794 hit CI red twice on a single bug-fix patch. Documented in `founder/MEMORY.md` session 18 (L1, L2, L3).
+
+## Before
+
+| Metric | Value |
+|---|---|
+| Windows agent: tests runnable without flags | No — every invocation needed `-p no:timeout` to skip SIGALRM crash (pytest-timeout v2.4.0, `timeout_method = "signal"`, Windows has no `signal.SIGALRM`) |
+| Windows agent: CLI runnable with glyphs | No — every invocation needed `PYTHONIOENCODING=utf-8` env prefix to avoid UnicodeEncodeError on star glyphs and arrows |
+| Pre-push feedback loop | None — agent commits → pushes → waits 2 min → reads `gh run view --log-failed` → guesses |
+| Smoke test selection | None — agent either runs full 1,200-test suite or runs nothing |
+| Local CI dryrun | None — `gaia validate` covers a fraction; no docs-cohesion or smoke gate |
+| Wave 1 (#793 -> #794) CI rounds | 2 (1 unrelated meta-sync drift + 1 from PR's own regressions) |
+| Wave 1 wall-clock | ~3 hr (orchestrator + sub-agent + 2x CI wait) |
+| Wave 1 cost (orchestrator + sub-agent) | ~$3.35 (logged in MEMORY.md session 18) |
+
+## After
+
+| Metric | Value |
+|---|---|
+| Windows agent: tests runnable | Yes — `python -m pytest -x` works out of the box (thread mode, no INTERNALERROR) |
+| Windows agent: CLI runnable | Yes — `gaia tree` prints glyphs natively without PYTHONIOENCODING |
+| Pre-push feedback loop | `task release:dryrun` — runs all 4 gates |
+| Smoke test selection | `pytest -m smoke` — 17 tests, runs in 4.49s on Windows |
+| Local CI dryrun | `task release:dryrun` runs all 4 gates sequentially (fail-fast) |
+| Projected Wave 2-6 CI rounds | Goal: <= 1 round per PR. Tracked in MEMORY.md session 19. |
+
+## Hypothesis: cost reduction
+
+Wave 1 burned ~$3.35 across two CI rounds and ~3 hours wall-clock. If `release:dryrun` had caught the regressions before push, each round saves:
+- ~2 min CI wait (free, but blocks the loop)
+- ~15k orchestrator tokens reading `gh run view --log-failed` and reasoning about the failure (~$0.30)
+- ~5 min agent wall-clock re-edit cycle
+
+**Projected savings for Waves 2-6 (4 PRs):** ~$1.20 in token spend, ~80 min wall-clock, 4 CI rounds avoided. Conservative estimate; real number tracked in MEMORY.md after the consolidated Wave 2-6 PR lands.
+
+## What was actually shipped
+
+| Step | Commit | Verification |
+|---|---|---|
+| 1 — pytest-timeout thread mode | 7ee8821b | `pytest -x` runs on Windows without `-p no:timeout`; SIGALRM INTERNALERROR gone |
+| 2 — UTF-8 console reconfigure | 4554e125 | `python -c "import gaia_cli; print('ok: ✅ ⭐ →')"` works without PYTHONIOENCODING |
+| 3 — `@pytest.mark.smoke` selection | dbf4db99 | 17 tests marked, runs in 4.49s on Windows; testpaths=["tests"] added to prevent root-level test_mcp.py INTERNALERROR during collection |
+| 4 — `task release:dryrun` | 24c2cc63 | 4 gates defined; validate.py passes, check_nav_mounts.py passes on clean tree |
+| 5 — This report | (this commit) | You are reading it |
+
+## Smoke test selection rationale
+
+The 17 smoke tests were chosen to cover the exact failure modes from #787 + #794:
+
+| Test | Failure mode it catches |
+|---|---|
+| `test_help_exits_zero` | Argparse regression — CLI won't start |
+| `test_parser_registers_all_public_commands` | New command added but not wired to subparser |
+| `test_scan_repo_skips_*` | Scanner breakage from CLI refactor |
+| `test_scan_repo_detailed_reports_*` | Scanner output contract |
+| `test_top_level_help_shows_all_public_commands_with_usage` | Help output drift |
+| `test_gaia_cli_package_imports` | Import error from broken __init__ |
+| `test_python_module_help_runs_with_gaia_prog_name` | Module entry point |
+| `test_console_script_points_to_canonical_package` | pyproject.toml script entry |
+| `test_gaia_cli_main_remains_importable` | main.py import chain |
+| `test_bundled_registry_is_used_*` | Bundled snapshot path (#793 regression) |
+| `test_write_commands_require_explicit_registry` | Registry resolution contract |
+| `test_parse_frontmatter_nested_links` | YAML frontmatter parser |
+| `test_registry_paths_use_new_layout` | Registry path layout contract |
+| `test_tree_manager_reads_and_writes_skill_trees` | Tree I/O contract |
+| `test_cycle` | DAG validation catches schema drift |
+| `test_bump_version` | Version bumping logic |
+| `test_verify_lockstep` | Version lockstep across pyproject + npm + mcp + registry |
+
+Tests excluded from smoke that were initially considered:
+- `test_init_writes_local_registry_path` — fails due to live 404 fetch in test env (pre-existing, not safe for smoke)
+- `test_clean_graph` — requires `registry/gaia.json` which is absent in worktree environments
+- `test_seed_skills_have_valid_levels` — same, requires registry/gaia.json
+
+## Recommended follow-ups (NOT in this PR)
+
+- **Pre-commit hook** wiring `task release:dryrun` — gated behind opt-in env var so it does not break legacy contributor flows.
+- **`gaia release dryrun` CLI verb** as a thin wrapper over `task release:dryrun` — discoverable in `gaia --help`.
+- **Test-contract classification audit** (L1) — separate "release artifact" tests from "working-tree state" tests so the latter can move out of PR-gating CI.
+- **Fix `test_init_*` network dependency** — the `gaia init` flow calls `fetch_command` unconditionally; a `--no-fetch` flag or mock would make these tests reliable for smoke.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ gaia_cli = [
 
 [tool.pytest.ini_options]
 pythonpath = ["src", "."]
+testpaths = ["tests"]
 norecursedirs = ["tests/_archive"]
 timeout = 60
 timeout_method = "thread"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,8 @@ gaia_cli = [
 pythonpath = ["src", "."]
 norecursedirs = ["tests/_archive"]
 timeout = 60
-timeout_method = "signal"
+timeout_method = "thread"
 markers = [
     "packaging: package build and wheel installation checks",
+    "smoke: fast pre-push subset; covers high-value contracts (schema sync, wheel build, init, registry resolution, docs cohesion)",
 ]

--- a/src/gaia_cli/__init__.py
+++ b/src/gaia_cli/__init__.py
@@ -1,0 +1,11 @@
+import sys as _sys
+
+# Windows console defaults to cp1252 which crashes with UnicodeEncodeError on
+# emoji / arrows / star glyphs that the CLI prints liberally. Reconfigure
+# to UTF-8 once at package import. No-op on POSIX.
+if _sys.platform == "win32":
+    try:
+        _sys.stdout.reconfigure(encoding="utf-8")
+        _sys.stderr.reconfigure(encoding="utf-8")
+    except AttributeError:
+        pass  # Python < 3.7

--- a/tests/test_cli_core.py
+++ b/tests/test_cli_core.py
@@ -170,11 +170,13 @@ class TestHelp:
     rather than raw help text.
     """
 
+    @pytest.mark.smoke
     def test_help_exits_zero(self, monkeypatch: pytest.MonkeyPatch, capsys):
         with pytest.raises(SystemExit) as exc:
             run_cli(monkeypatch, ["--help"])
         assert exc.value.code == 0
 
+    @pytest.mark.smoke
     def test_parser_registers_all_public_commands(self):
         """Every PUBLIC_COMMANDS entry must be a registered subparser choice."""
         import argparse

--- a/tests/test_dx.py
+++ b/tests/test_dx.py
@@ -73,6 +73,7 @@ def test_init_yes_mode_preserves_non_interactive_defaults(tmp_path, monkeypatch)
     assert config["scanPaths"] == ["scripts", "packages/cli-npm"]
 
 
+@pytest.mark.smoke
 def test_scan_repo_skips_generated_and_vendor_directories(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     (tmp_path / ".gaia").mkdir()
@@ -93,6 +94,7 @@ def test_scan_repo_skips_generated_and_vendor_directories(tmp_path, monkeypatch)
     assert "/autonomous-debug" not in tokens
 
 
+@pytest.mark.smoke
 def test_scan_repo_detailed_reports_file_and_candidate_counts(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     (tmp_path / ".gaia").mkdir()
@@ -121,6 +123,7 @@ def test_top_level_install_commands_are_restored(monkeypatch):
     assert exc.value.code == 0
 
 
+@pytest.mark.smoke
 def test_top_level_help_shows_all_public_commands_with_usage(monkeypatch, capsys):
     with pytest.raises(SystemExit) as exc:
         run_cli(monkeypatch, ["--help"])

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -98,12 +98,14 @@ def cleanup_staged_paths(paths):
             p.unlink(missing_ok=True)
 
 
+@pytest.mark.smoke
 def test_gaia_cli_package_imports():
     import gaia_cli
 
     assert gaia_cli.__name__ == "gaia_cli"
 
 
+@pytest.mark.smoke
 def test_python_module_help_runs_with_gaia_prog_name():
     result = run_python(["-m", "gaia_cli", "--help"])
 
@@ -111,18 +113,21 @@ def test_python_module_help_runs_with_gaia_prog_name():
     assert "usage: gaia" in result.stdout
 
 
+@pytest.mark.smoke
 def test_console_script_points_to_canonical_package():
     data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
 
     assert data["project"]["scripts"]["gaia"] == "gaia_cli.main:main"
 
 
+@pytest.mark.smoke
 def test_gaia_cli_main_remains_importable():
     import gaia_cli.main as compat_main
 
     assert callable(compat_main.main)
 
 
+@pytest.mark.smoke
 def test_bundled_registry_is_used_for_read_only_skills_without_registry(tmp_path):
     result = run_python(
         ["-m", "gaia_cli", "skills", "list"],
@@ -156,6 +161,7 @@ def test_scan_can_use_explicit_writable_registry(tmp_path):
     assert "Scanning installed custom skills" in result.stdout
 
 
+@pytest.mark.smoke
 def test_write_commands_require_explicit_registry(tmp_path):
     (tmp_path / ".gaia").mkdir()
     (tmp_path / ".gaia" / "config.json").write_text(
@@ -397,6 +403,7 @@ def test_install_cache_honors_gaia_home(tmp_path, monkeypatch):
     assert (gaia_home / "skills" / "alice" / "repo").exists()
 
 
+@pytest.mark.smoke
 def test_parse_frontmatter_nested_links(tmp_path):
     """_parse_frontmatter must return a dict with a dict under 'links', not a string."""
     from gaia_cli.install import _parse_frontmatter

--- a/tests/test_registry_layout.py
+++ b/tests/test_registry_layout.py
@@ -19,6 +19,7 @@ from gaia_cli.registry import (
 from gaia_cli.treeManager import load_tree, save_tree
 
 
+@pytest.mark.smoke
 def test_registry_paths_use_new_layout(tmp_path):
     assert registry_graph_path(tmp_path) == str(tmp_path / "registry" / "gaia.json")
     assert named_skills_dir(tmp_path) == str(tmp_path / "registry" / "named")
@@ -27,6 +28,7 @@ def test_registry_paths_use_new_layout(tmp_path):
     assert user_tree_path(tmp_path, "alice") == str(tmp_path / "skill-trees" / "alice" / "skill-tree.json")
 
 
+@pytest.mark.smoke
 def test_tree_manager_reads_and_writes_skill_trees(tmp_path):
     save_tree("alice", {"userId": "alice", "unlockedSkills": []}, registry_path=str(tmp_path))
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -4,6 +4,8 @@ import sys
 import unittest
 import json
 
+import pytest
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # Define paths
@@ -32,6 +34,7 @@ class TestValidate(unittest.TestCase):
         self.assertEqual(code, 0, f"Expected clean graph to pass, but it failed with output:\n{out}")
         self.assertIn("All validation checks passed.", out)
 
+    @pytest.mark.smoke
     def test_cycle(self):
         """Ensure a cycle is detected."""
         code, out = run_validate(os.path.join(FIXTURES_DIR, "cycle.json"))

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 from gaia_cli import versioning
 
+@pytest.mark.smoke
 def test_bump_version():
     assert versioning.bump_version("1.2.3", "patch") == "1.2.4"
     assert versioning.bump_version("1.2.3", "minor") == "1.3.0"
@@ -54,6 +55,7 @@ def test_read_versions(tmp_path: Path, monkeypatch):
     assert versions["docsGraph"] == "1.0.0"
 
 
+@pytest.mark.smoke
 def test_verify_lockstep(tmp_path: Path, monkeypatch):
     setup_mock_project(tmp_path)
     monkeypatch.setattr(versioning, "registry_graph_path", lambda root: str(Path(root) / "registry" / "gaia.json"))


### PR DESCRIPTION
Resolves #795.

## Summary

- **Step 1** — `pyproject.toml`: switch `timeout_method` from `signal` to `thread` (Windows has no `SIGALRM`; pytest-timeout was crashing every test run with `INTERNALERROR`). Also register `smoke` marker and add `testpaths = ["tests"]` to prevent root-level `test_mcp.py` from causing collection errors.
- **Step 2** — `src/gaia_cli/__init__.py`: reconfigure stdout/stderr to UTF-8 at package import on win32, so star glyphs/arrows/emoji print without `PYTHONIOENCODING=utf-8` env prefix.
- **Step 3** — Mark 17 high-value tests `@pytest.mark.smoke` covering the failure modes from #787 + #794. Suite runs in **4.49s** on Windows.
- **Step 4** — `Taskfile.yml`: add `release:dryrun` target that runs 4 gates fail-fast: `validate.py` → `pytest -m smoke -x` → `check_nav_mounts.py` → `gaia docs build --check`.
- **Step 5** — `founder/handovers/CI_CONFIDENCE_REPORT.md`: before/after report for Marco.

## Acceptance checklist

- [x] `python -m pytest -x` runs on Windows without `-p no:timeout`
- [x] `python -c "import gaia_cli; print('✅ ⭐ →')"` works without `PYTHONIOENCODING`
- [x] `python -m pytest -m smoke` — 17 tests, 4.49s on Windows
- [x] `task release:dryrun` — 4 gates defined, Gates 1 + 3 pass on clean tree
- [x] Handover report written with before/after table and SHAs

## Notes

`test_init_writes_local_registry_path` and `test_init_accepts_flags_*` were NOT marked smoke because `gaia init` unconditionally calls `fetch_command` which hits GitHub and gets 404 in isolated test environments. These are pre-existing failures tracked as a recommended follow-up (add `--no-fetch` flag).