### PR TITLE
feat(b2): stargazer heartbeat — monthly star pull + workflow

### DIFF
--- a/.github/workflows/stargazer-heartbeat.yml
+++ b/.github/workflows/stargazer-heartbeat.yml
@@ -1,0 +1,53 @@
+name: Stargazer Heartbeat
+
+on:
+  schedule:
+    - cron: '0 6 1 * *'   # 06:00 UTC on the 1st of every month
+  workflow_dispatch: {}    # allow manual trigger
+
+permissions:
+  contents: write
+
+jobs:
+  heartbeat:
+    runs-on: ubuntu-latest
+    if: github.ref_name == 'main' || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Run stargazer pull
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GAIA_OPERATOR_OVERRIDE: "1"
+        run: python scripts/stargazerHeartbeat.py --apply
+
+      - name: Check for registry changes
+        id: changes
+        run: |
+          if git diff --quiet registry/named/; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit star updates
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          git add registry/named/
+          git commit -m "chore(heartbeat): monthly stargazer refresh $(date +%Y-%m) [skip-gen]"
+          git push

--- a/docs/js/mounts.js
+++ b/docs/js/mounts.js
@@ -9,5 +9,5 @@
  */
 window.GAIA_MOUNTS = [
   'named', 'en', 'badges', 'u', 'samples', 'graph',
-  'evidence', 'share', 'trust', 'api', 'codex',
+  'evidence', 'share', 'trust', 'api', 'codex', 'trending',
 ];

--- a/docs/trending/index.html
+++ b/docs/trending/index.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en" data-icon-base="../assets/icons.svg">
+
+<head>
+  <script>window.GAIA_VERSION = "5.6.0";</script>
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+  <meta http-equiv="Pragma" content="no-cache">
+  <meta http-equiv="Expires" content="0">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Trending Skills — Gaia</title>
+  <meta name="description" content="Skills gaining trust this week — ranked by evidence velocity, not hype. Discover what's rising in the Gaia registry.">
+  <meta name="keywords" content="trending skills, AI skills, evidence velocity, skill registry, gaia trending">
+  <!-- OG meta -->
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Trending Skills — Gaia">
+  <meta property="og:description" content="Skills gaining trust this week — ranked by evidence velocity, not hype.">
+  <meta property="og:url" content="https://gaia.tiongson.co/trending/">
+  <!-- RSS feed -->
+  <link rel="alternate" type="application/rss+xml" title="Gaia Trending" href="feed.xml">
+  <!-- Web fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+  <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
+  <link rel="stylesheet" href="../css/styles.css?v=5.6.0">
+  <link rel="stylesheet" href="trending.css?v=5.6.0">
+  <!-- Icon sprite helper -->
+  <script src="../js/icons.js?v=5.6.0"></script>
+</head>
+
+<body class="trending-page">
+
+  <!-- ─── NAV ─── -->
+  <nav id="site-nav"></nav>
+  <script src="../js/mounts.js?v=5.6.0"></script>
+  <script src="../js/site-nav.js?v=5.6.0"></script>
+
+  <!-- ─── MAIN ─── -->
+  <main class="trending-main">
+
+    <!-- Back row -->
+    <div class="profile-back-row">
+      <a class="profile-back" href="../" aria-label="Back to Home" title="Back to Home">
+        <svg class="ico" width="14" height="14" aria-hidden="true"><use href="../assets/icons.svg#arrow-back"/></svg>
+        <span>Back</span>
+      </a>
+    </div>
+
+    <!-- Hero -->
+    <section class="process-hero trending-hero">
+      <p class="process-kicker">Discovery</p>
+      <h1>Trending Skills</h1>
+      <p class="process-lede">Skills gaining trust this week — ranked by evidence velocity, not hype.</p>
+    </section>
+
+    <!-- Bootstrap banner (shown by JS when firstRun=true) -->
+    <div id="trending-bootstrap-banner" class="trending-bootstrap-banner" hidden>
+      <svg class="ico" width="16" height="16" aria-hidden="true"><use href="../assets/icons.svg#info"/></svg>
+      <span>Trending data is bootstrapping — check back after the next registry update.</span>
+    </div>
+
+    <!-- Window toggle tabs -->
+    <div class="trending-tabs" role="tablist" aria-label="Time window">
+      <button class="trending-tab active" data-window="7d" role="tab" aria-selected="true">7 Days</button>
+      <button class="trending-tab" data-window="30d" role="tab" aria-selected="false">30 Days</button>
+    </div>
+
+    <!-- Main trending list -->
+    <section id="trending-list" class="trending-list-section" aria-label="Trending skills">
+      <div class="trending-loading" id="trending-loading">
+        <span class="trending-spinner" aria-hidden="true"></span>
+        <span>Loading trending skills…</span>
+      </div>
+    </section>
+
+    <!-- Recently Ascended -->
+    <section class="trending-section" id="section-ascended">
+      <div class="trending-section-header">
+        <h2>Recently Ascended</h2>
+        <p class="trending-sublede">Skills that ranked up in the last 30 days.</p>
+      </div>
+      <div id="ascended-list" class="ascended-list">
+        <div class="trending-loading" id="ascended-loading">
+          <span class="trending-spinner" aria-hidden="true"></span>
+          <span>Loading…</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- Most Contested -->
+    <section class="trending-section" id="section-contested">
+      <div class="trending-section-header">
+        <h2>Most Contested</h2>
+        <p class="trending-sublede">Generic skill buckets with multiple named implementations competing.</p>
+      </div>
+      <div id="contested-list" class="contested-list">
+        <div class="trending-loading" id="contested-loading">
+          <span class="trending-spinner" aria-hidden="true"></span>
+          <span>Loading…</span>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- ─── FOOTER ─── -->
+  <div id="site-footer-mount"></div>
+  <script src="../js/site-footer.js?v=5.6.0"></script>
+
+  <!-- ─── PAGE SCRIPT ─── -->
+  <script src="trending.js?v=5.6.0"></script>
+
+</body>
+</html>

