### PR TITLE
fix(leaderboard): filters inside chart panel + slash-id labels + TOC overhaul

### DIFF
--- a/docs/trust/leaderboard/index.html
+++ b/docs/trust/leaderboard/index.html
@@ -19,12 +19,12 @@
 
   <div class="lb-shell">
     <nav class="lb-toc" aria-label="Page sections">
-      <a href="#lbHero" data-toc="lbHero"><span class="lb-toc-dot"></span><span class="lb-toc-label">Trust Leaderboard</span></a>
-      <a href="#lbSuites" data-toc="lbSuites"><span class="lb-toc-dot"></span><span class="lb-toc-label">Suites</span></a>
-      <a href="#lbNamed" data-toc="lbNamed"><span class="lb-toc-dot"></span><span class="lb-toc-label">Named Skills</span></a>
-      <a href="#lbLedgerInline" data-toc="lbLedgerInline"><span class="lb-toc-dot"></span><span class="lb-toc-label">Trust Ledger</span></a>
-      <a href="#lbGeneric" data-toc="lbGeneric"><span class="lb-toc-dot"></span><span class="lb-toc-label">Starless</span></a>
-      <a href="#lbRegistry" data-toc="lbRegistry"><span class="lb-toc-dot"></span><span class="lb-toc-label">In Registry</span></a>
+      <a href="#lbHero" data-toc="lbHero"><svg class="lb-toc-icon" aria-hidden="true"><use href="../../assets/icons.svg#sparkle"/></svg><span class="lb-toc-label">Trust Leaderboard</span></a>
+      <a href="#lbSuites" data-toc="lbSuites"><svg class="lb-toc-icon" aria-hidden="true"><use href="../../assets/icons.svg#view-tile"/></svg><span class="lb-toc-label">Suites</span></a>
+      <a href="#lbNamed" data-toc="lbNamed"><svg class="lb-toc-icon" aria-hidden="true"><use href="../../assets/icons.svg#tier-glyph-unique"/></svg><span class="lb-toc-label">Named Skills</span></a>
+      <a href="#lbLedgerInline" data-toc="lbLedgerInline"><svg class="lb-toc-icon" aria-hidden="true"><use href="../../assets/icons.svg#view-list"/></svg><span class="lb-toc-label">Trust Ledger</span></a>
+      <a href="#lbGeneric" data-toc="lbGeneric"><svg class="lb-toc-icon" aria-hidden="true"><use href="../../assets/icons.svg#view-tree"/></svg><span class="lb-toc-label">Starless</span></a>
+      <a href="#lbRegistry" data-toc="lbRegistry"><svg class="lb-toc-icon" aria-hidden="true"><use href="../../assets/icons.svg#user"/></svg><span class="lb-toc-label">In Registry</span></a>
     </nav>
   <main class="lb-page">
     <!-- HERO HEADER -->
@@ -41,8 +41,12 @@
         <h2 class="lb-section-title">⬡ Suites</h2>
         <span class="lb-section-count" id="lbSuiteCount"></span>
       </div>
-      <p class="lb-section-note">Skills with component bundles — install one, get many.</p>
-      <div class="lb-chart-wrap lb-chart-wrap--scrollable" id="lbSuiteChart"></div>
+      <div class="lb-chart-panel">
+        <div class="lb-panel-header">
+          <p class="lb-panel-note">Skills with component bundles — install one, get many.</p>
+        </div>
+        <div class="lb-chart-wrap lb-chart-wrap--scrollable" id="lbSuiteChart"></div>
+      </div>
     </section>
 
     <!-- ULTIMATES — STACKED VERTICAL BAR CHART -->
@@ -60,47 +64,51 @@
         <h2 class="lb-section-title">◇ Named Skills</h2>
         <span class="lb-section-count" id="lbNamedCount"></span>
       </div>
