### PR TITLE
feat(b2): wire trending engine into build pipeline

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,4 @@ docs/graph/*.svg  -diff linguist-generated=true
 
 # API projection — generated JSON, collapse in PR diffs
 docs/api/v1/**/*.json linguist-generated=true
+docs/api/v1/trending/feed.xml linguist-generated=true

--- a/docs/api/v1/trending/30d.json
+++ b/docs/api/v1/trending/30d.json
@@ -1,0 +1,1957 @@
+{
+  "window": "30d",
+  "generatedAt": "2026-06-30T16:25:29Z",
+  "firstRun": true,
+  "skills": [
+    {
+      "id": "garrytan/gstack",
+      "name": "Founder Mode",
+      "level": "5★",
+      "contributor": "garrytan",
+      "trustMagnitude": 589.32,
+      "overallTrustGrade": "S",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/gstack.json"
+      }
+    },
+    {
+      "id": "ruvnet/ruflo",
+      "name": "Ruflo",
+      "level": "5★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 482.27,
+      "overallTrustGrade": "S",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/ruflo.json"
+      }
+    },
+    {
+      "id": "mattpocock/skills",
+      "name": "Matt Pocock Skills",
+      "level": "5★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 480.29,
+      "overallTrustGrade": "S",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/skills.json"
+      }
+    },
+    {
+      "id": "obra/superpowers",
+      "name": "Superpowers",
+      "level": "5★",
+      "contributor": "obra",
+      "trustMagnitude": 445.15,
+      "overallTrustGrade": "S",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/obra/superpowers.json"
+      }
+    },
+    {
+      "id": "mattpocock/engineering",
+      "name": "Engineering",
+      "level": "4★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 270.0,
+      "overallTrustGrade": "A",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/engineering.json"
+      }
+    },
+    {
+      "id": "ruvnet/agentdb",
+      "name": "AgentDB",
+      "level": "4★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 201.0,
+      "overallTrustGrade": "A",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/agentdb.json"
+      }
+    },
+    {
+      "id": "ruvnet/ruflo-v3",
+      "name": "Ruflo V3",
+      "level": "4★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 186.0,
+      "overallTrustGrade": "A",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/ruflo-v3.json"
+      }
+    },
+    {
+      "id": "garrytan/garrytan",
+      "name": "Autoplan",
+      "level": "4★",
+      "contributor": "garrytan",
+      "trustMagnitude": 156.0,
+      "overallTrustGrade": "A",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/garrytan.json"
+      }
+    },
+    {
+      "id": "ruvnet/dual-mode",
+      "name": "Dual Mode",
+      "level": "4★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 126.0,
+      "overallTrustGrade": "A",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/dual-mode.json"
+      }
+    },
+    {
+      "id": "pbakaus/impeccable",
+      "name": "Impeccable",
+      "level": "4★",
+      "contributor": "pbakaus",
+      "trustMagnitude": 122.8,
+      "overallTrustGrade": "A",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/pbakaus/impeccable.json"
+      }
+    },
+    {
+      "id": "mattpocock/productivity",
+      "name": "Productivity",
+      "level": "4★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 120.0,
+      "overallTrustGrade": "A",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/productivity.json"
+      }
+    },
+    {
+      "id": "ruvnet/reasoningbank",
+      "name": "ReasoningBank",
+      "level": "4★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 118.5,
+      "overallTrustGrade": "A",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/reasoningbank.json"
+      }
+    },
+    {
+      "id": "obra/subagent-driven-development",
+      "name": "Subagent-Driven Development",
+      "level": "4★",
+      "contributor": "obra",
+      "trustMagnitude": 117.65,
+      "overallTrustGrade": "A",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/obra/subagent-driven-development.json"
+      }
+    },
+    {
+      "id": "obra/using-git-worktrees",
+      "name": "Using Git Worktrees",
+      "level": "4★",
+      "contributor": "obra",
+      "trustMagnitude": 117.65,
+      "overallTrustGrade": "A",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/obra/using-git-worktrees.json"
+      }
+    },
+    {
+      "id": "safishamsi/graphify",
+      "name": "Graphify",
+      "level": "4★",
+      "contributor": "safishamsi",
+      "trustMagnitude": 116.57,
+      "overallTrustGrade": "A",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/safishamsi/graphify.json"
+      }
+    },
+    {
+      "id": "obra/writing-plans",
+      "name": "Writing Plans",
+      "level": "4★",
+      "contributor": "obra",
+      "trustMagnitude": 110.15,
+      "overallTrustGrade": "A",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/obra/writing-plans.json"
+      }
+    },
+    {
+      "id": "openai/few-shot-learning",
+      "name": "Few-Shot Learning",
+      "level": "4★",
+      "contributor": "openai",
+      "trustMagnitude": 100.0,
+      "overallTrustGrade": "A",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/openai/few-shot-learning.json"
+      }
+    },
+    {
+      "id": "openai/self-consistency",
+      "name": "Self-Consistency",
+      "level": "4★",
+      "contributor": "openai",
+      "trustMagnitude": 100.0,
+      "overallTrustGrade": "A",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/openai/self-consistency.json"
+      }
+    },
+    {
+      "id": "stanfordnlp/dspy",
+      "name": "DSPy",
+      "level": "4★",
+      "contributor": "stanfordnlp",
+      "trustMagnitude": 100.0,
+      "overallTrustGrade": "A",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/stanfordnlp/dspy.json"
+      }
+    },
+    {
+      "id": "ruvnet/hive-mind-coordination",
+      "name": "Hive Mind Coordination",
+      "level": "3★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 96.09,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/hive-mind-coordination.json"
+      }
+    },
+    {
+      "id": "ruvnet/flow-nexus",
+      "name": "Flow Nexus",
+      "level": "3★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 96.0,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/flow-nexus.json"
+      }
+    },
+    {
+      "id": "obra/brainstorming",
+      "name": "Brainstorming",
+      "level": "3★",
+      "contributor": "obra",
+      "trustMagnitude": 95.15,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/obra/brainstorming.json"
+      }
+    },
+    {
+      "id": "obra/executing-plans",
+      "name": "Executing Plans",
+      "level": "3★",
+      "contributor": "obra",
+      "trustMagnitude": 95.15,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/obra/executing-plans.json"
+      }
+    },
+    {
+      "id": "obra/verification-before-completion",
+      "name": "Verification Before Completion",
+      "level": "3★",
+      "contributor": "obra",
+      "trustMagnitude": 95.15,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/obra/verification-before-completion.json"
+      }
+    },
+    {
+      "id": "martin-stepanoski/nielsen-heuristics-audit",
+      "name": "Nielsen Heuristics Audit",
+      "level": "3★",
+      "contributor": "martin-stepanoski",
+      "trustMagnitude": 94.9,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/martin-stepanoski/nielsen-heuristics-audit.json"
+      }
+    },
+    {
+      "id": "mattpocock/diagnose",
+      "name": "Diagnose",
+      "level": "3★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 90.38,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/diagnose.json"
+      }
+    },
+    {
+      "id": "mattpocock/edit-article",
+      "name": "Edit Article",
+      "level": "3★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 90.38,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/edit-article.json"
+      }
+    },
+    {
+      "id": "mattpocock/obsidian-vault",
+      "name": "Obsidian Vault Manager",
+      "level": "3★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 90.38,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/obsidian-vault.json"
+      }
+    },
+    {
+      "id": "mattpocock/to-issues",
+      "name": "To Issues",
+      "level": "3★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 90.38,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/to-issues.json"
+      }
+    },
+    {
+      "id": "mattpocock/ubiquitous-language",
+      "name": "Ubiquitous Language",
+      "level": "3★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 90.38,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/ubiquitous-language.json"
+      }
+    },
+    {
+      "id": "anthropic/skill-creator",
+      "name": "Skill Creator",
+      "level": "3★",
+      "contributor": "anthropic",
+      "trustMagnitude": 90.0,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/anthropic/skill-creator.json"
+      }
+    },
+    {
+      "id": "garrytan/browse",
+      "name": "Browse",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 88.5,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/browse.json"
+      }
+    },
+    {
+      "id": "obra/dispatching-parallel-agents",
+      "name": "Dispatching Parallel Agents",
+      "level": "3★",
+      "contributor": "obra",
+      "trustMagnitude": 86.0,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/obra/dispatching-parallel-agents.json"
+      }
+    },
+    {
+      "id": "addy-osmani/performance-optimization",
+      "name": "Performance Optimization",
+      "level": "3★",
+      "contributor": "addy-osmani",
+      "trustMagnitude": 83.2,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/addy-osmani/performance-optimization.json"
+      }
+    },
+    {
+      "id": "garrytan/retro",
+      "name": "Retro",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 81.0,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/retro.json"
+      }
+    },
+    {
+      "id": "browser-use/browser-harness",
+      "name": "Browser Harness",
+      "level": "3★",
+      "contributor": "browser-use",
+      "trustMagnitude": 73.59,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/browser-use/browser-harness.json"
+      }
+    },
+    {
+      "id": "garrytan/careful",
+      "name": "Careful",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 66.0,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/careful.json"
+      }
+    },
+    {
+      "id": "garrytan/office-hours",
+      "name": "Office Hours",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 66.0,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/office-hours.json"
+      }
+    },
+    {
+      "id": "garrytan/plan-eng-review",
+      "name": "Plan Eng Review",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 66.0,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/plan-eng-review.json"
+      }
+    },
+    {
+      "id": "ruvnet/github-suite",
+      "name": "GitHub Suite",
+      "level": "3★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 66.0,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/github-suite.json"
+      }
+    },
+    {
+      "id": "obra/systematic-debugging",
+      "name": "Systematic Debugging",
+      "level": "3★",
+      "contributor": "obra",
+      "trustMagnitude": 65.15,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/obra/systematic-debugging.json"
+      }
+    },
+    {
+      "id": "garrytan/benchmark",
+      "name": "Benchmark",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/benchmark.json"
+      }
+    },
+    {
+      "id": "garrytan/canary",
+      "name": "Canary",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/canary.json"
+      }
+    },
+    {
+      "id": "garrytan/cso",
+      "name": "CSO",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/cso.json"
+      }
+    },
+    {
+      "id": "garrytan/design-consultation",
+      "name": "Design Consultation",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/design-consultation.json"
+      }
+    },
+    {
+      "id": "garrytan/design-html",
+      "name": "Design HTML",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/design-html.json"
+      }
+    },
+    {
+      "id": "garrytan/design-shotgun",
+      "name": "Design Shotgun",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/design-shotgun.json"
+      }
+    },
+    {
+      "id": "garrytan/document-generate",
+      "name": "Document Generate",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/document-generate.json"
+      }
+    },
+    {
+      "id": "garrytan/investigate",
+      "name": "Investigate",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/investigate.json"
+      }
+    },
+    {
+      "id": "garrytan/land-and-deploy",
+      "name": "Land and Deploy",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/land-and-deploy.json"
+      }
+    },
+    {
+      "id": "garrytan/plan-ceo-review",
+      "name": "Plan CEO Review",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/plan-ceo-review.json"
+      }
+    },
+    {
+      "id": "garrytan/plan-design-review",
+      "name": "Plan Design Review",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/plan-design-review.json"
+      }
+    },
+    {
+      "id": "garrytan/plan-devex-review",
+      "name": "Plan DevEx Review",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/plan-devex-review.json"
+      }
+    },
+    {
+      "id": "garrytan/qa",
+      "name": "QA",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/qa.json"
+      }
+    },
+    {
+      "id": "garrytan/review",
+      "name": "Review",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/review.json"
+      }
+    },
+    {
+      "id": "garrytan/ship",
+      "name": "Ship",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/ship.json"
+      }
+    },
+    {
+      "id": "garrytan/skillify",
+      "name": "Skillify",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/skillify.json"
+      }
+    },
+    {
+      "id": "mattpocock/grill-me",
+      "name": "Grill Me",
+      "level": "3★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 63.71,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/grill-me.json"
+      }
+    },
+    {
+      "id": "mattpocock/grill-with-docs",
+      "name": "Grill With Docs",
+      "level": "3★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 63.71,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/grill-with-docs.json"
+      }
+    },
+    {
+      "id": "mattpocock/handoff",
+      "name": "Handoff",
+      "level": "3★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 63.71,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/handoff.json"
+      }
+    },
+    {
+      "id": "mattpocock/to-prd",
+      "name": "To PRD",
+      "level": "3★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 63.71,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/to-prd.json"
+      }
+    },
+    {
+      "id": "mattpocock/personal",
+      "name": "Personal",
+      "level": "3★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 60.0,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/personal.json"
+      }
+    },
+    {
+      "id": "mattpocock/setup-matt-pocock-skills",
+      "name": "Setup Matt Pocock Skills",
+      "level": "3★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 56.21,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/setup-matt-pocock-skills.json"
+      }
+    },
+    {
+      "id": "mattpocock/triage",
+      "name": "Triage",
+      "level": "3★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 56.21,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/triage.json"
+      }
+    },
+    {
+      "id": "mattpocock/improve-codebase-architecture",
+      "name": "Improve Codebase Architecture",
+      "level": "2★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 45.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/improve-codebase-architecture.json"
+      }
+    },
+    {
+      "id": "mattpocock/write-a-skill",
+      "name": "Write a Skill",
+      "level": "2★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 45.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/write-a-skill.json"
+      }
+    },
+    {
+      "id": "mattpocock/prototype",
+      "name": "Prototype",
+      "level": "2★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 41.21,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/prototype.json"
+      }
+    },
+    {
+      "id": "bradautomates/claude-video",
+      "name": "Claude Video",
+      "level": "2★",
+      "contributor": "bradautomates",
+      "trustMagnitude": 37.47,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/bradautomates/claude-video.json"
+      }
+    },
+    {
+      "id": "Manavarya09/design-extract",
+      "name": "Design Extract",
+      "level": "2★",
+      "contributor": "Manavarya09",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/Manavarya09/design-extract.json"
+      }
+    },
+    {
+      "id": "addy-osmani/test-driven-development",
+      "name": "Test-Driven Development",
+      "level": "2★",
+      "contributor": "addy-osmani",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/addy-osmani/test-driven-development.json"
+      }
+    },
+    {
+      "id": "anthropic/pptx",
+      "name": "PPTX Editor",
+      "level": "2★",
+      "contributor": "anthropic",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/anthropic/pptx.json"
+      }
+    },
+    {
+      "id": "firecrawl/firecrawl",
+      "name": "Firecrawl",
+      "level": "2★",
+      "contributor": "firecrawl",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/firecrawl/firecrawl.json"
+      }
+    },
+    {
+      "id": "garrytan/benchmark-models",
+      "name": "Benchmark Models",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/benchmark-models.json"
+      }
+    },
+    {
+      "id": "garrytan/codex",
+      "name": "Codex",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/codex.json"
+      }
+    },
+    {
+      "id": "garrytan/context-restore",
+      "name": "Context Restore",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/context-restore.json"
+      }
+    },
+    {
+      "id": "garrytan/context-save",
+      "name": "Context Save",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/context-save.json"
+      }
+    },
+    {
+      "id": "garrytan/design-review",
+      "name": "Design Review",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/design-review.json"
+      }
+    },
+    {
+      "id": "garrytan/devex-review",
+      "name": "DevEx Review",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/devex-review.json"
+      }
+    },
+    {
+      "id": "garrytan/document-release",
+      "name": "Document Release",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/document-release.json"
+      }
+    },
+    {
+      "id": "garrytan/freeze",
+      "name": "Freeze",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/freeze.json"
+      }
+    },
+    {
+      "id": "garrytan/gstack-upgrade",
+      "name": "GStack Upgrade",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/gstack-upgrade.json"
+      }
+    },
+    {
+      "id": "garrytan/guard",
+      "name": "Guard",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/guard.json"
+      }
+    },
+    {
+      "id": "garrytan/health",
+      "name": "Health",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/health.json"
+      }
+    },
+    {
+      "id": "garrytan/landing-report",
+      "name": "Landing Report",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/landing-report.json"
+      }
+    },
+    {
+      "id": "garrytan/learn",
+      "name": "Learn",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/learn.json"
+      }
+    },
+    {
+      "id": "garrytan/make-pdf",
+      "name": "Make PDF",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/make-pdf.json"
+      }
+    },
+    {
+      "id": "garrytan/open-gstack-browser",
+      "name": "Open GStack Browser",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/open-gstack-browser.json"
+      }
+    },
+    {
+      "id": "garrytan/pair-agent",
+      "name": "Pair Agent",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/pair-agent.json"
+      }
+    },
+    {
+      "id": "garrytan/plan-tune",
+      "name": "Plan Tune",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/plan-tune.json"
+      }
+    },
+    {
+      "id": "garrytan/qa-only",
+      "name": "QA Only",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/qa-only.json"
+      }
+    },
+    {
+      "id": "garrytan/scrape",
+      "name": "Scrape",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/scrape.json"
+      }
+    },
+    {
+      "id": "garrytan/setup-browser-cookies",
+      "name": "Setup Browser Cookies",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/setup-browser-cookies.json"
+      }
+    },
+    {
+      "id": "garrytan/setup-deploy",
+      "name": "Setup Deploy",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/setup-deploy.json"
+      }
+    },
+    {
+      "id": "garrytan/setup-gbrain",
+      "name": "Setup GBrain",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/setup-gbrain.json"
+      }
+    },
+    {
+      "id": "garrytan/sync-gbrain",
+      "name": "Sync GBrain",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/sync-gbrain.json"
+      }
+    },
+    {
+      "id": "garrytan/unfreeze",
+      "name": "Unfreeze",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/unfreeze.json"
+      }
+    },
+    {
+      "id": "getagentseal/codeburn",
+      "name": "CodeBurn",
+      "level": "2★",
+      "contributor": "getagentseal",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/getagentseal/codeburn.json"
+      }
+    },
+    {
+      "id": "huggingface/semantic-cache",
+      "name": "Semantic Cache",
+      "level": "2★",
+      "contributor": "huggingface",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/huggingface/semantic-cache.json"
+      }
+    },
+    {
+      "id": "karpathy/autoresearch",
+      "name": "AutoResearch",
+      "level": "2★",
+      "contributor": "karpathy",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/karpathy/autoresearch.json"
+      }
+    },
+    {
+      "id": "laravel/upgrade-laravel-v13",
+      "name": "Upgrade Laravel v13",
+      "level": "2★",
+      "contributor": "laravel",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/laravel/upgrade-laravel-v13.json"
+      }
+    },
+    {
+      "id": "mbtiongson1/gaia-audit",
+      "name": "Gaia Audit",
+      "level": "2★",
+      "contributor": "mbtiongson1",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mbtiongson1/gaia-audit.json"
+      }
+    },
+    {
+      "id": "mbtiongson1/gaia-curation-review",
+      "name": "Gaia Curation Review",
+      "level": "2★",
+      "contributor": "mbtiongson1",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mbtiongson1/gaia-curation-review.json"
+      }
+    },
+    {
+      "id": "mbtiongson1/gaia-meta-audit",
+      "name": "Gaia Meta Audit",
+      "level": "2★",
+      "contributor": "mbtiongson1",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mbtiongson1/gaia-meta-audit.json"
+      }
+    },
+    {
+      "id": "mbtiongson1/gaia-preview",
+      "name": "Gaia Preview",
+      "level": "2★",
+      "contributor": "mbtiongson1",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mbtiongson1/gaia-preview.json"
+      }
+    },
+    {
+      "id": "mbtiongson1/graphify-triage",
+      "name": "Graphify Triage",
+      "level": "2★",
+      "contributor": "mbtiongson1",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mbtiongson1/graphify-triage.json"
+      }
+    },
+    {
+      "id": "nexu-io/open-design",
+      "name": "Open Design",
+      "level": "2★",
+      "contributor": "nexu-io",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/nexu-io/open-design.json"
+      }
+    },
+    {
+      "id": "nousresearch/feed-monitoring",
+      "name": "Feed Monitoring",
+      "level": "2★",
+      "contributor": "nousresearch",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/nousresearch/feed-monitoring.json"
+      }
+    },
+    {
+      "id": "obra/finishing-a-development-branch",
+      "name": "Finishing a Development Branch",
+      "level": "2★",
+      "contributor": "obra",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/obra/finishing-a-development-branch.json"
+      }
+    },
+    {
+      "id": "obra/receiving-code-review",
+      "name": "Receiving Code Review",
+      "level": "2★",
+      "contributor": "obra",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/obra/receiving-code-review.json"
+      }
+    },
+    {
+      "id": "obra/requesting-code-review",
+      "name": "Requesting Code Review",
+      "level": "2★",
+      "contributor": "obra",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/obra/requesting-code-review.json"
+      }
+    },
+    {
+      "id": "ruvnet/agentdb-advanced",
+      "name": "AgentDB Advanced",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/agentdb-advanced.json"
+      }
+    },
+    {
+      "id": "ruvnet/agentdb-memory-patterns",
+      "name": "AgentDB Memory Patterns",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/agentdb-memory-patterns.json"
+      }
+    },
+    {
+      "id": "ruvnet/agentdb-optimization",
+      "name": "AgentDB Optimization",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/agentdb-optimization.json"
+      }
+    },
+    {
+      "id": "ruvnet/agentdb-vector-search",
+      "name": "AgentDB Vector Search",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/agentdb-vector-search.json"
+      }
+    },
+    {
+      "id": "ruvnet/agentic-jujutsu",
+      "name": "Agentic Jujutsu",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/agentic-jujutsu.json"
+      }
+    },
+    {
+      "id": "ruvnet/dual-collect",
+      "name": "Dual Collect",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/dual-collect.json"
+      }
+    },
+    {
+      "id": "ruvnet/dual-coordinate",
+      "name": "Dual Coordinate",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/dual-coordinate.json"
+      }
+    },
+    {
+      "id": "ruvnet/dual-spawn",
+      "name": "Dual Spawn",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/dual-spawn.json"
+      }
+    },
+    {
+      "id": "ruvnet/flow-nexus-neural",
+      "name": "Flow Nexus Neural",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/flow-nexus-neural.json"
+      }
+    },
+    {
+      "id": "ruvnet/flow-nexus-platform",
+      "name": "Flow Nexus Platform",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/flow-nexus-platform.json"
+      }
+    },
+    {
+      "id": "ruvnet/github-multi-repo",
+      "name": "GitHub Multi-Repo",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/github-multi-repo.json"
+      }
+    },
+    {
+      "id": "ruvnet/pair-programming",
+      "name": "Pair Programming",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/pair-programming.json"
+      }
+    },
+    {
+      "id": "ruvnet/reasoningbank-intelligence",
+      "name": "ReasoningBank Intelligence",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/reasoningbank-intelligence.json"
+      }
+    },
+    {
+      "id": "ruvnet/stream-chain",
+      "name": "Stream Chain",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/stream-chain.json"
+      }
+    },
+    {
+      "id": "ruvnet/swarm-advanced",
+      "name": "Swarm Advanced",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/swarm-advanced.json"
+      }
+    },
+    {
+      "id": "ruvnet/swarm-orchestration",
+      "name": "Swarm Orchestration",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/swarm-orchestration.json"
+      }
+    },
+    {
+      "id": "ruvnet/v3-cli-modernization",
+      "name": "V3 CLI Modernization",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/v3-cli-modernization.json"
+      }
+    },
+    {
+      "id": "ruvnet/v3-core-implementation",
+      "name": "V3 Core Implementation",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/v3-core-implementation.json"
+      }
+    },
+    {
+      "id": "ruvnet/v3-ddd-architecture",
+      "name": "V3 DDD Architecture",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/v3-ddd-architecture.json"
+      }
+    },
+    {
+      "id": "ruvnet/v3-integration-deep",
+      "name": "V3 Integration Deep",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/v3-integration-deep.json"
+      }
+    },
+    {
+      "id": "ruvnet/verification-quality",
+      "name": "Verification Quality",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/verification-quality.json"
+      }
+    },
+    {
+      "id": "ruvnet/worker-integration",
+      "name": "Worker Integration",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/worker-integration.json"
+      }
+    },
+    {
+      "id": "santifer/career-ops",
+      "name": "Career-Ops",
+      "level": "2★",
+      "contributor": "santifer",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/santifer/career-ops.json"
+      }
+    },
+    {
+      "id": "spring-ai/readme-generate",
+      "name": "REST API README Generator",
+      "level": "2★",
+      "contributor": "spring-ai",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/spring-ai/readme-generate.json"
+      }
+    },
+    {
+      "id": "vercel/find-skills",
+      "name": "Find Skills",
+      "level": "2★",
+      "contributor": "vercel",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/vercel/find-skills.json"
+      }
+    },
+    {
+      "id": "upsonic/unittest-generator",
+      "name": "Unittest Generator",
+      "level": "2★",
+      "contributor": "upsonic",
+      "trustMagnitude": 33.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/upsonic/unittest-generator.json"
+      }
+    },
+    {
+      "id": "devin-ai/autonomous-swe",
+      "name": "Autonomous SWE",
+      "level": "2★",
+      "contributor": "devin-ai",
+      "trustMagnitude": 30.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/devin-ai/autonomous-swe.json"
+      }
+    },
+    {
+      "id": "mattpocock/caveman",
+      "name": "Caveman Mode",
+      "level": "2★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 30.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/caveman.json"
+      }
+    },
+    {
+      "id": "mattpocock/teach",
+      "name": "Teach",
+      "level": "2★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 0,
+      "overallTrustGrade": "ungraded",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/teach.json"
+      }
+    }
+  ],
+  "totalTrending": 139,
+  "_links": {
+    "self": "/api/v1/trending/30d.json"
+  }
+}