--- a/docs/trending/trending.css
+++ b/docs/trending/trending.css
@@ -1,0 +1,472 @@
+/*
+ * trending.css — Styles for /trending/ page.
+ * Design tokens only — zero hex values. All colours via tokens.css.
+ */
+
+/* ── Page layout ─────────────────────────────────────────────── */
+.trending-main {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 0 1.5rem 4rem;
+}
+
+/* ── Hero tweaks ─────────────────────────────────────────────── */
+.trending-hero {
+  margin-bottom: 0.5rem;
+}
+
+/* ── Bootstrap banner ────────────────────────────────────────── */
+.trending-bootstrap-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1.5rem;
+  border-radius: 0.5rem;
+  background: var(--rank-1-bg);
+  border: 1px solid var(--rank-1-border);
+  color: var(--rank-1);
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.trending-bootstrap-banner[hidden] {
+  display: none;
+}
+
+.trending-bootstrap-banner .ico {
+  flex-shrink: 0;
+  opacity: 0.85;
+}
+
+/* ── Window tabs ─────────────────────────────────────────────── */
+.trending-tabs {
+  display: flex;
+  gap: 0.375rem;
+  margin-bottom: 1.5rem;
+}
+
+.trending-tab {
+  padding: 0.4rem 1rem;
+  border-radius: 0.375rem;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--rank-0);
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.trending-tab:hover {
+  background: var(--rank-2-bg);
+  border-color: var(--rank-2-border);
+  color: var(--rank-2);
+}
+
+.trending-tab.active {
+  background: var(--rank-2-bg);
+  border-color: var(--rank-2-border);
+  color: var(--rank-2);
+}
+
+/* ── Loading spinners ────────────────────────────────────────── */
+.trending-loading {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 2rem 0;
+  color: var(--rank-0);
+  font-size: 0.875rem;
+}
+
+.trending-spinner {
+  display: inline-block;
+  width: 1rem;
+  height: 1rem;
+  border: 2px solid var(--rank-0-border);
+  border-top-color: var(--rank-2);
+  border-radius: 50%;
+  animation: trend-spin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes trend-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ── "Data not available" / error card ───────────────────────── */
+.trending-unavailable {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.375rem;
+  padding: 1.25rem 1.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--rank-0-border);
+  background: var(--rank-0-bg);
+  color: var(--rank-0);
+  font-size: 0.875rem;
+}
+
+.trending-unavailable strong {
+  font-size: 0.9375rem;
+  font-weight: 600;
+}
+
+/* ── Trending skill card grid ────────────────────────────────── */
+.trending-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+  margin-bottom: 0.5rem;
+}
+
+.trending-card {
+  display: grid;
+  grid-template-columns: 2.75rem 1fr auto;
+  align-items: center;
+  gap: 0.75rem 1rem;
+  padding: 0.875rem 1rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--rank-0-border);
+  background: transparent;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.trending-card:hover {
+  border-color: var(--rank-2-border);
+  background: var(--rank-2-bg);
+}
+
+/* Rank badge (position number) */
+.trending-rank {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 50%;
+  background: var(--rank-0-bg);
+  border: 1px solid var(--rank-0-border);
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--rank-0);
+  font-family: 'JetBrains Mono', monospace;
+  flex-shrink: 0;
+}
+
+.trending-rank.top3 {
+  background: var(--rank-3-bg);
+  border-color: var(--rank-3-border);
+  color: var(--rank-3);
+}
+
+/* Card body */
+.trending-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.trending-card-name {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.trending-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  font-size: 0.8125rem;
+  color: var(--rank-0);
+}
+
+.trending-card-contributor {
+  opacity: 0.75;
+}
+
+.trending-level-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1rem 0.45rem;
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  font-family: 'JetBrains Mono', monospace;
+  background: var(--rank-3-bg);
+  border: 1px solid var(--rank-3-border);
+  color: var(--rank-3);
+}
+
+/* Right side: TM + delta + grade */
+.trending-card-right {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.3rem;
+  flex-shrink: 0;
+}
+
+.trending-tm {
+  font-size: 0.9375rem;
+  font-weight: 700;
+  font-family: 'JetBrains Mono', monospace;
+  color: var(--rank-2);
+}
+
+.trending-delta {
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.trending-delta.positive {
+  color: var(--rank-2);
+}
+
+.trending-delta.negative {
+  color: var(--rank-4);
+}
+
+.trending-delta.neutral {
+  color: var(--rank-0);
+}
+
+.trending-delta-arrow {
+  font-size: 0.875rem;
+  line-height: 1;
+}
+
+.trending-grade-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1rem 0.45rem;
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.trending-grade-badge[data-grade="S"] {
+  background: rgba(var(--evidence-platinum-rgb), 0.15);
+  border: 1px solid rgba(var(--evidence-platinum-rgb), 0.4);
+  color: var(--evidence-platinum);
+}
+
+.trending-grade-badge[data-grade="A"] {
+  background: rgba(var(--evidence-gold-rgb), 0.15);
+  border: 1px solid rgba(var(--evidence-gold-rgb), 0.4);
+  color: var(--evidence-gold);
+}
+
+.trending-grade-badge[data-grade="B"] {
+  background: rgba(var(--evidence-silver-rgb), 0.15);
+  border: 1px solid rgba(var(--evidence-silver-rgb), 0.4);
+  color: var(--evidence-silver);
+}
+
+.trending-grade-badge[data-grade="C"],
+.trending-grade-badge[data-grade="D"],
+.trending-grade-badge[data-grade="F"] {
+  background: rgba(var(--evidence-bronze-rgb), 0.15);
+  border: 1px solid rgba(var(--evidence-bronze-rgb), 0.4);
+  color: var(--evidence-bronze);
+}
+
+/* New skill tag */
+.trending-new-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1rem 0.4rem;
+  border-radius: 0.25rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: var(--rank-1-bg);
+  border: 1px solid var(--rank-1-border);
+  color: var(--rank-1);
+}
+
+/* ── Section wrappers ────────────────────────────────────────── */
+.trending-section {
+  margin-top: 3rem;
+}
+
+.trending-section-header {
+  margin-bottom: 1.25rem;
+}
+
+.trending-section-header h2 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin: 0 0 0.25rem;
+}
+
+.trending-sublede {
+  font-size: 0.875rem;
+  color: var(--rank-0);
+  margin: 0;
+}
+
+/* ── Ascended list ───────────────────────────────────────────── */
+.ascended-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.ascended-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--rank-0-border);
+  background: transparent;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.ascended-card:hover {
+  border-color: var(--rank-3-border);
+  background: var(--rank-3-bg);
+}
+
+.ascended-card-left {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.ascended-card-name {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ascended-card-contributor {
+  font-size: 0.8125rem;
+  color: var(--rank-0);
+  opacity: 0.75;
+}
+
+.ascended-card-right {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.3rem;
+  flex-shrink: 0;
+}
+
+.ascended-date {
+  font-size: 0.75rem;
+  color: var(--rank-0);
+  font-family: 'JetBrains Mono', monospace;
+}
+
+/* ── Contested list ──────────────────────────────────────────── */
+.contested-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.contested-bucket {
+  padding: 0.875rem 1rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--rank-0-border);
+  background: transparent;
+}
+
+.contested-bucket-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.contested-bucket-name {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.contested-count-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.1rem 0.4rem;
+  border-radius: 0.25rem;
+  background: var(--rank-4-bg);
+  border: 1px solid var(--rank-4-border);
+  color: var(--rank-4);
+  font-family: 'JetBrains Mono', monospace;
+  flex-shrink: 0;
+}
+
+.contested-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+.contested-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.25rem 0.625rem;
+  border-radius: 0.375rem;
+  border: 1px solid var(--rank-0-border);
+  background: var(--rank-0-bg);
+  font-size: 0.8125rem;
+}
+
+.contested-chip-id {
+  font-family: 'JetBrains Mono', monospace;
+  opacity: 0.85;
+}
+
+.contested-chip-tm {
+  font-size: 0.75rem;
+  font-weight: 600;
+  font-family: 'JetBrains Mono', monospace;
+  color: var(--rank-2);
+}
+
+/* ── Result summary line ─────────────────────────────────────── */
+.trending-count-line {
+  font-size: 0.8125rem;
+  color: var(--rank-0);
+  margin-bottom: 0.75rem;
+}
+
+/* ── Responsive ──────────────────────────────────────────────── */
+@media (max-width: 540px) {
+  .trending-card {
+    grid-template-columns: 2.25rem 1fr auto;
+    gap: 0.5rem 0.75rem;
+    padding: 0.75rem 0.75rem;
+  }
+
+  .trending-card-right {
+    gap: 0.2rem;
+  }
+
+  .trending-tm {
+    font-size: 0.875rem;
+  }
+}

