### PR TITLE
fix(nav): handle ?tree=1 param to open Skill Tree dialog

### DIFF
--- a/docs/js/hud-toggle.js
+++ b/docs/js/hud-toggle.js
@@ -51,6 +51,12 @@
           if (trigger) trigger.click();
         }, 800);
       }
+      if (paramOn(params, 'tree')) {
+        setTimeout(function () {
+          var treeBtn = document.getElementById('treeNavBtn');
+          if (treeBtn) treeBtn.click();
+        }, 800);
+      }
     } catch (_) { /* ignore */ }
   }
 


### PR DESCRIPTION
## Summary
- Mobile hamburger nav "Skill Tree" links to `index.html?tree=1` but `hud-toggle.js` only handled `?field` and `?hud` — the param was silently ignored and the dialog never opened
- Added a `?tree=1` handler (same pattern as `?field`) that clicks `#treeNavBtn` after 800ms delay

## Test
Open `https://gaia.tiongson.co/index.html?tree=1` — Skill Tree dialog should auto-open.