### PR TITLE
fix(leaderboard): restore broken grid layout

### DIFF
--- a/docs/trust/leaderboard/leaderboard.css
+++ b/docs/trust/leaderboard/leaderboard.css
@@ -26,10 +26,22 @@
   min-width: 0; /* allow grid child to shrink */
 }
 
-/* ── Sticky left-rail Table of Contents (desktop only) ── */
-.lb-toc {
+/* ── Sticky left-rail Table of Contents (desktop only) ──
+   Selector must be nav.lb-toc (not .lb-toc) to outweigh the global
+   `nav:not(.footer-cols)` rule in docs/css/styles.css L300, which otherwise
+   forces position:fixed across the top of the viewport and removes the TOC
+   from the grid — collapsing the layout to look single-column.
+   Specificity ties at (0,1,1); leaderboard.css loads after styles.css so it wins.
+   We also explicitly null the inherited fixed/background/border/padding/z-index. */
+nav.lb-toc {
   position: sticky;
   top: 80px;
+  left: auto;
+  right: auto;
+  z-index: auto;
+  background: transparent;
+  border-bottom: 0;
+  padding: 0;
   align-self: start;
   display: flex;
   flex-direction: column;
@@ -619,7 +631,7 @@
     grid-template-columns: 1fr;
     gap: 0;
   }
-  .lb-toc {
+  nav.lb-toc {
     display: none;
   }
 }


### PR DESCRIPTION
## Root cause

Global rule `nav:not(.footer-cols)` in `docs/css/styles.css` L300 (specificity 0,1,1) was outweighing the page-scoped `.lb-toc` rule (0,1,0). It was forcing every `<nav>` on the page (including the leaderboard's left-rail TOC) into `position: fixed; top:0; left:0; right:0; z-index:200; padding:.9rem 2rem; background:var(--bg); border-bottom:...` — yanking the TOC out of the grid and pinning it across the top of the viewport.

Symptoms on `dev/leaderboard-redesign` HEAD = `5c8a08db`:
1. Left-rail TOC rendered at top of page (because it was fixed-positioned).
2. Main column compressed to ~1288px (the 220px grid track was still reserved, so `1fr` got `1540 - 220 - 32 = 1288` instead of the apparent full-width pre-grid layout).

## Fix

`docs/trust/leaderboard/leaderboard.css` only.

- Rename selector `.lb-toc` → `nav.lb-toc` on the main rule (specificity 0,1,1 — ties global rule; leaderboard.css loads after styles.css so the later cascade wins).
- Explicitly null the properties the global rule injected: `left: auto; right: auto; z-index: auto; background: transparent; border-bottom: 0; padding: 0`.
- Update the `@media (max-width: 1023px)` selector to `nav.lb-toc { display: none }` so it keeps winning on mobile.

No JS changes. No HTML changes. No version bump (cache-bust on `?v=5.6.0` should still apply since the file mtime changed; if CF preview is sticky, Marco can hard-refresh).

## Verify

After deploy, hard-refresh https://gaia-skill-tree.marco-tngsn.workers.dev/trust/leaderboard/ and confirm:
1. TOC renders as a sticky column on the LEFT, beside the main content (desktop ≥1024px).
2. Bars/labels in the charts use the full width of the main column (not compressed).
3. At <1024px viewport, TOC disappears (single-column responsive branch).

## Commit
- `855a63f2`