-      <!-- AA-style per-section controls -->
-      <div class="lb-section-controls" id="lbNamedControls">
-        <div class="lb-typetabs" id="lbTypeTabs" role="tablist" aria-label="Filter by evidence type"></div>
-        <div class="lb-named-dist" id="lbNamedDist">
-          <!-- populated by JS from distribution data -->
-        </div>
-        <div class="lb-section-meta">
-          <span class="lb-model-counter">
-            <strong id="lbShownCount">—</strong> of <span id="lbTotalCount">—</span> skills
-          </span>
-          <span class="lb-input-icon-wrap">
-            <svg class="lb-btn-icon" aria-hidden="true"><use href="../../assets/icons.svg#search"/></svg>
-            <input class="lb-skill-search" id="lbSkillSearch" type="search" placeholder="Search skills…" autocomplete="off">
-          </span>
-          <div class="lb-multiselect" id="lbContribMulti">
-            <button class="lb-ms-trigger" id="lbMsTrigger" type="button">
-              <svg class="lb-btn-icon" aria-hidden="true"><use href="../../assets/icons.svg#user"/></svg>
-              <span class="lb-ms-label" id="lbMsLabel">Add contributor…</span>
-              <span class="lb-ms-arrow">▾</span>
-            </button>
-            <div class="lb-ms-dropdown" id="lbMsDropdown" hidden>
-              <input class="lb-ms-search" id="lbMsSearch" type="search" placeholder="Search…" autocomplete="off">
-              <div class="lb-ms-list" id="lbMsList"></div>
-              <div class="lb-ms-footer">
-                <button class="lb-ms-clear-all" id="lbMsClearAll" type="button">Clear all</button>
-                <span class="lb-ms-selected-count" id="lbMsCount"></span>
+      <!-- Chart panel: tabs + filters live INSIDE the panel -->
+      <div class="lb-chart-panel">
+        <div class="lb-panel-header">
+          <div class="lb-typetabs" id="lbTypeTabs" role="tablist" aria-label="Filter by evidence type"></div>
+          <div class="lb-panel-filters" id="lbNamedControls">
+            <div class="lb-named-dist" id="lbNamedDist">
+              <!-- populated by JS from distribution data -->
+            </div>
+            <div class="lb-section-meta">
+              <span class="lb-model-counter">
+                <strong id="lbShownCount">—</strong> of <span id="lbTotalCount">—</span> skills
+              </span>
+              <span class="lb-input-icon-wrap">
+                <svg class="lb-btn-icon" aria-hidden="true"><use href="../../assets/icons.svg#search"/></svg>
+                <input class="lb-skill-search" id="lbSkillSearch" type="search" placeholder="Search skills…" autocomplete="off">
+              </span>
+              <div class="lb-multiselect" id="lbContribMulti">
+                <button class="lb-ms-trigger" id="lbMsTrigger" type="button">
+                  <svg class="lb-btn-icon" aria-hidden="true"><use href="../../assets/icons.svg#user"/></svg>
+                  <span class="lb-ms-label" id="lbMsLabel">Add contributor…</span>
+                  <span class="lb-ms-arrow">▾</span>
+                </button>
+                <div class="lb-ms-dropdown" id="lbMsDropdown" hidden>
+                  <input class="lb-ms-search" id="lbMsSearch" type="search" placeholder="Search…" autocomplete="off">
+                  <div class="lb-ms-list" id="lbMsList"></div>
+                  <div class="lb-ms-footer">
+                    <button class="lb-ms-clear-all" id="lbMsClearAll" type="button">Clear all</button>
+                    <span class="lb-ms-selected-count" id="lbMsCount"></span>
+                  </div>
+                </div>
               </div>
