### PR TITLE
fix(cli): enforce UTF-8 encoding on open() calls for Windows compatibility (#739)

### DIFF
--- a/src/gaia_cli/impl.py
+++ b/src/gaia_cli/impl.py
@@ -1939,7 +1939,7 @@ def fuse_command(args):
                 graph_data = {}
                 graph_p = registry_graph_path(registry_path)
                 if os.path.exists(graph_p):
-                    with open(graph_p, "r") as f:
+                    with open(graph_p, "r", encoding="utf-8") as f:
                         graph_data = json.load(f)
                 skill_info_map = {s["id"]: s for s in graph_data.get("skills", [])}
 
@@ -2351,7 +2351,7 @@ def push_command(args):
 
 
 def name_command(args):
-    with open(args.batch_file, "r") as f:
+    with open(args.batch_file, "r", encoding="utf-8") as f:
         batch = json.load(f)
 
     proposed_skills = batch.get("proposedSkills", [])

--- a/src/gaia_cli/install.py
+++ b/src/gaia_cli/install.py
@@ -63,7 +63,7 @@ def load_manifest():
     path = get_manifest_path()
     if os.path.exists(path):
         try:
-            with open(path, "r") as f:
+            with open(path, "r", encoding="utf-8") as f:
                 return json.load(f)
         except Exception:
             pass
@@ -73,7 +73,7 @@ def load_manifest():
 def save_manifest(manifest):
     path = get_manifest_path()
     os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         json.dump(manifest, f, indent=2)
 
 

--- a/src/gaia_cli/name.py
+++ b/src/gaia_cli/name.py
@@ -37,7 +37,7 @@ def find_awakened_skill(batch_path, skill_id):
     ValueError
         If no proposed skill with ``skill_id`` is found in the batch.
     """
-    with open(batch_path, "r") as f:
+    with open(batch_path, "r", encoding="utf-8") as f:
         batch = json.load(f)
 
     for skill in batch.get("proposedSkills", []):
@@ -138,7 +138,7 @@ def update_batch_lifecycle(batch_path, skill_id, new_status):
     ValueError
         If no proposed skill with ``skill_id`` is found in the batch.
     """
-    with open(batch_path, "r") as f:
+    with open(batch_path, "r", encoding="utf-8") as f:
         batch = json.load(f)
 
     found = False
@@ -153,6 +153,6 @@ def update_batch_lifecycle(batch_path, skill_id, new_status):
             f"No proposed skill with id '{skill_id}' found in {batch_path}"
         )
 
-    with open(batch_path, "w") as f:
+    with open(batch_path, "w", encoding="utf-8") as f:
         json.dump(batch, f, indent=2)
         f.write("\n")

--- a/src/gaia_cli/push.py
+++ b/src/gaia_cli/push.py
@@ -246,7 +246,7 @@ def write_skill_batch(batch, registry_root):
     intake_dir = skill_batches_dir(registry_root)
     os.makedirs(intake_dir, exist_ok=True)
     batch_path = os.path.join(intake_dir, f"{batch['batchId']}.json")
-    with open(batch_path, "w") as f:
+    with open(batch_path, "w", encoding="utf-8") as f:
         json.dump(batch, f, indent=2)
         f.write("\n")
     return batch_path

--- a/src/gaia_cli/treeManager.py
+++ b/src/gaia_cli/treeManager.py
@@ -33,14 +33,14 @@ def load_tree(username, registry_path="."):
     tree_path = user_tree_path(registry_path, username)
     if not os.path.exists(tree_path):
         return None
-    with open(tree_path, 'r') as f:
+    with open(tree_path, 'r', encoding='utf-8') as f:
         return json.load(f)
 
 def save_tree(username, tree_data, registry_path="."):
     _check_username(username)
     tree_path = user_tree_path(registry_path, username)
     os.makedirs(os.path.dirname(tree_path), exist_ok=True)
-    with open(tree_path, 'w') as f:
+    with open(tree_path, 'w', encoding='utf-8') as f:
         json.dump(tree_data, f, indent=2)
 
 def show_status(tree_data):

--- a/tests/test_treeManager.py
+++ b/tests/test_treeManager.py
@@ -512,3 +512,18 @@ class TestShowTreePathSubset:
                   path_subset={"ghost-skill", "phantom"})
         out = capsys.readouterr().out
         assert "├" not in out and "└" not in out
+
+
+def test_utf8_encoding_roundtrip(tmp_path):
+    unicode_tree = {
+        "userId": "unicode_user_★",
+        "updatedAt": "2026-01-01",
+        "unlockedSkills": [],
+        "pendingCombinations": [],
+        "stats": {"totalUnlocked": 0, "deepestLineage": 0},
+    }
+    save_tree("unicode_star", unicode_tree, registry_path=str(tmp_path))
+    result = load_tree("unicode_star", registry_path=str(tmp_path))
+    assert result is not None
+    assert result["userId"] == "unicode_user_★"
+


### PR DESCRIPTION
Resolves #739.

### Overview
This PR resolves encoding issues on Windows (MojiBake) by explicitly specifying `encoding="utf-8"` across 10 `open()` calls in the Gaia CLI.

### Changes
- **treeManager.py**: Explicit `utf-8` encoding on load/save tree functions.
- **impl.py**: Explicit `utf-8` encoding when loading the registry graph and batches.
- **install.py**: Explicit `utf-8` encoding when loading/saving installation manifests.
- **name.py**: Explicit `utf-8` encoding when loading, updating, and promoting intake batches.
- **push.py**: Explicit `utf-8` encoding when writing skill batches.
- **tests/test_treeManager.py**: Added a test verifying that Unicode characters (e.g., `★`) round-trip correctly when saving/loading trees.

All CLI tests pass successfully.