### PR TITLE
feat(b2): buildTrendingProjection.py — snapshot delta engine

### DIFF
--- a/scripts/buildTrendingProjection.py
+++ b/scripts/buildTrendingProjection.py
@@ -1,0 +1,512 @@
+#!/usr/bin/env python3
+"""Generate docs/api/v1/trending/ — snapshot-based trending engine.
+
+Usage:
+    python scripts/buildTrendingProjection.py --out-dir <path>
+
+Input sources:
+    docs/api/v1/skills/index.json               — current skills with TM values
+    docs/api/v1/skills/<contributor>/<skill>.json — individual skill details
+    <out-dir>/trending/snapshot.json            — prior run state (may not exist)
+    <out-dir>/trending/history/<YYYY-MM-DD>.json — daily archive
+
+Output files (all under <out-dir>/trending/):
+    snapshot.json      — current state dict {skill_id: {tm, grade, level, updatedAt}}
+    history/<date>.json — copy of today's snapshot
+    7d.json            — 7-day trending list
+    30d.json           — 30-day trending list
+    ascended.json      — skills with rank_up/calibrate events in last 30 days
+    contested.json     — genericSkillRef buckets with >=2 named implementations
+
+Constraint: No new scoring. TM values are read from existing API projection as-is.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from gaia_cli.redaction import is_redacted  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_version() -> str:
+    """Extract version string from pyproject.toml via regex (no tomllib dep)."""
+    text = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    m = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    return m.group(1) if m else "0.0.0"
+
+
+def _write_json(path: Path, obj: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _slug_from_id(skill_id: str) -> tuple[str, str]:
+    """Split 'contributor/skill-name' into (contributor, skill_slug)."""
+    parts = skill_id.split("/", 1)
+    if len(parts) == 2:
+        return parts[0], parts[1]
+    return skill_id, skill_id
+
+
+def _utcnow() -> datetime:
+    """Return current UTC time as a naive datetime (for consistent arithmetic)."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _iso_now() -> str:
+    return _utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _today_str() -> str:
+    return _utcnow().strftime("%Y-%m-%d")
+
+
+# ---------------------------------------------------------------------------
+# Snapshot I/O
+# ---------------------------------------------------------------------------
+
+
+def _load_snapshot(snapshot_path: Path) -> dict:
+    """Load prior snapshot. Returns empty dict on missing/corrupt file."""
+    if not snapshot_path.exists():
+        return {}
+    try:
+        return json.loads(snapshot_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_snapshot(snapshot_path: Path, state: dict, generated_at: str) -> None:
+    """Write current state as snapshot.json."""
+    _write_json(snapshot_path, {
+        "generatedAt": generated_at,
+        "skills": state,
+    })
+
+
+def _archive_history(history_dir: Path, state: dict, generated_at: str) -> None:
+    """Write today's snapshot to history/ and prune to 30 days."""
+    today = _today_str()
+    _write_json(history_dir / f"{today}.json", {
+        "date": today,
+        "generatedAt": generated_at,
+        "skills": state,
+    })
+
+    # Prune history files older than 30 days
+    cutoff = _utcnow() - timedelta(days=30)
+    for f in sorted(history_dir.glob("*.json")):
+        try:
+            file_date = datetime.strptime(f.stem, "%Y-%m-%d")
+            if file_date < cutoff:
+                f.unlink()
+        except ValueError:
+            pass  # skip files that don't match date pattern
+
+
+def _find_history_snapshot(
+    history_dir: Path, target_date: datetime, tolerance_days: int = 2
+) -> dict:
+    """Find the history snapshot nearest to target_date within ±tolerance_days."""
+    best: dict = {}
+    best_delta = timedelta(days=tolerance_days + 1)
+
+    for f in history_dir.glob("*.json"):
+        try:
+            file_date = datetime.strptime(f.stem, "%Y-%m-%d")
+            delta = abs(file_date - target_date)
+            if delta <= timedelta(days=tolerance_days) and delta < best_delta:
+                data = json.loads(f.read_text(encoding="utf-8"))
+                best = data.get("skills", {})
+                best_delta = delta
+        except (ValueError, json.JSONDecodeError, OSError):
+            pass
+
+    return best
+
+
+# ---------------------------------------------------------------------------
+# Skill data loading
+# ---------------------------------------------------------------------------
+
+
+def _load_skills_index(api_dir: Path) -> list[dict]:
+    """Load all skills from docs/api/v1/skills/index.json and paginated pages."""
+    index_path = api_dir / "skills" / "index.json"
+    if not index_path.exists():
+        return []
+
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    all_skills = list(index.get("skills", []))
+
+    # Load additional pages if present
+    total_pages = index.get("totalPages", 1)
+    for page_num in range(2, total_pages + 1):
+        page_path = api_dir / "skills" / f"page-{page_num}.json"
+        if page_path.exists():
+            try:
+                page_data = json.loads(page_path.read_text(encoding="utf-8"))
+                all_skills.extend(page_data.get("skills", []))
+            except (json.JSONDecodeError, OSError):
+                pass
+
+    return all_skills
+
+
+def _load_skill_detail(api_dir: Path, skill_id: str) -> dict:
+    """Load full skill detail JSON for a given skill_id."""
+    contributor, slug = _slug_from_id(skill_id)
+    path = api_dir / "skills" / contributor / f"{slug}.json"
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# Trending score formula (read-only — no TM recomputation)
+# ---------------------------------------------------------------------------
+
+
+def _trending_score(
+    cur_tm: float,
+    prior_tm: float,
+    timeline: list[dict],
+    window_days: int,
+) -> float:
+    """Compute trending score from TM delta and timeline signals."""
+    cutoff = (_utcnow() - timedelta(days=window_days)).isoformat()
+
+    tm_delta = cur_tm - prior_tm
+    tm_delta_pct = tm_delta / max(prior_tm, 1.0)
+
+    rank_changed = any(
+        e.get("action") in ("rank_up", "demote", "calibrate")
+        and e.get("timestamp", "") >= cutoff
+        for e in timeline
+    )
+
+    evidence_added = sum(
+        1 for e in timeline
+        if e.get("action") == "evidence_added"
+        and e.get("timestamp", "") >= cutoff
+    )
+    evidence_signal = min(evidence_added, 5)
+
+    score = (
+        tm_delta * 1.0
+        + tm_delta_pct * 20.0
+        + (50.0 if rank_changed else 0.0)
+        + evidence_signal * 10.0
+    )
+    return round(score, 2)
+
+
+# ---------------------------------------------------------------------------
+# Output builders
+# ---------------------------------------------------------------------------
+
+
+def build_trending_window(
+    out_dir: Path,
+    window: str,
+    window_days: int,
+    current_skills: list[dict],
+    api_dir: Path,
+    prior_snapshot: dict,
+    first_run: bool,
+    generated_at: str,
+) -> None:
+    """Build 7d.json or 30d.json trending list."""
+    entries = []
+
+    for skill in current_skills:
+        skill_id = skill.get("id", "")
+        cur_tm = skill.get("trustMagnitude", 0) or 0
+
+        # Skip redacted skills
+        if is_redacted(skill.get("level", "")):
+            continue
+
+        detail = _load_skill_detail(api_dir, skill_id)
+        timeline = detail.get("timeline", [])
+
+        is_new = skill_id not in prior_snapshot
+        prior_entry = prior_snapshot.get(skill_id, {})
+        prior_tm = prior_entry.get("tm", 0) if prior_entry else 0
+
+        if first_run:
+            # Cold start: sort by TM descending, no trending scores
+            score = 0.0
+            tm_delta = 0.0
+        elif is_new:
+            score = round(cur_tm * 0.5, 2)
+            tm_delta = cur_tm
+        else:
+            prior_tm_val = float(prior_tm)
+            tm_delta = round(cur_tm - prior_tm_val, 4)
+            score = _trending_score(cur_tm, prior_tm_val, timeline, window_days)
+
+        if not first_run and score <= 0:
+            continue
+
+        contributor, slug = _slug_from_id(skill_id)
+        entry = {
+            "id": skill_id,
+            "name": skill.get("name", ""),
+            "level": skill.get("level", ""),
+            "contributor": skill.get("contributor", contributor),
+            "trustMagnitude": cur_tm,
+            "overallTrustGrade": skill.get("overallTrustGrade"),
+            "trendingScore": score,
+            "tmDelta": round(tm_delta, 4) if not first_run else 0.0,
+            "new": is_new and not first_run,
+            "_links": {"self": f"/api/v1/skills/{contributor}/{slug}.json"},
+        }
+        entries.append(entry)
+
+    # Sort: cold start → TM descending; normal → trending score descending
+    if first_run:
+        entries.sort(key=lambda e: -e["trustMagnitude"])
+    else:
+        entries.sort(key=lambda e: -e["trendingScore"])
+
+    _write_json(out_dir / f"{window}.json", {
+        "window": window,
+        "generatedAt": generated_at,
+        "firstRun": first_run,
+        "skills": entries,
+        "totalTrending": len(entries),
+        "_links": {"self": f"/api/v1/trending/{window}.json"},
+    })
+
+
+def build_ascended(
+    out_dir: Path,
+    current_skills: list[dict],
+    api_dir: Path,
+    generated_at: str,
+    window_days: int = 30,
+) -> None:
+    """Build ascended.json — skills with rank_up/calibrate events in last 30 days."""
+    cutoff = (_utcnow() - timedelta(days=window_days)).isoformat()
+    entries = []
+
+    for skill in current_skills:
+        skill_id = skill.get("id", "")
+
+        if is_redacted(skill.get("level", "")):
+            continue
+
+        detail = _load_skill_detail(api_dir, skill_id)
+        timeline = detail.get("timeline", [])
+
+        # Find the most recent rank_up/calibrate event within window
+        ascend_events = [
+            e for e in timeline
+            if e.get("action") in ("rank_up", "calibrate")
+            and e.get("timestamp", "") >= cutoff
+        ]
+
+        if not ascend_events:
+            continue
+
+        # Most recent event timestamp
+        ascended_at = max(e.get("timestamp", "") for e in ascend_events)
+
+        contributor, slug = _slug_from_id(skill_id)
+        entries.append({
+            "id": skill_id,
+            "name": skill.get("name", ""),
+            "level": skill.get("level", ""),
+            "contributor": skill.get("contributor", contributor),
+            "trustMagnitude": skill.get("trustMagnitude", 0),
+            "overallTrustGrade": skill.get("overallTrustGrade"),
+            "ascendedAt": ascended_at,
+            "_links": {"self": f"/api/v1/skills/{contributor}/{slug}.json"},
+        })
+
+    # Sort by most recent ascendedAt descending
+    entries.sort(key=lambda e: e.get("ascendedAt", ""), reverse=True)
+    entries = entries[:30]
+
+    _write_json(out_dir / "ascended.json", {
+        "generatedAt": generated_at,
+        "skills": entries,
+        "_links": {"self": "/api/v1/trending/ascended.json"},
+    })
+
+
+def build_contested(
+    out_dir: Path,
+    current_skills: list[dict],
+    api_dir: Path,
+    generated_at: str,
+) -> None:
+    """Build contested.json — genericSkillRef buckets with >=2 named implementations."""
+    # Build buckets keyed by genericSkillRef
+    buckets: dict[str, list[dict]] = {}
+
+    for skill in current_skills:
+        if is_redacted(skill.get("level", "")):
+            continue
+
+        skill_id = skill.get("id", "")
+        detail = _load_skill_detail(api_dir, skill_id)
+        generic_ref = detail.get("genericSkillRef") or ""
+
+        if not generic_ref:
+            continue
+
+        contributor, slug = _slug_from_id(skill_id)
+        entry = {
+            "id": skill_id,
+            "trustMagnitude": skill.get("trustMagnitude", 0),
+            "level": skill.get("level", ""),
+            "overallTrustGrade": skill.get("overallTrustGrade"),
+        }
+        buckets.setdefault(generic_ref, []).append(entry)
+
+    # Filter to buckets with >= 2 implementations
+    contested = {ref: skills for ref, skills in buckets.items() if len(skills) >= 2}
+
+    # Build output — sort each bucket by TM descending
+    bucket_list = []
+    for ref, skills in contested.items():
+        skills.sort(key=lambda s: -(s.get("trustMagnitude") or 0))
+        top_tm = skills[0].get("trustMagnitude", 0) if skills else 0
+        bucket_list.append({
+            "genericSkillRef": ref,
+            "implementations": len(skills),
+            "topTM": top_tm,
+            "skills": skills,
+        })
+
+    # Sort buckets by topTM descending
+    bucket_list.sort(key=lambda b: -(b.get("topTM") or 0))
+    bucket_list = bucket_list[:20]
+
+    _write_json(out_dir / "contested.json", {
+        "generatedAt": generated_at,
+        "buckets": bucket_list,
+        "_links": {"self": "/api/v1/trending/contested.json"},
+    })
+
+
+# ---------------------------------------------------------------------------
+# Main entrypoint
+# ---------------------------------------------------------------------------
+
+
+def run(out_dir: Path) -> int:
+    """Execute the full trending projection. Returns 0 on success, 1 on error."""
+    api_dir = ROOT / "docs" / "api" / "v1"
+    trending_dir = out_dir / "trending"
+    snapshot_path = trending_dir / "snapshot.json"
+    history_dir = trending_dir / "history"
+
+    # Load the committed API projection (NOT registry/named-skills.json)
+    current_skills = _load_skills_index(api_dir)
+
+    if not current_skills:
+        print(
+            "FATAL: No skills found in docs/api/v1/skills/index.json. "
+            "Run `python scripts/buildApiProjection.py` first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Filter redacted skills
+    current_skills = [
+        s for s in current_skills if not is_redacted(s.get("level", ""))
+    ]
+
+    generated_at = _iso_now()
+    today = _today_str()
+
+    # Load prior snapshot
+    snapshot_data = _load_snapshot(snapshot_path)
+    prior_skills_state: dict = snapshot_data.get("skills", {}) if snapshot_data else {}
+
+    first_run = not bool(prior_skills_state)
+
+    # Build current state dict for snapshot
+    current_state: dict = {}
+    for skill in current_skills:
+        skill_id = skill.get("id", "")
+        current_state[skill_id] = {
+            "tm": skill.get("trustMagnitude", 0),
+            "grade": skill.get("overallTrustGrade"),
+            "level": skill.get("level", ""),
+            "updatedAt": generated_at,
+        }
+
+    # Resolve prior snapshots for 7d and 30d windows
+    now_dt = _utcnow()
+    history_dir.mkdir(parents=True, exist_ok=True)
+
+    target_7d = now_dt - timedelta(days=7)
+    target_30d = now_dt - timedelta(days=30)
+
+    prior_7d = _find_history_snapshot(history_dir, target_7d)
+    prior_30d = _find_history_snapshot(history_dir, target_30d)
+
+    # On first run, use current state as the prior (delta = 0)
+    if first_run:
+        prior_7d = current_state
+        prior_30d = current_state
+
+    # Save snapshot and archive history BEFORE building trending files
+    _save_snapshot(snapshot_path, current_state, generated_at)
+    _archive_history(history_dir, current_state, generated_at)
+
+    # Build output files
+    build_trending_window(
+        trending_dir, "7d", 7, current_skills, api_dir,
+        prior_7d, first_run, generated_at,
+    )
+    build_trending_window(
+        trending_dir, "30d", 30, current_skills, api_dir,
+        prior_30d, first_run, generated_at,
+    )
+    build_ascended(trending_dir, current_skills, api_dir, generated_at)
+    build_contested(trending_dir, current_skills, api_dir, generated_at)
+
+    print(f"Trending projection written to {trending_dir}/")
+    print(f"  snapshot.json, history/{today}.json")
+    print(f"  7d.json, 30d.json, ascended.json, contested.json")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate docs/api/v1/trending/ static JSON trending projection."
+    )
+    parser.add_argument(
+        "--out-dir",
+        required=True,
+        help="Output directory root (trending/ subdir is written here)",
+    )
+    args = parser.parse_args(argv)
+    rc = run(Path(args.out_dir))
+    sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_trending_script.py
+++ b/tests/test_trending_script.py
@@ -1,0 +1,403 @@
+"""Hermetic tests for scripts/buildTrendingProjection.py.
+
+No network, no git, no real registry.  All fixtures are created in tmp_path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load the script under test without invoking main()
+# ---------------------------------------------------------------------------
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "buildTrendingProjection.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("buildTrendingProjection", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+btp = _load_module()
+
+# ---------------------------------------------------------------------------
+# Helpers for fixture construction
+# ---------------------------------------------------------------------------
+
+
+def _skill(
+    skill_id: str,
+    name: str = "Test Skill",
+    level: str = "2★",
+    tm: float = 10.0,
+    grade: str = "C",
+    generic_ref: str | None = None,
+    timeline: list[dict] | None = None,
+) -> dict:
+    contributor, slug = skill_id.split("/", 1)
+    return {
+        "id": skill_id,
+        "name": name,
+        "level": level,
+        "trustMagnitude": tm,
+        "overallTrustGrade": grade,
+        "contributor": contributor,
+        "type": "basic",
+        "genericSkillRef": generic_ref,
+        "timeline": timeline or [],
+        "_links": {"self": f"/api/v1/skills/{contributor}/{slug}.json"},
+    }
+
+
+def _write_api(tmp_path: Path, skills: list[dict]) -> Path:
+    """Write a minimal docs/api/v1/ layout in tmp_path."""
+    api_dir = tmp_path / "api" / "v1"
+    skills_dir = api_dir / "skills"
+    skills_dir.mkdir(parents=True, exist_ok=True)
+
+    # Write index.json
+    slim = []
+    for s in skills:
+        contributor, slug = s["id"].split("/", 1)
+        slim.append({
+            "id": s["id"],
+            "name": s["name"],
+            "level": s["level"],
+            "trustMagnitude": s["trustMagnitude"],
+            "overallTrustGrade": s["overallTrustGrade"],
+            "contributor": s["contributor"],
+            "type": s["type"],
+            "_links": {"self": f"/api/v1/skills/{contributor}/{slug}.json"},
+        })
+
+    (skills_dir / "index.json").write_text(
+        json.dumps({"skills": slim, "page": 1, "totalPages": 1, "totalSkills": len(slim)}),
+        encoding="utf-8",
+    )
+
+    # Write per-skill detail files
+    for s in skills:
+        contributor, slug = s["id"].split("/", 1)
+        detail_dir = skills_dir / contributor
+        detail_dir.mkdir(exist_ok=True)
+        (detail_dir / f"{slug}.json").write_text(
+            json.dumps(s), encoding="utf-8"
+        )
+
+    return api_dir
+
+
+# ---------------------------------------------------------------------------
+# Test: cold start produces valid JSON with firstRun: true
+# ---------------------------------------------------------------------------
+
+
+def test_cold_start_first_run(tmp_path):
+    skills = [
+        _skill("alice/foo", tm=50.0, grade="B"),
+        _skill("bob/bar", tm=30.0, grade="C"),
+    ]
+    api_dir = _write_api(tmp_path, skills)
+    trending_dir = tmp_path / "trending"
+    trending_dir.mkdir()
+
+    visible = [s for s in skills if not btp.is_redacted(s.get("level", ""))]
+    current_state = {
+        s["id"]: {"tm": s["trustMagnitude"], "grade": s["overallTrustGrade"],
+                  "level": s["level"], "updatedAt": "2026-06-28T12:00:00Z"}
+        for s in visible
+    }
+
+    btp.build_trending_window(
+        trending_dir, "7d", 7, visible, api_dir,
+        current_state,  # cold start: prior = current (all deltas = 0)
+        first_run=True,
+        generated_at="2026-06-28T12:00:00Z",
+    )
+
+    result = json.loads((trending_dir / "7d.json").read_text())
+
+    assert result["firstRun"] is True
+    assert result["window"] == "7d"
+    assert isinstance(result["skills"], list)
+    assert len(result["skills"]) == 2
+    # Cold start: sorted by TM descending
+    assert result["skills"][0]["id"] == "alice/foo"
+    assert result["skills"][1]["id"] == "bob/bar"
+    # All tmDelta should be 0 on cold start
+    for s in result["skills"]:
+        assert s["tmDelta"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Test: skill with positive TM delta appears in trending list
+# ---------------------------------------------------------------------------
+
+
+def test_positive_delta_appears_in_trending(tmp_path):
+    skills = [
+        _skill("alice/foo", tm=60.0, grade="B"),
+    ]
+    api_dir = _write_api(tmp_path, skills)
+    out_dir = tmp_path / "out"
+    trending_dir = out_dir / "trending"
+    trending_dir.mkdir(parents=True)
+
+    prior_snapshot = {
+        "alice/foo": {"tm": 50.0, "grade": "C", "level": "2★", "updatedAt": "2026-06-21T00:00:00Z"}
+    }
+
+    visible = [s for s in skills if not btp.is_redacted(s.get("level", ""))]
+
+    btp.build_trending_window(
+        trending_dir, "7d", 7, visible, api_dir,
+        prior_snapshot,
+        first_run=False,
+        generated_at="2026-06-28T12:00:00Z",
+    )
+
+    result = json.loads((trending_dir / "7d.json").read_text())
+    assert result["firstRun"] is False
+    assert len(result["skills"]) == 1
+    skill = result["skills"][0]
+    assert skill["id"] == "alice/foo"
+    assert skill["trendingScore"] > 0
+    assert skill["tmDelta"] == pytest.approx(10.0, abs=0.01)
+
+
+# ---------------------------------------------------------------------------
+# Test: skill with negative score is excluded
+# ---------------------------------------------------------------------------
+
+
+def test_negative_score_excluded(tmp_path):
+    skills = [
+        _skill("alice/foo", tm=40.0, grade="C"),  # TM dropped from 50 -> 40
+    ]
+    api_dir = _write_api(tmp_path, skills)
+    trending_dir = tmp_path / "trending"
+    trending_dir.mkdir(parents=True)
+
+    prior_snapshot = {
+        "alice/foo": {"tm": 50.0, "grade": "B", "level": "2★", "updatedAt": "2026-06-21T00:00:00Z"}
+    }
+
+    visible = [s for s in skills if not btp.is_redacted(s.get("level", ""))]
+
+    btp.build_trending_window(
+        trending_dir, "7d", 7, visible, api_dir,
+        prior_snapshot,
+        first_run=False,
+        generated_at="2026-06-28T12:00:00Z",
+    )
+
+    result = json.loads((trending_dir / "7d.json").read_text())
+    # Negative delta (-10), no rank events, no evidence → score < 0 → excluded
+    assert result["totalTrending"] == 0
+    assert result["skills"] == []
+
+
+# ---------------------------------------------------------------------------
+# Test: skill absent from prior snapshot gets new: true
+# ---------------------------------------------------------------------------
+
+
+def test_new_skill_flagged(tmp_path):
+    skills = [
+        _skill("alice/foo", tm=50.0, grade="B"),  # existing
+        _skill("bob/new", tm=20.0, grade="C"),    # new (not in prior)
+    ]
+    api_dir = _write_api(tmp_path, skills)
+    trending_dir = tmp_path / "trending"
+    trending_dir.mkdir(parents=True)
+
+    # Only alice/foo in prior; bob/new is new
+    prior_snapshot = {
+        "alice/foo": {"tm": 50.0, "grade": "B", "level": "2★", "updatedAt": "2026-06-21T00:00:00Z"}
+    }
+
+    visible = [s for s in skills if not btp.is_redacted(s.get("level", ""))]
+
+    btp.build_trending_window(
+        trending_dir, "7d", 7, visible, api_dir,
+        prior_snapshot,
+        first_run=False,
+        generated_at="2026-06-28T12:00:00Z",
+    )
+
+    result = json.loads((trending_dir / "7d.json").read_text())
+    ids = {s["id"]: s for s in result["skills"]}
+
+    assert "bob/new" in ids
+    assert ids["bob/new"]["new"] is True
+    assert ids["bob/new"]["trendingScore"] == pytest.approx(20.0 * 0.5, abs=0.01)
+
+    # alice has no delta → not in trending (score=0, excluded)
+    assert "alice/foo" not in ids
+
+
+# ---------------------------------------------------------------------------
+# Test: ascended — skill with rank_up event within window appears
+# ---------------------------------------------------------------------------
+
+
+def test_ascended_rank_up_within_window(tmp_path):
+    recent_ts = (datetime.utcnow() - timedelta(days=5)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    old_ts = (datetime.utcnow() - timedelta(days=60)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    skills = [
+        _skill(
+            "alice/hero",
+            tm=80.0,
+            grade="A",
+            timeline=[
+                {"action": "rank_up", "timestamp": recent_ts, "details": "Promoted"},
+            ],
+        ),
+        _skill(
+            "bob/stale",
+            tm=40.0,
+            grade="C",
+            timeline=[
+                {"action": "rank_up", "timestamp": old_ts, "details": "Old promotion"},
+            ],
+        ),
+    ]
+    api_dir = _write_api(tmp_path, skills)
+    trending_dir = tmp_path / "trending"
+    trending_dir.mkdir(parents=True)
+
+    visible = [s for s in skills if not btp.is_redacted(s.get("level", ""))]
+
+    btp.build_ascended(
+        trending_dir, visible, api_dir,
+        generated_at="2026-06-28T12:00:00Z",
+        window_days=30,
+    )
+
+    result = json.loads((trending_dir / "ascended.json").read_text())
+    ids = [s["id"] for s in result["skills"]]
+
+    assert "alice/hero" in ids
+    assert "bob/stale" not in ids
+
+    hero = next(s for s in result["skills"] if s["id"] == "alice/hero")
+    assert hero["ascendedAt"] == recent_ts
+
+
+# ---------------------------------------------------------------------------
+# Test: contested — bucket with 2 skills on same genericSkillRef appears
+# ---------------------------------------------------------------------------
+
+
+def test_contested_bucket(tmp_path):
+    skills = [
+        _skill("alice/foo", tm=80.0, grade="A", generic_ref="browser-control"),
+        _skill("bob/bar", tm=50.0, grade="B", generic_ref="browser-control"),
+        _skill("carol/baz", tm=30.0, grade="C", generic_ref="unique-skill"),  # solo → excluded
+    ]
+    api_dir = _write_api(tmp_path, skills)
+    trending_dir = tmp_path / "trending"
+    trending_dir.mkdir(parents=True)
+
+    visible = [s for s in skills if not btp.is_redacted(s.get("level", ""))]
+
+    btp.build_contested(
+        trending_dir, visible, api_dir,
+        generated_at="2026-06-28T12:00:00Z",
+    )
+
+    result = json.loads((trending_dir / "contested.json").read_text())
+    refs = [b["genericSkillRef"] for b in result["buckets"]]
+
+    assert "browser-control" in refs
+    assert "unique-skill" not in refs  # only 1 implementation → excluded
+
+    bucket = next(b for b in result["buckets"] if b["genericSkillRef"] == "browser-control")
+    assert bucket["implementations"] == 2
+    assert bucket["topTM"] == pytest.approx(80.0)
+    # Sorted by TM desc within bucket
+    assert bucket["skills"][0]["id"] == "alice/foo"
+    assert bucket["skills"][1]["id"] == "bob/bar"
+
+
+# ---------------------------------------------------------------------------
+# Test: snapshot round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_round_trip(tmp_path):
+    snapshot_path = tmp_path / "snapshot.json"
+    state = {
+        "alice/foo": {"tm": 42.0, "grade": "B", "level": "3★", "updatedAt": "2026-06-28T00:00:00Z"},
+    }
+    btp._save_snapshot(snapshot_path, state, "2026-06-28T00:00:00Z")
+    loaded = btp._load_snapshot(snapshot_path)
+    assert loaded["skills"] == state
+
+
+# ---------------------------------------------------------------------------
+# Test: history pruning keeps only 30 days
+# ---------------------------------------------------------------------------
+
+
+def test_history_prune(tmp_path):
+    history_dir = tmp_path / "history"
+    history_dir.mkdir()
+
+    # Write 35 day-old files + 1 recent
+    now = datetime.utcnow()
+    for i in range(35):
+        date_str = (now - timedelta(days=35 - i)).strftime("%Y-%m-%d")
+        (history_dir / f"{date_str}.json").write_text("{}", encoding="utf-8")
+
+    btp._archive_history(history_dir, {}, "2026-06-28T12:00:00Z")
+
+    remaining = sorted(f.name for f in history_dir.glob("*.json"))
+    # Should have 30 days worth + today
+    assert len(remaining) <= 31  # at most 30 history + today
+
+
+# ---------------------------------------------------------------------------
+# Test: redacted (1-star) skills are excluded everywhere
+# ---------------------------------------------------------------------------
+
+
+def test_redacted_excluded(tmp_path):
+    skills = [
+        _skill("alice/visible", tm=30.0, grade="C", level="2★"),
+        _skill("bob/hidden", tm=99.0, grade="A", level="1★"),  # redacted
+    ]
+    api_dir = _write_api(tmp_path, skills)
+    trending_dir = tmp_path / "trending"
+    trending_dir.mkdir(parents=True)
+
+    visible = [s for s in skills if not btp.is_redacted(s.get("level", ""))]
+
+    # cold start
+    current_state = {
+        s["id"]: {"tm": s["trustMagnitude"], "grade": s["overallTrustGrade"],
+                  "level": s["level"], "updatedAt": "2026-06-28T12:00:00Z"}
+        for s in visible
+    }
+
+    btp.build_trending_window(
+        trending_dir, "7d", 7, visible, api_dir,
+        current_state,
+        first_run=True,
+        generated_at="2026-06-28T12:00:00Z",
+    )
+
+    result = json.loads((trending_dir / "7d.json").read_text())
+    ids = [s["id"] for s in result["skills"]]
+    assert "alice/visible" in ids
+    assert "bob/hidden" not in ids


### PR DESCRIPTION
Implements the B2 trending engine script.

## What
- `scripts/buildTrendingProjection.py`: reads existing TM values from `docs/api/v1/skills/`, computes snapshot-based deltas, writes `docs/api/v1/trending/{7d,30d,ascended,contested,snapshot}.json`
- Snapshot history archive with 30-day rotation
- Cold-start safe (first run seeds snapshot, all deltas=0)
- Uses `is_redacted()` — consistent with `buildApiProjection.py`
- Tests in `tests/test_trending_script.py`

## Constraint
No new scoring. TM values read from existing API projection files as-is.

Resolves #651