--- a/docs/api/v1/trending/7d.json
+++ b/docs/api/v1/trending/7d.json
@@ -1,0 +1,1957 @@
+{
+  "window": "7d",
+  "generatedAt": "2026-06-30T16:25:29Z",
+  "firstRun": true,
+  "skills": [
+    {
+      "id": "garrytan/gstack",
+      "name": "Founder Mode",
+      "level": "5★",
+      "contributor": "garrytan",
+      "trustMagnitude": 589.32,
+      "overallTrustGrade": "S",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/gstack.json"
+      }
+    },
+    {
+      "id": "ruvnet/ruflo",
+      "name": "Ruflo",
+      "level": "5★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 482.27,
+      "overallTrustGrade": "S",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/ruflo.json"
+      }
+    },
+    {
+      "id": "mattpocock/skills",
+      "name": "Matt Pocock Skills",
+      "level": "5★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 480.29,
+      "overallTrustGrade": "S",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/skills.json"
+      }
+    },
+    {
+      "id": "obra/superpowers",
+      "name": "Superpowers",
+      "level": "5★",
+      "contributor": "obra",
+      "trustMagnitude": 445.15,
+      "overallTrustGrade": "S",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/obra/superpowers.json"
+      }
+    },
+    {
+      "id": "mattpocock/engineering",
+      "name": "Engineering",
+      "level": "4★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 270.0,
+      "overallTrustGrade": "A",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/engineering.json"
+      }
+    },
+    {
+      "id": "ruvnet/agentdb",
+      "name": "AgentDB",
+      "level": "4★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 201.0,
+      "overallTrustGrade": "A",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/agentdb.json"
+      }
+    },
+    {
+      "id": "ruvnet/ruflo-v3",
+      "name": "Ruflo V3",
+      "level": "4★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 186.0,
+      "overallTrustGrade": "A",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/ruflo-v3.json"
+      }
+    },
+    {
+      "id": "garrytan/garrytan",
+      "name": "Autoplan",
+      "level": "4★",
+      "contributor": "garrytan",
+      "trustMagnitude": 156.0,
+      "overallTrustGrade": "A",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/garrytan.json"
+      }
+    },
+    {
+      "id": "ruvnet/dual-mode",
+      "name": "Dual Mode",
+      "level": "4★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 126.0,
+      "overallTrustGrade": "A",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/dual-mode.json"
+      }
+    },
+    {
+      "id": "pbakaus/impeccable",
+      "name": "Impeccable",
+      "level": "4★",
+      "contributor": "pbakaus",
+      "trustMagnitude": 122.8,
+      "overallTrustGrade": "A",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/pbakaus/impeccable.json"
+      }
+    },
+    {
+      "id": "mattpocock/productivity",
+      "name": "Productivity",
+      "level": "4★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 120.0,
+      "overallTrustGrade": "A",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/productivity.json"
+      }
+    },
+    {
+      "id": "ruvnet/reasoningbank",
+      "name": "ReasoningBank",
+      "level": "4★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 118.5,
+      "overallTrustGrade": "A",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/reasoningbank.json"
+      }
+    },
+    {
+      "id": "obra/subagent-driven-development",
+      "name": "Subagent-Driven Development",
+      "level": "4★",
+      "contributor": "obra",
+      "trustMagnitude": 117.65,
+      "overallTrustGrade": "A",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/obra/subagent-driven-development.json"
+      }
+    },
+    {
+      "id": "obra/using-git-worktrees",
+      "name": "Using Git Worktrees",
+      "level": "4★",
+      "contributor": "obra",
+      "trustMagnitude": 117.65,
+      "overallTrustGrade": "A",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/obra/using-git-worktrees.json"
+      }
+    },
+    {
+      "id": "safishamsi/graphify",
+      "name": "Graphify",
+      "level": "4★",
+      "contributor": "safishamsi",
+      "trustMagnitude": 116.57,
+      "overallTrustGrade": "A",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/safishamsi/graphify.json"
+      }
+    },
+    {
+      "id": "obra/writing-plans",
+      "name": "Writing Plans",
+      "level": "4★",
+      "contributor": "obra",
+      "trustMagnitude": 110.15,
+      "overallTrustGrade": "A",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/obra/writing-plans.json"
+      }
+    },
+    {
+      "id": "openai/few-shot-learning",
+      "name": "Few-Shot Learning",
+      "level": "4★",
+      "contributor": "openai",
+      "trustMagnitude": 100.0,
+      "overallTrustGrade": "A",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/openai/few-shot-learning.json"
+      }
+    },
+    {
+      "id": "openai/self-consistency",
+      "name": "Self-Consistency",
+      "level": "4★",
+      "contributor": "openai",
+      "trustMagnitude": 100.0,
+      "overallTrustGrade": "A",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/openai/self-consistency.json"
+      }
+    },
+    {
+      "id": "stanfordnlp/dspy",
+      "name": "DSPy",
+      "level": "4★",
+      "contributor": "stanfordnlp",
+      "trustMagnitude": 100.0,
+      "overallTrustGrade": "A",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/stanfordnlp/dspy.json"
+      }
+    },
+    {
+      "id": "ruvnet/hive-mind-coordination",
+      "name": "Hive Mind Coordination",
+      "level": "3★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 96.09,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/hive-mind-coordination.json"
+      }
+    },
+    {
+      "id": "ruvnet/flow-nexus",
+      "name": "Flow Nexus",
+      "level": "3★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 96.0,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/flow-nexus.json"
+      }
+    },
+    {
+      "id": "obra/brainstorming",
+      "name": "Brainstorming",
+      "level": "3★",
+      "contributor": "obra",
+      "trustMagnitude": 95.15,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/obra/brainstorming.json"
+      }
+    },
+    {
+      "id": "obra/executing-plans",
+      "name": "Executing Plans",
+      "level": "3★",
+      "contributor": "obra",
+      "trustMagnitude": 95.15,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/obra/executing-plans.json"
+      }
+    },
+    {
+      "id": "obra/verification-before-completion",
+      "name": "Verification Before Completion",
+      "level": "3★",
+      "contributor": "obra",
+      "trustMagnitude": 95.15,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/obra/verification-before-completion.json"
+      }
+    },
+    {
+      "id": "martin-stepanoski/nielsen-heuristics-audit",
+      "name": "Nielsen Heuristics Audit",
+      "level": "3★",
+      "contributor": "martin-stepanoski",
+      "trustMagnitude": 94.9,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/martin-stepanoski/nielsen-heuristics-audit.json"
+      }
+    },
+    {
+      "id": "mattpocock/diagnose",
+      "name": "Diagnose",
+      "level": "3★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 90.38,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/diagnose.json"
+      }
+    },
+    {
+      "id": "mattpocock/edit-article",
+      "name": "Edit Article",
+      "level": "3★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 90.38,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/edit-article.json"
+      }
+    },
+    {
+      "id": "mattpocock/obsidian-vault",
+      "name": "Obsidian Vault Manager",
+      "level": "3★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 90.38,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/obsidian-vault.json"
+      }
+    },
+    {
+      "id": "mattpocock/to-issues",
+      "name": "To Issues",
+      "level": "3★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 90.38,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/to-issues.json"
+      }
+    },
+    {
+      "id": "mattpocock/ubiquitous-language",
+      "name": "Ubiquitous Language",
+      "level": "3★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 90.38,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/ubiquitous-language.json"
+      }
+    },
+    {
+      "id": "anthropic/skill-creator",
+      "name": "Skill Creator",
+      "level": "3★",
+      "contributor": "anthropic",
+      "trustMagnitude": 90.0,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/anthropic/skill-creator.json"
+      }
+    },
+    {
+      "id": "garrytan/browse",
+      "name": "Browse",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 88.5,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/browse.json"
+      }
+    },
+    {
+      "id": "obra/dispatching-parallel-agents",
+      "name": "Dispatching Parallel Agents",
+      "level": "3★",
+      "contributor": "obra",
+      "trustMagnitude": 86.0,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/obra/dispatching-parallel-agents.json"
+      }
+    },
+    {
+      "id": "addy-osmani/performance-optimization",
+      "name": "Performance Optimization",
+      "level": "3★",
+      "contributor": "addy-osmani",
+      "trustMagnitude": 83.2,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/addy-osmani/performance-optimization.json"
+      }
+    },
+    {
+      "id": "garrytan/retro",
+      "name": "Retro",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 81.0,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/retro.json"
+      }
+    },
+    {
+      "id": "browser-use/browser-harness",
+      "name": "Browser Harness",
+      "level": "3★",
+      "contributor": "browser-use",
+      "trustMagnitude": 73.59,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/browser-use/browser-harness.json"
+      }
+    },
+    {
+      "id": "garrytan/careful",
+      "name": "Careful",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 66.0,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/careful.json"
+      }
+    },
+    {
+      "id": "garrytan/office-hours",
+      "name": "Office Hours",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 66.0,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/office-hours.json"
+      }
+    },
+    {
+      "id": "garrytan/plan-eng-review",
+      "name": "Plan Eng Review",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 66.0,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/plan-eng-review.json"
+      }
+    },
+    {
+      "id": "ruvnet/github-suite",
+      "name": "GitHub Suite",
+      "level": "3★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 66.0,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/github-suite.json"
+      }
+    },
+    {
+      "id": "obra/systematic-debugging",
+      "name": "Systematic Debugging",
+      "level": "3★",
+      "contributor": "obra",
+      "trustMagnitude": 65.15,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/obra/systematic-debugging.json"
+      }
+    },
+    {
+      "id": "garrytan/benchmark",
+      "name": "Benchmark",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/benchmark.json"
+      }
+    },
+    {
+      "id": "garrytan/canary",
+      "name": "Canary",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/canary.json"
+      }
+    },
+    {
+      "id": "garrytan/cso",
+      "name": "CSO",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/cso.json"
+      }
+    },
+    {
+      "id": "garrytan/design-consultation",
+      "name": "Design Consultation",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/design-consultation.json"
+      }
+    },
+    {
+      "id": "garrytan/design-html",
+      "name": "Design HTML",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/design-html.json"
+      }
+    },
+    {
+      "id": "garrytan/design-shotgun",
+      "name": "Design Shotgun",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/design-shotgun.json"
+      }
+    },
+    {
+      "id": "garrytan/document-generate",
+      "name": "Document Generate",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/document-generate.json"
+      }
+    },
+    {
+      "id": "garrytan/investigate",
+      "name": "Investigate",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/investigate.json"
+      }
+    },
+    {
+      "id": "garrytan/land-and-deploy",
+      "name": "Land and Deploy",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/land-and-deploy.json"
+      }
+    },
+    {
+      "id": "garrytan/plan-ceo-review",
+      "name": "Plan CEO Review",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/plan-ceo-review.json"
+      }
+    },
+    {
+      "id": "garrytan/plan-design-review",
+      "name": "Plan Design Review",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/plan-design-review.json"
+      }
+    },
+    {
+      "id": "garrytan/plan-devex-review",
+      "name": "Plan DevEx Review",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/plan-devex-review.json"
+      }
+    },
+    {
+      "id": "garrytan/qa",
+      "name": "QA",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/qa.json"
+      }
+    },
+    {
+      "id": "garrytan/review",
+      "name": "Review",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/review.json"
+      }
+    },
+    {
+      "id": "garrytan/ship",
+      "name": "Ship",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/ship.json"
+      }
+    },
+    {
+      "id": "garrytan/skillify",
+      "name": "Skillify",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 63.73,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/skillify.json"
+      }
+    },
+    {
+      "id": "mattpocock/grill-me",
+      "name": "Grill Me",
+      "level": "3★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 63.71,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/grill-me.json"
+      }
+    },
+    {
+      "id": "mattpocock/grill-with-docs",
+      "name": "Grill With Docs",
+      "level": "3★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 63.71,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/grill-with-docs.json"
+      }
+    },
+    {
+      "id": "mattpocock/handoff",
+      "name": "Handoff",
+      "level": "3★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 63.71,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/handoff.json"
+      }
+    },
+    {
+      "id": "mattpocock/to-prd",
+      "name": "To PRD",
+      "level": "3★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 63.71,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/to-prd.json"
+      }
+    },
+    {
+      "id": "mattpocock/personal",
+      "name": "Personal",
+      "level": "3★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 60.0,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/personal.json"
+      }
+    },
+    {
+      "id": "mattpocock/setup-matt-pocock-skills",
+      "name": "Setup Matt Pocock Skills",
+      "level": "3★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 56.21,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/setup-matt-pocock-skills.json"
+      }
+    },
+    {
+      "id": "mattpocock/triage",
+      "name": "Triage",
+      "level": "3★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 56.21,
+      "overallTrustGrade": "B",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/triage.json"
+      }
+    },
+    {
+      "id": "mattpocock/improve-codebase-architecture",
+      "name": "Improve Codebase Architecture",
+      "level": "2★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 45.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/improve-codebase-architecture.json"
+      }
+    },
+    {
+      "id": "mattpocock/write-a-skill",
+      "name": "Write a Skill",
+      "level": "2★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 45.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/write-a-skill.json"
+      }
+    },
+    {
+      "id": "mattpocock/prototype",
+      "name": "Prototype",
+      "level": "2★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 41.21,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/prototype.json"
+      }
+    },
+    {
+      "id": "bradautomates/claude-video",
+      "name": "Claude Video",
+      "level": "2★",
+      "contributor": "bradautomates",
+      "trustMagnitude": 37.47,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/bradautomates/claude-video.json"
+      }
+    },
+    {
+      "id": "Manavarya09/design-extract",
+      "name": "Design Extract",
+      "level": "2★",
+      "contributor": "Manavarya09",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/Manavarya09/design-extract.json"
+      }
+    },
+    {
+      "id": "addy-osmani/test-driven-development",
+      "name": "Test-Driven Development",
+      "level": "2★",
+      "contributor": "addy-osmani",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/addy-osmani/test-driven-development.json"
+      }
+    },
+    {
+      "id": "anthropic/pptx",
+      "name": "PPTX Editor",
+      "level": "2★",
+      "contributor": "anthropic",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/anthropic/pptx.json"
+      }
+    },
+    {
+      "id": "firecrawl/firecrawl",
+      "name": "Firecrawl",
+      "level": "2★",
+      "contributor": "firecrawl",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/firecrawl/firecrawl.json"
+      }
+    },
+    {
+      "id": "garrytan/benchmark-models",
+      "name": "Benchmark Models",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/benchmark-models.json"
+      }
+    },
+    {
+      "id": "garrytan/codex",
+      "name": "Codex",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/codex.json"
+      }
+    },
+    {
+      "id": "garrytan/context-restore",
+      "name": "Context Restore",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/context-restore.json"
+      }
+    },
+    {
+      "id": "garrytan/context-save",
+      "name": "Context Save",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/context-save.json"
+      }
+    },
+    {
+      "id": "garrytan/design-review",
+      "name": "Design Review",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/design-review.json"
+      }
+    },
+    {
+      "id": "garrytan/devex-review",
+      "name": "DevEx Review",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/devex-review.json"
+      }
+    },
+    {
+      "id": "garrytan/document-release",
+      "name": "Document Release",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/document-release.json"
+      }
+    },
+    {
+      "id": "garrytan/freeze",
+      "name": "Freeze",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/freeze.json"
+      }
+    },
+    {
+      "id": "garrytan/gstack-upgrade",
+      "name": "GStack Upgrade",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/gstack-upgrade.json"
+      }
+    },
+    {
+      "id": "garrytan/guard",
+      "name": "Guard",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/guard.json"
+      }
+    },
+    {
+      "id": "garrytan/health",
+      "name": "Health",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/health.json"
+      }
+    },
+    {
+      "id": "garrytan/landing-report",
+      "name": "Landing Report",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/landing-report.json"
+      }
+    },
+    {
+      "id": "garrytan/learn",
+      "name": "Learn",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/learn.json"
+      }
+    },
+    {
+      "id": "garrytan/make-pdf",
+      "name": "Make PDF",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/make-pdf.json"
+      }
+    },
+    {
+      "id": "garrytan/open-gstack-browser",
+      "name": "Open GStack Browser",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/open-gstack-browser.json"
+      }
+    },
+    {
+      "id": "garrytan/pair-agent",
+      "name": "Pair Agent",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/pair-agent.json"
+      }
+    },
+    {
+      "id": "garrytan/plan-tune",
+      "name": "Plan Tune",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/plan-tune.json"
+      }
+    },
+    {
+      "id": "garrytan/qa-only",
+      "name": "QA Only",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/qa-only.json"
+      }
+    },
+    {
+      "id": "garrytan/scrape",
+      "name": "Scrape",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/scrape.json"
+      }
+    },
+    {
+      "id": "garrytan/setup-browser-cookies",
+      "name": "Setup Browser Cookies",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/setup-browser-cookies.json"
+      }
+    },
+    {
+      "id": "garrytan/setup-deploy",
+      "name": "Setup Deploy",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/setup-deploy.json"
+      }
+    },
+    {
+      "id": "garrytan/setup-gbrain",
+      "name": "Setup GBrain",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/setup-gbrain.json"
+      }
+    },
+    {
+      "id": "garrytan/sync-gbrain",
+      "name": "Sync GBrain",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/sync-gbrain.json"
+      }
+    },
+    {
+      "id": "garrytan/unfreeze",
+      "name": "Unfreeze",
+      "level": "2★",
+      "contributor": "garrytan",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/garrytan/unfreeze.json"
+      }
+    },
+    {
+      "id": "getagentseal/codeburn",
+      "name": "CodeBurn",
+      "level": "2★",
+      "contributor": "getagentseal",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/getagentseal/codeburn.json"
+      }
+    },
+    {
+      "id": "huggingface/semantic-cache",
+      "name": "Semantic Cache",
+      "level": "2★",
+      "contributor": "huggingface",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/huggingface/semantic-cache.json"
+      }
+    },
+    {
+      "id": "karpathy/autoresearch",
+      "name": "AutoResearch",
+      "level": "2★",
+      "contributor": "karpathy",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/karpathy/autoresearch.json"
+      }
+    },
+    {
+      "id": "laravel/upgrade-laravel-v13",
+      "name": "Upgrade Laravel v13",
+      "level": "2★",
+      "contributor": "laravel",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/laravel/upgrade-laravel-v13.json"
+      }
+    },
+    {
+      "id": "mbtiongson1/gaia-audit",
+      "name": "Gaia Audit",
+      "level": "2★",
+      "contributor": "mbtiongson1",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mbtiongson1/gaia-audit.json"
+      }
+    },
+    {
+      "id": "mbtiongson1/gaia-curation-review",
+      "name": "Gaia Curation Review",
+      "level": "2★",
+      "contributor": "mbtiongson1",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mbtiongson1/gaia-curation-review.json"
+      }
+    },
+    {
+      "id": "mbtiongson1/gaia-meta-audit",
+      "name": "Gaia Meta Audit",
+      "level": "2★",
+      "contributor": "mbtiongson1",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mbtiongson1/gaia-meta-audit.json"
+      }
+    },
+    {
+      "id": "mbtiongson1/gaia-preview",
+      "name": "Gaia Preview",
+      "level": "2★",
+      "contributor": "mbtiongson1",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mbtiongson1/gaia-preview.json"
+      }
+    },
+    {
+      "id": "mbtiongson1/graphify-triage",
+      "name": "Graphify Triage",
+      "level": "2★",
+      "contributor": "mbtiongson1",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mbtiongson1/graphify-triage.json"
+      }
+    },
+    {
+      "id": "nexu-io/open-design",
+      "name": "Open Design",
+      "level": "2★",
+      "contributor": "nexu-io",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/nexu-io/open-design.json"
+      }
+    },
+    {
+      "id": "nousresearch/feed-monitoring",
+      "name": "Feed Monitoring",
+      "level": "2★",
+      "contributor": "nousresearch",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/nousresearch/feed-monitoring.json"
+      }
+    },
+    {
+      "id": "obra/finishing-a-development-branch",
+      "name": "Finishing a Development Branch",
+      "level": "2★",
+      "contributor": "obra",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/obra/finishing-a-development-branch.json"
+      }
+    },
+    {
+      "id": "obra/receiving-code-review",
+      "name": "Receiving Code Review",
+      "level": "2★",
+      "contributor": "obra",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/obra/receiving-code-review.json"
+      }
+    },
+    {
+      "id": "obra/requesting-code-review",
+      "name": "Requesting Code Review",
+      "level": "2★",
+      "contributor": "obra",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/obra/requesting-code-review.json"
+      }
+    },
+    {
+      "id": "ruvnet/agentdb-advanced",
+      "name": "AgentDB Advanced",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/agentdb-advanced.json"
+      }
+    },
+    {
+      "id": "ruvnet/agentdb-memory-patterns",
+      "name": "AgentDB Memory Patterns",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/agentdb-memory-patterns.json"
+      }
+    },
+    {
+      "id": "ruvnet/agentdb-optimization",
+      "name": "AgentDB Optimization",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/agentdb-optimization.json"
+      }
+    },
+    {
+      "id": "ruvnet/agentdb-vector-search",
+      "name": "AgentDB Vector Search",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/agentdb-vector-search.json"
+      }
+    },
+    {
+      "id": "ruvnet/agentic-jujutsu",
+      "name": "Agentic Jujutsu",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/agentic-jujutsu.json"
+      }
+    },
+    {
+      "id": "ruvnet/dual-collect",
+      "name": "Dual Collect",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/dual-collect.json"
+      }
+    },
+    {
+      "id": "ruvnet/dual-coordinate",
+      "name": "Dual Coordinate",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/dual-coordinate.json"
+      }
+    },
+    {
+      "id": "ruvnet/dual-spawn",
+      "name": "Dual Spawn",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/dual-spawn.json"
+      }
+    },
+    {
+      "id": "ruvnet/flow-nexus-neural",
+      "name": "Flow Nexus Neural",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/flow-nexus-neural.json"
+      }
+    },
+    {
+      "id": "ruvnet/flow-nexus-platform",
+      "name": "Flow Nexus Platform",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/flow-nexus-platform.json"
+      }
+    },
+    {
+      "id": "ruvnet/github-multi-repo",
+      "name": "GitHub Multi-Repo",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/github-multi-repo.json"
+      }
+    },
+    {
+      "id": "ruvnet/pair-programming",
+      "name": "Pair Programming",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/pair-programming.json"
+      }
+    },
+    {
+      "id": "ruvnet/reasoningbank-intelligence",
+      "name": "ReasoningBank Intelligence",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/reasoningbank-intelligence.json"
+      }
+    },
+    {
+      "id": "ruvnet/stream-chain",
+      "name": "Stream Chain",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/stream-chain.json"
+      }
+    },
+    {
+      "id": "ruvnet/swarm-advanced",
+      "name": "Swarm Advanced",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/swarm-advanced.json"
+      }
+    },
+    {
+      "id": "ruvnet/swarm-orchestration",
+      "name": "Swarm Orchestration",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/swarm-orchestration.json"
+      }
+    },
+    {
+      "id": "ruvnet/v3-cli-modernization",
+      "name": "V3 CLI Modernization",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/v3-cli-modernization.json"
+      }
+    },
+    {
+      "id": "ruvnet/v3-core-implementation",
+      "name": "V3 Core Implementation",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/v3-core-implementation.json"
+      }
+    },
+    {
+      "id": "ruvnet/v3-ddd-architecture",
+      "name": "V3 DDD Architecture",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/v3-ddd-architecture.json"
+      }
+    },
+    {
+      "id": "ruvnet/v3-integration-deep",
+      "name": "V3 Integration Deep",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/v3-integration-deep.json"
+      }
+    },
+    {
+      "id": "ruvnet/verification-quality",
+      "name": "Verification Quality",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/verification-quality.json"
+      }
+    },
+    {
+      "id": "ruvnet/worker-integration",
+      "name": "Worker Integration",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/worker-integration.json"
+      }
+    },
+    {
+      "id": "santifer/career-ops",
+      "name": "Career-Ops",
+      "level": "2★",
+      "contributor": "santifer",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/santifer/career-ops.json"
+      }
+    },
+    {
+      "id": "spring-ai/readme-generate",
+      "name": "REST API README Generator",
+      "level": "2★",
+      "contributor": "spring-ai",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/spring-ai/readme-generate.json"
+      }
+    },
+    {
+      "id": "vercel/find-skills",
+      "name": "Find Skills",
+      "level": "2★",
+      "contributor": "vercel",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/vercel/find-skills.json"
+      }
+    },
+    {
+      "id": "upsonic/unittest-generator",
+      "name": "Unittest Generator",
+      "level": "2★",
+      "contributor": "upsonic",
+      "trustMagnitude": 33.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/upsonic/unittest-generator.json"
+      }
+    },
+    {
+      "id": "devin-ai/autonomous-swe",
+      "name": "Autonomous SWE",
+      "level": "2★",
+      "contributor": "devin-ai",
+      "trustMagnitude": 30.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/devin-ai/autonomous-swe.json"
+      }
+    },
+    {
+      "id": "mattpocock/caveman",
+      "name": "Caveman Mode",
+      "level": "2★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 30.0,
+      "overallTrustGrade": "C",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/caveman.json"
+      }
+    },
+    {
+      "id": "mattpocock/teach",
+      "name": "Teach",
+      "level": "2★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 0,
+      "overallTrustGrade": "ungraded",
+      "trendingScore": 0.0,
+      "tmDelta": 0.0,
+      "new": false,
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/teach.json"
+      }
+    }
+  ],
+  "totalTrending": 139,
+  "_links": {
+    "self": "/api/v1/trending/7d.json"
+  }
+}

