### PR TITLE
fix(leaderboard): 10 superadmin nitpicks

### DIFF
--- a/docs/trust/leaderboard/index.html
+++ b/docs/trust/leaderboard/index.html
@@ -108,17 +108,22 @@
           </div>
         </div>
         <div class="lb-chart-wrap lb-chart-wrap--scrollable" id="lbNamedChart"></div>
+        <div class="lb-origin-tip" aria-label="About origin skills">
+          <svg class="lb-origin-tip-icon" aria-hidden="true"><use href="../../assets/icons.svg#origin-badge"/></svg>
+          <span><strong>Origin skills</strong> — the canonical implementation by the contributor who first published the technique. Marked with the laurel-wreath inside the bar.</span>
+        </div>
+        <section class="lb-tm-accordion" id="lbTmAccordion" aria-label="Trust Magnitude methodology">
+          <button class="lb-tm-toggle" id="lbTmToggle" type="button" aria-expanded="false">
+            <svg class="lb-tm-info" aria-hidden="true"><use href="../../assets/icons.svg#info"/></svg>
+            <span class="lb-tm-label">Trust Magnitude methodology</span>
+            <svg class="lb-tm-plus" aria-hidden="true" viewBox="0 0 16 16"><line x1="8" y1="2" x2="8" y2="14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><line x1="2" y1="8" x2="14" y2="8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
+          </button>
+          <div class="lb-tm-body" id="lbTmBody" hidden></div>
+        </section>
       </div>
       <div class="lb-show-more" id="lbShowMore">
         <button class="lb-show-more-btn" id="lbShowMoreBtn" type="button">Show more</button>
       </div>
-      <section class="lb-tm-accordion" id="lbTmAccordion" aria-label="Trust Magnitude methodology">
-        <button class="lb-tm-toggle" id="lbTmToggle" type="button" aria-expanded="false">
-          <span class="lb-tm-glyph" aria-hidden="true">+</span>
-          <span class="lb-tm-label">Trust Magnitude methodology</span>
-        </button>
-        <div class="lb-tm-body" id="lbTmBody" hidden></div>
-      </section>
       <!-- Inline ledger table -->
       <div class="lb-ledger-inline" id="lbLedgerInline">
         <div class="lb-ledger-head">

--- a/docs/trust/leaderboard/leaderboard.css
+++ b/docs/trust/leaderboard/leaderboard.css
@@ -397,6 +397,7 @@ nav.lb-toc a.is-active .lb-toc-icon { opacity: 1; }
 
 .lb-chart-wrap svg {
   display: block;
+  transition: height 0.35s ease;
 }
 
 /* ── SVG bar styling (applied via JS classes) ── */
@@ -435,6 +436,13 @@ nav.lb-toc a.is-active .lb-toc-icon { opacity: 1; }
   fill: var(--muted);
 }
 
+/* Skill-name (slash-id) labels — the rotated x-axis bar labels — are white. */
+.lb-axis-label--name {
+  fill: rgba(255, 255, 255, 0.92);
+  font-family: var(--font-data);
+  font-weight: 500;
+}
+
 .lb-axis-value {
   font-family: var(--font-data);
   font-size: 10px;
@@ -442,6 +450,14 @@ nav.lb-toc a.is-active .lb-toc-icon { opacity: 1; }
   opacity: 0.6;
   font-variant-numeric: tabular-nums;
   letter-spacing: -0.01em;
+}
+
+/* In-bar TM number — always pure white, full opacity. Higher specificity beats
+   the base .lb-axis-value muted color so the inline number stays readable. */
+.lb-axis-value.lb-axis-value--inbar {
+  fill: rgb(255, 255, 255);
+  opacity: 1;
+  font-weight: 600;
 }
 
 .lb-gridline {
@@ -978,72 +994,128 @@ nav.lb-toc a.is-active .lb-toc-icon { opacity: 1; }
   opacity: 0.7;
 }
 