+              <div class="lb-sort-wrap">
+                <svg class="lb-btn-icon" aria-hidden="true"><use href="../../assets/icons.svg#sort-arrows"/></svg>
+                <select class="lb-sort-select" id="lbSortSelect">
+                  <option value="tm">Sort: By TM</option>
+                  <option value="grade">Sort: By Grade</option>
+                  <option value="contributor">Sort: By Contributor</option>
+                </select>
+              </div>
+              <button class="lb-group-toggle" id="lbGroupToggle" title="Toggle grouping of identical-grade skills"><svg class="lb-btn-icon" aria-hidden="true"><use href="../../assets/icons.svg#view-tile"/></svg> Grouped</button>
             </div>
           </div>
-          <div class="lb-sort-wrap">
-            <svg class="lb-btn-icon" aria-hidden="true"><use href="../../assets/icons.svg#sort-arrows"/></svg>
-            <select class="lb-sort-select" id="lbSortSelect">
-              <option value="tm">Sort: By TM</option>
-              <option value="grade">Sort: By Grade</option>
-              <option value="contributor">Sort: By Contributor</option>
-            </select>
-          </div>
-          <button class="lb-group-toggle" id="lbGroupToggle" title="Toggle grouping of identical-grade skills"><svg class="lb-btn-icon" aria-hidden="true"><use href="../../assets/icons.svg#view-tile"/></svg> Grouped</button>
         </div>
+        <div class="lb-chart-wrap lb-chart-wrap--scrollable" id="lbNamedChart"></div>
       </div>
-      <div class="lb-chart-wrap lb-chart-wrap--scrollable" id="lbNamedChart"></div>
       <div class="lb-show-more" id="lbShowMore">
         <button class="lb-show-more-btn" id="lbShowMoreBtn" type="button">Show more</button>
       </div>
@@ -111,7 +119,6 @@
         </button>
         <div class="lb-tm-body" id="lbTmBody" hidden></div>
       </section>
-      <p class="lb-chart-caption">Origin skills carry a laurel wreath under the contributor handle.</p>
       <!-- Inline ledger table -->
       <div class="lb-ledger-inline" id="lbLedgerInline">
         <div class="lb-ledger-head">
@@ -144,8 +151,12 @@
         <h2 class="lb-section-title lb-section-title--muted">◎ Starless</h2>
         <span class="lb-section-count" id="lbGenericCount"></span>
       </div>
-      <p class="lb-section-note">Generic skill nodes · each bar = one capability, segments = named implementations</p>
-      <div class="lb-chart-wrap lb-chart-wrap--scrollable" id="lbGenericChart"></div>
+      <div class="lb-chart-panel">
+        <div class="lb-panel-header">
+          <p class="lb-panel-note">Generic skill nodes · each bar = one capability, segments = named implementations</p>
+        </div>
+        <div class="lb-chart-wrap lb-chart-wrap--scrollable" id="lbGenericChart"></div>
+      </div>
     </section>
 
     <!-- IN REGISTRY — COMPACT LIST -->

--- a/docs/trust/leaderboard/leaderboard.css
+++ b/docs/trust/leaderboard/leaderboard.css
@@ -35,73 +35,62 @@
    We also explicitly null the inherited fixed/background/border/padding/z-index. */
 nav.lb-toc {
   position: sticky;
-  top: 80px;
+  top: 140px;
   left: auto;
   right: auto;
   z-index: auto;
   background: transparent;
   border-bottom: 0;
-  padding: 0;
+  padding: 0.5rem 0;
   align-self: start;
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
+  gap: 0.15rem;
   font-family: var(--font-body);
-  max-height: calc(100vh - 100px);
+  max-height: calc(100vh - 160px);
   overflow-y: auto;
 }
 
