### PR TITLE
infra: clarify Cloudflare hosting — rename preview workflow + DEV.md §0

### DIFF
--- a/.github/workflows/cf-pr-preview.yml
+++ b/.github/workflows/cf-pr-preview.yml
@@ -1,4 +1,4 @@
-name: Cloudflare Deploy
+name: CF PR Preview (Worker)
 
 on:
   workflow_dispatch:
@@ -7,6 +7,20 @@ on:
         description: 'Branch to deploy'
         required: true
         default: 'main'
+
+# ── What this workflow does ────────────────────────────────────────────────────
+# Deploys a Cloudflare Worker with Static Assets (wrangler deploy) to a
+# workers.dev preview URL for manual PR inspection.
+#
+# This is NOT the production deploy. Production is:
+#   GitHub Pages (serving docs/ from main branch) → Cloudflare CDN (DNS proxy)
+#
+# The Worker (worker/index.js) handles badge ?repo= validation for previews.
+# For production, badges are validated by the same Worker logic but deployed
+# separately. Static assets including docs/api/v1/ are served by GitHub Pages.
+#
+# Trigger: workflow_dispatch only (manual). Supply the branch name to preview.
+# ──────────────────────────────────────────────────────────────────────────────
 
 permissions:
   contents: read
@@ -20,7 +34,7 @@ permissions:
 
 jobs:
   deploy:
-    name: Deploy to Cloudflare Pages
+    name: Deploy PR Preview to Cloudflare Worker
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/DEV.md
+++ b/DEV.md
@@ -4,6 +4,41 @@ This document provides a quick reference for setting up the local development en
 
 ---
 
+## 0. Hosting Architecture (Read This First — Agents Often Get This Wrong)
+
+Understanding how the site is hosted prevents wrong assumptions about CORS, headers, and deploys.
+
+### Production: GitHub Pages + Cloudflare CDN
+
+```
+Browser → Cloudflare (DNS proxy + CDN) → GitHub Pages → docs/ on main branch
+```
+
+- **GitHub Pages** is the origin host. When `main` gets a new commit, GitHub automatically serves the updated `docs/` folder at `gaia.tiongson.co`. This is configured via `docs/CNAME`.
+- **Cloudflare** sits in front as a CDN/DNS proxy (`Server: cloudflare` in response headers). It caches and accelerates pages but does NOT host them.
+- **`_headers` files do NOT work here.** That is a Cloudflare Pages-only feature. This site is GitHub Pages — a `_headers` file in `docs/` would be served as a plain text download.
+- **CORS** (`Access-Control-Allow-Origin: *`) is already applied site-wide by Cloudflare — verified by checking response headers. All `docs/api/v1/` JSON files inherit this automatically.
+- **To deploy to production:** merge to `main`. GitHub Pages does the rest. There is no manual deploy step.
+
+### PR Previews: Cloudflare Worker with Static Assets
+
+- The `.github/workflows/cf-pr-preview.yml` workflow (`workflow_dispatch` only) deploys the branch as a Cloudflare Worker with Static Assets to a `gaia-skill-tree.<account>.workers.dev` preview URL.
+- The Worker (`worker/index.js`) handles badge `?repo=` validation. This is the *only* thing the Worker does.
+- `wrangler.toml` configures this preview Worker — it is **not** used by the production site.
+- Despite the `run_worker_first = true` setting in `wrangler.toml`, this only affects the Worker preview environment. Production has no Worker in the request path.
+
+### What this means for new features
+
+| Feature | Where it lives | Deploy path |
+|---|---|---|
+| New HTML/JS/CSS page | `docs/<section>/` | Merge to `main` → auto-served |
+| New static JSON (e.g. API) | `docs/api/v1/` | Merge to `main` → auto-served |
+| CORS headers | Already on all responses (Cloudflare) | No action needed |
+| `_headers` file | ❌ Not supported (GitHub Pages) | Use Cloudflare Dashboard Transform Rules instead |
+| Badge validation logic | `worker/index.js` | `cf-pr-preview.yml` dispatch |
+
+---
+
 ## 1. Local Environment Setup
 
 Since this repository contains a pre-configured Python virtual environment (`.venv`), you should run commands within it to avoid "externally managed environment" errors or missing executable errors (e.g., `command not found: pip` or `command not found: gaia`).

--- a/founder/MEMORY.md
+++ b/founder/MEMORY.md
@@ -2,6 +2,61 @@
 
 Maintained by the Orchestrator agent. Newest entries first within each section.
 
