### PR TITLE
fix(cli): resolve missing custom skills in fuse and tree

### DIFF
--- a/src/gaia_cli/impl.py
+++ b/src/gaia_cli/impl.py
@@ -1000,12 +1000,12 @@ def scan_command(args):
         _scan_state = {
             "skills": [
                 {
-                    "id": sk["mapped_to"],
+                    "id": sk["mapped_to"] if sk.get("match_type") in ("origin", "named", "exact_generic") else sk["id"].lstrip("/"),
                     "localId": sk["id"].lstrip("/"),
                     "level": sk["canon_level"],
                     "type": sk.get("skill_type", "basic"),
                     "description": sk.get("description", ""),
-                    "local": sk.get("match_type") is None and sk["mapped_score"] == 0.0,
+                    "local": sk.get("match_type") not in ("origin", "named", "exact_generic"),
                     "origin": sk.get("match_type") == "origin",
                     "namedRef": sk["mapped_to"] if sk.get("match_type") in ("origin", "named") else None,
                     "matchType": sk.get("match_type"),
@@ -1966,7 +1966,7 @@ def fuse_command(args):
                         {
                             "id": sid,
                             "type": ss.get("type") or sinfo.get("type", "basic"),
-                            "level": ss.get("level") or sinfo.get("level", "0★"),
+                            "level": ss.get("level") or sinfo.get("level") or ctx._effective_ranks.get(sid, "0★"),
                             "description": ss.get("description") or sinfo.get("description", ""),
                             "local": ss.get("local", sid in ctx.novel_ids),
                             "origin": ss.get("origin", ctx.is_origin(sid)),
@@ -1987,7 +1987,7 @@ def fuse_command(args):
                 for sid in selected:
                     ss = scan_map.get(sid) or {}
                     sinfo = skill_info_map.get(sid, {})
-                    lvl = ss.get("level") or sinfo.get("level", "0★")
+                    lvl = ss.get("level") or sinfo.get("level") or ctx._effective_ranks.get(sid, "0★")
                     max_stars = max(max_stars, level_num(lvl))
                 max_stars_str = f"{max_stars}★"
 

--- a/src/gaia_cli/localContext.py
+++ b/src/gaia_cli/localContext.py
@@ -125,9 +125,12 @@ class LocalContext:
                             origin_ids.add(cid)
 
                         if mid:
-                            owned_ids.add(mid)
-                            if username:
-                                named_map[mid] = f"{username}/{cid}"
+                            if mtype == "generic":
+                                owned_ids.add(cid)
+                            else:
+                                owned_ids.add(mid)
+                                if username and mtype != "exact_generic":
+                                    named_map[mid] = f"{username}/{cid.lstrip('/')}"
                         elif cid:
                             owned_ids.add(cid)
                             if username and cid not in named_map:
@@ -197,6 +200,9 @@ class LocalContext:
                         ranks = [level_num(s.get("level", "0★")) for s in skills]
                         if ranks:
                             effective_ranks[bucket] = f"{max(ranks)}★"
+                        for s in skills:
+                            if s.get("id"):
+                                effective_ranks[s["id"]] = s.get("level", "0★")
             except Exception:
                 pass
 
@@ -487,8 +493,9 @@ def _build_agent_dir_map(
             origin_skills=origin_skills, named_skills=named_skills
         )
         if match:
-            canonical_id = match[0]
-            result[canonical_id] = f"{username}/{dir_name}"
+            canonical_id, _, m_type = match
+            if m_type not in ("generic", "exact_generic"):
+                result[canonical_id] = f"{username}/{dir_name}"
     return result
 
 

--- a/src/gaia_cli/treeManager.py
+++ b/src/gaia_cli/treeManager.py
@@ -607,7 +607,7 @@ def show_tree(tree_data, graph_data=None, registry_path=".", mode="default", can
             m_type = csk.get("match_type")
             mapped_to = csk.get("mapped_to")
             
-            node_id = mapped_to if mapped_to else cid
+            node_id = mapped_to if m_type in ("origin", "named", "exact_generic") and mapped_to else cid
             
             if node_id not in skill_map:
                 skill_map[node_id] = {
@@ -631,7 +631,7 @@ def show_tree(tree_data, graph_data=None, registry_path=".", mode="default", can
             if m_type in ("generic", "exact_generic") and mapped_to:
                 local_by_ref[node_id] = {"id": cid}
                 
-            if m_type not in ("origin", "named", "generic", "exact_generic"):
+            if m_type not in ("origin", "named", "exact_generic"):
                 custom_nodes.add(node_id)
                 
         for fname in fusions.keys():


### PR DESCRIPTION
Fixes a bug where generic semantic matches were incorrectly mapped to their canonical IDs when building visual trees or fusions, causing them to disappear as unowned prerequisites. It also ensures named suite skills correctly fall back to their effective ranks.