-.lb-toc a {
+nav.lb-toc a {
   display: flex;
   align-items: center;
-  gap: 0.65rem;
+  gap: 0.6rem;
   text-decoration: none;
   color: var(--muted);
-  font-size: 0.78rem;
-  padding: 0.15rem 0;
-  transition: color 0.15s;
+  font-size: 0.8rem;
+  padding: 0.4rem 0.65rem;
+  border-radius: 6px;
+  border-left: 2px solid transparent;
+  transition: color 0.15s, background 0.15s, border-color 0.15s;
   position: relative;
 }
 
-.lb-toc a:hover {
+nav.lb-toc a:hover {
   color: var(--text);
+  background: rgba(var(--evidence-silver-rgb), 0.04);
 }
 
-.lb-toc-dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: rgba(var(--evidence-silver-rgb), 0.3);
+.lb-toc-icon {
+  width: 14px;
+  height: 14px;
   flex-shrink: 0;
-  transition: background 0.2s, transform 0.2s;
+  opacity: 0.6;
+  transition: opacity 0.15s;
 }
+nav.lb-toc a:hover .lb-toc-icon { opacity: 0.95; }
 
-.lb-toc a.is-active {
+nav.lb-toc a.is-active {
   color: var(--text);
   font-weight: 600;
+  background: rgba(var(--evidence-silver-rgb), 0.07);
+  border-left-color: var(--text);
 }
-
-.lb-toc a.is-active .lb-toc-dot {
-  background: var(--text);
-  transform: scale(1.3);
-}
+nav.lb-toc a.is-active .lb-toc-icon { opacity: 1; }
 
 .lb-toc-label {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-/* Connector line behind the dots */
-.lb-toc::before {
-  content: '';
-  position: absolute;
-  left: 3px; /* aligns with dot centerline */
-  top: 0.5rem;
-  bottom: 0.5rem;
-  width: 1px;
-  background: rgba(var(--evidence-silver-rgb), 0.12);
-  z-index: -1;
 }
 
 /* ── Hero header ── */
@@ -226,6 +215,55 @@ nav.lb-toc {
   color: var(--muted);
   margin: -0.75rem 0 1.5rem;
   font-style: italic;
+}
+
+/* ── Chart panel — wraps header (tabs/filters/note) + chart in one bordered box ── */
+.lb-chart-panel {
+  background: rgba(var(--evidence-silver-rgb), 0.015);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+.lb-chart-panel .lb-chart-wrap {
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  padding: 1.25rem 0 1rem;
+}
+.lb-chart-panel .lb-chart-wrap--scrollable {
+  overflow-x: auto;
+}
+
+.lb-panel-header {
+  padding: 0.85rem 1.1rem 0.85rem;
+  border-bottom: 1px solid var(--border);
+  background: rgba(var(--evidence-silver-rgb), 0.025);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.lb-panel-note {
+  margin: 0;
+  font-family: var(--font-body);
+  font-size: 0.82rem;
+  color: var(--muted);
+  font-style: italic;
+}
+
+.lb-panel-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+  justify-content: space-between;
+}
+.lb-panel-filters .lb-named-dist {
+  margin-bottom: 0;
+  flex: 1 1 auto;
+}
+.lb-panel-filters .lb-section-meta {
+  flex: 0 0 auto;
 }
 
 /* ── AA-style per-section controls ── */
@@ -940,14 +978,6 @@ nav.lb-toc {
   opacity: 0.7;
 }
 
-/* ── Chart caption (origin laurel wreath explainer) ── */
-.lb-chart-caption {
-  font-size: 0.78rem;
-  color: var(--muted);
-  margin-top: 0.5rem;
-  font-style: italic;
-}
-
 /* ── Evidence-type filter tabs (above Named chart) ── */
 .lb-typetabs {
   display: flex;
@@ -956,8 +986,12 @@ nav.lb-toc {
   border: 1px solid var(--border);
   border-radius: 6px;
   overflow: hidden;
-  margin-bottom: 1rem;
   align-self: stretch;
+  background: rgba(var(--evidence-silver-rgb), 0.02);
+}
+.lb-typetabs .lb-stab {
+  font-size: 0.72rem;
+  padding: 0.3rem 0.65rem;
 }
 
 /* ── Trust Magnitude methodology accordion (below Named chart) ── */

--- a/docs/trust/leaderboard/leaderboard.js
+++ b/docs/trust/leaderboard/leaderboard.js
@@ -258,15 +258,27 @@
   }
 
   // ── ORIGIN BADGE HELPER ──
-  // Renders a small laurel-wreath glyph under a contributor avatar to mark origin skills.
+  // Renders a small laurel-wreath glyph in the top-left interior of a bar to mark origin skills.
+  // Anchored to (barX, barY, barW); badge sits inside the bar, never overlapping labels below.
   // Uses currentColor + color: var(--honor-red) so we avoid hardcoding hex (CI guard).
-  function appendOriginBadge(parent, cx, cy) {
+  function appendOriginBadge(parent, barX, barY, barW) {
+    var size = Math.max(10, Math.min(14, barW * 0.45));
+    var margin = 3;
+    // Soft dark scrim behind the glyph so it stays legible against light bars
+    var scrim = svgEl('circle', {
+      cx: barX + margin + size / 2,
+      cy: barY + margin + size / 2,
+      r: String(size / 2 + 1.5),
+      fill: 'rgba(0,0,0,0.45)',
+      'pointer-events': 'none'
+    });
+    parent.appendChild(scrim);
     var u = document.createElementNS(SVG_NS, 'use');
     u.setAttribute('href', '../../assets/icons.svg#origin-badge');
-    u.setAttribute('x', String(cx - 6));
-    u.setAttribute('y', String(cy - 6));
-    u.setAttribute('width', '12');
-    u.setAttribute('height', '12');
+    u.setAttribute('x', String(barX + margin));
+    u.setAttribute('y', String(barY + margin));
+    u.setAttribute('width', String(size));
+    u.setAttribute('height', String(size));
     u.setAttribute('fill', 'currentColor');
     u.setAttribute('color', 'var(--honor-red)');
     u.setAttribute('pointer-events', 'none');
@@ -391,12 +403,19 @@
   }
 
   // ── STICKY TOC ──
+  // Scroll-driven active state: the active section is the last one whose top
+  // is above the viewport's 30% line. Robust across very tall sections (Named)
+  // and very short ones (CTA/Registry) where IntersectionObserver thresholds
+  // would otherwise miss the transition.
   function wireTocObserver() {
     var links = document.querySelectorAll('.lb-toc a');
     if (!links.length) return;
     var linkMap = {};
+    var ids = [];
     links.forEach(function(a) {
-      linkMap[a.getAttribute('data-toc')] = a;
+      var id = a.getAttribute('data-toc');
+      linkMap[id] = a;
+      ids.push(id);
     });
 
     // Smooth scroll on click
@@ -409,26 +428,40 @@
       });
     });
 
-    // Active state via IntersectionObserver
-    var observer = new IntersectionObserver(function(entries) {
-      entries.forEach(function(entry) {
-        var id = entry.target.id;
-        var link = linkMap[id];
-        if (!link) return;
-        if (entry.isIntersecting && entry.intersectionRatio > 0.1) {
-          links.forEach(function(a) { a.classList.remove('is-active'); });
-          link.classList.add('is-active');
-        }
-      });
-    }, {
-      rootMargin: '-30% 0px -60% 0px',
-      threshold: [0, 0.1, 0.25, 0.5]
-    });
+    function setActive(id) {
+      links.forEach(function(a) { a.classList.remove('is-active'); });
+      if (linkMap[id]) linkMap[id].classList.add('is-active');
+    }
 
-    ['lbHero', 'lbSuites', 'lbNamed', 'lbLedgerInline', 'lbGeneric', 'lbRegistry'].forEach(function(id) {
-      var el = document.getElementById(id);
-      if (el) observer.observe(el);
-    });
+    function recompute() {
+      var anchorY = window.innerHeight * 0.30; // activation line ~30% from top
+      var current = ids[0];
+      for (var i = 0; i < ids.length; i++) {
+        var el = document.getElementById(ids[i]);
+        if (!el) continue;
+        var rect = el.getBoundingClientRect();
+        if (rect.top - anchorY <= 0) {
+          current = ids[i];
+        } else {
+          break;
+        }
+      }
+      setActive(current);
+    }
+
+    var ticking = false;
+    function onScroll() {
+      if (ticking) return;
+      ticking = true;
+      window.requestAnimationFrame(function() {
+        recompute();
+        ticking = false;
+      });
+    }
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onScroll, { passive: true });
+    recompute();
   }
 
   // ── DISTRIBUTION HEADER ──
@@ -884,15 +917,15 @@
       });
       barGroup.appendChild(avatarImg);
 
