### PR TITLE
fix(ci): copy registry/named from workspace in publish-pypi workflow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -66,7 +66,7 @@ jobs:
           rm -rf src/gaia_cli/data/registry/named
           cp /tmp/gaia-snap/registry/gaia.json          src/gaia_cli/data/registry/gaia.json
           cp /tmp/gaia-snap/registry/named-skills.json  src/gaia_cli/data/registry/named-skills.json
-          cp -r /tmp/gaia-snap/registry/named           src/gaia_cli/data/registry/named
+          cp -r registry/named                          src/gaia_cli/data/registry/named
           echo "Bundled snapshot refreshed from ${TAG}."
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Copy registry/named from checkout workspace instead of downloaded tarball in publish-pypi workflow.