--- a/docs/api/v1/trending/ascended.json
+++ b/docs/api/v1/trending/ascended.json
@@ -1,0 +1,368 @@
+{
+  "generatedAt": "2026-06-30T16:25:29Z",
+  "skills": [
+    {
+      "id": "safishamsi/graphify",
+      "name": "Graphify",
+      "level": "4★",
+      "contributor": "safishamsi",
+      "trustMagnitude": 116.57,
+      "overallTrustGrade": "A",
+      "ascendedAt": "2026-06-20T06:31:38Z",
+      "_links": {
+        "self": "/api/v1/skills/safishamsi/graphify.json"
+      }
+    },
+    {
+      "id": "stanfordnlp/dspy",
+      "name": "DSPy",
+      "level": "4★",
+      "contributor": "stanfordnlp",
+      "trustMagnitude": 100.0,
+      "overallTrustGrade": "A",
+      "ascendedAt": "2026-06-20T06:31:38Z",
+      "_links": {
+        "self": "/api/v1/skills/stanfordnlp/dspy.json"
+      }
+    },
+    {
+      "id": "ruvnet/reasoningbank-intelligence",
+      "name": "ReasoningBank Intelligence",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "ascendedAt": "2026-06-20T06:31:37Z",
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/reasoningbank-intelligence.json"
+      }
+    },
+    {
+      "id": "ruvnet/swarm-advanced",
+      "name": "Swarm Advanced",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "ascendedAt": "2026-06-20T06:31:37Z",
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/swarm-advanced.json"
+      }
+    },
+    {
+      "id": "ruvnet/swarm-orchestration",
+      "name": "Swarm Orchestration",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "ascendedAt": "2026-06-20T06:31:37Z",
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/swarm-orchestration.json"
+      }
+    },
+    {
+      "id": "ruvnet/dual-mode",
+      "name": "Dual Mode",
+      "level": "4★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 126.0,
+      "overallTrustGrade": "A",
+      "ascendedAt": "2026-06-20T06:31:36Z",
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/dual-mode.json"
+      }
+    },
+    {
+      "id": "ruvnet/reasoningbank",
+      "name": "ReasoningBank",
+      "level": "4★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 118.5,
+      "overallTrustGrade": "A",
+      "ascendedAt": "2026-06-20T06:31:36Z",
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/reasoningbank.json"
+      }
+    },
+    {
+      "id": "ruvnet/flow-nexus-neural",
+      "name": "Flow Nexus Neural",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "ascendedAt": "2026-06-20T06:31:36Z",
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/flow-nexus-neural.json"
+      }
+    },
+    {
+      "id": "ruvnet/flow-nexus-platform",
+      "name": "Flow Nexus Platform",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "ascendedAt": "2026-06-20T06:31:36Z",
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/flow-nexus-platform.json"
+      }
+    },
+    {
+      "id": "obra/writing-plans",
+      "name": "Writing Plans",
+      "level": "4★",
+      "contributor": "obra",
+      "trustMagnitude": 110.15,
+      "overallTrustGrade": "A",
+      "ascendedAt": "2026-06-20T06:31:35Z",
+      "_links": {
+        "self": "/api/v1/skills/obra/writing-plans.json"
+      }
+    },
+    {
+      "id": "openai/few-shot-learning",
+      "name": "Few-Shot Learning",
+      "level": "4★",
+      "contributor": "openai",
+      "trustMagnitude": 100.0,
+      "overallTrustGrade": "A",
+      "ascendedAt": "2026-06-20T06:31:35Z",
+      "_links": {
+        "self": "/api/v1/skills/openai/few-shot-learning.json"
+      }
+    },
+    {
+      "id": "openai/self-consistency",
+      "name": "Self-Consistency",
+      "level": "4★",
+      "contributor": "openai",
+      "trustMagnitude": 100.0,
+      "overallTrustGrade": "A",
+      "ascendedAt": "2026-06-20T06:31:35Z",
+      "_links": {
+        "self": "/api/v1/skills/openai/self-consistency.json"
+      }
+    },
+    {
+      "id": "obra/verification-before-completion",
+      "name": "Verification Before Completion",
+      "level": "3★",
+      "contributor": "obra",
+      "trustMagnitude": 95.15,
+      "overallTrustGrade": "B",
+      "ascendedAt": "2026-06-20T06:31:35Z",
+      "_links": {
+        "self": "/api/v1/skills/obra/verification-before-completion.json"
+      }
+    },
+    {
+      "id": "ruvnet/agentdb-advanced",
+      "name": "AgentDB Advanced",
+      "level": "2★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "ascendedAt": "2026-06-20T06:31:35Z",
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/agentdb-advanced.json"
+      }
+    },
+    {
+      "id": "obra/using-git-worktrees",
+      "name": "Using Git Worktrees",
+      "level": "4★",
+      "contributor": "obra",
+      "trustMagnitude": 117.65,
+      "overallTrustGrade": "A",
+      "ascendedAt": "2026-06-20T06:31:34Z",
+      "_links": {
+        "self": "/api/v1/skills/obra/using-git-worktrees.json"
+      }
+    },
+    {
+      "id": "obra/brainstorming",
+      "name": "Brainstorming",
+      "level": "3★",
+      "contributor": "obra",
+      "trustMagnitude": 95.15,
+      "overallTrustGrade": "B",
+      "ascendedAt": "2026-06-20T06:31:34Z",
+      "_links": {
+        "self": "/api/v1/skills/obra/brainstorming.json"
+      }
+    },
+    {
+      "id": "obra/executing-plans",
+      "name": "Executing Plans",
+      "level": "3★",
+      "contributor": "obra",
+      "trustMagnitude": 95.15,
+      "overallTrustGrade": "B",
+      "ascendedAt": "2026-06-20T06:31:34Z",
+      "_links": {
+        "self": "/api/v1/skills/obra/executing-plans.json"
+      }
+    },
+    {
+      "id": "nexu-io/open-design",
+      "name": "Open Design",
+      "level": "2★",
+      "contributor": "nexu-io",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "ascendedAt": "2026-06-20T06:31:34Z",
+      "_links": {
+        "self": "/api/v1/skills/nexu-io/open-design.json"
+      }
+    },
+    {
+      "id": "nousresearch/feed-monitoring",
+      "name": "Feed Monitoring",
+      "level": "2★",
+      "contributor": "nousresearch",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "ascendedAt": "2026-06-20T06:31:34Z",
+      "_links": {
+        "self": "/api/v1/skills/nousresearch/feed-monitoring.json"
+      }
+    },
+    {
+      "id": "mattpocock/to-prd",
+      "name": "To PRD",
+      "level": "3★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 63.71,
+      "overallTrustGrade": "B",
+      "ascendedAt": "2026-06-20T06:31:32Z",
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/to-prd.json"
+      }
+    },
+    {
+      "id": "mattpocock/edit-article",
+      "name": "Edit Article",
+      "level": "3★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 90.38,
+      "overallTrustGrade": "B",
+      "ascendedAt": "2026-06-20T06:31:31Z",
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/edit-article.json"
+      }
+    },
+    {
+      "id": "martin-stepanoski/nielsen-heuristics-audit",
+      "name": "Nielsen Heuristics Audit",
+      "level": "3★",
+      "contributor": "martin-stepanoski",
+      "trustMagnitude": 94.9,
+      "overallTrustGrade": "B",
+      "ascendedAt": "2026-06-20T06:31:30Z",
+      "_links": {
+        "self": "/api/v1/skills/martin-stepanoski/nielsen-heuristics-audit.json"
+      }
+    },
+    {
+      "id": "mattpocock/diagnose",
+      "name": "Diagnose",
+      "level": "3★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 90.38,
+      "overallTrustGrade": "B",
+      "ascendedAt": "2026-06-20T06:31:30Z",
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/diagnose.json"
+      }
+    },
+    {
+      "id": "huggingface/semantic-cache",
+      "name": "Semantic Cache",
+      "level": "2★",
+      "contributor": "huggingface",
+      "trustMagnitude": 36.0,
+      "overallTrustGrade": "C",
+      "ascendedAt": "2026-06-20T06:31:28Z",
+      "_links": {
+        "self": "/api/v1/skills/huggingface/semantic-cache.json"
+      }
+    },
+    {
+      "id": "garrytan/careful",
+      "name": "Careful",
+      "level": "3★",
+      "contributor": "garrytan",
+      "trustMagnitude": 66.0,
+      "overallTrustGrade": "B",
+      "ascendedAt": "2026-06-20T06:31:21Z",
+      "_links": {
+        "self": "/api/v1/skills/garrytan/careful.json"
+      }
+    },
+    {
+      "id": "anthropic/skill-creator",
+      "name": "Skill Creator",
+      "level": "3★",
+      "contributor": "anthropic",
+      "trustMagnitude": 90.0,
+      "overallTrustGrade": "B",
+      "ascendedAt": "2026-06-20T06:31:20Z",
+      "_links": {
+        "self": "/api/v1/skills/anthropic/skill-creator.json"
+      }
+    },
+    {
+      "id": "browser-use/browser-harness",
+      "name": "Browser Harness",
+      "level": "3★",
+      "contributor": "browser-use",
+      "trustMagnitude": 73.59,
+      "overallTrustGrade": "B",
+      "ascendedAt": "2026-06-20T06:31:20Z",
+      "_links": {
+        "self": "/api/v1/skills/browser-use/browser-harness.json"
+      }
+    },
+    {
+      "id": "devin-ai/autonomous-swe",
+      "name": "Autonomous SWE",
+      "level": "2★",
+      "contributor": "devin-ai",
+      "trustMagnitude": 30.0,
+      "overallTrustGrade": "C",
+      "ascendedAt": "2026-06-20T06:31:20Z",
+      "_links": {
+        "self": "/api/v1/skills/devin-ai/autonomous-swe.json"
+      }
+    },
+    {
+      "id": "mattpocock/teach",
+      "name": "Teach",
+      "level": "2★",
+      "contributor": "mattpocock",
+      "trustMagnitude": 0.0,
+      "overallTrustGrade": "ungraded",
+      "ascendedAt": "2026-06-19T18:41:33Z",
+      "_links": {
+        "self": "/api/v1/skills/mattpocock/teach.json"
+      }
+    },
+    {
+      "id": "ruvnet/hive-mind-coordination",
+      "name": "Hive Mind Coordination",
+      "level": "3★",
+      "contributor": "ruvnet",
+      "trustMagnitude": 96.09,
+      "overallTrustGrade": "B",
+      "ascendedAt": "2026-06-04T20:30:55Z",
+      "_links": {
+        "self": "/api/v1/skills/ruvnet/hive-mind-coordination.json"
+      }
+    }
+  ],
+  "_links": {
+    "self": "/api/v1/trending/ascended.json"
+  }
+}