-      // Origin laurel-wreath badge (pre-baked by C1)
+      // Origin laurel-wreath badge (pre-baked by C1) — top-left interior of bar
       if (suite.origin === true) {
-        appendOriginBadge(barGroup, avatarCx, avatarCy + avatarR + 10);
+        appendOriginBadge(barGroup, x, y, SB);
       }
 
-      // Skill name label (adaptive rotation/font/truncation)
+      // Skill name label (slash-named form: contributor/skill, adaptive rotation/font/truncation)
       var labelY = innerH + avatarR * 2 + 14;
       var label = makeLabel(x + SB / 2, labelY, ls.rotation, ls.fontPx);
-      truncLabel(label, suite.name || suite.id.split('/')[1], ls.maxChars);
+      truncLabel(label, suite.id || suite.name, Math.max(ls.maxChars, 14));
       barGroup.appendChild(label);
 
       // Contributor handle (placed below name label, with extra space if rotated)
@@ -1314,15 +1347,15 @@
       });
       barGroup.appendChild(avatarImg);
 
-      // Origin laurel-wreath badge (pre-baked by C1)
+      // Origin laurel-wreath badge (pre-baked by C1) — top-left interior of bar
       if (skill.origin === true) {
-        appendOriginBadge(barGroup, avatarCx, avatarCy + avatarR + 10);
+        appendOriginBadge(barGroup, x, y, NB);
       }
 
