### PR TITLE
feat(install): NTFS junction + hardlink fallback for Windows symlink failures

### DIFF
--- a/src/gaia_cli/install.py
+++ b/src/gaia_cli/install.py
@@ -15,6 +15,7 @@ from datetime import datetime, timezone
 
 from gaia_cli.registry import named_skills_dir
 from gaia_cli.formatting import _fg, _reset, get_harness_color
+from gaia_cli.windowsLinks import makeLink, isLinkOrJunction
 
 
 def get_gaia_home():
@@ -187,18 +188,29 @@ def _install_single(sid: str, meta: dict, registry_path: str, visited: set[str],
 
     source_skill_path = os.path.join(global_cache, subpath)
 
-    if os.path.exists(local_skill_path) or os.path.islink(local_skill_path):
-        if os.path.islink(local_skill_path):
-            os.remove(local_skill_path)
+    if os.path.exists(local_skill_path) or os.path.islink(local_skill_path) or isLinkOrJunction(local_skill_path):
+        if os.path.islink(local_skill_path) or isLinkOrJunction(local_skill_path):
+            try:
+                os.remove(local_skill_path)
+            except OSError:
+                # Junction removal on Windows may need rmdir-style handling
+                os.rmdir(local_skill_path)
         else:
             shutil.rmtree(local_skill_path)
 
     h_color = get_harness_color(local_skill_path)
     print(f"Installing {sid} to {_fg(*h_color)}{local_skill_path}{_reset()}...")
-    if sys.platform != "win32":
-        os.symlink(source_skill_path, local_skill_path)
-    else:
-        # On Windows, copy if symlinks aren't enabled for user
+    try:
+        mechanism = makeLink(source_skill_path, local_skill_path)
+        if mechanism != "symlink":
+            print(f"  (used {mechanism} fallback on this platform)")
+    except OSError as e:
+        # Last-resort: copy. Preserves Windows behavior from before this
+        # module existed, so a totally locked-down host still installs.
+        print(
+            f"  Link creation failed ({e}); falling back to copy.",
+            file=sys.stderr,
+        )
         if os.path.isdir(source_skill_path):
             shutil.copytree(source_skill_path, local_skill_path)
         else:
@@ -219,10 +231,13 @@ def _install_single(sid: str, meta: dict, registry_path: str, visited: set[str],
         # If reinstalling with different location, clean up old path
         old_path = existing.get("localPath")
         old_location = existing.get("location", "local")
-        if old_path and old_location != location and (os.path.exists(old_path) or os.path.islink(old_path)):
+        if old_path and old_location != location and (os.path.exists(old_path) or os.path.islink(old_path) or isLinkOrJunction(old_path)):
             try:
-                if os.path.islink(old_path):
-                    os.remove(old_path)
+                if os.path.islink(old_path) or isLinkOrJunction(old_path):
+                    try:
+                        os.remove(old_path)
+                    except OSError:
+                        os.rmdir(old_path)
                 elif os.path.isdir(old_path):
                     shutil.rmtree(old_path)
                 else:
@@ -370,9 +385,12 @@ def uninstall_skill(skill_id):
 
     if "localPath" in entry:
         lp = entry["localPath"]
-        if os.path.exists(lp) or os.path.islink(lp):
-            if os.path.islink(lp):
-                os.remove(lp)
+        if os.path.exists(lp) or os.path.islink(lp) or isLinkOrJunction(lp):
+            if os.path.islink(lp) or isLinkOrJunction(lp):
+                try:
+                    os.remove(lp)
+                except OSError:
+                    os.rmdir(lp)
             elif os.path.isdir(lp):
                 shutil.rmtree(lp)
             else:

--- a/src/gaia_cli/windowsLinks.py
+++ b/src/gaia_cli/windowsLinks.py
@@ -1,0 +1,136 @@
+"""Cross-platform link creation with Windows-specific fallbacks.
+
+The standard library ``os.symlink`` works reliably on Linux and macOS, but on
+Windows it requires either Administrator privileges, Developer Mode, or the
+``SeCreateSymbolicLinkPrivilege``. Even with Developer Mode enabled, some
+Python builds, CI environments, anti-virus products, and group policies will
+still reject the call.
+
+This module provides ``makeLink`` which transparently falls back to mechanisms
+that do *not* require elevation on Windows:
+
+* For directories: NTFS junctions (``mklink /J``).
+* For files: hardlinks (``os.link``), then a copy via ``shutil.copy2``.
+
+On Linux and macOS the fallback code is unreachable — ``os.symlink`` is the
+sole path executed and the function behaves exactly like the stdlib call.
+
+A companion helper ``isLinkOrJunction`` lets tests assert that *some* form of
+link was created without caring whether it is a true symlink or an NTFS
+junction.
+
+Caveat: ``os.readlink`` does NOT work on NTFS junctions. Callers that need to
+read the link target back should use ``os.path.realpath`` (which resolves
+junctions transparently) instead.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from typing import Union
+
+PathLike = Union[str, "os.PathLike[str]"]
+
+
+def makeLink(
+    src: PathLike,
+    dst: PathLike,
+    *,
+    targetIsDirectory: bool | None = None,
+) -> str:
+    """Create a link from ``dst`` pointing at ``src``.
+
+    Args:
+        src: The existing path to link to.
+        dst: The new path to create.
+        targetIsDirectory: Whether the target is a directory. Inferred from
+            ``src`` via ``os.path.isdir`` when ``None`` (matches the semantics
+            of ``os.symlink``'s ``target_is_directory`` argument).
+
+    Returns:
+        A string describing the mechanism used: ``"symlink"`` (the default
+        path on every platform), ``"junction"`` (Windows directory fallback),
+        ``"hardlink"`` (Windows file fallback), or ``"copy"`` (Windows file
+        last-resort).
+
+    Raises:
+        OSError: When ``os.symlink`` fails on a non-Windows platform, or when
+            every Windows fallback also fails.
+    """
+    srcPath = os.fspath(src)
+    dstPath = os.fspath(dst)
+    if targetIsDirectory is None:
+        targetIsDirectory = os.path.isdir(srcPath)
+
+    # Primary path: real symlink. Works on Linux/macOS unconditionally; works
+    # on Windows when symlink creation is permitted for the current user.
+    try:
+        os.symlink(srcPath, dstPath, target_is_directory=targetIsDirectory)
+        return "symlink"
+    except OSError as primaryError:
+        if sys.platform != "win32":
+            raise
+
+    # ---- Windows fallbacks below this point ----
+
+    if targetIsDirectory:
+        # NTFS junction: same-volume only, but no elevation required.
+        try:
+            subprocess.run(
+                ["cmd", "/c", "mklink", "/J", dstPath, srcPath],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            return "junction"
+        except (subprocess.CalledProcessError, FileNotFoundError) as junctionError:
+            stderr = getattr(junctionError, "stderr", "") or ""
+            raise OSError(
+                f"Failed to link {dstPath!r} -> {srcPath!r}: "
+                f"symlink denied ({primaryError}) and junction failed "
+                f"({stderr.strip() or junctionError})"
+            ) from junctionError
+
+    # File fallbacks: try hardlink first (same-volume only, no elevation),
+    # then a plain copy.
+    try:
+        os.link(srcPath, dstPath)
+        return "hardlink"
+    except OSError:
+        shutil.copy2(srcPath, dstPath)
+        return "copy"
+
+
+def isLinkOrJunction(path: PathLike) -> bool:
+    """Return True when ``path`` is a symlink or an NTFS junction.
+
+    ``os.path.islink`` returns False for junctions on Windows, so tests that
+    only care that *some* form of link exists should use this helper.
+    """
+    p = os.fspath(path)
+    if os.path.islink(p):
+        return True
+    if sys.platform != "win32":
+        return False
+    # On Windows, a junction is a reparse point with a directory attribute.
+    # The cheapest reliable detection is the FILE_ATTRIBUTE_REPARSE_POINT
+    # bit on the lstat result.
+    try:
+        attrs = os.lstat(p).st_file_attributes  # type: ignore[attr-defined]
+    except (OSError, AttributeError):
+        return False
+    FILE_ATTRIBUTE_REPARSE_POINT = 0x400
+    return bool(attrs & FILE_ATTRIBUTE_REPARSE_POINT)
+
+
+def readLinkTarget(path: PathLike) -> str:
+    """Return the resolved absolute path that ``path`` ultimately points to.
+
+    Works for both real symlinks and NTFS junctions. Prefer this over
+    ``os.readlink`` in cross-platform code — ``os.readlink`` does not support
+    junctions and raises ``OSError`` for them.
+    """
+    return os.path.realpath(os.fspath(path))

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -247,10 +247,11 @@ class TestInstallFlow:
         install_skill("testuser/my-skill", str(tmp_path))
 
         link = tmp_path / ".agents" / "skills" / "my-skill"
-        assert link.is_symlink(), "Expected a symlink for the installed skill"
-        target = os.readlink(str(link))
-        assert target.startswith(cache_base), (
-            f"Symlink target {target!r} is not inside cache dir {cache_base!r}"
+        from gaia_cli.windowsLinks import isLinkOrJunction
+        assert isLinkOrJunction(str(link)), "Expected a symlink or junction for the installed skill"
+        target = os.path.realpath(str(link))
+        assert target.startswith(os.path.realpath(cache_base)), (
+            f"Link target {target!r} is not inside cache dir {cache_base!r}"
         )
 
     def test_install_deduplicates_manifest_entry(self, tmp_path, monkeypatch):

--- a/tests/test_suite_install.py
+++ b/tests/test_suite_install.py
@@ -285,10 +285,11 @@ class TestSuiteInstallFlow:
         install_suite("testuser/my-suite", str(tmp_path))
 
         link = tmp_path / ".agents" / "skills" / "alpha"
-        assert link.is_symlink(), "Expected a symlink for installed skill"
-        link_target = os.readlink(str(link))
-        assert link_target.startswith(cache_base), (
-            f"Symlink target {link_target!r} is not inside cache dir {cache_base!r}"
+        from gaia_cli.windowsLinks import isLinkOrJunction
+        assert isLinkOrJunction(str(link)), "Expected a symlink or junction for installed skill"
+        link_target = os.path.realpath(str(link))
+        assert link_target.startswith(os.path.realpath(cache_base)), (
+            f"Link target {link_target!r} is not inside cache dir {cache_base!r}"
         )
 
     def test_install_suite_prevents_circular_recursion(self, tmp_path, monkeypatch):

--- a/tests/test_windowsLinks.py
+++ b/tests/test_windowsLinks.py
@@ -1,0 +1,146 @@
+"""Tests for gaia_cli.windowsLinks.
+
+The default code path (real ``os.symlink``) is exercised on every platform.
+The Windows-only fallbacks (junction, hardlink, copy) are exercised by
+monkeypatching ``os.symlink`` to raise ``OSError`` and forcing ``sys.platform``
+to ``win32`` for that single call. The fallback unit tests are skipped on
+non-Windows because they depend on the ``cmd /c mklink /J`` subprocess which
+only exists on Windows.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import pytest
+
+from gaia_cli import windowsLinks
+from gaia_cli.windowsLinks import makeLink, isLinkOrJunction, readLinkTarget
+
+
+class TestMakeLinkPrimaryPath:
+    """The default path: os.symlink succeeds. Works on every platform."""
+
+    def testDirectoryLinkRoundTrip(self, tmp_path):
+        src = tmp_path / "source"
+        src.mkdir()
+        (src / "marker.txt").write_text("hello")
+
+        dst = tmp_path / "linked"
+        try:
+            mechanism = makeLink(src, dst)
+        except OSError:
+            # Windows without symlink privilege: skip the primary-path test
+            # (the fallback test below covers the Windows behavior).
+            pytest.skip("Symlink creation not permitted on this host")
+
+        assert mechanism in {"symlink", "junction"}
+        assert isLinkOrJunction(dst)
+        assert (dst / "marker.txt").read_text() == "hello"
+        assert readLinkTarget(dst) == os.path.realpath(str(src))
+
+    def testFileLinkRoundTrip(self, tmp_path):
+        src = tmp_path / "source.txt"
+        src.write_text("content")
+
+        dst = tmp_path / "linked.txt"
+        try:
+            mechanism = makeLink(src, dst)
+        except OSError:
+            pytest.skip("Symlink creation not permitted on this host")
+
+        assert mechanism in {"symlink", "hardlink", "copy"}
+        assert dst.exists()
+        assert dst.read_text() == "content"
+
+    def testInferredDirectoryFlag(self, tmp_path):
+        """targetIsDirectory is inferred from src when None."""
+        src = tmp_path / "src-dir"
+        src.mkdir()
+        dst = tmp_path / "dst-dir"
+        try:
+            makeLink(src, dst)
+        except OSError:
+            pytest.skip("Symlink creation not permitted on this host")
+        assert dst.is_dir()
+
+
+class TestMakeLinkFallbacks:
+    """Force ``os.symlink`` to raise so the Windows fallback branches run."""
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Junctions are Windows-only")
+    def testJunctionFallbackForDirectory(self, tmp_path, monkeypatch):
+        src = tmp_path / "source"
+        src.mkdir()
+        (src / "marker.txt").write_text("hi")
+
+        def boom(*args, **kwargs):
+            raise OSError("simulated symlink denial")
+
+        monkeypatch.setattr(os, "symlink", boom)
+
+        dst = tmp_path / "junction"
+        mechanism = makeLink(src, dst)
+        assert mechanism == "junction"
+        assert isLinkOrJunction(dst)
+        assert (dst / "marker.txt").read_text() == "hi"
+        # os.readlink does NOT work on junctions — verify readLinkTarget does.
+        assert readLinkTarget(dst) == os.path.realpath(str(src))
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="File fallback uses os.link semantics that vary")
+    def testHardlinkOrCopyFallbackForFile(self, tmp_path, monkeypatch):
+        src = tmp_path / "source.txt"
+        src.write_text("payload")
+
+        def boom(*args, **kwargs):
+            raise OSError("simulated symlink denial")
+
+        monkeypatch.setattr(os, "symlink", boom)
+
+        dst = tmp_path / "linked.txt"
+        mechanism = makeLink(src, dst)
+        assert mechanism in {"hardlink", "copy"}
+        assert dst.read_text() == "payload"
+
+    def testLinuxRaisesWhenSymlinkFails(self, tmp_path, monkeypatch):
+        """On Linux/macOS the fallback path must NOT execute — OSError propagates."""
+        if sys.platform == "win32":
+            pytest.skip("This test pins the non-Windows propagation behavior")
+
+        def boom(*args, **kwargs):
+            raise OSError("simulated denial")
+
+        monkeypatch.setattr(os, "symlink", boom)
+
+        src = tmp_path / "source"
+        src.mkdir()
+        dst = tmp_path / "linked"
+        with pytest.raises(OSError, match="simulated denial"):
+            makeLink(src, dst)
+
+
+class TestIsLinkOrJunction:
+    def testRegularDirectoryReturnsFalse(self, tmp_path):
+        d = tmp_path / "real"
+        d.mkdir()
+        assert isLinkOrJunction(d) is False
+
+    def testRegularFileReturnsFalse(self, tmp_path):
+        f = tmp_path / "real.txt"
+        f.write_text("x")
+        assert isLinkOrJunction(f) is False
+
+    def testNonexistentPathReturnsFalse(self, tmp_path):
+        assert isLinkOrJunction(tmp_path / "missing") is False
+
+
+class TestReadLinkTarget:
+    def testResolvesThroughLink(self, tmp_path):
+        src = tmp_path / "src"
+        src.mkdir()
+        dst = tmp_path / "dst"
+        try:
+            makeLink(src, dst)
+        except OSError:
+            pytest.skip("Link creation not permitted on this host")
+        assert readLinkTarget(dst) == os.path.realpath(str(src))


### PR DESCRIPTION
## Problem

Windows `os.symlink()` fails in several scenarios even when Developer Mode is enabled:

- Some Python builds don't fully honor the Developer Mode policy.
- CI / container / nested-process contexts may not inherit the privilege.
- Anti-virus or group policy can intercept `CreateSymbolicLinkW`.

Marco (Windows 11 with Dev Mode on) is hitting these and the install + test suite blow up because of it.

## Fix

New module `src/gaia_cli/windowsLinks.py` with three small helpers:

- `makeLink(src, dst, *, targetIsDirectory=None) -> str`
  - Tries `os.symlink` first. On Linux/macOS this is the *only* path executed.
  - On Windows, falls back to **NTFS junctions** (`cmd /c mklink /J`) for directories — no elevation needed.
  - On Windows, falls back to `os.link` (hardlink) and then `shutil.copy2` for files.
  - Returns `"symlink"`, `"junction"`, `"hardlink"`, or `"copy"` so callers can log/decide.
- `isLinkOrJunction(path) -> bool` — `os.path.islink` returns False for junctions on Windows; tests need this.
- `readLinkTarget(path) -> str` — thin wrapper over `os.path.realpath`. `os.readlink` does **not** support junctions, so cross-platform code must avoid it.

`install.py` is refactored to call `makeLink` in `_install_single`, and the three cleanup paths (`_install_single` overwrite, location-change cleanup in install_skill, and `uninstall_skill`) all now recognize junctions as removable links.

## Tests

- `tests/test_windowsLinks.py` — 10 new tests. Primary path runs on every platform; Windows-only fallback tests use `monkeypatch` to force `os.symlink` to raise `OSError`, then assert the junction / hardlink / copy paths take over.
- `tests/test_install.py::test_install_creates_symlink_pointing_to_cache` and `tests/test_suite_install.py::test_install_suite_symlink_resolves_to_correct_cache_dir` now use `isLinkOrJunction` and `os.path.realpath` instead of `is_symlink()` + `os.readlink`, so they pass uniformly whether the install picked a real symlink or a junction.

## Results

Before this PR, on Windows:

- `python -m pytest tests/test_install.py tests/test_suite_install.py` — failed on the two symlink-asserting tests when symlink privilege wasn't available.

After this PR, on Windows:

```
tests/test_install.py + tests/test_suite_install.py + tests/test_windowsLinks.py
53 passed, 1 skipped in 1.68s
```

The 1 skip is the Linux-only OSError-propagation test (correctly gated by `sys.platform != "win32"`).

## Out of scope

Pre-existing Windows failures NOT fixed by this PR (verified to fail on `origin/main` HEAD with my changes reverted):

- `tests/test_validate.py::TestNamedSkillValidation::test_invalid_github_url_casing_fails_validation` — NTFS is case-insensitive but case-preserving; this is a separate bug.
- `tests/test_packaging.py::test_local_registry_auto_resolves_for_write_command`, `test_wheel_install_smoke_tests_console_script`
- `tests/test_push.py::test_push_no_pr_writes_batch_file`, `test_push_dry_run_separates_known_and_proposed_skills`
- `tests/test_redaction.py::test_redaction_validator_passes_on_repo`
- `tests/test_timelines.py::test_repo_timelines_are_consistent`
- `tests/test_pr635_review.py` (2 tests)
- `tests/test_path_command.py::test_path_output_contains_markers`

There is also a large cluster of pytest teardown "ValueError: I/O operation on closed file" errors when the full suite runs together on Windows — pytest's capture plugin closes stdout mid-stream. Pre-existing infrastructure issue, not caused by this PR.

## Architectural surprise

`os.readlink` does NOT work on NTFS junctions — it raises `OSError`. Two tests previously used it (`tests/test_install.py:251` and `tests/test_suite_install.py:289`); both are updated to use `os.path.realpath`. **No other call sites in the repo currently use `os.readlink`**, so this is contained. If new code paths ever need to read a link back, use `readLinkTarget` from `windowsLinks.py`.

## Context

Related to PR #803 (Windows symlink failures surfaced by sub-agent investigation).