-/* ── Evidence-type filter tabs (above Named chart) ── */
+/* ── Evidence-type filter tabs (above Named chart) ──
+   Serif text-link style — no pill chrome. Active link underlined. */
 .lb-typetabs {
   display: flex;
   flex-wrap: wrap;
-  gap: 0;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  overflow: hidden;
+  gap: 0.5rem 1.1rem;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
   align-self: stretch;
-  background: rgba(var(--evidence-silver-rgb), 0.02);
+  padding: 0.15rem 0;
 }
 .lb-typetabs .lb-stab {
-  font-size: 0.72rem;
-  padding: 0.3rem 0.65rem;
+  font-family: var(--font-display);
+  font-size: 0.92rem;
+  font-weight: 400;
+  letter-spacing: 0;
+  padding: 0.15rem 0;
+  background: transparent;
+  border: 0;
+  color: var(--muted);
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+  border-bottom: 1px solid transparent;
+  white-space: nowrap;
+}
+.lb-typetabs .lb-stab:hover {
+  color: var(--text);
+  background: transparent;
+  border-bottom-color: rgba(var(--evidence-silver-rgb), 0.4);
+}
+.lb-typetabs .lb-stab.is-active {
+  color: var(--text);
+  background: transparent;
+  font-weight: 500;
+  font-style: italic;
+  border-bottom-color: var(--text);
 }
 
-/* ── Trust Magnitude methodology accordion (below Named chart) ── */
+/* ── Trust Magnitude methodology accordion (in-panel) ── */
 .lb-tm-accordion {
-  margin-top: 1.5rem;
+  margin: 0;
+  border: 0;
+  padding: 0.85rem 1.1rem 0.95rem;
   border-top: 1px solid var(--border);
-  padding-top: 1rem;
+  background: rgba(var(--evidence-silver-rgb), 0.025);
 }
 .lb-tm-toggle {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.6rem;
   background: transparent;
-  border: none;
+  border: 0;
   color: var(--text);
-  font-family: var(--font-body);
-  font-size: 0.9rem;
+  font-family: var(--font-display);
+  font-size: 0.95rem;
   font-weight: 500;
   cursor: pointer;
-  padding: 0.4rem 0;
+  padding: 0;
   width: 100%;
   text-align: left;
+  letter-spacing: 0;
 }
-.lb-tm-toggle:hover {
-  color: var(--tier-basic);
+.lb-tm-toggle .lb-tm-info {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  opacity: 0.75;
+  color: var(--muted);
 }
-.lb-tm-glyph {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 18px;
-  height: 18px;
-  border: 1px solid var(--border);
-  border-radius: 50%;
-  font-family: var(--font-data);
-  font-size: 0.85rem;
-  font-weight: 400;
-  line-height: 1;
+.lb-tm-toggle .lb-tm-label {
+  flex: 1 1 auto;
+}
+.lb-tm-toggle .lb-tm-plus {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  transform-origin: center;
+  transition: transform 0.3s ease;
+  color: var(--muted);
+}
+.lb-tm-toggle:hover { color: var(--tier-basic); }
+.lb-tm-toggle:hover .lb-tm-info,
+.lb-tm-toggle:hover .lb-tm-plus { color: var(--text); opacity: 1; }
+.lb-tm-accordion.is-open .lb-tm-plus {
+  transform: rotate(45deg); /* + → × via a 45° rotation */
 }
 .lb-tm-body {
   max-height: 0;
   overflow: hidden;
-  transition: max-height 0.3s ease, padding 0.3s ease;
+  transition: max-height 0.35s ease, padding 0.35s ease, opacity 0.25s ease;
   padding: 0;
   font-family: var(--font-body);
   font-size: 0.85rem;
   color: var(--muted);
   line-height: 1.55;
+  opacity: 0;
 }
 .lb-tm-accordion.is-open .lb-tm-body {
   max-height: 800px;
-  padding: 1rem 0;
+  padding: 0.85rem 0 0.15rem;
+  opacity: 1;
+}
+
+/* Origin tip — single line above the methodology toggle, with the laurel-wreath icon */
+.lb-origin-tip {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.65rem 1.1rem 0.7rem;
+  border-top: 1px solid var(--border);
+  background: rgba(var(--evidence-silver-rgb), 0.02);
+  font-family: var(--font-body);
+  font-size: 0.78rem;
+  color: var(--muted);
+  font-style: italic;
+}
+.lb-origin-tip-icon {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  color: var(--honor-red);
 }
 .lb-tm-types {
   list-style: none;

--- a/docs/trust/leaderboard/leaderboard.js
+++ b/docs/trust/leaderboard/leaderboard.js
@@ -179,7 +179,7 @@
       attrs = {
         x: x, y: y,
         'text-anchor': 'middle',
-        'class': 'lb-axis-label',
+        'class': 'lb-axis-label lb-axis-label--name',
         'font-size': String(fontPx)
       };
     } else {
@@ -188,7 +188,7 @@
         x: 0, y: 0,
         transform: 'translate(' + x + ',' + y + ') rotate(' + rotation + ')',
         'text-anchor': anchor,
-        'class': 'lb-axis-label',
+        'class': 'lb-axis-label lb-axis-label--name',
         'font-size': String(fontPx)
       };
     }
@@ -244,17 +244,36 @@
     parent.appendChild(cap);
   }
 