-      // Skill name label (adaptive rotation/font/truncation)
+      // Skill name label (slash-named form: contributor/skill, adaptive rotation/font/truncation)
       var labelY = innerH + avatarR * 2 + 14;
       var label = makeLabel(x + NB / 2, labelY, ls.rotation, ls.fontPx);
-      truncLabel(label, skill.id.split('/')[1] || skill.name, ls.maxChars);
+      truncLabel(label, skill.id, Math.max(ls.maxChars, 14));
       barGroup.appendChild(label);
     });
 
@@ -1362,8 +1395,8 @@
     var countEl = document.getElementById('lbGenericCount');
     if (!container) return;
 
-    var GPAD = { top: 24, right: 24, bottom: 0, left: 54 }; // bottom computed below
-    var GCHART_H = 320;
+    var GPAD = { top: 28, right: 24, bottom: 0, left: 54 }; // bottom computed below
+    var GCHART_H = 440;
 
     if (countEl) countEl.textContent = nodes.length + ' generic skills \u00B7 ' +
       nodes.reduce(function(s, n) { return s + (n._children ? n._children.length : 0); }, 0) + ' named implementations';
@@ -1373,9 +1406,9 @@
       return;
     }
 
-    // Fix 7: pagination — when N > 50, show first 20 with toggle.
-    var PAGINATION_THRESHOLD_GEN = 50;
-    var PAGINATION_INITIAL_GEN = 20;
+    // Fix 7: pagination — initial slice is smaller so each bar has room to breathe.
+    var PAGINATION_THRESHOLD_GEN = 30;
+    var PAGINATION_INITIAL_GEN = 12;
     var needsPaginationGen = nodes.length > PAGINATION_THRESHOLD_GEN;
     var allNodes = nodes;
     var displayNodes = (needsPaginationGen && !state.genericExpanded) ? nodes.slice(0, PAGINATION_INITIAL_GEN) : nodes;