--- a/docs/api/v1/trending/contested.json
+++ b/docs/api/v1/trending/contested.json
@@ -1,0 +1,454 @@
+{
+  "generatedAt": "2026-06-30T16:25:29Z",
+  "buckets": [
+    {
+      "genericSkillRef": "vertical-slice-planning",
+      "implementations": 2,
+      "topTM": 156.0,
+      "skills": [
+        {
+          "id": "garrytan/garrytan",
+          "trustMagnitude": 156.0,
+          "level": "4★",
+          "overallTrustGrade": "A"
+        },
+        {
+          "id": "mattpocock/to-issues",
+          "trustMagnitude": 90.38,
+          "level": "3★",
+          "overallTrustGrade": "B"
+        }
+      ]
+    },
+    {
+      "genericSkillRef": "ux-audit",
+      "implementations": 6,
+      "topTM": 122.8,
+      "skills": [
+        {
+          "id": "pbakaus/impeccable",
+          "trustMagnitude": 122.8,
+          "level": "4★",
+          "overallTrustGrade": "A"
+        },
+        {
+          "id": "martin-stepanoski/nielsen-heuristics-audit",
+          "trustMagnitude": 94.9,
+          "level": "3★",
+          "overallTrustGrade": "B"
+        },
+        {
+          "id": "garrytan/plan-design-review",
+          "trustMagnitude": 63.73,
+          "level": "3★",
+          "overallTrustGrade": "B"
+        },
+        {
+          "id": "garrytan/plan-devex-review",
+          "trustMagnitude": 63.73,
+          "level": "3★",
+          "overallTrustGrade": "B"
+        },
+        {
+          "id": "garrytan/design-review",
+          "trustMagnitude": 36.0,
+          "level": "2★",
+          "overallTrustGrade": "C"
+        },
+        {
+          "id": "garrytan/devex-review",
+          "trustMagnitude": 36.0,
+          "level": "2★",
+          "overallTrustGrade": "C"
+        }
+      ]
+    },
+    {
+      "genericSkillRef": "subagent-driven-development",
+      "implementations": 2,
+      "topTM": 117.65,
+      "skills": [
+        {
+          "id": "obra/subagent-driven-development",
+          "trustMagnitude": 117.65,
+          "level": "4★",
+          "overallTrustGrade": "A"
+        },
+        {
+          "id": "ruvnet/pair-programming",
+          "trustMagnitude": 36.0,
+          "level": "2★",
+          "overallTrustGrade": "C"
+        }
+      ]
+    },
+    {
+      "genericSkillRef": "prompt-optimization",
+      "implementations": 2,
+      "topTM": 100.0,
+      "skills": [
+        {
+          "id": "stanfordnlp/dspy",
+          "trustMagnitude": 100.0,
+          "level": "4★",
+          "overallTrustGrade": "A"
+        },
+        {
+          "id": "garrytan/plan-tune",
+          "trustMagnitude": 36.0,
+          "level": "2★",
+          "overallTrustGrade": "C"
+        }
+      ]
+    },
+    {
+      "genericSkillRef": "verification-before-completion",
+      "implementations": 2,
+      "topTM": 95.15,
+      "skills": [
+        {
+          "id": "obra/verification-before-completion",
+          "trustMagnitude": 95.15,
+          "level": "3★",
+          "overallTrustGrade": "B"
+        },
+        {
+          "id": "ruvnet/verification-quality",
+          "trustMagnitude": 36.0,
+          "level": "2★",
+          "overallTrustGrade": "C"
+        }
+      ]
+    },
+    {
+      "genericSkillRef": "autonomous-debug",
+      "implementations": 2,
+      "topTM": 90.38,
+      "skills": [
+        {
+          "id": "mattpocock/diagnose",
+          "trustMagnitude": 90.38,
+          "level": "3★",
+          "overallTrustGrade": "B"
+        },
+        {
+          "id": "devin-ai/autonomous-swe",
+          "trustMagnitude": 30.0,
+          "level": "2★",
+          "overallTrustGrade": "C"
+        }
+      ]
+    },
+    {
+      "genericSkillRef": "document-editing",
+      "implementations": 4,
+      "topTM": 90.38,
+      "skills": [
+        {
+          "id": "mattpocock/edit-article",
+          "trustMagnitude": 90.38,
+          "level": "3★",
+          "overallTrustGrade": "B"
+        },
+        {
+          "id": "garrytan/document-generate",
+          "trustMagnitude": 63.73,
+          "level": "3★",
+          "overallTrustGrade": "B"
+        },
+        {
+          "id": "anthropic/pptx",
+          "trustMagnitude": 36.0,
+          "level": "2★",
+          "overallTrustGrade": "C"
+        },
+        {
+          "id": "garrytan/document-release",
+          "trustMagnitude": 36.0,
+          "level": "2★",
+          "overallTrustGrade": "C"
+        }
+      ]
+    },
+    {
+      "genericSkillRef": "ubiquitous-language",
+      "implementations": 2,
+      "topTM": 90.38,
+      "skills": [
+        {
+          "id": "mattpocock/ubiquitous-language",
+          "trustMagnitude": 90.38,
+          "level": "3★",
+          "overallTrustGrade": "B"
+        },
+        {
+          "id": "ruvnet/v3-ddd-architecture",
+          "trustMagnitude": 36.0,
+          "level": "2★",
+          "overallTrustGrade": "C"
+        }
+      ]
+    },
+    {
+      "genericSkillRef": "tool-creation",
+      "implementations": 2,
+      "topTM": 90.0,
+      "skills": [
+        {
+          "id": "anthropic/skill-creator",
+          "trustMagnitude": 90.0,
+          "level": "3★",
+          "overallTrustGrade": "B"
+        },
+        {
+          "id": "mattpocock/write-a-skill",
+          "trustMagnitude": 45.0,
+          "level": "2★",
+          "overallTrustGrade": "C"
+        }
+      ]
+    },
+    {
+      "genericSkillRef": "browser-control",
+      "implementations": 4,
+      "topTM": 88.5,
+      "skills": [
+        {
+          "id": "garrytan/browse",
+          "trustMagnitude": 88.5,
+          "level": "3★",
+          "overallTrustGrade": "B"
+        },
+        {
+          "id": "browser-use/browser-harness",
+          "trustMagnitude": 73.59,
+          "level": "3★",
+          "overallTrustGrade": "B"
+        },
+        {
+          "id": "garrytan/open-gstack-browser",
+          "trustMagnitude": 36.0,
+          "level": "2★",
+          "overallTrustGrade": "C"
+        },
+        {
+          "id": "garrytan/setup-browser-cookies",
+          "trustMagnitude": 36.0,
+          "level": "2★",
+          "overallTrustGrade": "C"
+        }
+      ]
+    },
+    {
+      "genericSkillRef": "write-report",
+      "implementations": 2,
+      "topTM": 81.0,
+      "skills": [
+        {
+          "id": "garrytan/retro",
+          "trustMagnitude": 81.0,
+          "level": "3★",
+          "overallTrustGrade": "B"
+        },
+        {
+          "id": "spring-ai/readme-generate",
+          "trustMagnitude": 36.0,
+          "level": "2★",
+          "overallTrustGrade": "C"
+        }
+      ]
+    },
+    {
+      "genericSkillRef": "guardrails",
+      "implementations": 4,
+      "topTM": 66.0,
+      "skills": [
+        {
+          "id": "garrytan/careful",
+          "trustMagnitude": 66.0,
+          "level": "3★",
+          "overallTrustGrade": "B"
+        },
+        {
+          "id": "garrytan/freeze",
+          "trustMagnitude": 36.0,
+          "level": "2★",
+          "overallTrustGrade": "C"
+        },
+        {
+          "id": "garrytan/guard",
+          "trustMagnitude": 36.0,
+          "level": "2★",
+          "overallTrustGrade": "C"
+        },
+        {
+          "id": "garrytan/unfreeze",
+          "trustMagnitude": 36.0,
+          "level": "2★",
+          "overallTrustGrade": "C"
+        }
+      ]
+    },
+    {
+      "genericSkillRef": "code-review-pipeline",
+      "implementations": 2,
+      "topTM": 66.0,
+      "skills": [
+        {
+          "id": "garrytan/plan-eng-review",
+          "trustMagnitude": 66.0,
+          "level": "3★",
+          "overallTrustGrade": "B"
+        },
+        {
+          "id": "garrytan/review",
+          "trustMagnitude": 63.73,
+          "level": "3★",
+          "overallTrustGrade": "B"
+        }
+      ]
+    },
+    {
+      "genericSkillRef": "systematic-debugging",
+      "implementations": 2,
+      "topTM": 65.15,
+      "skills": [
+        {
+          "id": "obra/systematic-debugging",
+          "trustMagnitude": 65.15,
+          "level": "3★",
+          "overallTrustGrade": "B"
+        },
+        {
+          "id": "garrytan/investigate",
+          "trustMagnitude": 63.73,
+          "level": "3★",
+          "overallTrustGrade": "B"
+        }
+      ]
+    },
+    {
+      "genericSkillRef": "evaluate-output",
+      "implementations": 2,
+      "topTM": 63.73,
+      "skills": [
+        {
+          "id": "garrytan/benchmark",
+          "trustMagnitude": 63.73,
+          "level": "3★",
+          "overallTrustGrade": "B"
+        },
+        {
+          "id": "garrytan/plan-ceo-review",
+          "trustMagnitude": 63.73,
+          "level": "3★",
+          "overallTrustGrade": "B"
+        }
+      ]
+    },
+    {
+      "genericSkillRef": "design-system-extraction",
+      "implementations": 2,
+      "topTM": 63.73,
+      "skills": [
+        {
+          "id": "garrytan/design-consultation",
+          "trustMagnitude": 63.73,
+          "level": "3★",
+          "overallTrustGrade": "B"
+        },
+        {
+          "id": "Manavarya09/design-extract",
+          "trustMagnitude": 36.0,
+          "level": "2★",
+          "overallTrustGrade": "C"
+        }
+      ]
+    },
+    {
+      "genericSkillRef": "deployment-automation",
+      "implementations": 3,
+      "topTM": 63.73,
+      "skills": [
+        {
+          "id": "garrytan/land-and-deploy",
+          "trustMagnitude": 63.73,
+          "level": "3★",
+          "overallTrustGrade": "B"
+        },
+        {
+          "id": "garrytan/setup-deploy",
+          "trustMagnitude": 36.0,
+          "level": "2★",
+          "overallTrustGrade": "C"
+        },
+        {
+          "id": "mbtiongson1/gaia-preview",
+          "trustMagnitude": 36.0,
+          "level": "2★",
+          "overallTrustGrade": "C"
+        }
+      ]
+    },
+    {
+      "genericSkillRef": "e2e-testing",
+      "implementations": 2,
+      "topTM": 63.73,
+      "skills": [
+        {
+          "id": "garrytan/qa",
+          "trustMagnitude": 63.73,
+          "level": "3★",
+          "overallTrustGrade": "B"
+        },
+        {
+          "id": "garrytan/qa-only",
+          "trustMagnitude": 36.0,
+          "level": "2★",
+          "overallTrustGrade": "C"
+        }
+      ]
+    },
+    {
+      "genericSkillRef": "finishing-a-development-branch",
+      "implementations": 2,
+      "topTM": 63.73,
+      "skills": [
+        {
+          "id": "garrytan/ship",
+          "trustMagnitude": 63.73,
+          "level": "3★",
+          "overallTrustGrade": "B"
+        },
+        {
+          "id": "obra/finishing-a-development-branch",
+          "trustMagnitude": 36.0,
+          "level": "2★",
+          "overallTrustGrade": "C"
+        }
+      ]
+    },
+    {
+      "genericSkillRef": "web-scrape",
+      "implementations": 2,
+      "topTM": 36.0,
+      "skills": [
+        {
+          "id": "firecrawl/firecrawl",
+          "trustMagnitude": 36.0,
+          "level": "2★",
+          "overallTrustGrade": "C"
+        },
+        {
+          "id": "garrytan/scrape",
+          "trustMagnitude": 36.0,
+          "level": "2★",
+          "overallTrustGrade": "C"
+        }
+      ]
+    }
+  ],
+  "_links": {
+    "self": "/api/v1/trending/contested.json"
+  }
+}