-  // ── WATERMARK HELPER ──
-  // Renders the seal-diamond-wordmark glyph faintly in the top-right of a chart SVG.
+  // ── WATERMARK + UPDATED BADGE HELPERS ──
+  // Watermark — seal+wordmark, top-right; visible but unobtrusive.
   function appendWatermark(svg, totalW) {
     var u = document.createElementNS(SVG_NS, 'use');
     u.setAttribute('href', '../../assets/icons.svg#seal-diamond-wordmark');
-    u.setAttribute('x', String(totalW - 95));
-    u.setAttribute('y', '6');
-    u.setAttribute('width', '75');
-    u.setAttribute('opacity', '0.18');
+    var W = 110;
+    u.setAttribute('x', String(totalW - W - 14));
+    u.setAttribute('y', '8');
+    u.setAttribute('width', String(W));
+    u.setAttribute('height', '40');
+    u.setAttribute('opacity', '0.42');
     u.setAttribute('pointer-events', 'none');
     svg.appendChild(u);
+  }
+
+  // "Updated YYYY-MM-DD" tag in apex-gold, top-left interior of each chart SVG.
+  function appendUpdatedBadge(svg, dateStr) {
+    if (!dateStr) return;
+    var g = svgEl('g', { 'pointer-events': 'none', transform: 'translate(14, 22)' });
+    var t = svgEl('text', {
+      x: 0, y: 0,
+      'font-family': 'var(--font-data)',
+      'font-size': '10',
+      'letter-spacing': '0.06em',
+      style: 'fill: var(--apex-gold); opacity: 0.95; pointer-events: none',
+      'font-weight': '600'
+    });
+    t.textContent = 'UPDATED ' + dateStr;
+    g.appendChild(t);
+    svg.appendChild(g);
   }
 
   // ── ORIGIN BADGE HELPER ──
@@ -318,7 +337,8 @@
     genericExpanded: false,
     skillSearchQuery: '',
     evidenceType: 'all',
-    tmMethodologyOpen: false
+    tmMethodologyOpen: false,
+    updatedDate: ''
   };
 
   // ── DATA FETCH (parallel) ──
@@ -342,6 +362,11 @@
       if (!page || !page.skills) return;
       page.skills.forEach(function(s) { skillMap[s.id] = s; });
     });
