### PR TITLE
feat: sticky TOC rail + filter icons

### DIFF
--- a/docs/trust/leaderboard/index.html
+++ b/docs/trust/leaderboard/index.html
@@ -17,9 +17,18 @@
   <script src="../../js/mounts.js?v=5.6.0"></script>
   <script src="../../js/site-nav.js?v=5.6.0"></script>
 
+  <div class="lb-shell">
+    <nav class="lb-toc" aria-label="Page sections">
+      <a href="#lbHero" data-toc="lbHero"><span class="lb-toc-dot"></span><span class="lb-toc-label">Trust Leaderboard</span></a>
+      <a href="#lbSuites" data-toc="lbSuites"><span class="lb-toc-dot"></span><span class="lb-toc-label">Suites</span></a>
+      <a href="#lbNamed" data-toc="lbNamed"><span class="lb-toc-dot"></span><span class="lb-toc-label">Named Skills</span></a>
+      <a href="#lbLedgerInline" data-toc="lbLedgerInline"><span class="lb-toc-dot"></span><span class="lb-toc-label">Trust Ledger</span></a>
+      <a href="#lbGeneric" data-toc="lbGeneric"><span class="lb-toc-dot"></span><span class="lb-toc-label">Starless</span></a>
+      <a href="#lbRegistry" data-toc="lbRegistry"><span class="lb-toc-dot"></span><span class="lb-toc-label">In Registry</span></a>
+    </nav>
   <main class="lb-page">
     <!-- HERO HEADER -->
-    <header class="lb-hero">
+    <header class="lb-hero" id="lbHero">
       <a class="lb-breadcrumb" href="../../codex/trust-methodology.html">← Trust Methodology</a>
       <h1 class="lb-title">Trust Leaderboard</h1>
       <p class="lb-subtitle">Evidence-backed skill rankings across the registry</p>
@@ -61,9 +70,13 @@
           <span class="lb-model-counter">
             <strong id="lbShownCount">—</strong> of <span id="lbTotalCount">—</span> skills
           </span>
-          <input class="lb-skill-search" id="lbSkillSearch" type="search" placeholder="Search skills…" autocomplete="off">
+          <span class="lb-input-icon-wrap">
+            <svg class="lb-btn-icon" aria-hidden="true"><use href="../../assets/icons.svg#search"/></svg>
+            <input class="lb-skill-search" id="lbSkillSearch" type="search" placeholder="Search skills…" autocomplete="off">
+          </span>
           <div class="lb-multiselect" id="lbContribMulti">
             <button class="lb-ms-trigger" id="lbMsTrigger" type="button">
+              <svg class="lb-btn-icon" aria-hidden="true"><use href="../../assets/icons.svg#user"/></svg>
               <span class="lb-ms-label" id="lbMsLabel">Add contributor…</span>
               <span class="lb-ms-arrow">▾</span>
             </button>
@@ -77,13 +90,14 @@
             </div>
           </div>
           <div class="lb-sort-wrap">
+            <svg class="lb-btn-icon" aria-hidden="true"><use href="../../assets/icons.svg#sort-arrows"/></svg>
             <select class="lb-sort-select" id="lbSortSelect">
               <option value="tm">Sort: By TM</option>
               <option value="grade">Sort: By Grade</option>
               <option value="contributor">Sort: By Contributor</option>
             </select>
           </div>
-          <button class="lb-group-toggle" id="lbGroupToggle" title="Toggle grouping of identical-grade skills">⊞ Grouped</button>
+          <button class="lb-group-toggle" id="lbGroupToggle" title="Toggle grouping of identical-grade skills"><svg class="lb-btn-icon" aria-hidden="true"><use href="../../assets/icons.svg#view-tile"/></svg> Grouped</button>
         </div>
       </div>
       <div class="lb-chart-wrap lb-chart-wrap--scrollable" id="lbNamedChart"></div>
@@ -153,6 +167,7 @@
       <a class="lb-cta-link" href="https://github.com/mbtiongson1/gaia-skill-tree/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">Contributing Guide →</a>
     </section>
   </main>
+  </div>
 
   <!-- TOOLTIP (position: fixed, escapes overflow) -->
   <div class="lb-tooltip" id="lbTooltip" hidden aria-hidden="true"></div>

--- a/docs/trust/leaderboard/leaderboard.css
+++ b/docs/trust/leaderboard/leaderboard.css
@@ -11,10 +11,85 @@
 }
 
 /* ── Page container ── */