--- a/docs/trending/trending.js
+++ b/docs/trending/trending.js
@@ -1,0 +1,361 @@
+/**
+ * trending.js — /trending/ page logic.
+ *
+ * Fetches /api/v1/trending/{7d,30d,ascended,contested}.json and renders:
+ *   - Trending skill cards with rank badge, TM, delta, grade
+ *   - Recently Ascended list
+ *   - Most Contested buckets
+ *
+ * Gracefully handles 404 / fetch errors (Worker A data may not exist yet).
+ * No jQuery, no external dependencies — vanilla JS only.
+ */
+(function () {
+  'use strict';
+
+  /* ── Configuration ──────────────────────────────────────────── */
+  var API_BASE = '../api/v1/trending/';
+  var ENDPOINTS = {
+    '7d':      API_BASE + '7d.json',
+    '30d':     API_BASE + '30d.json',
+    ascended:  API_BASE + 'ascended.json',
+    contested: API_BASE + 'contested.json',
+  };
+
+  /* ── State ──────────────────────────────────────────────────── */
+  var state = {
+    activeWindow: '7d',
+    data: { '7d': null, '30d': null, ascended: null, contested: null },
+    loaded: { '7d': false, '30d': false, ascended: false, contested: false },
+    errors: { '7d': false, '30d': false, ascended: false, contested: false },
+  };
+
+  /* ── DOM references ─────────────────────────────────────────── */
+  var trendingList    = document.getElementById('trending-list');
+  var ascendedList    = document.getElementById('ascended-list');
+  var contestedList   = document.getElementById('contested-list');
+  var bootstrapBanner = document.getElementById('trending-bootstrap-banner');
+  var tabs            = document.querySelectorAll('.trending-tab');
+
+  /* ── Utilities ──────────────────────────────────────────────── */
+
+  /**
+   * Fetch JSON from a URL; resolves to {ok: true, data} or {ok: false, status}.
+   */
+  function fetchJSON(url) {
+    return fetch(url)
+      .then(function (res) {
+        if (!res.ok) {
+          return { ok: false, status: res.status };
+        }
+        return res.json().then(function (data) {
+          return { ok: true, data: data };
+        });
+      })
+      .catch(function () {
+        return { ok: false, status: 0 };
+      });
+  }
+
+  /** Escape HTML to prevent XSS. */
+  function esc(str) {
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  /**
+   * Format an ISO 8601 date string as a human-readable relative or absolute
+   * label, e.g. "3 days ago" or "Jun 20, 2026".
+   */
+  function formatDate(isoString) {
+    var d = new Date(isoString);
+    if (isNaN(d.getTime())) return isoString;
+    var now = Date.now();
+    var diffMs = now - d.getTime();
+    var diffDays = Math.floor(diffMs / 86400000);
+    if (diffDays === 0) return 'today';
+    if (diffDays === 1) return 'yesterday';
+    if (diffDays < 30) return diffDays + ' days ago';
+    return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  }
+
+  /** Build a "data not available" card for sections that failed to load. */
+  function unavailableCard(message) {
+    var el = document.createElement('div');
+    el.className = 'trending-unavailable';
+    el.innerHTML =
+      '<strong>Data not yet available</strong>' +
+      '<span>' + esc(message || 'Check back after the next registry update.') + '</span>';
+    return el;
+  }
+
+  /* ── Render: trending cards (7d / 30d) ──────────────────────── */
+
+  function renderTrending(window) {
+    trendingList.innerHTML = '';
+
+    var result = state.data[window];
+    var hasError = state.errors[window];
+
+    if (hasError || !result) {
+      trendingList.appendChild(unavailableCard(
+        'Trending data for the ' + window + ' window is not yet available.'
+      ));
+      return;
+    }
+
+    /* Bootstrap banner */
+    if (result.firstRun) {
+      bootstrapBanner.removeAttribute('hidden');
+    }
+
+    var skills = result.skills || [];
+
+    if (skills.length === 0) {
+      trendingList.appendChild(unavailableCard('No trending skills found for this window.'));
+      return;
+    }
+
+    /* Count line */
+    var countLine = document.createElement('p');
+    countLine.className = 'trending-count-line';
+    countLine.textContent = skills.length + ' skill' + (skills.length !== 1 ? 's' : '') + ' trending';
+    trendingList.appendChild(countLine);
+
+    var cards = document.createElement('div');
+    cards.className = 'trending-cards';
+
+    skills.forEach(function (skill, idx) {
+      var rank = idx + 1;
+      var isTop3 = rank <= 3;
+      var delta = typeof skill.tmDelta === 'number' ? skill.tmDelta : null;
+      var deltaClass = delta === null ? 'neutral' : (delta > 0 ? 'positive' : (delta < 0 ? 'negative' : 'neutral'));
+      var deltaArrow = delta > 0 ? '↑' : (delta < 0 ? '↓' : '');
+      var deltaText = delta !== null
+        ? (deltaArrow ? ('<span class="trending-delta-arrow">' + esc(deltaArrow) + '</span>') : '') +
+          esc((delta > 0 ? '+' : '') + delta.toFixed(1))
+        : '—';
+
+      var card = document.createElement('div');
+      card.className = 'trending-card';
+      card.setAttribute('role', 'listitem');
+
+      /* Rank badge */
+      var rankBadge = '<div class="trending-rank' + (isTop3 ? ' top3' : '') + '" aria-label="Rank ' + rank + '">' + rank + '</div>';
+
+      /* Body */
+      var newTag = skill.new ? '<span class="trending-new-tag">New</span>' : '';
+      var levelBadge = skill.level
+        ? '<span class="trending-level-badge">' + esc(skill.level) + '</span>'
+        : '';
+      var body =
+        '<div class="trending-card-body">' +
+          '<div class="trending-card-name">' + esc(skill.name || skill.id) + '</div>' +
+          '<div class="trending-card-meta">' +
+            '<span class="trending-card-contributor">@' + esc(skill.contributor || '') + '</span>' +
+            levelBadge +
+            newTag +
+          '</div>' +
+        '</div>';
+
+      /* Right: TM + delta + grade */
+      var tm = typeof skill.trustMagnitude === 'number' ? skill.trustMagnitude.toFixed(1) : '—';
+      var grade = skill.overallTrustGrade || '';
+      var gradeBadge = grade
+        ? '<span class="trending-grade-badge" data-grade="' + esc(grade) + '">' + esc(grade) + '</span>'
+        : '';
+      var right =
+        '<div class="trending-card-right">' +
+          '<span class="trending-tm">' + esc(tm) + '</span>' +
+          '<span class="trending-delta ' + deltaClass + '">' + deltaText + '</span>' +
+          gradeBadge +
+        '</div>';
+
+      card.innerHTML = rankBadge + body + right;
+      cards.appendChild(card);
+    });
+
+    trendingList.appendChild(cards);
+  }
+
+  /* ── Render: recently ascended ──────────────────────────────── */
+
+  function renderAscended() {
+    ascendedList.innerHTML = '';
+
+    var result = state.data.ascended;
+    var hasError = state.errors.ascended;
+
+    if (hasError || !result) {
+      ascendedList.appendChild(unavailableCard('Ascension data is not yet available.'));
+      return;
+    }
+
+    var skills = result.skills || [];
+
+    if (skills.length === 0) {
+      ascendedList.appendChild(unavailableCard('No recently ascended skills.'));
+      return;
+    }
+
+    var list = document.createElement('div');
+    list.className = 'ascended-list';
+
+    skills.forEach(function (skill) {
+      var card = document.createElement('div');
+      card.className = 'ascended-card';
+      card.setAttribute('role', 'listitem');
+
+      var levelBadge = skill.level
+        ? '<span class="trending-level-badge">' + esc(skill.level) + '</span>'
+        : '';
+      var gradeBadge = skill.overallTrustGrade
+        ? '<span class="trending-grade-badge" data-grade="' + esc(skill.overallTrustGrade) + '">' + esc(skill.overallTrustGrade) + '</span>'
+        : '';
+      var dateStr = skill.ascendedAt ? formatDate(skill.ascendedAt) : '';
+
+      card.innerHTML =
+        '<div class="ascended-card-left">' +
+          '<div class="ascended-card-name">' + esc(skill.name || skill.id) + '</div>' +
+          '<div class="ascended-card-contributor">@' + esc(skill.contributor || '') + '</div>' +
+        '</div>' +
+        '<div class="ascended-card-right">' +
+          levelBadge +
+          gradeBadge +
+          (dateStr ? '<span class="ascended-date">' + esc(dateStr) + '</span>' : '') +
+        '</div>';
+
+      list.appendChild(card);
+    });
+
+    ascendedList.appendChild(list);
+  }
+
+  /* ── Render: most contested ─────────────────────────────────── */
+
+  function renderContested() {
+    contestedList.innerHTML = '';
+
+    var result = state.data.contested;
+    var hasError = state.errors.contested;
+
+    if (hasError || !result) {
+      contestedList.appendChild(unavailableCard('Contested skills data is not yet available.'));
+      return;
+    }
+
+    var buckets = result.buckets || [];
+
+    if (buckets.length === 0) {
+      contestedList.appendChild(unavailableCard('No contested skill buckets found.'));
+      return;
+    }
+
+    var list = document.createElement('div');
+    list.className = 'contested-list';
+
+    buckets.forEach(function (bucket) {
+      var bucketEl = document.createElement('div');
+      bucketEl.className = 'contested-bucket';
+
+      var impls = bucket.implementations || (bucket.skills || []).length;
+      var countBadge = '<span class="contested-count-badge">' + impls + ' impl' + (impls !== 1 ? 's' : '') + '</span>';
+
+      var chips = (bucket.skills || []).map(function (s) {
+        var gradeBadge = s.overallTrustGrade
+          ? '<span class="trending-grade-badge" data-grade="' + esc(s.overallTrustGrade) + '">' + esc(s.overallTrustGrade) + '</span>'
+          : '';
+        var tm = typeof s.trustMagnitude === 'number'
+          ? '<span class="contested-chip-tm">' + s.trustMagnitude.toFixed(1) + '</span>'
+          : '';
+        return '<span class="contested-chip">' +
+          '<span class="contested-chip-id">' + esc(s.id) + '</span>' +
+          tm +
+          gradeBadge +
+          '</span>';
+      }).join('');
+
+      bucketEl.innerHTML =
+        '<div class="contested-bucket-header">' +
+          '<span class="contested-bucket-name">' + esc(bucket.genericSkillRef || '') + '</span>' +
+          countBadge +
+        '</div>' +
+        '<div class="contested-chips">' + chips + '</div>';
+
+      list.appendChild(bucketEl);
+    });
+
+    contestedList.appendChild(list);
+  }
+
+  /* ── Tab switching ──────────────────────────────────────────── */
+
+  function activateTab(win) {
+    state.activeWindow = win;
+    tabs.forEach(function (tab) {
+      var isActive = tab.dataset.window === win;
+      tab.classList.toggle('active', isActive);
+      tab.setAttribute('aria-selected', isActive ? 'true' : 'false');
+    });
+    renderTrending(win);
+  }
+
+  tabs.forEach(function (tab) {
+    tab.addEventListener('click', function () {
+      activateTab(tab.dataset.window);
+    });
+  });
+
+  /* ── Fetch all endpoints in parallel ───────────────────────── */
+
+  var fetches = Object.keys(ENDPOINTS).map(function (key) {
+    return fetchJSON(ENDPOINTS[key]).then(function (result) {
+      state.loaded[key] = true;
+      if (result.ok) {
+        state.data[key] = result.data;
+        state.errors[key] = false;
+      } else {
+        state.data[key] = null;
+        state.errors[key] = true;
+      }
+    });
+  });
+
+  /* Render sections progressively as each fetch completes. */
+  fetchJSON(ENDPOINTS['7d']).then(function (result) {
+    state.loaded['7d'] = true;
+    state.data['7d'] = result.ok ? result.data : null;
+    state.errors['7d'] = !result.ok;
+    renderTrending('7d');
+  });
+
+  fetchJSON(ENDPOINTS['30d']).then(function (result) {
+    state.loaded['30d'] = true;
+    state.data['30d'] = result.ok ? result.data : null;
+    state.errors['30d'] = !result.ok;
+    /* Only re-render if 30d is currently active (user already clicked) */
+    if (state.activeWindow === '30d') {
+      renderTrending('30d');
+    }
+  });
+
+  fetchJSON(ENDPOINTS.ascended).then(function (result) {
+    state.loaded.ascended = true;
+    state.data.ascended = result.ok ? result.data : null;
+    state.errors.ascended = !result.ok;
+    renderAscended();
+  });
+
+  fetchJSON(ENDPOINTS.contested).then(function (result) {
+    state.loaded.contested = true;
+    state.data.contested = result.ok ? result.data : null;
+    state.errors.contested = !result.ok;
+    renderContested();
+  });
+
+  /* Suppress unused-variable lint on `fetches` — it's kept for reference. */
+  void fetches;
+
+})();

--- a/registry/named/addy-osmani/performance-optimization.md
+++ b/registry/named/addy-osmani/performance-optimization.md
@@ -79,12 +79,13 @@ evidence:
   grade: B
 - source: https://github.com/addyosmani/agent-skills/stargazers
   evaluator: mbtiongson1
+  updatedAt: '2026-06-28'
   date: '2026-06-19'
   type: github-stars-own
   class: A
   notes: 47,200 GitHub stars as of 2026-06-19 (verified via firecrawl validation report;
     standalone skill)
-  stars: 47200
+  stars: 67239
   grade: B
 trustMagnitude: 83.2
 overallTrustGrade: B

--- a/registry/named/garrytan/benchmark.md
+++ b/registry/named/garrytan/benchmark.md
@@ -37,13 +37,14 @@ evidence:
   grade: B
 - source: https://github.com/garrytan/gstack
   evaluator: unknown
+  updatedAt: '2026-06-28'
   date: '2026-06-20'
   type: github-stars-own
   trustNumber: 85.0
   grade: C
   notes: gstack suite repo — 110,930 GitHub stars; benchmark is 1 of 42 named skills
     (verified 2026-06-20)
-  stars: 110930
+  stars: 117106
   skillCountInRepo: 42
   sourceStartedAt: '2024-01-01'
 timeline:

--- a/registry/named/garrytan/canary.md
+++ b/registry/named/garrytan/canary.md
@@ -38,13 +38,14 @@ evidence:
   grade: B
 - source: https://github.com/garrytan/gstack
   evaluator: unknown
+  updatedAt: '2026-06-28'
   date: '2026-06-20'
   type: github-stars-own
   trustNumber: 85.0
   grade: C
   notes: gstack suite repo — 110,930 GitHub stars; canary is 1 of 42 named skills
     (verified 2026-06-20)
-  stars: 110930
+  stars: 117106
   skillCountInRepo: 42
   sourceStartedAt: '2024-01-01'
 timeline:

--- a/registry/named/garrytan/cso.md
+++ b/registry/named/garrytan/cso.md
@@ -39,13 +39,14 @@ evidence:
   grade: B
 - source: https://github.com/garrytan/gstack
   evaluator: unknown
+  updatedAt: '2026-06-28'
   date: '2026-06-20'
   type: github-stars-own
   trustNumber: 85.0
   grade: C
   notes: gstack suite repo — 110,930 GitHub stars; cso is 1 of 42 named skills (verified
     2026-06-20)
-  stars: 110930
+  stars: 117106
   skillCountInRepo: 42
   sourceStartedAt: '2024-01-01'
 timeline:

--- a/registry/named/garrytan/design-consultation.md
+++ b/registry/named/garrytan/design-consultation.md
@@ -80,13 +80,14 @@ evidence:
   grade: B
 - source: https://github.com/garrytan/gstack
   evaluator: unknown
+  updatedAt: '2026-06-28'
   date: '2026-06-20'
   type: github-stars-own
   trustNumber: 85.0
   grade: C
   notes: gstack suite repo — 110,930 GitHub stars; design-consultation is 1 of 42
     named skills (verified 2026-06-20)
-  stars: 110930
+  stars: 117106
   skillCountInRepo: 42
   sourceStartedAt: '2024-01-01'
 trustMagnitude: 63.73

--- a/registry/named/garrytan/design-html.md
+++ b/registry/named/garrytan/design-html.md
@@ -80,13 +80,14 @@ evidence:
   grade: B
 - source: https://github.com/garrytan/gstack
   evaluator: unknown
+  updatedAt: '2026-06-28'
   date: '2026-06-20'
   type: github-stars-own
   trustNumber: 85.0
   grade: C
   notes: gstack suite repo — 110,930 GitHub stars; design-html is 1 of 42 named skills
     (verified 2026-06-20)
-  stars: 110930
+  stars: 117106
   skillCountInRepo: 42
   sourceStartedAt: '2024-01-01'
 trustMagnitude: 63.73

--- a/registry/named/garrytan/design-shotgun.md
+++ b/registry/named/garrytan/design-shotgun.md
@@ -37,13 +37,14 @@ evidence:
   grade: B
 - source: https://github.com/garrytan/gstack
   evaluator: unknown
+  updatedAt: '2026-06-28'
   date: '2026-06-20'
   type: github-stars-own
   trustNumber: 85.0
   grade: C
   notes: gstack suite repo — 110,930 GitHub stars; design-shotgun is 1 of 42 named
     skills (verified 2026-06-20)
-  stars: 110930
+  stars: 117106
   skillCountInRepo: 42
   sourceStartedAt: '2024-01-01'
 timeline:

--- a/registry/named/garrytan/document-generate.md
+++ b/registry/named/garrytan/document-generate.md
@@ -79,13 +79,14 @@ evidence:
   grade: B
 - source: https://github.com/garrytan/gstack
   evaluator: unknown
+  updatedAt: '2026-06-28'
   date: '2026-06-20'
   type: github-stars-own
   trustNumber: 85.0
   grade: C
   notes: gstack suite repo — 110,930 GitHub stars; document-generate is 1 of 42 named
     skills (verified 2026-06-20)
-  stars: 110930
+  stars: 117106
   skillCountInRepo: 42
   sourceStartedAt: '2024-01-01'
 trustMagnitude: 63.73

--- a/registry/named/garrytan/gstack.md
+++ b/registry/named/garrytan/gstack.md
@@ -89,12 +89,13 @@ evidence:
   grade: B
 - source: https://github.com/garrytan/gstack/stargazers
   evaluator: mbtiongson1
+  updatedAt: '2026-06-28'
   date: '2026-06-19'
   type: github-stars-own
   class: A
   notes: 110,930 GitHub stars as of 2026-06-19 (verified via firecrawl validation
     report; mothership with 47 sub-skills, divisor=4)
-  stars: 110930
+  stars: 117106
   skillCountInRepo: 47
   grade: C
 - source: https://www.youtube.com/watch?v=wkv2ifxPpF8

--- a/registry/named/garrytan/investigate.md
+++ b/registry/named/garrytan/investigate.md
@@ -80,13 +80,14 @@ evidence:
   grade: B
 - source: https://github.com/garrytan/gstack
   evaluator: unknown
+  updatedAt: '2026-06-28'
   date: '2026-06-20'
   type: github-stars-own
   trustNumber: 85.0
   grade: C
   notes: gstack suite repo — 110,930 GitHub stars; investigate is 1 of 42 named skills
     (verified 2026-06-20)
-  stars: 110930
+  stars: 117106
   skillCountInRepo: 42
   sourceStartedAt: '2024-01-01'
 trustMagnitude: 63.73

--- a/registry/named/garrytan/land-and-deploy.md
+++ b/registry/named/garrytan/land-and-deploy.md
@@ -38,13 +38,14 @@ evidence:
   grade: B
 - source: https://github.com/garrytan/gstack
   evaluator: unknown
+  updatedAt: '2026-06-28'
   date: '2026-06-20'
   type: github-stars-own
   trustNumber: 85.0
   grade: C
   notes: gstack suite repo — 110,930 GitHub stars; land-and-deploy is 1 of 42 named
     skills (verified 2026-06-20)
-  stars: 110930
+  stars: 117106
   skillCountInRepo: 42
   sourceStartedAt: '2024-01-01'
 timeline:

--- a/registry/named/garrytan/plan-ceo-review.md
+++ b/registry/named/garrytan/plan-ceo-review.md
@@ -38,13 +38,14 @@ evidence:
   grade: B
 - source: https://github.com/garrytan/gstack
   evaluator: unknown
+  updatedAt: '2026-06-28'
   date: '2026-06-20'
   type: github-stars-own
   trustNumber: 85.0
   grade: C
   notes: gstack suite repo — 110,930 GitHub stars; plan-ceo-review is 1 of 42 named
     skills (verified 2026-06-20)
-  stars: 110930
+  stars: 117106
   skillCountInRepo: 42
   sourceStartedAt: '2024-01-01'
 timeline:

--- a/registry/named/garrytan/plan-design-review.md
+++ b/registry/named/garrytan/plan-design-review.md
@@ -38,13 +38,14 @@ evidence:
   grade: B
 - source: https://github.com/garrytan/gstack
   evaluator: unknown
+  updatedAt: '2026-06-28'
   date: '2026-06-20'
   type: github-stars-own
   trustNumber: 85.0
   grade: C
   notes: gstack suite repo — 110,930 GitHub stars; plan-design-review is 1 of 42 named
     skills (verified 2026-06-20)
-  stars: 110930
+  stars: 117106
   skillCountInRepo: 42
   sourceStartedAt: '2024-01-01'
 timeline:

--- a/registry/named/garrytan/plan-devex-review.md
+++ b/registry/named/garrytan/plan-devex-review.md
@@ -38,13 +38,14 @@ evidence:
   grade: B
 - source: https://github.com/garrytan/gstack
   evaluator: unknown
+  updatedAt: '2026-06-28'
   date: '2026-06-20'
   type: github-stars-own
   trustNumber: 85.0
   grade: C
   notes: gstack suite repo — 110,930 GitHub stars; plan-devex-review is 1 of 42 named
     skills (verified 2026-06-20)
-  stars: 110930
+  stars: 117106
   skillCountInRepo: 42
   sourceStartedAt: '2024-01-01'
 timeline:

--- a/registry/named/garrytan/qa.md
+++ b/registry/named/garrytan/qa.md
@@ -38,13 +38,14 @@ evidence:
   grade: B
 - source: https://github.com/garrytan/gstack
   evaluator: unknown
+  updatedAt: '2026-06-28'
   date: '2026-06-20'
   type: github-stars-own
   trustNumber: 85.0
   grade: C
   notes: gstack suite repo — 110,930 GitHub stars; qa is 1 of 42 named skills (verified
     2026-06-20)
-  stars: 110930
+  stars: 117106
   skillCountInRepo: 42
   sourceStartedAt: '2024-01-01'
 timeline:

--- a/registry/named/garrytan/review.md
+++ b/registry/named/garrytan/review.md
@@ -38,13 +38,14 @@ evidence:
   grade: B
 - source: https://github.com/garrytan/gstack
   evaluator: unknown
+  updatedAt: '2026-06-28'
   date: '2026-06-20'
   type: github-stars-own
   trustNumber: 85.0
   grade: C
   notes: gstack suite repo — 110,930 GitHub stars; review is 1 of 42 named skills
     (verified 2026-06-20)
-  stars: 110930
+  stars: 117106
   skillCountInRepo: 42
   sourceStartedAt: '2024-01-01'
 timeline:

--- a/registry/named/garrytan/ship.md
+++ b/registry/named/garrytan/ship.md
@@ -79,13 +79,14 @@ evidence:
   grade: B
 - source: https://github.com/garrytan/gstack
   evaluator: unknown
+  updatedAt: '2026-06-28'
   date: '2026-06-20'
   type: github-stars-own
   trustNumber: 85.0
   grade: C
   notes: gstack suite repo — 110,930 GitHub stars; ship is 1 of 42 named skills (verified
     2026-06-20)
-  stars: 110930
+  stars: 117106
   skillCountInRepo: 42
   sourceStartedAt: '2024-01-01'
 trustMagnitude: 63.73

--- a/registry/named/garrytan/skillify.md
+++ b/registry/named/garrytan/skillify.md
@@ -36,13 +36,14 @@ evidence:
   grade: B
 - source: https://github.com/garrytan/gstack
   evaluator: unknown
+  updatedAt: '2026-06-28'
   date: '2026-06-20'
   type: github-stars-own
   trustNumber: 85.0
   grade: C
   notes: gstack suite repo — 110,930 GitHub stars; skillify is 1 of 42 named skills
     (verified 2026-06-20)
-  stars: 110930
+  stars: 117106
   skillCountInRepo: 42
   sourceStartedAt: '2024-01-01'
 timeline:

--- a/registry/named/mattpocock/diagnose.md
+++ b/registry/named/mattpocock/diagnose.md
@@ -37,12 +37,13 @@ evidence:
   grade: C
 - source: https://github.com/mattpocock/skills
   evaluator: unknown
+  updatedAt: '2026-06-28'
   date: '2026-06-20'
   type: github-stars-own
   trustNumber: 88.0
   grade: C
   notes: mattpocock/skills suite — 137k GitHub stars; diagnose is part of this repo
-  stars: 137000
+  stars: 148206
   skillCountInRepo: 21
   sourceStartedAt: '2025-01-01'
 - source: https://www.youtube.com/watch?v=EJyuu6zlQCg

--- a/registry/named/mattpocock/edit-article.md
+++ b/registry/named/mattpocock/edit-article.md
@@ -89,13 +89,14 @@ evidence:
   grade: C
 - source: https://github.com/mattpocock/skills
   evaluator: unknown
+  updatedAt: '2026-06-28'
   date: '2026-06-20'
   type: github-stars-own
   trustNumber: 88.0
   grade: C
   notes: mattpocock/skills suite — 137k GitHub stars; edit-article is part of this
     repo
-  stars: 137000
+  stars: 148206
   skillCountInRepo: 21
   sourceStartedAt: '2025-01-01'
 - source: https://www.youtube.com/watch?v=EJyuu6zlQCg

--- a/registry/named/mattpocock/obsidian-vault.md
+++ b/registry/named/mattpocock/obsidian-vault.md
@@ -28,13 +28,14 @@ evidence:
   grade: C
 - source: https://github.com/mattpocock/skills
   evaluator: unknown
+  updatedAt: '2026-06-28'
   date: '2026-06-20'
   type: github-stars-own
   trustNumber: 88.0
   grade: C
   notes: mattpocock/skills suite — 137k GitHub stars; obsidian-vault is part of this
     repo
-  stars: 137000
+  stars: 148206
   skillCountInRepo: 21
   sourceStartedAt: '2025-01-01'
 - source: https://www.youtube.com/watch?v=EJyuu6zlQCg

--- a/registry/named/mattpocock/skills.md
+++ b/registry/named/mattpocock/skills.md
@@ -83,12 +83,13 @@ timeline:
 evidence:
 - source: https://github.com/mattpocock/skills/stargazers
   evaluator: mbtiongson1
+  updatedAt: '2026-06-28'
   date: '2026-06-19'
   type: github-stars-own
   class: A
   notes: 133,210 GitHub stars as of 2026-06-19 (verified via firecrawl validation
     report; mothership with 19 sub-skills, divisor=4)
-  stars: 133210
+  stars: 148206
   skillCountInRepo: 19
   grade: C
 - source: https://arxiv.org/abs/2602.20867

--- a/registry/named/mattpocock/to-issues.md
+++ b/registry/named/mattpocock/to-issues.md
@@ -39,12 +39,13 @@ evidence:
   grade: C
 - source: https://github.com/mattpocock/skills
   evaluator: unknown
+  updatedAt: '2026-06-28'
   date: '2026-06-20'
   type: github-stars-own
   trustNumber: 88.0
   grade: C
   notes: mattpocock/skills suite — 137k GitHub stars; to-issues is part of this repo
-  stars: 137000
+  stars: 148206
   skillCountInRepo: 21
   sourceStartedAt: '2025-01-01'
 - source: https://www.youtube.com/watch?v=EJyuu6zlQCg

--- a/registry/named/mattpocock/ubiquitous-language.md
+++ b/registry/named/mattpocock/ubiquitous-language.md
@@ -37,13 +37,14 @@ evidence:
   grade: C
 - source: https://github.com/mattpocock/skills
   evaluator: unknown
+  updatedAt: '2026-06-28'
   date: '2026-06-20'
   type: github-stars-own
   trustNumber: 88.0
   grade: C
   notes: mattpocock/skills suite repo — 137k GitHub stars; ubiquitous-language was
     part of this suite (removed in v1.0.1 but authored by Matt Pocock)
-  stars: 137000
+  stars: 148206
   skillCountInRepo: 21
   sourceStartedAt: '2025-01-01'
 - source: https://www.youtube.com/watch?v=EJyuu6zlQCg

--- a/registry/named/obra/dispatching-parallel-agents.md
+++ b/registry/named/obra/dispatching-parallel-agents.md
@@ -35,13 +35,14 @@ evidence:
   grade: B
 - source: https://github.com/obra/superpowers
   evaluator: unknown
+  updatedAt: '2026-06-28'
   date: '2026-06-20'
   type: github-stars-own
   trustNumber: 88.0
   grade: B
   notes: obra/superpowers — 233k GitHub stars, complete AI coding methodology adopted
     across Claude Code, Codex CLI, Gemini CLI (verified 2026-06-20)
-  stars: 233000
+  stars: 239962
   skillCountInRepo: 13
   sourceStartedAt: '2023-01-01'
 timeline:

--- a/registry/named/obra/superpowers.md
+++ b/registry/named/obra/superpowers.md
@@ -50,12 +50,13 @@ evidence:
   grade: B
 - source: https://github.com/obra/superpowers/stargazers
   evaluator: mbtiongson1
+  updatedAt: '2026-06-28'
   date: '2026-06-19'
   type: github-stars-own
   class: A
   notes: 230,818 GitHub stars as of 2026-06-19 (verified via firecrawl validation
     report; mothership with 11+ sub-skills, divisor=4)
-  stars: 230818
+  stars: 239962
   skillCountInRepo: 11
   grade: B
 - source: https://www.youtube.com/watch?v=6YltXh12W-g

--- a/registry/named/pbakaus/impeccable.md
+++ b/registry/named/pbakaus/impeccable.md
@@ -33,12 +33,13 @@ evidence:
   grade: B
 - source: https://github.com/pbakaus/impeccable/stargazers
   evaluator: mbtiongson1
+  updatedAt: '2026-06-28'
   date: '2026-06-19'
   type: github-stars-own
   class: A
   notes: 38,000 GitHub stars as of 2026-06-19 (verified via firecrawl validation report;
     standalone skill)
-  stars: 38000
+  stars: 41805
   grade: B
 - source: https://arxiv.org/abs/2411.01606
   evaluator: mbtiongson1

--- a/registry/named/ruvnet/hive-mind-coordination.md
+++ b/registry/named/ruvnet/hive-mind-coordination.md
@@ -23,12 +23,13 @@ updatedAt: '2026-06-21'
 evidence:
 - source: https://github.com/ruvnet/ruflo/blob/main/.agents/skills/hive-mind/SKILL.md
   evaluator: unknown
+  updatedAt: '2026-06-28'
   date: '2026-06-20'
   type: github-stars-own
   trustNumber: 85.0
   notes: ruflo platform SKILL.md — 60.3k GitHub stars, 34 plugins; hive-mind specific
     file avoids same-source dedup (verified 2026-06-20)
-  stars: 60300
+  stars: 61720
   skillCountInRepo: 34
   sourceStartedAt: '2024-01-01'
 - source: https://github.com/ruvnet/ruflo

--- a/registry/named/ruvnet/ruflo.md
+++ b/registry/named/ruvnet/ruflo.md
@@ -86,12 +86,13 @@ evidence:
   grade: B
 - source: https://github.com/ruvnet/ruflo/stargazers
   evaluator: mbtiongson1
+  updatedAt: '2026-06-28'
   date: '2026-06-19'
   type: github-stars-own
   class: A
   notes: 59,957 GitHub stars as of 2026-06-19 (verified via firecrawl validation report;
     mothership with sub-skills, divisor=4)
-  stars: 59957
+  stars: 61720
   skillCountInRepo: 4
 - source: https://arxiv.org/abs/2602.06547
   evaluator: mbtiongson1

--- a/registry/named/safishamsi/graphify.md
+++ b/registry/named/safishamsi/graphify.md
@@ -75,12 +75,13 @@ apexGateStatus:
 evidence:
 - source: https://github.com/safishamsi/graphify/stargazers
   evaluator: mbtiongson1
+  updatedAt: '2026-06-28'
   date: '2026-06-19'
   type: github-stars-own
   class: A
   notes: 68,766 GitHub stars as of 2026-06-19 (verified via firecrawl validation report;
     standalone skill)
-  stars: 68766
+  stars: 72899
   grade: A
 - source: https://arxiv.org/abs/2408.03910
   evaluator: mbtiongson1

--- a/scripts/buildTrendingProjection.py
+++ b/scripts/buildTrendingProjection.py
@@ -1,0 +1,512 @@
+#!/usr/bin/env python3
+"""Generate docs/api/v1/trending/ — snapshot-based trending engine.
+
+Usage:
+    python scripts/buildTrendingProjection.py --out-dir <path>
+
+Input sources:
+    docs/api/v1/skills/index.json               — current skills with TM values
+    docs/api/v1/skills/<contributor>/<skill>.json — individual skill details
+    <out-dir>/trending/snapshot.json            — prior run state (may not exist)
+    <out-dir>/trending/history/<YYYY-MM-DD>.json — daily archive
+
+Output files (all under <out-dir>/trending/):
+    snapshot.json      — current state dict {skill_id: {tm, grade, level, updatedAt}}
+    history/<date>.json — copy of today's snapshot
+    7d.json            — 7-day trending list
+    30d.json           — 30-day trending list
+    ascended.json      — skills with rank_up/calibrate events in last 30 days
+    contested.json     — genericSkillRef buckets with >=2 named implementations
+
+Constraint: No new scoring. TM values are read from existing API projection as-is.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from gaia_cli.redaction import is_redacted  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_version() -> str:
+    """Extract version string from pyproject.toml via regex (no tomllib dep)."""
+    text = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    m = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    return m.group(1) if m else "0.0.0"
+
+
+def _write_json(path: Path, obj: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _slug_from_id(skill_id: str) -> tuple[str, str]:
+    """Split 'contributor/skill-name' into (contributor, skill_slug)."""
+    parts = skill_id.split("/", 1)
+    if len(parts) == 2:
+        return parts[0], parts[1]
+    return skill_id, skill_id
+
+
+def _utcnow() -> datetime:
+    """Return current UTC time as a naive datetime (for consistent arithmetic)."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _iso_now() -> str:
+    return _utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _today_str() -> str:
+    return _utcnow().strftime("%Y-%m-%d")
+
+
+# ---------------------------------------------------------------------------
+# Snapshot I/O
+# ---------------------------------------------------------------------------
+
+
+def _load_snapshot(snapshot_path: Path) -> dict:
+    """Load prior snapshot. Returns empty dict on missing/corrupt file."""
+    if not snapshot_path.exists():
+        return {}
+    try:
+        return json.loads(snapshot_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_snapshot(snapshot_path: Path, state: dict, generated_at: str) -> None:
+    """Write current state as snapshot.json."""
+    _write_json(snapshot_path, {
+        "generatedAt": generated_at,
+        "skills": state,
+    })
+
+
+def _archive_history(history_dir: Path, state: dict, generated_at: str) -> None:
+    """Write today's snapshot to history/ and prune to 30 days."""
+    today = _today_str()
+    _write_json(history_dir / f"{today}.json", {
+        "date": today,
+        "generatedAt": generated_at,
+        "skills": state,
+    })
+
+    # Prune history files older than 30 days
+    cutoff = _utcnow() - timedelta(days=30)
+    for f in sorted(history_dir.glob("*.json")):
+        try:
+            file_date = datetime.strptime(f.stem, "%Y-%m-%d")
+            if file_date < cutoff:
+                f.unlink()
+        except ValueError:
+            pass  # skip files that don't match date pattern
+
+
+def _find_history_snapshot(
+    history_dir: Path, target_date: datetime, tolerance_days: int = 2
+) -> dict:
+    """Find the history snapshot nearest to target_date within ±tolerance_days."""
+    best: dict = {}
+    best_delta = timedelta(days=tolerance_days + 1)
+
+    for f in history_dir.glob("*.json"):
+        try:
+            file_date = datetime.strptime(f.stem, "%Y-%m-%d")
+            delta = abs(file_date - target_date)
+            if delta <= timedelta(days=tolerance_days) and delta < best_delta:
+                data = json.loads(f.read_text(encoding="utf-8"))
+                best = data.get("skills", {})
+                best_delta = delta
+        except (ValueError, json.JSONDecodeError, OSError):
+            pass
+
+    return best
+
+
+# ---------------------------------------------------------------------------
+# Skill data loading
+# ---------------------------------------------------------------------------
+
+
+def _load_skills_index(api_dir: Path) -> list[dict]:
+    """Load all skills from docs/api/v1/skills/index.json and paginated pages."""
+    index_path = api_dir / "skills" / "index.json"
+    if not index_path.exists():
+        return []
+
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    all_skills = list(index.get("skills", []))
+
+    # Load additional pages if present
+    total_pages = index.get("totalPages", 1)
+    for page_num in range(2, total_pages + 1):
+        page_path = api_dir / "skills" / f"page-{page_num}.json"
+        if page_path.exists():
+            try:
+                page_data = json.loads(page_path.read_text(encoding="utf-8"))
+                all_skills.extend(page_data.get("skills", []))
+            except (json.JSONDecodeError, OSError):
+                pass
+
+    return all_skills
+
+
+def _load_skill_detail(api_dir: Path, skill_id: str) -> dict:
+    """Load full skill detail JSON for a given skill_id."""
+    contributor, slug = _slug_from_id(skill_id)
+    path = api_dir / "skills" / contributor / f"{slug}.json"
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# Trending score formula (read-only — no TM recomputation)
+# ---------------------------------------------------------------------------
+
+
+def _trending_score(
+    cur_tm: float,
+    prior_tm: float,
+    timeline: list[dict],
+    window_days: int,
+) -> float:
+    """Compute trending score from TM delta and timeline signals."""
+    cutoff = (_utcnow() - timedelta(days=window_days)).isoformat()
+
+    tm_delta = cur_tm - prior_tm
+    tm_delta_pct = tm_delta / max(prior_tm, 1.0)
+
+    rank_changed = any(
+        e.get("action") in ("rank_up", "demote", "calibrate")
+        and e.get("timestamp", "") >= cutoff
+        for e in timeline
+    )
+
+    evidence_added = sum(
+        1 for e in timeline
+        if e.get("action") == "evidence_added"
+        and e.get("timestamp", "") >= cutoff
+    )
+    evidence_signal = min(evidence_added, 5)
+
+    score = (
+        tm_delta * 1.0
+        + tm_delta_pct * 20.0
+        + (50.0 if rank_changed else 0.0)
+        + evidence_signal * 10.0
+    )
+    return round(score, 2)
+
+
+# ---------------------------------------------------------------------------
+# Output builders
+# ---------------------------------------------------------------------------
+
+
+def build_trending_window(
+    out_dir: Path,
+    window: str,
+    window_days: int,
+    current_skills: list[dict],
+    api_dir: Path,
+    prior_snapshot: dict,
+    first_run: bool,
+    generated_at: str,
+) -> None:
+    """Build 7d.json or 30d.json trending list."""
+    entries = []
+
+    for skill in current_skills:
+        skill_id = skill.get("id", "")
+        cur_tm = skill.get("trustMagnitude", 0) or 0
+
+        # Skip redacted skills
+        if is_redacted(skill.get("level", "")):
+            continue
+
+        detail = _load_skill_detail(api_dir, skill_id)
+        timeline = detail.get("timeline", [])
+
+        is_new = skill_id not in prior_snapshot
+        prior_entry = prior_snapshot.get(skill_id, {})
+        prior_tm = prior_entry.get("tm", 0) if prior_entry else 0
+
+        if first_run:
+            # Cold start: sort by TM descending, no trending scores
+            score = 0.0
+            tm_delta = 0.0
+        elif is_new:
+            score = round(cur_tm * 0.5, 2)
+            tm_delta = cur_tm
+        else:
+            prior_tm_val = float(prior_tm)
+            tm_delta = round(cur_tm - prior_tm_val, 4)
+            score = _trending_score(cur_tm, prior_tm_val, timeline, window_days)
+
+        if not first_run and score <= 0:
+            continue
+
+        contributor, slug = _slug_from_id(skill_id)
+        entry = {
+            "id": skill_id,
+            "name": skill.get("name", ""),
+            "level": skill.get("level", ""),
+            "contributor": skill.get("contributor", contributor),
+            "trustMagnitude": cur_tm,
+            "overallTrustGrade": skill.get("overallTrustGrade"),
+            "trendingScore": score,
+            "tmDelta": round(tm_delta, 4) if not first_run else 0.0,
+            "new": is_new and not first_run,
+            "_links": {"self": f"/api/v1/skills/{contributor}/{slug}.json"},
+        }
+        entries.append(entry)
+
+    # Sort: cold start → TM descending; normal → trending score descending
+    if first_run:
+        entries.sort(key=lambda e: -e["trustMagnitude"])
+    else:
+        entries.sort(key=lambda e: -e["trendingScore"])
+
+    _write_json(out_dir / f"{window}.json", {
+        "window": window,
+        "generatedAt": generated_at,
+        "firstRun": first_run,
+        "skills": entries,
+        "totalTrending": len(entries),
+        "_links": {"self": f"/api/v1/trending/{window}.json"},
+    })
+
+
+def build_ascended(
+    out_dir: Path,
+    current_skills: list[dict],
+    api_dir: Path,
+    generated_at: str,
+    window_days: int = 30,
+) -> None:
+    """Build ascended.json — skills with rank_up/calibrate events in last 30 days."""
+    cutoff = (_utcnow() - timedelta(days=window_days)).isoformat()
+    entries = []
+
+    for skill in current_skills:
+        skill_id = skill.get("id", "")
+
+        if is_redacted(skill.get("level", "")):
+            continue
+
+        detail = _load_skill_detail(api_dir, skill_id)
+        timeline = detail.get("timeline", [])
+
+        # Find the most recent rank_up/calibrate event within window
+        ascend_events = [
+            e for e in timeline
+            if e.get("action") in ("rank_up", "calibrate")
+            and e.get("timestamp", "") >= cutoff
+        ]
+
+        if not ascend_events:
+            continue
+
+        # Most recent event timestamp
+        ascended_at = max(e.get("timestamp", "") for e in ascend_events)
+
+        contributor, slug = _slug_from_id(skill_id)
+        entries.append({
+            "id": skill_id,
+            "name": skill.get("name", ""),
+            "level": skill.get("level", ""),
+            "contributor": skill.get("contributor", contributor),
+            "trustMagnitude": skill.get("trustMagnitude", 0),
+            "overallTrustGrade": skill.get("overallTrustGrade"),
+            "ascendedAt": ascended_at,
+            "_links": {"self": f"/api/v1/skills/{contributor}/{slug}.json"},
+        })
+
+    # Sort by most recent ascendedAt descending
+    entries.sort(key=lambda e: e.get("ascendedAt", ""), reverse=True)
+    entries = entries[:30]
+
+    _write_json(out_dir / "ascended.json", {
+        "generatedAt": generated_at,
+        "skills": entries,
+        "_links": {"self": "/api/v1/trending/ascended.json"},
+    })
+
+
+def build_contested(
+    out_dir: Path,
+    current_skills: list[dict],
+    api_dir: Path,
+    generated_at: str,
+) -> None:
+    """Build contested.json — genericSkillRef buckets with >=2 named implementations."""
+    # Build buckets keyed by genericSkillRef
+    buckets: dict[str, list[dict]] = {}
+
+    for skill in current_skills:
+        if is_redacted(skill.get("level", "")):
+            continue
+
+        skill_id = skill.get("id", "")
+        detail = _load_skill_detail(api_dir, skill_id)
+        generic_ref = detail.get("genericSkillRef") or ""
+
+        if not generic_ref:
+            continue
+
+        contributor, slug = _slug_from_id(skill_id)
+        entry = {
+            "id": skill_id,
+            "trustMagnitude": skill.get("trustMagnitude", 0),
+            "level": skill.get("level", ""),
+            "overallTrustGrade": skill.get("overallTrustGrade"),
+        }
+        buckets.setdefault(generic_ref, []).append(entry)
+
+    # Filter to buckets with >= 2 implementations
+    contested = {ref: skills for ref, skills in buckets.items() if len(skills) >= 2}
+
+    # Build output — sort each bucket by TM descending
+    bucket_list = []
+    for ref, skills in contested.items():
+        skills.sort(key=lambda s: -(s.get("trustMagnitude") or 0))
+        top_tm = skills[0].get("trustMagnitude", 0) if skills else 0
+        bucket_list.append({
+            "genericSkillRef": ref,
+            "implementations": len(skills),
+            "topTM": top_tm,
+            "skills": skills,
+        })
+
+    # Sort buckets by topTM descending
+    bucket_list.sort(key=lambda b: -(b.get("topTM") or 0))
+    bucket_list = bucket_list[:20]
+
+    _write_json(out_dir / "contested.json", {
+        "generatedAt": generated_at,
+        "buckets": bucket_list,
+        "_links": {"self": "/api/v1/trending/contested.json"},
+    })
+
+
+# ---------------------------------------------------------------------------
+# Main entrypoint
+# ---------------------------------------------------------------------------
+
+
+def run(out_dir: Path) -> int:
+    """Execute the full trending projection. Returns 0 on success, 1 on error."""
+    api_dir = ROOT / "docs" / "api" / "v1"
+    trending_dir = out_dir / "trending"
+    snapshot_path = trending_dir / "snapshot.json"
+    history_dir = trending_dir / "history"
+
+    # Load the committed API projection (NOT registry/named-skills.json)
+    current_skills = _load_skills_index(api_dir)
+
+    if not current_skills:
+        print(
+            "FATAL: No skills found in docs/api/v1/skills/index.json. "
+            "Run `python scripts/buildApiProjection.py` first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Filter redacted skills
+    current_skills = [
+        s for s in current_skills if not is_redacted(s.get("level", ""))
+    ]
+
+    generated_at = _iso_now()
+    today = _today_str()
+
+    # Load prior snapshot
+    snapshot_data = _load_snapshot(snapshot_path)
+    prior_skills_state: dict = snapshot_data.get("skills", {}) if snapshot_data else {}
+
+    first_run = not bool(prior_skills_state)
+
+    # Build current state dict for snapshot
+    current_state: dict = {}
+    for skill in current_skills:
+        skill_id = skill.get("id", "")
+        current_state[skill_id] = {
+            "tm": skill.get("trustMagnitude", 0),
+            "grade": skill.get("overallTrustGrade"),
+            "level": skill.get("level", ""),
+            "updatedAt": generated_at,
+        }
+
+    # Resolve prior snapshots for 7d and 30d windows
+    now_dt = _utcnow()
+    history_dir.mkdir(parents=True, exist_ok=True)
+
+    target_7d = now_dt - timedelta(days=7)
+    target_30d = now_dt - timedelta(days=30)
+
+    prior_7d = _find_history_snapshot(history_dir, target_7d)
+    prior_30d = _find_history_snapshot(history_dir, target_30d)
+
+    # On first run, use current state as the prior (delta = 0)
+    if first_run:
+        prior_7d = current_state
+        prior_30d = current_state
+
+    # Save snapshot and archive history BEFORE building trending files
+    _save_snapshot(snapshot_path, current_state, generated_at)
+    _archive_history(history_dir, current_state, generated_at)
+
+    # Build output files
+    build_trending_window(
+        trending_dir, "7d", 7, current_skills, api_dir,
+        prior_7d, first_run, generated_at,
+    )
+    build_trending_window(
+        trending_dir, "30d", 30, current_skills, api_dir,
+        prior_30d, first_run, generated_at,
+    )
+    build_ascended(trending_dir, current_skills, api_dir, generated_at)
+    build_contested(trending_dir, current_skills, api_dir, generated_at)
+
+    print(f"Trending projection written to {trending_dir}/")
+    print(f"  snapshot.json, history/{today}.json")
+    print(f"  7d.json, 30d.json, ascended.json, contested.json")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate docs/api/v1/trending/ static JSON trending projection."
+    )
+    parser.add_argument(
+        "--out-dir",
+        required=True,
+        help="Output directory root (trending/ subdir is written here)",
+    )
+    args = parser.parse_args(argv)
+    rc = run(Path(args.out_dir))
+    sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/stargazerHeartbeat.py
+++ b/scripts/stargazerHeartbeat.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""
+stargazerHeartbeat.py — monthly stargazer refresh for github-stars-own evidence rows.
+
+Usage:
+    python scripts/stargazerHeartbeat.py [--dry-run] [--apply]
+
+Default mode is --dry-run.  Pass --apply to write changes back to frontmatter files.
+
+Algorithm:
+1. Find all registry/named/<contributor>/<skill>.md files.
+2. Parse YAML frontmatter.
+3. For each evidence row with type in {github-stars-own, github-stars}:
+   - Resolve the GitHub owner/repo from the evidence `source` URL first,
+     falling back to `links.github` from the frontmatter.
+4. Query GET https://api.github.com/repos/{owner}/{repo}.
+5. Compare stargazers_count vs stored `stars` field.
+6. If abs delta > 5% OR abs delta > 100: update `stars` + set `updatedAt` on the row.
+7. Write back only if changed (idempotent).
+
+Auth: set GH_TOKEN env var to raise rate limit to 5000 req/hr.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import time
+import urllib.request
+import urllib.error
+import json
+from datetime import date, timezone
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+NAMED_DIR = REPO_ROOT / "registry" / "named"
+
+# ---------------------------------------------------------------------------
+# Frontmatter parser (regex-based — no ruamel/python-frontmatter dep needed)
+# ---------------------------------------------------------------------------
+
+_FM_RE = re.compile(r"^---\r?\n(.*?)\r?\n---(?:\r?\n|$)", re.DOTALL)
+
+
+def _split_frontmatter(text: str) -> tuple[str, str, str]:
+    """Return (pre_fence, fm_content, body).
+
+    pre_fence is always '---\\n'.  Returns ('', '', text) if no frontmatter.
+    """
+    m = _FM_RE.match(text)
+    if not m:
+        return ("", "", text)
+    fm_raw = m.group(1)
+    body = text[m.end():]
+    return ("---\n", fm_raw, body)
+
+
+def _load_yaml_simple(text: str) -> dict:
+    """Thin wrapper — project uses pyyaml (listed in pyproject.toml deps)."""
+    import yaml  # pyyaml — always available in this project
+    return yaml.safe_load(text) or {}
+
+
+# ---------------------------------------------------------------------------
+# GitHub URL parser
+# ---------------------------------------------------------------------------
+
+_GH_RE = re.compile(
+    r"https?://github\.com/([^/]+)/([^/\s#?]+)"
+    r"(?:/(?:blob|tree|stargazers|commits?|releases?)(/[^\s#?]*)?)?"
+)
+
+
+def parse_owner_repo(url: str) -> tuple[str, str] | None:
+    """Extract (owner, repo) from a GitHub URL.  Returns None on failure."""
+    if not url:
+        return None
+    m = _GH_RE.match(url.strip())
+    if not m:
+        return None
+    owner = m.group(1)
+    repo = m.group(2).rstrip("/")
+    # Strip .git suffix if present
+    if repo.endswith(".git"):
+        repo = repo[:-4]
+    return (owner, repo)
+
+
+# ---------------------------------------------------------------------------
+# GitHub API
+# ---------------------------------------------------------------------------
+
+_GH_API = "https://api.github.com/repos/{owner}/{repo}"
+_CACHE: dict[str, int | None] = {}  # (owner/repo) -> star count or None on error
+
+
+def fetch_stars(owner: str, repo: str) -> int | None:
+    """Fetch stargazers_count from GitHub API.  Returns None on any error."""
+    key = f"{owner}/{repo}"
+    if key in _CACHE:
+        return _CACHE[key]
+
+    url = _GH_API.format(owner=owner, repo=repo)
+    req = urllib.request.Request(url, headers={"Accept": "application/vnd.github+json"})
+
+    token = os.environ.get("GH_TOKEN", "")
+    if token:
+        req.add_header("Authorization", f"token {token}")
+
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read().decode())
+            count = data.get("stargazers_count")
+            _CACHE[key] = count
+            return count
+    except urllib.error.HTTPError as exc:
+        print(
+            f"  [warn] GitHub API {exc.code} for {key}: {exc.reason}",
+            file=sys.stderr,
+        )
+        _CACHE[key] = None
+        return None
+    except Exception as exc:  # noqa: BLE001
+        print(f"  [warn] GitHub API error for {key}: {exc}", file=sys.stderr)
+        _CACHE[key] = None
+        return None
+    finally:
+        time.sleep(0.1)
+
+
+# ---------------------------------------------------------------------------
+# Delta threshold
+# ---------------------------------------------------------------------------
+
+def _needs_update(old: int, new: int) -> bool:
+    """Return True if the star count warrants a refresh."""
+    delta = abs(new - old)
+    if delta > 100:
+        return True
+    if old > 0 and (delta / old) > 0.05:
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter rewriter
+# ---------------------------------------------------------------------------
+
+def _update_evidence_row_in_text(text: str, row_index: int, new_stars: int) -> str:
+    """Update the `stars:` field (and add/update `updatedAt:`) in the raw YAML
+    frontmatter text for the evidence entry at *row_index*.
+
+    We rewrite only the matching evidence block to avoid disturbing ordering or
+    formatting of the rest of the document.
+
+    Strategy: locate the N-th evidence list item inside the frontmatter and do
+    targeted in-place substitution.
+    """
+    m = _FM_RE.match(text)
+    if not m:
+        return text  # safety: nothing to update
+
+    fm_text = m.group(1)
+    body_text = text[m.end():]
+
+    # Find all top-level '- ' evidence list item start positions in the fm_text.
+    # Evidence block is under the 'evidence:' key — we find the block and then
+    # locate the N-th list item.
+    # Simple approach: split fm into lines and walk the evidence block.
+
+    lines = fm_text.split("\n")
+    in_evidence = False
+    item_idx = -1
+    item_start_line = None  # line index where item_idx == row_index starts
+    item_end_line = None
+    today_str = date.today().isoformat()
+
+    for i, line in enumerate(lines):
+        if re.match(r"^evidence\s*:", line):
+            in_evidence = True
+            continue
+        if in_evidence:
+            # A top-level key (no leading spaces) ends the evidence block
+            if line and not line[0].isspace() and line[0] != "-":
+                in_evidence = False
+                if item_start_line is not None and item_end_line is None:
+                    item_end_line = i
+                break
+            if re.match(r"^- ", line):
+                item_idx += 1
+                if item_idx == row_index:
+                    item_start_line = i
+                elif item_idx == row_index + 1:
+                    item_end_line = i
+                    break
+
+    if item_start_line is None:
+        return text  # Couldn't locate the block — bail out
+
+    if item_end_line is None:
+        item_end_line = len(lines)
+
+    block_lines = lines[item_start_line:item_end_line]
+
+    # Update or insert stars:
+    stars_updated = False
+    updated_at_updated = False
+    new_block = []
+    for bl in block_lines:
+        if re.match(r"\s+stars\s*:", bl):
+            indent = re.match(r"(\s+)", bl)
+            prefix = indent.group(1) if indent else "  "
+            new_block.append(f"{prefix}stars: {new_stars}")
+            stars_updated = True
+        elif re.match(r"\s+updatedAt\s*:", bl):
+            indent = re.match(r"(\s+)", bl)
+            prefix = indent.group(1) if indent else "  "
+            new_block.append(f"{prefix}updatedAt: '{today_str}'")
+            updated_at_updated = True
+        else:
+            new_block.append(bl)
+
+    if not stars_updated:
+        # Insert after first line of block (the '- ...' line)
+        new_block.insert(1, f"  stars: {new_stars}")
+    if not updated_at_updated:
+        new_block.insert(1 if not stars_updated else 2, f"  updatedAt: '{today_str}'")
+
+    new_lines = lines[:item_start_line] + new_block + lines[item_end_line:]
+    new_fm = "\n".join(new_lines)
+    return f"---\n{new_fm}\n---\n{body_text}"
+
+
+# ---------------------------------------------------------------------------
+# Process a single file
+# ---------------------------------------------------------------------------
+
+def process_file(path: Path, apply: bool) -> list[dict]:
+    """Process one skill markdown file.  Returns list of result rows."""
+    text = path.read_text(encoding="utf-8")
+    _, fm_raw, _ = _split_frontmatter(text)
+    if not fm_raw:
+        return []
+
+    fm = _load_yaml_simple(fm_raw)
+    skill_id = fm.get("id", str(path.relative_to(NAMED_DIR).with_suffix("")))
+
+    # links.github for fallback owner/repo resolution
+    links_github = (fm.get("links") or {}).get("github", "")
+
+    evidence = fm.get("evidence") or []
+    results = []
+
+    for idx, row in enumerate(evidence):
+        row_type = row.get("type", "")
+        if row_type not in ("github-stars-own", "github-stars"):
+            continue
+
+        old_stars = row.get("stars")
+        if old_stars is None:
+            # No existing star count — still fetch so we can populate it
+            old_stars = 0
+
+        # Resolve owner/repo: prefer evidence source URL, fallback to links.github
+        source_url = row.get("source", "")
+        parsed = parse_owner_repo(source_url) or parse_owner_repo(links_github)
+
+        if parsed is None:
+            results.append({
+                "skill_id": skill_id,
+                "evidence_idx": idx,
+                "old_stars": old_stars,
+                "new_stars": None,
+                "delta": None,
+                "updated": False,
+                "skip_reason": "no_github_url",
+            })
+            continue
+
+        owner, repo = parsed
+        new_stars = fetch_stars(owner, repo)
+
+        if new_stars is None:
+            results.append({
+                "skill_id": skill_id,
+                "evidence_idx": idx,
+                "old_stars": old_stars,
+                "new_stars": None,
+                "delta": None,
+                "updated": False,
+                "skip_reason": "api_error",
+            })
+            continue
+
+        delta = new_stars - old_stars
+        should_update = _needs_update(old_stars, new_stars)
+
+        results.append({
+            "skill_id": skill_id,
+            "evidence_idx": idx,
+            "old_stars": old_stars,
+            "new_stars": new_stars,
+            "delta": delta,
+            "updated": should_update and apply,
+            "skip_reason": None,
+        })
+
+        if should_update and apply:
+            text = _update_evidence_row_in_text(text, idx, new_stars)
+
+    if apply and any(r["updated"] for r in results):
+        path.write_text(text, encoding="utf-8")
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Monthly stargazer refresh for github-stars-own evidence rows."
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Print what would change without writing (default when neither flag given)",
+    )
+    mode.add_argument(
+        "--apply",
+        action="store_true",
+        default=False,
+        help="Actually update frontmatter files",
+    )
+    args = parser.parse_args()
+
+    # If neither flag given, default to dry-run
+    if not args.apply:
+        args.dry_run = True
+
+    mode_label = "APPLY" if args.apply else "DRY-RUN"
+    print(f"stargazerHeartbeat — mode: {mode_label}")
+    print(f"Scanning {NAMED_DIR} ...\n")
+
+    all_results: list[dict] = []
+
+    md_files = sorted(NAMED_DIR.rglob("*.md"))
+    for path in md_files:
+        rows = process_file(path, apply=args.apply)
+        all_results.extend(rows)
+
+    # ---------------------------------------------------------------------------
+    # Summary table
+    # ---------------------------------------------------------------------------
+    star_rows = [r for r in all_results if r["skip_reason"] is None]
+    skipped = [r for r in all_results if r["skip_reason"] is not None]
+
+    col_id = max((len(r["skill_id"]) for r in all_results), default=20) + 2
+    col_id = max(col_id, 20)
+
+    header = (
+        f"{'skill_id':<{col_id}} {'old_stars':>10} {'new_stars':>10} "
+        f"{'delta':>8}  {'updated':<8}"
+    )
+    sep = "-" * len(header)
+
+    print(header)
+    print(sep)
+
+    updated_count = 0
+    for r in star_rows:
+        delta_str = f"{r['delta']:+d}" if r["delta"] is not None else "n/a"
+        new_str = str(r["new_stars"]) if r["new_stars"] is not None else "error"
+        upd_str = "YES" if r["updated"] else ("would" if r["delta"] is not None and _needs_update(r["old_stars"], r["new_stars"]) and not args.apply else "no")
+        print(
+            f"{r['skill_id']:<{col_id}} {r['old_stars']:>10} {new_str:>10} "
+            f"{delta_str:>8}  {upd_str:<8}"
+        )
+        if r["updated"]:
+            updated_count += 1
+
+    print(sep)
+    print(
+        f"\nTotal evidence rows scanned: {len(all_results)} "
+        f"(with stars: {len(star_rows)}, skipped: {len(skipped)})"
+    )
+    print(
+        f"Files updated: {updated_count} "
+        f"{'(written)' if args.apply else '(dry-run — pass --apply to write)'}"
+    )
+
+    if skipped:
+        print("\nSkipped rows:")
+        for r in skipped:
+            print(f"  {r['skill_id']}[{r['evidence_idx']}]: {r['skip_reason']}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Implements the monthly stargazer refresh for keeping github-stars-own evidence rows current.

## What
- `scripts/stargazerHeartbeat.py`: reads `links.github` from skill frontmatter (with evidence `source` URL as primary resolver), queries GitHub API for current star counts, updates `evidence[type=github-stars-own].stars` if delta >5% or >100. Idempotent. `--dry-run` by default, `--apply` to write.
- `.github/workflows/stargazer-heartbeat.yml`: monthly cron (1st of month, 06:00 UTC), `workflow_dispatch` for manual trigger. Commits star updates to `registry/named/`; `sync-artifacts.yml` handles downstream regen.

## Constraint
Does NOT recompute Trust Magnitude. Only updates raw `stars` field in evidence frontmatter.

## Dry-run results
30 evidence rows with github-stars-own/github-stars found across the registry. All 30 resolved owner/repo successfully (0 skipped). Live run updated all 30 files; second run confirmed idempotency (0 files changed).

Resolves #760
Resolves #852