+## State Snapshot (2026-06-26, session 23 — Sprint B scaffolding: EPIC #855 filed, 12 issues under Sprint B milestone)
+
+### TLDR
+
+- **Sprint B board is now fully scaffolded.** EPIC #855 is the single tracker to return to at the start of every session until Sprint B closes.
+- **12 open issues** under milestone "Sprint B — API + Trending + Hall of Heroes" (milestone #10).
+- **#757** (71 ungraded skills) accepted as tech-debt — removed from Immediate Next 30 Days milestone, labeled `tech-debt`. Not Sprint B scope.
+- **#761** confirmed already closed (per-evidence Grade follow-up — was Sprint A, done).
+- **Sprint A stragglers** still open: #759 (CLI pre-flight), #746 (apex gate A-graded origins). Not blocking Sprint B but tracked inside EPIC #855 for visibility.
+- **`sprint-b` label created** (`#0052CC`).
+
+### Sprint B EPIC — #855
+
+**URL:** https://github.com/mbtiongson1/gaia-skill-tree/issues/855  
+**Start every session here.** Read the EPIC, check the kill criteria, orient, then dispatch.
+
+### Sprint B issue registry
+
+| # | Workstream | Title | Size |
+|---|---|---|---|
+| #849 | B1 | feat(api): build-time static JSON projection — /api/v1/ endpoint scaffold | L |
+| #850 | B1 | feat(api): OpenAPI 3.1 spec + /api/ docs page | S |
+| #851 | B1 | feat(sdk): @gaia-registry/api-client — Python + TypeScript SDK | M |
+| #651 | B2 | Implement Trending Engine (re-milestoned) | L |
+| #697 | B2 | Implement Rising Skills View (re-milestoned) | M |
+| #698 | B2 | Implement Rising Repositories View (re-milestoned) | M |
+| #852 | B2 | feat(trending): RSS feed + 'Trending This Week' auto-post | M |
+| #853 | B2 | feat(trending): 'Recently Ascended' + 'Most Contested' sections | S |
+| #760 | B2 | infra: stargazer pull + monthly TM recompute (re-milestoned) | M |
+| #854 | B3 | feat(heroes): wire Hall of Heroes to homepage + nav + /heroes/ route | S |
+| #762 | cross | automate source curation workflow (already in Sprint B, confirmed) | M |
+| #855 | EPIC | Sprint B EPIC tracking issue | — |
+
+### Kill criteria (Sprint B done when all three pass)
+
+1. `curl https://gaia.tiongson.co/api/v1/skills/garrytan/gstack` returns valid JSON with `trustMagnitude` and `overallTrustGrade`
+2. `/trending/7d` shows real movement (not zeros) on Monday morning
+3. A tweet-length pitch — *'Gaia tracks which AI agent skills are trending'* — has a clickable URL
+
+### Board hygiene done this session
+
+- `sprint-b` label created (`#0052CC`)
+- #757 milestone cleared + `tech-debt` label added (accepted debt)
+- #697, #698, #651, #760, #762 re-milestoned to Sprint B + `sprint-b` label added
+- #761 confirmed closed (Sprint A)
+- Existing Sprint A open items (#759, #746) left as-is — still valid, not Sprint B blockers
+
+### Token spend (session 23)
+
+- Orchestrator inline (no sub-agents — pi environment has no Anthropic key for sub-agents): ~40k in / ~8k out / **~$0.60**
+- **Session 23 total: ~$0.60**
+- **Cumulative post-5.0.0: ~$37.55**
+
+---
+
 ## State Snapshot (2026-06-24, session 22 — Badge restore + auto-sync banned from `docs/badges/` + warn-only CI)
 
 ### TLDR


### PR DESCRIPTION
## What this does

Fixes a recurring source of agent confusion: the `cloudflare-deploy.yml` workflow is named 'Deploy to Cloudflare Pages' but has nothing to do with the production site. This PR:

1. Renames `.github/workflows/cloudflare-deploy.yml` → `cf-pr-preview.yml` and updates internal names to reflect its true purpose (manual PR preview via Cloudflare Worker)
2. Adds `DEV.md §0 — Hosting Architecture` explaining that production is GitHub Pages + Cloudflare CDN, what that means for CORS, `_headers`, and deploys

### Why this matters

During Sprint B API planning (EPIC #855), two Opus planning passes wasted significant context on CORS setup because the agents assumed the site was Cloudflare Pages (where `_headers` works). The actual architecture is:

```
Production:  Browser → Cloudflare CDN → GitHub Pages → docs/ on main
Previews:    workflow_dispatch → wrangler deploy → workers.dev URL
```

CORS is already handled site-wide by Cloudflare. No code change needed for the API.

### Files changed
- `.github/workflows/cloudflare-deploy.yml` → `.github/workflows/cf-pr-preview.yml` (renamed)
- `DEV.md` — new §0 (Hosting Architecture)

### Branch scope
`infra/` — touches `.github/workflows/` and `*.md`. Within scope.

---
*Part of EPIC #855 Sprint B planning housekeeping.*