--- a/docs/api/v1/trending/history/2026-06-30.json
+++ b/docs/api/v1/trending/history/2026-06-30.json
@@ -1,0 +1,840 @@
+{
+  "date": "2026-06-30",
+  "generatedAt": "2026-06-30T16:25:29Z",
+  "skills": {
+    "garrytan/gstack": {
+      "tm": 589.32,
+      "grade": "S",
+      "level": "5★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/ruflo": {
+      "tm": 482.27,
+      "grade": "S",
+      "level": "5★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/skills": {
+      "tm": 480.29,
+      "grade": "S",
+      "level": "5★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "obra/superpowers": {
+      "tm": 445.15,
+      "grade": "S",
+      "level": "5★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/engineering": {
+      "tm": 270.0,
+      "grade": "A",
+      "level": "4★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/agentdb": {
+      "tm": 201.0,
+      "grade": "A",
+      "level": "4★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/ruflo-v3": {
+      "tm": 186.0,
+      "grade": "A",
+      "level": "4★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/garrytan": {
+      "tm": 156.0,
+      "grade": "A",
+      "level": "4★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/dual-mode": {
+      "tm": 126.0,
+      "grade": "A",
+      "level": "4★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "pbakaus/impeccable": {
+      "tm": 122.8,
+      "grade": "A",
+      "level": "4★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/productivity": {
+      "tm": 120.0,
+      "grade": "A",
+      "level": "4★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/reasoningbank": {
+      "tm": 118.5,
+      "grade": "A",
+      "level": "4★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "obra/subagent-driven-development": {
+      "tm": 117.65,
+      "grade": "A",
+      "level": "4★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "obra/using-git-worktrees": {
+      "tm": 117.65,
+      "grade": "A",
+      "level": "4★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "safishamsi/graphify": {
+      "tm": 116.57,
+      "grade": "A",
+      "level": "4★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "obra/writing-plans": {
+      "tm": 110.15,
+      "grade": "A",
+      "level": "4★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "openai/few-shot-learning": {
+      "tm": 100.0,
+      "grade": "A",
+      "level": "4★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "openai/self-consistency": {
+      "tm": 100.0,
+      "grade": "A",
+      "level": "4★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "stanfordnlp/dspy": {
+      "tm": 100.0,
+      "grade": "A",
+      "level": "4★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/hive-mind-coordination": {
+      "tm": 96.09,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/flow-nexus": {
+      "tm": 96.0,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "obra/brainstorming": {
+      "tm": 95.15,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "obra/executing-plans": {
+      "tm": 95.15,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "obra/verification-before-completion": {
+      "tm": 95.15,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "martin-stepanoski/nielsen-heuristics-audit": {
+      "tm": 94.9,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/diagnose": {
+      "tm": 90.38,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/edit-article": {
+      "tm": 90.38,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/obsidian-vault": {
+      "tm": 90.38,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/to-issues": {
+      "tm": 90.38,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/ubiquitous-language": {
+      "tm": 90.38,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "anthropic/skill-creator": {
+      "tm": 90.0,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/browse": {
+      "tm": 88.5,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "obra/dispatching-parallel-agents": {
+      "tm": 86.0,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "addy-osmani/performance-optimization": {
+      "tm": 83.2,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/retro": {
+      "tm": 81.0,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "browser-use/browser-harness": {
+      "tm": 73.59,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/careful": {
+      "tm": 66.0,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/office-hours": {
+      "tm": 66.0,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/plan-eng-review": {
+      "tm": 66.0,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/github-suite": {
+      "tm": 66.0,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "obra/systematic-debugging": {
+      "tm": 65.15,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/benchmark": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/canary": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/cso": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/design-consultation": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/design-html": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/design-shotgun": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/document-generate": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/investigate": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/land-and-deploy": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/plan-ceo-review": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/plan-design-review": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/plan-devex-review": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/qa": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/review": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/ship": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/skillify": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/grill-me": {
+      "tm": 63.71,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/grill-with-docs": {
+      "tm": 63.71,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/handoff": {
+      "tm": 63.71,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/to-prd": {
+      "tm": 63.71,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/personal": {
+      "tm": 60.0,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/setup-matt-pocock-skills": {
+      "tm": 56.21,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/triage": {
+      "tm": 56.21,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/improve-codebase-architecture": {
+      "tm": 45.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/write-a-skill": {
+      "tm": 45.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/prototype": {
+      "tm": 41.21,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "bradautomates/claude-video": {
+      "tm": 37.47,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "Manavarya09/design-extract": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "addy-osmani/test-driven-development": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "anthropic/pptx": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "firecrawl/firecrawl": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/benchmark-models": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/codex": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/context-restore": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/context-save": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/design-review": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/devex-review": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/document-release": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/freeze": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/gstack-upgrade": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/guard": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/health": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/landing-report": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/learn": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/make-pdf": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/open-gstack-browser": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/pair-agent": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/plan-tune": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/qa-only": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/scrape": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/setup-browser-cookies": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/setup-deploy": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/setup-gbrain": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/sync-gbrain": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/unfreeze": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "getagentseal/codeburn": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "huggingface/semantic-cache": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "karpathy/autoresearch": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "laravel/upgrade-laravel-v13": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mbtiongson1/gaia-audit": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mbtiongson1/gaia-curation-review": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mbtiongson1/gaia-meta-audit": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mbtiongson1/gaia-preview": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mbtiongson1/graphify-triage": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "nexu-io/open-design": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "nousresearch/feed-monitoring": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "obra/finishing-a-development-branch": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "obra/receiving-code-review": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "obra/requesting-code-review": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/agentdb-advanced": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/agentdb-memory-patterns": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/agentdb-optimization": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/agentdb-vector-search": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/agentic-jujutsu": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/dual-collect": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/dual-coordinate": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/dual-spawn": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/flow-nexus-neural": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/flow-nexus-platform": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/github-multi-repo": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/pair-programming": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/reasoningbank-intelligence": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/stream-chain": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/swarm-advanced": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/swarm-orchestration": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/v3-cli-modernization": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/v3-core-implementation": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/v3-ddd-architecture": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/v3-integration-deep": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/verification-quality": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/worker-integration": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "santifer/career-ops": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "spring-ai/readme-generate": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "vercel/find-skills": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "upsonic/unittest-generator": {
+      "tm": 33.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "devin-ai/autonomous-swe": {
+      "tm": 30.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/caveman": {
+      "tm": 30.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/teach": {
+      "tm": 0.0,
+      "grade": "ungraded",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    }
+  }
+}

--- a/docs/api/v1/trending/snapshot.json
+++ b/docs/api/v1/trending/snapshot.json
@@ -1,0 +1,839 @@
+{
+  "generatedAt": "2026-06-30T16:25:29Z",
+  "skills": {
+    "garrytan/gstack": {
+      "tm": 589.32,
+      "grade": "S",
+      "level": "5★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/ruflo": {
+      "tm": 482.27,
+      "grade": "S",
+      "level": "5★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/skills": {
+      "tm": 480.29,
+      "grade": "S",
+      "level": "5★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "obra/superpowers": {
+      "tm": 445.15,
+      "grade": "S",
+      "level": "5★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/engineering": {
+      "tm": 270.0,
+      "grade": "A",
+      "level": "4★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/agentdb": {
+      "tm": 201.0,
+      "grade": "A",
+      "level": "4★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/ruflo-v3": {
+      "tm": 186.0,
+      "grade": "A",
+      "level": "4★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/garrytan": {
+      "tm": 156.0,
+      "grade": "A",
+      "level": "4★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/dual-mode": {
+      "tm": 126.0,
+      "grade": "A",
+      "level": "4★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "pbakaus/impeccable": {
+      "tm": 122.8,
+      "grade": "A",
+      "level": "4★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/productivity": {
+      "tm": 120.0,
+      "grade": "A",
+      "level": "4★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/reasoningbank": {
+      "tm": 118.5,
+      "grade": "A",
+      "level": "4★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "obra/subagent-driven-development": {
+      "tm": 117.65,
+      "grade": "A",
+      "level": "4★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "obra/using-git-worktrees": {
+      "tm": 117.65,
+      "grade": "A",
+      "level": "4★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "safishamsi/graphify": {
+      "tm": 116.57,
+      "grade": "A",
+      "level": "4★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "obra/writing-plans": {
+      "tm": 110.15,
+      "grade": "A",
+      "level": "4★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "openai/few-shot-learning": {
+      "tm": 100.0,
+      "grade": "A",
+      "level": "4★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "openai/self-consistency": {
+      "tm": 100.0,
+      "grade": "A",
+      "level": "4★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "stanfordnlp/dspy": {
+      "tm": 100.0,
+      "grade": "A",
+      "level": "4★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/hive-mind-coordination": {
+      "tm": 96.09,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/flow-nexus": {
+      "tm": 96.0,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "obra/brainstorming": {
+      "tm": 95.15,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "obra/executing-plans": {
+      "tm": 95.15,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "obra/verification-before-completion": {
+      "tm": 95.15,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "martin-stepanoski/nielsen-heuristics-audit": {
+      "tm": 94.9,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/diagnose": {
+      "tm": 90.38,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/edit-article": {
+      "tm": 90.38,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/obsidian-vault": {
+      "tm": 90.38,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/to-issues": {
+      "tm": 90.38,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/ubiquitous-language": {
+      "tm": 90.38,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "anthropic/skill-creator": {
+      "tm": 90.0,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/browse": {
+      "tm": 88.5,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "obra/dispatching-parallel-agents": {
+      "tm": 86.0,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "addy-osmani/performance-optimization": {
+      "tm": 83.2,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/retro": {
+      "tm": 81.0,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "browser-use/browser-harness": {
+      "tm": 73.59,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/careful": {
+      "tm": 66.0,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/office-hours": {
+      "tm": 66.0,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/plan-eng-review": {
+      "tm": 66.0,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/github-suite": {
+      "tm": 66.0,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "obra/systematic-debugging": {
+      "tm": 65.15,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/benchmark": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/canary": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/cso": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/design-consultation": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/design-html": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/design-shotgun": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/document-generate": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/investigate": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/land-and-deploy": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/plan-ceo-review": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/plan-design-review": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/plan-devex-review": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/qa": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/review": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/ship": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/skillify": {
+      "tm": 63.73,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/grill-me": {
+      "tm": 63.71,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/grill-with-docs": {
+      "tm": 63.71,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/handoff": {
+      "tm": 63.71,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/to-prd": {
+      "tm": 63.71,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/personal": {
+      "tm": 60.0,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/setup-matt-pocock-skills": {
+      "tm": 56.21,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/triage": {
+      "tm": 56.21,
+      "grade": "B",
+      "level": "3★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/improve-codebase-architecture": {
+      "tm": 45.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/write-a-skill": {
+      "tm": 45.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/prototype": {
+      "tm": 41.21,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "bradautomates/claude-video": {
+      "tm": 37.47,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "Manavarya09/design-extract": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "addy-osmani/test-driven-development": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "anthropic/pptx": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "firecrawl/firecrawl": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/benchmark-models": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/codex": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/context-restore": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/context-save": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/design-review": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/devex-review": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/document-release": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/freeze": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/gstack-upgrade": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/guard": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/health": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/landing-report": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/learn": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/make-pdf": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/open-gstack-browser": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/pair-agent": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/plan-tune": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/qa-only": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/scrape": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/setup-browser-cookies": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/setup-deploy": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/setup-gbrain": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/sync-gbrain": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "garrytan/unfreeze": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "getagentseal/codeburn": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "huggingface/semantic-cache": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "karpathy/autoresearch": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "laravel/upgrade-laravel-v13": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mbtiongson1/gaia-audit": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mbtiongson1/gaia-curation-review": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mbtiongson1/gaia-meta-audit": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mbtiongson1/gaia-preview": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mbtiongson1/graphify-triage": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "nexu-io/open-design": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "nousresearch/feed-monitoring": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "obra/finishing-a-development-branch": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "obra/receiving-code-review": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "obra/requesting-code-review": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/agentdb-advanced": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/agentdb-memory-patterns": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/agentdb-optimization": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/agentdb-vector-search": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/agentic-jujutsu": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/dual-collect": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/dual-coordinate": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/dual-spawn": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/flow-nexus-neural": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/flow-nexus-platform": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/github-multi-repo": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/pair-programming": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/reasoningbank-intelligence": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/stream-chain": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/swarm-advanced": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/swarm-orchestration": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/v3-cli-modernization": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/v3-core-implementation": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/v3-ddd-architecture": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/v3-integration-deep": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/verification-quality": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "ruvnet/worker-integration": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "santifer/career-ops": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "spring-ai/readme-generate": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "vercel/find-skills": {
+      "tm": 36.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "upsonic/unittest-generator": {
+      "tm": 33.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "devin-ai/autonomous-swe": {
+      "tm": 30.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/caveman": {
+      "tm": 30.0,
+      "grade": "C",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    },
+    "mattpocock/teach": {
+      "tm": 0.0,
+      "grade": "ungraded",
+      "level": "2★",
+      "updatedAt": "2026-06-30T16:25:29Z"
+    }
+  }
+}

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -387,6 +387,7 @@ def build_html_cache_busting(check: bool) -> bool:
         "codex/trust-methodology.html",
         "u/index.html",
         "api/index.html",  # pre-registered for Issue #850 (docs page not yet created)
+        "trending/index.html",
     ):
         path = ROOT / "docs" / filename
         if not path.exists():
@@ -667,6 +668,55 @@ def build_api_projection(check: bool) -> bool:
             import shutil
             shutil.rmtree(committed)
             shutil.copytree(out_dir, committed)
+        return True
+
+
+def build_trending_projection(check: bool) -> bool:
+    """Run buildTrendingProjection.py to a tempdir and diff against docs/api/v1/trending/."""
+    script = SCRIPTS / "buildTrendingProjection.py"
+    if not script.exists():
+        return False
+    committed = ROOT / "docs" / "api" / "v1" / "trending"
+    with tempfile.TemporaryDirectory() as tmp:
+        out_dir = Path(tmp) / "v1"
+        # Seed prior state so trending engine can compute real deltas
+        if committed.exists():
+            import shutil as _shutil
+            trending_tmp = out_dir / "trending"
+            trending_tmp.mkdir(parents=True, exist_ok=True)
+            snapshot = committed / "snapshot.json"
+            if snapshot.exists():
+                _shutil.copy2(snapshot, trending_tmp / "snapshot.json")
+            hist = committed / "history"
+            if hist.exists():
+                _shutil.copytree(hist, trending_tmp / "history")
+        rc, output = _run_script(script, ["--out-dir", str(out_dir)])
+        if rc != 0:
+            if check:
+                print(f"diff docs/api/v1/trending/ (regen failed: rc={rc})")
+                print(output)
+            raise RuntimeError(f"docs/api/v1/trending/ regen failed: rc={rc}")
+        generated = out_dir / "trending"
+        if not generated.exists():
+            return False
+        if not committed.exists():
+            if check:
+                print("diff docs/api/v1/trending/ (missing)")
+            else:
+                committed.parent.mkdir(parents=True, exist_ok=True)
+                import shutil
+                shutil.copytree(generated, committed)
+            return True
+        drifts = _diff_tree(committed, generated)
+        if not drifts:
+            return False
+        if check:
+            for d in drifts:
+                print(f"diff docs/api/v1/trending/{d}")
+        else:
+            import shutil
+            shutil.rmtree(committed)
+            shutil.copytree(generated, committed)
         return True
 
 
@@ -1137,6 +1187,7 @@ def main(argv: list[str] | None = None) -> int:
     named_index_changed = _run_step("named-index", build_named_index, args.check)
     docs_named_changed = _run_step("docs-named-index", build_docs_named_index, args.check)
     api_changed = _run_step("api-projection", build_api_projection, args.check)
+    trending_changed = _run_step("trending-projection", build_trending_projection, args.check)
     profiles_changed = _run_step("profiles", build_profile_pages, args.check)
     # Badges step honors a `[skip-badge-check]` opt-in escape: if the most
     # recent commit's SUBJECT (first line, not body) contains that marker,
@@ -1208,6 +1259,7 @@ def main(argv: list[str] | None = None) -> int:
         or named_index_changed
         or docs_named_changed
         or api_changed
+        or trending_changed
         or profiles_changed
         # badges_changed: intentionally omitted — see warn-only block above.
         or og_changed

--- a/tests/test_trending_wiring.py
+++ b/tests/test_trending_wiring.py
@@ -1,0 +1,56 @@
+"""Integration test: verify build pipeline wires trending JSON correctly.
+
+These tests confirm that docs/api/v1/trending/ exists on disk with valid
+content after `build_docs.py` has been run. They are marked integration
+because they require committed Class S artifacts on disk, not just the
+source scripts.
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+TRENDING_DIR = Path(__file__).resolve().parents[1] / "docs" / "api" / "v1" / "trending"
+
+
+@pytest.mark.integration
+def test_7d_json_exists_and_valid():
+    path = TRENDING_DIR / "7d.json"
+    assert path.exists(), "docs/api/v1/trending/7d.json must exist"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict), "7d.json must be a JSON object"
+
+
+@pytest.mark.integration
+def test_30d_json_exists_and_valid():
+    path = TRENDING_DIR / "30d.json"
+    assert path.exists(), "docs/api/v1/trending/30d.json must exist"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict), "30d.json must be a JSON object"
+
+
+@pytest.mark.integration
+def test_ascended_json_exists():
+    path = TRENDING_DIR / "ascended.json"
+    assert path.exists(), "docs/api/v1/trending/ascended.json must exist"
+
+
+@pytest.mark.integration
+def test_contested_json_exists():
+    path = TRENDING_DIR / "contested.json"
+    assert path.exists(), "docs/api/v1/trending/contested.json must exist"
+
+
+@pytest.mark.integration
+def test_snapshot_json_exists():
+    path = TRENDING_DIR / "snapshot.json"
+    assert path.exists(), "docs/api/v1/trending/snapshot.json must exist"
+
+
+@pytest.mark.integration
+def test_7d_json_has_expected_top_level_keys():
+    path = TRENDING_DIR / "7d.json"
+    assert path.exists(), "docs/api/v1/trending/7d.json must exist"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    for key in ("window", "skills", "generatedAt"):
+        assert key in data, f"7d.json is missing top-level key '{key}'"


### PR DESCRIPTION
Resolves #651, #697, #698

## What

Wires the existing `buildTrendingProjection.py` into `build_docs.py` so that `gaia dev docs` generates trending JSON at `docs/api/v1/trending/`. The frontend shell at `docs/trending/` will now have real data to render.

## Changes
- Added `build_trending_projection()` to `scripts/build_docs.py`
- Registered trending step in build pipeline (after api-projection)
- Added `trending/index.html` to cache-busting list
- Added `.gitattributes` entry for feed.xml
- Seeded initial trending data (all deltas = 0 on first run)
- Added integration test for wiring verification