+
+    // Stamp the "Updated" date (apex-gold tag in every chart).
+    if (leaderboard.generatedAt) {
+      state.updatedDate = leaderboard.generatedAt.slice(0, 10); // YYYY-MM-DD
+    }
 
     // Enrich leaderboard rows
     var allRows = leaderboard.rows.map(function(row) {
@@ -618,6 +643,7 @@
     svg.appendChild(defs);
 
     appendWatermark(svg, totalW);
+    appendUpdatedBadge(svg, state.updatedDate);
 
     // Build per-bar gradients
     ultimates.forEach(function(ult, i) {
@@ -659,7 +685,7 @@
           x: x + UB / 2,
           y: y + h / 2 + 4,
           'text-anchor': 'middle',
-          'class': 'lb-axis-value',
+          'class': 'lb-axis-value lb-axis-value--inbar',
           'font-size': String(Math.max(10, ls.fontPx + 1)),
           fill: 'rgba(255, 255, 255, 0.95)',
           'font-weight': '600'
@@ -826,6 +852,7 @@
     svg.appendChild(defs);
 
     appendWatermark(svg, totalW);
+    appendUpdatedBadge(svg, state.updatedDate);
 
     // Build per-bar gradients
     visible.forEach(function(suite, i) {
@@ -883,7 +910,7 @@
         var tmText = svgEl('text', {
           x: x + SB / 2, y: y + h / 2 + 4,
           'text-anchor': 'middle',
-          'class': 'lb-axis-value', 'font-size': String(Math.max(9, ls.fontPx + 1)),
+          'class': 'lb-axis-value lb-axis-value--inbar', 'font-size': String(Math.max(9, ls.fontPx + 1)),
           fill: 'rgba(255, 255, 255, 0.95)',
           'font-weight': '600'
         });
@@ -1196,17 +1223,34 @@
     var maxTM = Math.max.apply(null, toShow.map(function(s) { return tmForType(s, state.evidenceType); }));
     maxTM = Math.max(maxTM, 50); // floor
 
+    // Dynamic chart height — under a type filter, scale height so the tallest
+    // bar always fills ~75% of the chart, keeping bar density consistent across
+    // tabs. CSS transition on .lb-chart-wrap eases the height change visually.
+    var dynH = CHART_H;
+    if (state.evidenceType && state.evidenceType !== 'all') {
+      // Compare this type's max against the all-time TM ceiling (use full named
+      // max as the reference). If filtered max is much smaller, shrink chart.
+      var refMax = state._refMaxAll || (function() {
+        var m = Math.max.apply(null, state.namedSkills.map(function(s) { return s.trustMagnitude || 0; }));
+        state._refMaxAll = Math.max(m, 50);
+        return state._refMaxAll;
+      })();
+      var ratio = Math.max(0.25, Math.min(1, maxTM / refMax));
+      dynH = Math.round(220 + (CHART_H - 220) * Math.sqrt(ratio));
+    }
+
     var totalW = Math.max(metrics.totalW, 320);
-    var innerH = CHART_H - NPAD.top - NPAD.bottom;
+    var innerH = dynH - NPAD.top - NPAD.bottom;
     if (innerH < 80) innerH = 80;
 
-    var svg = createSvg(totalW, CHART_H);
+    var svg = createSvg(totalW, dynH);
 
     // Create defs block first
     var defs = svgEl('defs');
     svg.appendChild(defs);
 
     appendWatermark(svg, totalW);
+    appendUpdatedBadge(svg, state.updatedDate);
 
     // Build per-bar gradients
     toShow.forEach(function(skill, i) {
@@ -1290,33 +1334,33 @@
         barGroup.appendChild(badgeText);
       }
 
-      // Fix 6: only render rank pill + TM label when bar is tall enough
-      if (h >= 30) {
+      // Rank stars \u2014 always render above bar, regardless of bar height.
       var rankN = parseInt(skill.level) || 2;
       if (rankN > 0) {
+        var starY = Math.max(NPAD.top - 4, y - 6);
         var rankPill = svgEl('text', {
           x: x + NB / 2,
-          y: y - 20,
+          y: starY,
           'text-anchor': 'middle',
-          'font-size': String(Math.max(8, ls.fontPx - 1)),
-          fill: 'rgba(' + rankRgb(rankN) + ', 0.85)'
+          'font-size': String(Math.max(9, ls.fontPx)),
+          'font-weight': '600',
+          fill: 'rgba(' + rankRgb(rankN) + ', 0.95)'
         });
         rankPill.textContent = rankN + '\u2605';
         barGroup.appendChild(rankPill);
       }
 
-      // TM score centered inside bar
-      var tmText = svgEl('text', {
-        x: x + NB / 2,
-        y: y + h / 2 + 4,
-        'text-anchor': 'middle',
-        'class': 'lb-axis-value',
-        'font-size': String(Math.max(8, ls.fontPx - 1)),
-        fill: 'rgba(255, 255, 255, 0.95)',
-        'font-weight': '600'
-      });
-      tmText.textContent = Math.round(tmVal);
-      barGroup.appendChild(tmText);
+      // TM score centered inside bar (visible only when bar is tall enough to host the number)
+      if (h >= 22) {
+        var tmText = svgEl('text', {
+          x: x + NB / 2,
+          y: y + h / 2 + 4,
+          'text-anchor': 'middle',
+          'class': 'lb-axis-value lb-axis-value--inbar',
+          'font-size': String(Math.max(8, ls.fontPx - 1))
+        });
+        tmText.textContent = Math.round(tmVal);
+        barGroup.appendChild(tmText);
       }
 
       // Avatar — radius scales with bar width
@@ -1440,6 +1484,7 @@
     svg.appendChild(defs);
 
     appendWatermark(svg, totalW);
+    appendUpdatedBadge(svg, state.updatedDate);
 
     // Build gradients per node (muted, handle-hue based)
     displayNodes.forEach(function(node, i) {
@@ -1818,8 +1863,7 @@
       section.classList.toggle('is-open', state.tmMethodologyOpen);
       toggle.setAttribute('aria-expanded', String(state.tmMethodologyOpen));
       body.hidden = !state.tmMethodologyOpen;
-      var glyph = toggle.querySelector('.lb-tm-glyph');
-      if (glyph) glyph.textContent = state.tmMethodologyOpen ? '×' : '+';
+      // The +→× swap is handled by CSS rotating .lb-tm-plus 45deg when .is-open.
     });
   }
 
@@ -1844,6 +1888,15 @@
         var id = (s.contributor + '/' + s.slug).toLowerCase();
         var name = (s.name || s.slug || '').toLowerCase();
         return id.indexOf(state.skillSearchQuery) !== -1 || name.indexOf(state.skillSearchQuery) !== -1;
+      });
+    }
+
+    // Evidence-type filter — when a specific type is active, drop skills whose
+    // contribution from that type is zero (otherwise the chart would render
+    // a wall of 0-height bars with no useful info).
+    if (state.evidenceType && state.evidenceType !== 'all') {
+      filtered = filtered.filter(function(s) {
+        return tmForType(s, state.evidenceType) > 0;
       });
     }
 

--- a/founder/CLAUDE.md
+++ b/founder/CLAUDE.md
@@ -2,6 +2,25 @@
 
 This folder is owned by the **Orchestrator agent** for the GAIA project. It is the planning, memory, and asset workspace — NOT the code repository.
 
+## 🔒 Superadmin Mode (private — Marco + Orchestrator only)
+
+Marco may invoke **"superadmin mode"** when he wants the orchestrator to **code directly** instead of delegating to subagents. Heuristic: he wants speed + intent-fidelity on small surgical UI/UX iterations where a subagent's onboarding overhead outweighs its execution cost, and where his intent is too compressed to fully transcribe into a dispatch prompt without losing nuance.
+
+Signals that superadmin is active:
+- Marco explicitly says "superadmin mode", "please code", "you code this", "you fix this", "no subagents", or names me as "the one fixing this".
+- Marco uses second-person directives ("please put", "make fonts white", "see if you can understand my intention") on a list of nitpicks he expects shipped in one pass.
+
+Behavior in superadmin mode:
+- Edit code DIRECTLY with Read/Edit/Write. No `Agent` calls for the duration of the task.
+- Keep commits surgical (one tight commit per pass; squash-merge a single PR rather than chaining 4-commit fan-outs).
+- Lower ceremony: don't restate the plan back, don't ask AskUserQuestion unless genuinely blocked, don't fan into Plan-mode for tasks under ~150 LoC.
+- Still respect ALL hard boundaries (Never push to main; branch-scope; redaction exemptions; CI guard rules; Class P/S; data-file no-touch; etc.).
+- Still log token spend at session close, but the spend is overwhelmingly orchestrator-only — note that.
+
+Reverting to normal (delegate-first) mode: Marco says "delegate this", names a model ("use Opus agents in backend"), or the task scope crosses the heuristic (>200 LoC, multi-module, requires worktree isolation for parallel agents). When in doubt, ask once.
+
+Logged 2026-06-29.
+
 ## Role
 
 The Orchestrator: tracks high-level goals against the roadmap, audits GitHub state (issues, milestones, Project board #2), drafts specs and handover documents for coding agents, builds dashboards/tools inside this folder, maintains memory files, and prepares GitHub operations for Marco's approval.


### PR DESCRIPTION
Marco's superadmin pass — direct-code from orchestrator, single squash commit.

### Charts
1. **In-bar TM numbers white** — new `.lb-axis-value--inbar` modifier overrides the muted base color
2. **Stars always render** — `h>=30` rank-pill guard removed; the rank sits above the bar regardless of bar height. TM-inside-bar still respects `h>=22`
3. **Zero-skip on type filter** — `applyFilter` now drops skills with `tmForType === 0` when a specific evidence type is active
4. **Type tabs restyled** — serif (EB Garamond), no pill chrome, underlined active state
5. **"UPDATED YYYY-MM-DD" badge** — apex-gold tag in top-left interior of every chart SVG, pulled from `data.json` `generatedAt`
6. **Watermark visible** — opacity 0.18→0.42, width 75→110
7. **Methodology accordion in-panel** — ⓘ info icon left, label, + icon right, no pill. `+` rotates 45° to × on open; body fades in via opacity + max-height ease
8. **Origin tip line** — single-line muted notice above the methodology accordion with the wreath glyph (honor-red), short explanation
9. **Slash-name labels white** — `.lb-axis-label--name` modifier; Y-axis ticks stay muted
10. **Dynamic chart height per type** — height scales 220–320 based on filtered max-TM; CSS easing on SVG height for smooth transition

### Plus
- `founder/CLAUDE.md`: superadmin mode documented (private — orchestrator-only direct-code mode)