@@ -1383,20 +1416,20 @@
     var maxTM = Math.max.apply(null, displayNodes.map(function(n) { return n.trustMagnitude || 0; }));
     maxTM = Math.max(maxTM, 10);
 
-    // Fix 1: dynamic bar metrics
-    var metrics = computeBarMetrics(displayNodes.length, chartContainerW(), GPAD.left, GPAD.right, 8, 22, 0.4);
+    // Fix 1: dynamic bar metrics — larger min bar width for readability
+    var metrics = computeBarMetrics(displayNodes.length, chartContainerW(), GPAD.left, GPAD.right, 22, 56, 0.5);
     var GB = metrics.barW;
     var GG = metrics.gap;
     var barSpacing = GB + GG;
 
-    // Fix 2: adaptive label style
+    // Fix 2: adaptive label style — bumped minimum font sizes for readability
     var ls = labelStyleFor(barSpacing);
-    var childFontPx = Math.max(7, ls.fontPx - 2);
-    var childMaxChars = Math.max(6, ls.maxChars - 4);
+    var childFontPx = Math.max(9, ls.fontPx - 1);
+    var childMaxChars = Math.max(8, ls.maxChars - 2);
     var childLines = 4;
 
     // Fix 3: bottom padding = rotated name label + child label stack
-    GPAD.bottom = computeBottomPad(ls.rotation, 1, ls.fontPx) + childLines * (childFontPx + 3) + 16;
+    GPAD.bottom = computeBottomPad(ls.rotation, 1, ls.fontPx) + childLines * (childFontPx + 3) + 20;
 
     var totalW = Math.max(metrics.totalW, 320);
     var innerH = GCHART_H - GPAD.top - GPAD.bottom;
@@ -1512,10 +1545,9 @@
       var rotatedLabelH = Math.abs(Math.sin(ls.rotation * Math.PI / 180)) * ls.fontPx * 14;
       var childStartY = nameY + rotatedLabelH + 4;
 
-      // Origin laurel-wreath badge for parent generic node (pre-baked by C1)
+      // Origin laurel-wreath badge for parent generic node (pre-baked by C1) — top-left interior of bar
       if (node.origin === true) {
-        appendOriginBadge(barGroup, x + GB / 2, childStartY - 8);
-        childStartY += 8;
+        appendOriginBadge(barGroup, x, y, GB);
       }
 
       var shownChildren = children.slice(0, 3);


### PR DESCRIPTION
Marco's iteration pass 3 — direct from orchestrator, not subagent.

## Changes

### Filters & tabs INSIDE the chart panel
New `.lb-chart-panel` wraps the per-section header (tabs + filter row) with the chart itself in one bordered container. Applied to Suites, Named, and Starless.

### Slash-skill labels on bars
Bar x-labels now show the canonical `contributor/skill` slash-id (e.g. `mattpocock/build-a-suspense-component`) instead of the raw display title.

### Origin badge into bar interior
Laurel wreath now lives in the **top-left of the bar**, with a soft dark scrim disc behind it. No more overlap with the skill title. Caption removed — the badge is self-evident in context.

### Starless readable
Min bar width 8→22, min font 7px→9px, chart height 320→440, pagination initial 20→12.

### Left rail TOC
Sticky top 80→140, dots → inline section icons (sparkle/view-tile/tier-glyph-unique/view-list/view-tree/user), left-border active state, scroll-driven recompute observer (every header reliably highlights now).

## Verify
1. Tabs + filters live INSIDE the bordered Named-chart panel.
2. Bar labels read like `gstack/office-hours`.
3. Wreath sits at the bar top-left interior, not overlapping titles.
4. Starless is readable end-to-end at first glance.
5. TOC active state transitions smoothly across every section.