-.lb-page {
-  max-width: 1320px;
+.lb-shell {
+  max-width: 1540px; /* 1320 page + 220 rail */
   margin: 0 auto;
   padding: 2.5rem 2rem 5rem;
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: 2rem;
+  position: relative;
+}
+
+.lb-page {
+  /* lb-page is now column-2 of the grid */
+  min-width: 0; /* allow grid child to shrink */
+}
+
+/* ── Sticky left-rail Table of Contents (desktop only) ── */
+.lb-toc {
+  position: sticky;
+  top: 80px;
+  align-self: start;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  font-family: var(--font-body);
+  max-height: calc(100vh - 100px);
+  overflow-y: auto;
+}
+
+.lb-toc a {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  text-decoration: none;
+  color: var(--muted);
+  font-size: 0.78rem;
+  padding: 0.15rem 0;
+  transition: color 0.15s;
+  position: relative;
+}
+
+.lb-toc a:hover {
+  color: var(--text);
+}
+
+.lb-toc-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: rgba(var(--evidence-silver-rgb), 0.3);
+  flex-shrink: 0;
+  transition: background 0.2s, transform 0.2s;
+}
+
+.lb-toc a.is-active {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.lb-toc a.is-active .lb-toc-dot {
+  background: var(--text);
+  transform: scale(1.3);
+}
+
+.lb-toc-label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Connector line behind the dots */
+.lb-toc::before {
+  content: '';
+  position: absolute;
+  left: 3px; /* aligns with dot centerline */
+  top: 0.5rem;
+  bottom: 0.5rem;
+  width: 1px;
+  background: rgba(var(--evidence-silver-rgb), 0.12);
+  z-index: -1;
 }
 
 /* ── Hero header ── */
@@ -539,8 +614,18 @@
 }
 
 /* ── Responsive ── */
+@media (max-width: 1023px) {
+  .lb-shell {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+  .lb-toc {
+    display: none;
+  }
+}
+
 @media (max-width: 768px) {
-  .lb-page {
+  .lb-shell {
     padding: 1.5rem 1rem 3rem;
   }
   .lb-hero {
@@ -565,7 +650,7 @@
 }
 
 @media (max-width: 480px) {
-  .lb-page {
+  .lb-shell {
     padding: 1rem 0.75rem 2.5rem;
   }
   .lb-registry-grid {
@@ -932,3 +1017,25 @@
   color: var(--tier-basic);
   text-decoration: underline;
 }
+
+/* ── Filter button icon prefixes ── */
+.lb-btn-icon {
+  width: 12px;
+  height: 12px;
+  vertical-align: middle;
+  flex-shrink: 0;
+  opacity: 0.75;
+}
+
+.lb-sort-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.lb-input-icon-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+

--- a/docs/trust/leaderboard/leaderboard.js
+++ b/docs/trust/leaderboard/leaderboard.js
@@ -385,6 +385,50 @@
 
     // Detect suites (skills with suiteComponents) via detail fetches
     detectSuites(allRows, skillMap);
+
+    // Sticky TOC active-state observer
+    wireTocObserver();
+  }
+
+  // ── STICKY TOC ──
+  function wireTocObserver() {
+    var links = document.querySelectorAll('.lb-toc a');
+    if (!links.length) return;
+    var linkMap = {};
+    links.forEach(function(a) {
+      linkMap[a.getAttribute('data-toc')] = a;
+    });
+
+    // Smooth scroll on click
+    links.forEach(function(a) {
+      a.addEventListener('click', function(e) {
+        e.preventDefault();
+        var id = a.getAttribute('data-toc');
+        var target = document.getElementById(id);
+        if (target) target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      });
+    });
+
+    // Active state via IntersectionObserver
+    var observer = new IntersectionObserver(function(entries) {
+      entries.forEach(function(entry) {
+        var id = entry.target.id;
+        var link = linkMap[id];
+        if (!link) return;
+        if (entry.isIntersecting && entry.intersectionRatio > 0.1) {
+          links.forEach(function(a) { a.classList.remove('is-active'); });
+          link.classList.add('is-active');
+        }
+      });
+    }, {
+      rootMargin: '-30% 0px -60% 0px',
+      threshold: [0, 0.1, 0.25, 0.5]
+    });
+
+    ['lbHero', 'lbSuites', 'lbNamed', 'lbLedgerInline', 'lbGeneric', 'lbRegistry'].forEach(function(id) {
+      var el = document.getElementById(id);
+      if (el) observer.observe(el);
+    });
   }
 
   // ── DISTRIBUTION HEADER ──


### PR DESCRIPTION
Frontend C4 (final commit) of leaderboard iteration pass 2

- Wraps main in .lb-shell grid (220px rail + 1fr content)
- Sticky .lb-toc with 6 anchors + IntersectionObserver active state + connector line
- Hidden below 1024px viewport; single-column on mobile
- Adds small SVG icon prefixes to sort, contributor, group, and search controls

Closes out the AA-iteration pass (C1-C4).