### PR TITLE
fix(cli): preserve hand-authored openapi.json across api-projection regen (Closes #888)

### DIFF
--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -621,6 +621,11 @@ def build_docs_named_index(check: bool) -> bool:
     return True
 
 
+# Files that live in docs/api/v1/ but are hand-authored (not emitted by
+# buildApiProjection.py).  They must be preserved across every regen cycle.
+_API_HAND_AUTHORED = ["openapi.json"]
+
+
 def build_api_projection(check: bool) -> bool:
     """Run buildApiProjection.py to a tempdir and diff against docs/api/v1/."""
     script = SCRIPTS / "buildApiProjection.py"
@@ -635,6 +640,15 @@ def build_api_projection(check: bool) -> bool:
                 print(f"diff docs/api/v1/ (regen failed: rc={rc})")
                 print(output)
             raise RuntimeError(f"docs/api/v1/ regen failed: rc={rc}")
+        # Preserve hand-authored files that the generator does not emit.
+        # Copy them from the committed tree into out_dir so the diff and
+        # copytree round-trip keeps them intact.
+        if committed.exists():
+            import shutil as _shutil
+            for fname in _API_HAND_AUTHORED:
+                src = committed / fname
+                if src.exists():
+                    _shutil.copy2(src, out_dir / fname)
         if not committed.exists():
             if check:
                 print("diff docs/api/v1/ (missing)")


### PR DESCRIPTION
## Problem

`build_api_projection()` in `scripts/build_docs.py` uses `shutil.rmtree + copytree` to refresh `docs/api/v1/`. `docs/api/v1/openapi.json` is hand-authored and not emitted by `buildApiProjection.py`, so it was silently deleted on every `gaia dev docs` run.

Caught in session 29 (2026-06-30). Required manual `git checkout HEAD -- docs/api/v1/openapi.json` as a workaround.

## Fix

Added module-level constant `_API_HAND_AUTHORED = ['openapi.json']` and a copy step in `build_api_projection()` that runs after the generator writes `out_dir` but before the diff/replace cycle. Any file listed in `_API_HAND_AUTHORED` that exists in the committed tree is copied into `out_dir` so it survives the round-trip.

## Testing

- `gaia dev docs --check` → no drift
- `gaia dev docs` → `docs/api/v1/openapi.json` present after regen ✓

Closes #888