### PR TITLE
feat(b2): RSS feed + Ascended/Contested sections on /trending/

### DIFF
--- a/docs/api/v1/trending/30d.json
+++ b/docs/api/v1/trending/30d.json
@@ -1,6 +1,6 @@
 {
   "window": "30d",
-  "generatedAt": "2026-06-30T16:25:29Z",
+  "generatedAt": "2026-06-30T16:58:34Z",
   "firstRun": true,
   "skills": [
     {

--- a/docs/api/v1/trending/7d.json
+++ b/docs/api/v1/trending/7d.json
@@ -1,6 +1,6 @@
 {
   "window": "7d",
-  "generatedAt": "2026-06-30T16:25:29Z",
+  "generatedAt": "2026-06-30T16:58:34Z",
   "firstRun": true,
   "skills": [
     {

--- a/docs/api/v1/trending/ascended.json
+++ b/docs/api/v1/trending/ascended.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-30T16:25:29Z",
+  "generatedAt": "2026-06-30T16:58:34Z",
   "skills": [
     {
       "id": "safishamsi/graphify",
@@ -11,7 +11,8 @@
       "ascendedAt": "2026-06-20T06:31:38Z",
       "_links": {
         "self": "/api/v1/skills/safishamsi/graphify.json"
-      }
+      },
+      "previousLevel": "1★"
     },
     {
       "id": "stanfordnlp/dspy",
@@ -23,7 +24,8 @@
       "ascendedAt": "2026-06-20T06:31:38Z",
       "_links": {
         "self": "/api/v1/skills/stanfordnlp/dspy.json"
-      }
+      },
+      "previousLevel": "1★"
     },
     {
       "id": "ruvnet/reasoningbank-intelligence",
@@ -35,7 +37,8 @@
       "ascendedAt": "2026-06-20T06:31:37Z",
       "_links": {
         "self": "/api/v1/skills/ruvnet/reasoningbank-intelligence.json"
-      }
+      },
+      "previousLevel": "1★"
     },
     {
       "id": "ruvnet/swarm-advanced",
@@ -47,7 +50,8 @@
       "ascendedAt": "2026-06-20T06:31:37Z",
       "_links": {
         "self": "/api/v1/skills/ruvnet/swarm-advanced.json"
-      }
+      },
+      "previousLevel": "1★"
     },
     {
       "id": "ruvnet/swarm-orchestration",
@@ -59,7 +63,8 @@
       "ascendedAt": "2026-06-20T06:31:37Z",
       "_links": {
         "self": "/api/v1/skills/ruvnet/swarm-orchestration.json"
-      }
+      },
+      "previousLevel": "1★"
     },
     {
       "id": "ruvnet/dual-mode",
@@ -71,7 +76,8 @@
       "ascendedAt": "2026-06-20T06:31:36Z",
       "_links": {
         "self": "/api/v1/skills/ruvnet/dual-mode.json"
-      }
+      },
+      "previousLevel": "3★"
     },
     {
       "id": "ruvnet/reasoningbank",
@@ -83,7 +89,8 @@
       "ascendedAt": "2026-06-20T06:31:36Z",
       "_links": {
         "self": "/api/v1/skills/ruvnet/reasoningbank.json"
-      }
+      },
+      "previousLevel": "3★"
     },
     {
       "id": "ruvnet/flow-nexus-neural",
@@ -95,7 +102,8 @@
       "ascendedAt": "2026-06-20T06:31:36Z",
       "_links": {
         "self": "/api/v1/skills/ruvnet/flow-nexus-neural.json"
-      }
+      },
+      "previousLevel": "1★"
     },
     {
       "id": "ruvnet/flow-nexus-platform",
@@ -107,7 +115,8 @@
       "ascendedAt": "2026-06-20T06:31:36Z",
       "_links": {
         "self": "/api/v1/skills/ruvnet/flow-nexus-platform.json"
-      }
+      },
+      "previousLevel": "1★"
     },
     {
       "id": "obra/writing-plans",
@@ -119,7 +128,8 @@
       "ascendedAt": "2026-06-20T06:31:35Z",
       "_links": {
         "self": "/api/v1/skills/obra/writing-plans.json"
-      }
+      },
+      "previousLevel": "2★"
     },
     {
       "id": "openai/few-shot-learning",
@@ -131,7 +141,8 @@
       "ascendedAt": "2026-06-20T06:31:35Z",
       "_links": {
         "self": "/api/v1/skills/openai/few-shot-learning.json"
-      }
+      },
+      "previousLevel": "2★"
     },
     {
       "id": "openai/self-consistency",
@@ -143,7 +154,8 @@
       "ascendedAt": "2026-06-20T06:31:35Z",
       "_links": {
         "self": "/api/v1/skills/openai/self-consistency.json"
-      }
+      },
+      "previousLevel": "2★"
     },
     {
       "id": "obra/verification-before-completion",
@@ -155,7 +167,8 @@
       "ascendedAt": "2026-06-20T06:31:35Z",
       "_links": {
         "self": "/api/v1/skills/obra/verification-before-completion.json"
-      }
+      },
+      "previousLevel": "2★"
     },
     {
       "id": "ruvnet/agentdb-advanced",
@@ -167,7 +180,8 @@
       "ascendedAt": "2026-06-20T06:31:35Z",
       "_links": {
         "self": "/api/v1/skills/ruvnet/agentdb-advanced.json"
-      }
+      },
+      "previousLevel": "1★"
     },
     {
       "id": "obra/using-git-worktrees",
@@ -179,7 +193,8 @@
       "ascendedAt": "2026-06-20T06:31:34Z",
       "_links": {
         "self": "/api/v1/skills/obra/using-git-worktrees.json"
-      }
+      },
+      "previousLevel": "2★"
     },
     {
       "id": "obra/brainstorming",
@@ -191,7 +206,8 @@
       "ascendedAt": "2026-06-20T06:31:34Z",
       "_links": {
         "self": "/api/v1/skills/obra/brainstorming.json"
-      }
+      },
+      "previousLevel": "2★"
     },
     {
       "id": "obra/executing-plans",
@@ -203,7 +219,8 @@
       "ascendedAt": "2026-06-20T06:31:34Z",
       "_links": {
         "self": "/api/v1/skills/obra/executing-plans.json"
-      }
+      },
+      "previousLevel": "2★"
     },
     {
       "id": "nexu-io/open-design",
@@ -215,7 +232,8 @@
       "ascendedAt": "2026-06-20T06:31:34Z",
       "_links": {
         "self": "/api/v1/skills/nexu-io/open-design.json"
-      }
+      },
+      "previousLevel": "1★"
     },
     {
       "id": "nousresearch/feed-monitoring",
@@ -227,7 +245,8 @@
       "ascendedAt": "2026-06-20T06:31:34Z",
       "_links": {
         "self": "/api/v1/skills/nousresearch/feed-monitoring.json"
-      }
+      },
+      "previousLevel": "1★"
     },
     {
       "id": "mattpocock/to-prd",
@@ -239,7 +258,8 @@
       "ascendedAt": "2026-06-20T06:31:32Z",
       "_links": {
         "self": "/api/v1/skills/mattpocock/to-prd.json"
-      }
+      },
+      "previousLevel": "2★"
     },
     {
       "id": "mattpocock/edit-article",
@@ -251,7 +271,8 @@
       "ascendedAt": "2026-06-20T06:31:31Z",
       "_links": {
         "self": "/api/v1/skills/mattpocock/edit-article.json"
-      }
+      },
+      "previousLevel": "2★"
     },
     {
       "id": "martin-stepanoski/nielsen-heuristics-audit",
@@ -263,7 +284,8 @@
       "ascendedAt": "2026-06-20T06:31:30Z",
       "_links": {
         "self": "/api/v1/skills/martin-stepanoski/nielsen-heuristics-audit.json"
-      }
+      },
+      "previousLevel": "2★"
     },
     {
       "id": "mattpocock/diagnose",
@@ -275,7 +297,8 @@
       "ascendedAt": "2026-06-20T06:31:30Z",
       "_links": {
         "self": "/api/v1/skills/mattpocock/diagnose.json"
-      }
+      },
+      "previousLevel": "2★"
     },
     {
       "id": "huggingface/semantic-cache",
@@ -287,7 +310,8 @@
       "ascendedAt": "2026-06-20T06:31:28Z",
       "_links": {
         "self": "/api/v1/skills/huggingface/semantic-cache.json"
-      }
+      },
+      "previousLevel": "1★"
     },
     {
       "id": "garrytan/careful",
@@ -299,7 +323,8 @@
       "ascendedAt": "2026-06-20T06:31:21Z",
       "_links": {
         "self": "/api/v1/skills/garrytan/careful.json"
-      }
+      },
+      "previousLevel": "2★"
     },
     {
       "id": "anthropic/skill-creator",
@@ -311,7 +336,8 @@
       "ascendedAt": "2026-06-20T06:31:20Z",
       "_links": {
         "self": "/api/v1/skills/anthropic/skill-creator.json"
-      }
+      },
+      "previousLevel": "2★"
     },
     {
       "id": "browser-use/browser-harness",
@@ -323,7 +349,8 @@
       "ascendedAt": "2026-06-20T06:31:20Z",
       "_links": {
         "self": "/api/v1/skills/browser-use/browser-harness.json"
-      }
+      },
+      "previousLevel": "2★"
     },
     {
       "id": "devin-ai/autonomous-swe",
@@ -335,7 +362,8 @@
       "ascendedAt": "2026-06-20T06:31:20Z",
       "_links": {
         "self": "/api/v1/skills/devin-ai/autonomous-swe.json"
-      }
+      },
+      "previousLevel": "1★"
     },
     {
       "id": "mattpocock/teach",
@@ -347,7 +375,8 @@
       "ascendedAt": "2026-06-19T18:41:33Z",
       "_links": {
         "self": "/api/v1/skills/mattpocock/teach.json"
-      }
+      },
+      "previousLevel": "awakened"
     },
     {
       "id": "ruvnet/hive-mind-coordination",
@@ -359,7 +388,8 @@
       "ascendedAt": "2026-06-04T20:30:55Z",
       "_links": {
         "self": "/api/v1/skills/ruvnet/hive-mind-coordination.json"
-      }
+      },
+      "previousLevel": "1★"
     }
   ],
   "_links": {

--- a/docs/api/v1/trending/contested.json
+++ b/docs/api/v1/trending/contested.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-30T16:25:29Z",
+  "generatedAt": "2026-06-30T16:58:34Z",
   "buckets": [
     {
       "genericSkillRef": "vertical-slice-planning",
@@ -10,13 +10,15 @@
           "id": "garrytan/garrytan",
           "trustMagnitude": 156.0,
           "level": "4★",
-          "overallTrustGrade": "A"
+          "overallTrustGrade": "A",
+          "origin": true
         },
         {
           "id": "mattpocock/to-issues",
           "trustMagnitude": 90.38,
           "level": "3★",
-          "overallTrustGrade": "B"
+          "overallTrustGrade": "B",
+          "origin": false
         }
       ]
     },
@@ -29,37 +31,43 @@
           "id": "pbakaus/impeccable",
           "trustMagnitude": 122.8,
           "level": "4★",
-          "overallTrustGrade": "A"
+          "overallTrustGrade": "A",
+          "origin": true
         },
         {
           "id": "martin-stepanoski/nielsen-heuristics-audit",
           "trustMagnitude": 94.9,
           "level": "3★",
-          "overallTrustGrade": "B"
+          "overallTrustGrade": "B",
+          "origin": false
         },
         {
           "id": "garrytan/plan-design-review",
           "trustMagnitude": 63.73,
           "level": "3★",
-          "overallTrustGrade": "B"
+          "overallTrustGrade": "B",
+          "origin": false
         },
         {
           "id": "garrytan/plan-devex-review",
           "trustMagnitude": 63.73,
           "level": "3★",
-          "overallTrustGrade": "B"
+          "overallTrustGrade": "B",
+          "origin": false
         },
         {
           "id": "garrytan/design-review",
           "trustMagnitude": 36.0,
           "level": "2★",
-          "overallTrustGrade": "C"
+          "overallTrustGrade": "C",
+          "origin": false
         },
         {
           "id": "garrytan/devex-review",
           "trustMagnitude": 36.0,
           "level": "2★",
-          "overallTrustGrade": "C"
+          "overallTrustGrade": "C",
+          "origin": false
         }
       ]
     },
@@ -72,13 +80,15 @@
           "id": "obra/subagent-driven-development",
           "trustMagnitude": 117.65,
           "level": "4★",
-          "overallTrustGrade": "A"
+          "overallTrustGrade": "A",
+          "origin": true
         },
         {
           "id": "ruvnet/pair-programming",
           "trustMagnitude": 36.0,
           "level": "2★",
-          "overallTrustGrade": "C"
+          "overallTrustGrade": "C",
+          "origin": false
         }
       ]
     },
@@ -91,13 +101,15 @@
           "id": "stanfordnlp/dspy",
           "trustMagnitude": 100.0,
           "level": "4★",
-          "overallTrustGrade": "A"
+          "overallTrustGrade": "A",
+          "origin": true
         },
         {
           "id": "garrytan/plan-tune",
           "trustMagnitude": 36.0,
           "level": "2★",
-          "overallTrustGrade": "C"
+          "overallTrustGrade": "C",
+          "origin": false
         }
       ]
     },
@@ -110,13 +122,15 @@
           "id": "obra/verification-before-completion",
           "trustMagnitude": 95.15,
           "level": "3★",
-          "overallTrustGrade": "B"
+          "overallTrustGrade": "B",
+          "origin": true
         },
         {
           "id": "ruvnet/verification-quality",
           "trustMagnitude": 36.0,
           "level": "2★",
-          "overallTrustGrade": "C"
+          "overallTrustGrade": "C",
+          "origin": false
         }
       ]
     },
@@ -129,13 +143,15 @@
           "id": "mattpocock/diagnose",
           "trustMagnitude": 90.38,
           "level": "3★",
-          "overallTrustGrade": "B"
+          "overallTrustGrade": "B",
+          "origin": true
         },
         {
           "id": "devin-ai/autonomous-swe",
           "trustMagnitude": 30.0,
           "level": "2★",
-          "overallTrustGrade": "C"
+          "overallTrustGrade": "C",
+          "origin": false
         }
       ]
     },
@@ -148,25 +164,29 @@
           "id": "mattpocock/edit-article",
           "trustMagnitude": 90.38,
           "level": "3★",
-          "overallTrustGrade": "B"
+          "overallTrustGrade": "B",
+          "origin": true
         },
         {
           "id": "garrytan/document-generate",
           "trustMagnitude": 63.73,
           "level": "3★",
-          "overallTrustGrade": "B"
+          "overallTrustGrade": "B",
+          "origin": false
         },
         {
           "id": "anthropic/pptx",
           "trustMagnitude": 36.0,
           "level": "2★",
-          "overallTrustGrade": "C"
+          "overallTrustGrade": "C",
+          "origin": false
         },
         {
           "id": "garrytan/document-release",
           "trustMagnitude": 36.0,
           "level": "2★",
-          "overallTrustGrade": "C"
+          "overallTrustGrade": "C",
+          "origin": false
         }
       ]
     },
@@ -179,13 +199,15 @@
           "id": "mattpocock/ubiquitous-language",
           "trustMagnitude": 90.38,
           "level": "3★",
-          "overallTrustGrade": "B"
+          "overallTrustGrade": "B",
+          "origin": true
         },
         {
           "id": "ruvnet/v3-ddd-architecture",
           "trustMagnitude": 36.0,
           "level": "2★",
-          "overallTrustGrade": "C"
+          "overallTrustGrade": "C",
+          "origin": false
         }
       ]
     },
@@ -198,13 +220,15 @@
           "id": "anthropic/skill-creator",
           "trustMagnitude": 90.0,
           "level": "3★",
-          "overallTrustGrade": "B"
+          "overallTrustGrade": "B",
+          "origin": true
         },
         {
           "id": "mattpocock/write-a-skill",
           "trustMagnitude": 45.0,
           "level": "2★",
-          "overallTrustGrade": "C"
+          "overallTrustGrade": "C",
+          "origin": false
         }
       ]
     },
@@ -217,25 +241,29 @@
           "id": "garrytan/browse",
           "trustMagnitude": 88.5,
           "level": "3★",
-          "overallTrustGrade": "B"
+          "overallTrustGrade": "B",
+          "origin": true
         },
         {
           "id": "browser-use/browser-harness",
           "trustMagnitude": 73.59,
           "level": "3★",
-          "overallTrustGrade": "B"
+          "overallTrustGrade": "B",
+          "origin": false
         },
         {
           "id": "garrytan/open-gstack-browser",
           "trustMagnitude": 36.0,
           "level": "2★",
-          "overallTrustGrade": "C"
+          "overallTrustGrade": "C",
+          "origin": false
         },
         {
           "id": "garrytan/setup-browser-cookies",
           "trustMagnitude": 36.0,
           "level": "2★",
-          "overallTrustGrade": "C"
+          "overallTrustGrade": "C",
+          "origin": false
         }
       ]
     },
@@ -248,13 +276,15 @@
           "id": "garrytan/retro",
           "trustMagnitude": 81.0,
           "level": "3★",
-          "overallTrustGrade": "B"
+          "overallTrustGrade": "B",
+          "origin": true
         },
         {
           "id": "spring-ai/readme-generate",
           "trustMagnitude": 36.0,
           "level": "2★",
-          "overallTrustGrade": "C"
+          "overallTrustGrade": "C",
+          "origin": false
         }
       ]
     },
@@ -267,25 +297,29 @@
           "id": "garrytan/careful",
           "trustMagnitude": 66.0,
           "level": "3★",
-          "overallTrustGrade": "B"
+          "overallTrustGrade": "B",
+          "origin": true
         },
         {
           "id": "garrytan/freeze",
           "trustMagnitude": 36.0,
           "level": "2★",
-          "overallTrustGrade": "C"
+          "overallTrustGrade": "C",
+          "origin": false
         },
         {
           "id": "garrytan/guard",
           "trustMagnitude": 36.0,
           "level": "2★",
-          "overallTrustGrade": "C"
+          "overallTrustGrade": "C",
+          "origin": false
         },
         {
           "id": "garrytan/unfreeze",
           "trustMagnitude": 36.0,
           "level": "2★",
-          "overallTrustGrade": "C"
+          "overallTrustGrade": "C",
+          "origin": false
         }
       ]
     },
@@ -298,13 +332,15 @@
           "id": "garrytan/plan-eng-review",
           "trustMagnitude": 66.0,
           "level": "3★",
-          "overallTrustGrade": "B"
+          "overallTrustGrade": "B",
+          "origin": true
         },
         {
           "id": "garrytan/review",
           "trustMagnitude": 63.73,
           "level": "3★",
-          "overallTrustGrade": "B"
+          "overallTrustGrade": "B",
+          "origin": false
         }
       ]
     },
@@ -317,13 +353,15 @@
           "id": "obra/systematic-debugging",
           "trustMagnitude": 65.15,
           "level": "3★",
-          "overallTrustGrade": "B"
+          "overallTrustGrade": "B",
+          "origin": true
         },
         {
           "id": "garrytan/investigate",
           "trustMagnitude": 63.73,
           "level": "3★",
-          "overallTrustGrade": "B"
+          "overallTrustGrade": "B",
+          "origin": false
         }
       ]
     },
@@ -336,13 +374,15 @@
           "id": "garrytan/benchmark",
           "trustMagnitude": 63.73,
           "level": "3★",
-          "overallTrustGrade": "B"
+          "overallTrustGrade": "B",
+          "origin": true
         },
         {
           "id": "garrytan/plan-ceo-review",
           "trustMagnitude": 63.73,
           "level": "3★",
-          "overallTrustGrade": "B"
+          "overallTrustGrade": "B",
+          "origin": false
         }
       ]
     },
@@ -355,13 +395,15 @@
           "id": "garrytan/design-consultation",
           "trustMagnitude": 63.73,
           "level": "3★",
-          "overallTrustGrade": "B"
+          "overallTrustGrade": "B",
+          "origin": true
         },
         {
           "id": "Manavarya09/design-extract",
           "trustMagnitude": 36.0,
           "level": "2★",
-          "overallTrustGrade": "C"
+          "overallTrustGrade": "C",
+          "origin": false
         }
       ]
     },
@@ -374,19 +416,22 @@
           "id": "garrytan/land-and-deploy",
           "trustMagnitude": 63.73,
           "level": "3★",
-          "overallTrustGrade": "B"
+          "overallTrustGrade": "B",
+          "origin": true
         },
         {
           "id": "garrytan/setup-deploy",
           "trustMagnitude": 36.0,
           "level": "2★",
-          "overallTrustGrade": "C"
+          "overallTrustGrade": "C",
+          "origin": false
         },
         {
           "id": "mbtiongson1/gaia-preview",
           "trustMagnitude": 36.0,
           "level": "2★",
-          "overallTrustGrade": "C"
+          "overallTrustGrade": "C",
+          "origin": false
         }
       ]
     },
@@ -399,13 +444,15 @@
           "id": "garrytan/qa",
           "trustMagnitude": 63.73,
           "level": "3★",
-          "overallTrustGrade": "B"
+          "overallTrustGrade": "B",
+          "origin": true
         },
         {
           "id": "garrytan/qa-only",
           "trustMagnitude": 36.0,
           "level": "2★",
-          "overallTrustGrade": "C"
+          "overallTrustGrade": "C",
+          "origin": false
         }
       ]
     },
@@ -418,13 +465,15 @@
           "id": "garrytan/ship",
           "trustMagnitude": 63.73,
           "level": "3★",
-          "overallTrustGrade": "B"
+          "overallTrustGrade": "B",
+          "origin": true
         },
         {
           "id": "obra/finishing-a-development-branch",
           "trustMagnitude": 36.0,
           "level": "2★",
-          "overallTrustGrade": "C"
+          "overallTrustGrade": "C",
+          "origin": false
         }
       ]
     },
@@ -437,13 +486,15 @@
           "id": "firecrawl/firecrawl",
           "trustMagnitude": 36.0,
           "level": "2★",
-          "overallTrustGrade": "C"
+          "overallTrustGrade": "C",
+          "origin": true
         },
         {
           "id": "garrytan/scrape",
           "trustMagnitude": 36.0,
           "level": "2★",
-          "overallTrustGrade": "C"
+          "overallTrustGrade": "C",
+          "origin": false
         }
       ]
     }

--- a/docs/api/v1/trending/feed.xml
+++ b/docs/api/v1/trending/feed.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Gaia Trending Skills</title>
+    <link>https://gaia.tiongson.co/trending/</link>
+    <description>Skills gaining trust this week — ranked by evidence velocity, not hype.</description>
+    <language>en-us</language>
+    <lastBuildDate>Tue, 30 Jun 2026 16:58:34 +0000</lastBuildDate>
+    <atom:link href="https://gaia.tiongson.co/api/v1/trending/feed.xml" rel="self" type="application/rss+xml"/>
+    <item>
+      <title>Founder Mode</title>
+      <link>https://gaia.tiongson.co/named/#explorer/garrytan/gstack</link>
+      <description>Trust Magnitude: 589.3 · Grade S</description>
+      <pubDate>Tue, 30 Jun 2026 16:58:34 +0000</pubDate>
+      <guid isPermaLink="false">gaia-trending-garrytan/gstack-2026-06-30</guid>
+    </item>
+    <item>
+      <title>Ruflo</title>
+      <link>https://gaia.tiongson.co/named/#explorer/ruvnet/ruflo</link>
+      <description>Trust Magnitude: 482.3 · Grade S</description>
+      <pubDate>Tue, 30 Jun 2026 16:58:34 +0000</pubDate>
+      <guid isPermaLink="false">gaia-trending-ruvnet/ruflo-2026-06-30</guid>
+    </item>
+    <item>
+      <title>Matt Pocock Skills</title>
+      <link>https://gaia.tiongson.co/named/#explorer/mattpocock/skills</link>
+      <description>Trust Magnitude: 480.3 · Grade S</description>
+      <pubDate>Tue, 30 Jun 2026 16:58:34 +0000</pubDate>
+      <guid isPermaLink="false">gaia-trending-mattpocock/skills-2026-06-30</guid>
+    </item>
+    <item>
+      <title>Superpowers</title>
+      <link>https://gaia.tiongson.co/named/#explorer/obra/superpowers</link>
+      <description>Trust Magnitude: 445.1 · Grade S</description>
+      <pubDate>Tue, 30 Jun 2026 16:58:34 +0000</pubDate>
+      <guid isPermaLink="false">gaia-trending-obra/superpowers-2026-06-30</guid>
+    </item>
+    <item>
+      <title>Engineering</title>
+      <link>https://gaia.tiongson.co/named/#explorer/mattpocock/engineering</link>
+      <description>Trust Magnitude: 270.0 · Grade A</description>
+      <pubDate>Tue, 30 Jun 2026 16:58:34 +0000</pubDate>
+      <guid isPermaLink="false">gaia-trending-mattpocock/engineering-2026-06-30</guid>
+    </item>
+    <item>
+      <title>AgentDB</title>
+      <link>https://gaia.tiongson.co/named/#explorer/ruvnet/agentdb</link>
+      <description>Trust Magnitude: 201.0 · Grade A</description>
+      <pubDate>Tue, 30 Jun 2026 16:58:34 +0000</pubDate>
+      <guid isPermaLink="false">gaia-trending-ruvnet/agentdb-2026-06-30</guid>
+    </item>
+    <item>
+      <title>Ruflo V3</title>
+      <link>https://gaia.tiongson.co/named/#explorer/ruvnet/ruflo-v3</link>
+      <description>Trust Magnitude: 186.0 · Grade A</description>
+      <pubDate>Tue, 30 Jun 2026 16:58:34 +0000</pubDate>
+      <guid isPermaLink="false">gaia-trending-ruvnet/ruflo-v3-2026-06-30</guid>
+    </item>
+    <item>
+      <title>Autoplan</title>
+      <link>https://gaia.tiongson.co/named/#explorer/garrytan/garrytan</link>
+      <description>Trust Magnitude: 156.0 · Grade A</description>
+      <pubDate>Tue, 30 Jun 2026 16:58:34 +0000</pubDate>
+      <guid isPermaLink="false">gaia-trending-garrytan/garrytan-2026-06-30</guid>
+    </item>
+    <item>
+      <title>Dual Mode</title>
+      <link>https://gaia.tiongson.co/named/#explorer/ruvnet/dual-mode</link>
+      <description>Trust Magnitude: 126.0 · Grade A</description>
+      <pubDate>Tue, 30 Jun 2026 16:58:34 +0000</pubDate>
+      <guid isPermaLink="false">gaia-trending-ruvnet/dual-mode-2026-06-30</guid>
+    </item>
+    <item>
+      <title>Impeccable</title>
+      <link>https://gaia.tiongson.co/named/#explorer/pbakaus/impeccable</link>
+      <description>Trust Magnitude: 122.8 · Grade A</description>
+      <pubDate>Tue, 30 Jun 2026 16:58:34 +0000</pubDate>
+      <guid isPermaLink="false">gaia-trending-pbakaus/impeccable-2026-06-30</guid>
+    </item>
+    <item>
+      <title>Productivity</title>
+      <link>https://gaia.tiongson.co/named/#explorer/mattpocock/productivity</link>
+      <description>Trust Magnitude: 120.0 · Grade A</description>
+      <pubDate>Tue, 30 Jun 2026 16:58:34 +0000</pubDate>
+      <guid isPermaLink="false">gaia-trending-mattpocock/productivity-2026-06-30</guid>
+    </item>
+    <item>
+      <title>ReasoningBank</title>
+      <link>https://gaia.tiongson.co/named/#explorer/ruvnet/reasoningbank</link>
+      <description>Trust Magnitude: 118.5 · Grade A</description>
+      <pubDate>Tue, 30 Jun 2026 16:58:34 +0000</pubDate>
+      <guid isPermaLink="false">gaia-trending-ruvnet/reasoningbank-2026-06-30</guid>
+    </item>
+    <item>
+      <title>Subagent-Driven Development</title>
+      <link>https://gaia.tiongson.co/named/#explorer/obra/subagent-driven-development</link>
+      <description>Trust Magnitude: 117.7 · Grade A</description>
+      <pubDate>Tue, 30 Jun 2026 16:58:34 +0000</pubDate>
+      <guid isPermaLink="false">gaia-trending-obra/subagent-driven-development-2026-06-30</guid>
+    </item>
+    <item>
+      <title>Using Git Worktrees</title>
+      <link>https://gaia.tiongson.co/named/#explorer/obra/using-git-worktrees</link>
+      <description>Trust Magnitude: 117.7 · Grade A</description>
+      <pubDate>Tue, 30 Jun 2026 16:58:34 +0000</pubDate>
+      <guid isPermaLink="false">gaia-trending-obra/using-git-worktrees-2026-06-30</guid>
+    </item>
+    <item>
+      <title>Graphify</title>
+      <link>https://gaia.tiongson.co/named/#explorer/safishamsi/graphify</link>
+      <description>Trust Magnitude: 116.6 · Grade A</description>
+      <pubDate>Tue, 30 Jun 2026 16:58:34 +0000</pubDate>
+      <guid isPermaLink="false">gaia-trending-safishamsi/graphify-2026-06-30</guid>
+    </item>
+    <item>
+      <title>Writing Plans</title>
+      <link>https://gaia.tiongson.co/named/#explorer/obra/writing-plans</link>
+      <description>Trust Magnitude: 110.2 · Grade A</description>
+      <pubDate>Tue, 30 Jun 2026 16:58:34 +0000</pubDate>
+      <guid isPermaLink="false">gaia-trending-obra/writing-plans-2026-06-30</guid>
+    </item>
+    <item>
+      <title>Few-Shot Learning</title>
+      <link>https://gaia.tiongson.co/named/#explorer/openai/few-shot-learning</link>
+      <description>Trust Magnitude: 100.0 · Grade A</description>
+      <pubDate>Tue, 30 Jun 2026 16:58:34 +0000</pubDate>
+      <guid isPermaLink="false">gaia-trending-openai/few-shot-learning-2026-06-30</guid>
+    </item>
+    <item>
+      <title>Self-Consistency</title>
+      <link>https://gaia.tiongson.co/named/#explorer/openai/self-consistency</link>
+      <description>Trust Magnitude: 100.0 · Grade A</description>
+      <pubDate>Tue, 30 Jun 2026 16:58:34 +0000</pubDate>
+      <guid isPermaLink="false">gaia-trending-openai/self-consistency-2026-06-30</guid>
+    </item>
+    <item>
+      <title>DSPy</title>
+      <link>https://gaia.tiongson.co/named/#explorer/stanfordnlp/dspy</link>
+      <description>Trust Magnitude: 100.0 · Grade A</description>
+      <pubDate>Tue, 30 Jun 2026 16:58:34 +0000</pubDate>
+      <guid isPermaLink="false">gaia-trending-stanfordnlp/dspy-2026-06-30</guid>
+    </item>
+    <item>
+      <title>Hive Mind Coordination</title>
+      <link>https://gaia.tiongson.co/named/#explorer/ruvnet/hive-mind-coordination</link>
+      <description>Trust Magnitude: 96.1 · Grade B</description>
+      <pubDate>Tue, 30 Jun 2026 16:58:34 +0000</pubDate>
+      <guid isPermaLink="false">gaia-trending-ruvnet/hive-mind-coordination-2026-06-30</guid>
+    </item>
+  </channel>
+</rss>

--- a/docs/api/v1/trending/history/2026-06-30.json
+++ b/docs/api/v1/trending/history/2026-06-30.json
@@ -1,840 +1,840 @@
 {
   "date": "2026-06-30",
-  "generatedAt": "2026-06-30T16:25:29Z",
+  "generatedAt": "2026-06-30T16:58:34Z",
   "skills": {
     "garrytan/gstack": {
       "tm": 589.32,
       "grade": "S",
       "level": "5★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/ruflo": {
       "tm": 482.27,
       "grade": "S",
       "level": "5★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/skills": {
       "tm": 480.29,
       "grade": "S",
       "level": "5★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "obra/superpowers": {
       "tm": 445.15,
       "grade": "S",
       "level": "5★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/engineering": {
       "tm": 270.0,
       "grade": "A",
       "level": "4★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/agentdb": {
       "tm": 201.0,
       "grade": "A",
       "level": "4★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/ruflo-v3": {
       "tm": 186.0,
       "grade": "A",
       "level": "4★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/garrytan": {
       "tm": 156.0,
       "grade": "A",
       "level": "4★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/dual-mode": {
       "tm": 126.0,
       "grade": "A",
       "level": "4★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "pbakaus/impeccable": {
       "tm": 122.8,
       "grade": "A",
       "level": "4★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/productivity": {
       "tm": 120.0,
       "grade": "A",
       "level": "4★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/reasoningbank": {
       "tm": 118.5,
       "grade": "A",
       "level": "4★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "obra/subagent-driven-development": {
       "tm": 117.65,
       "grade": "A",
       "level": "4★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "obra/using-git-worktrees": {
       "tm": 117.65,
       "grade": "A",
       "level": "4★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "safishamsi/graphify": {
       "tm": 116.57,
       "grade": "A",
       "level": "4★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "obra/writing-plans": {
       "tm": 110.15,
       "grade": "A",
       "level": "4★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "openai/few-shot-learning": {
       "tm": 100.0,
       "grade": "A",
       "level": "4★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "openai/self-consistency": {
       "tm": 100.0,
       "grade": "A",
       "level": "4★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "stanfordnlp/dspy": {
       "tm": 100.0,
       "grade": "A",
       "level": "4★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/hive-mind-coordination": {
       "tm": 96.09,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/flow-nexus": {
       "tm": 96.0,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "obra/brainstorming": {
       "tm": 95.15,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "obra/executing-plans": {
       "tm": 95.15,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "obra/verification-before-completion": {
       "tm": 95.15,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "martin-stepanoski/nielsen-heuristics-audit": {
       "tm": 94.9,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/diagnose": {
       "tm": 90.38,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/edit-article": {
       "tm": 90.38,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/obsidian-vault": {
       "tm": 90.38,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/to-issues": {
       "tm": 90.38,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/ubiquitous-language": {
       "tm": 90.38,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "anthropic/skill-creator": {
       "tm": 90.0,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/browse": {
       "tm": 88.5,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "obra/dispatching-parallel-agents": {
       "tm": 86.0,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "addy-osmani/performance-optimization": {
       "tm": 83.2,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/retro": {
       "tm": 81.0,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "browser-use/browser-harness": {
       "tm": 73.59,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/careful": {
       "tm": 66.0,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/office-hours": {
       "tm": 66.0,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/plan-eng-review": {
       "tm": 66.0,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/github-suite": {
       "tm": 66.0,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "obra/systematic-debugging": {
       "tm": 65.15,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/benchmark": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/canary": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/cso": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/design-consultation": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/design-html": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/design-shotgun": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/document-generate": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/investigate": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/land-and-deploy": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/plan-ceo-review": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/plan-design-review": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/plan-devex-review": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/qa": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/review": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/ship": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/skillify": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/grill-me": {
       "tm": 63.71,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/grill-with-docs": {
       "tm": 63.71,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/handoff": {
       "tm": 63.71,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/to-prd": {
       "tm": 63.71,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/personal": {
       "tm": 60.0,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/setup-matt-pocock-skills": {
       "tm": 56.21,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/triage": {
       "tm": 56.21,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/improve-codebase-architecture": {
       "tm": 45.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/write-a-skill": {
       "tm": 45.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/prototype": {
       "tm": 41.21,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "bradautomates/claude-video": {
       "tm": 37.47,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "Manavarya09/design-extract": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "addy-osmani/test-driven-development": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "anthropic/pptx": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "firecrawl/firecrawl": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/benchmark-models": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/codex": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/context-restore": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/context-save": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/design-review": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/devex-review": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/document-release": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/freeze": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/gstack-upgrade": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/guard": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/health": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/landing-report": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/learn": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/make-pdf": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/open-gstack-browser": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/pair-agent": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/plan-tune": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/qa-only": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/scrape": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/setup-browser-cookies": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/setup-deploy": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/setup-gbrain": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/sync-gbrain": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/unfreeze": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "getagentseal/codeburn": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "huggingface/semantic-cache": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "karpathy/autoresearch": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "laravel/upgrade-laravel-v13": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mbtiongson1/gaia-audit": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mbtiongson1/gaia-curation-review": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mbtiongson1/gaia-meta-audit": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mbtiongson1/gaia-preview": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mbtiongson1/graphify-triage": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "nexu-io/open-design": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "nousresearch/feed-monitoring": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "obra/finishing-a-development-branch": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "obra/receiving-code-review": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "obra/requesting-code-review": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/agentdb-advanced": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/agentdb-memory-patterns": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/agentdb-optimization": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/agentdb-vector-search": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/agentic-jujutsu": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/dual-collect": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/dual-coordinate": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/dual-spawn": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/flow-nexus-neural": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/flow-nexus-platform": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/github-multi-repo": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/pair-programming": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/reasoningbank-intelligence": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/stream-chain": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/swarm-advanced": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/swarm-orchestration": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/v3-cli-modernization": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/v3-core-implementation": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/v3-ddd-architecture": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/v3-integration-deep": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/verification-quality": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/worker-integration": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "santifer/career-ops": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "spring-ai/readme-generate": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "vercel/find-skills": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "upsonic/unittest-generator": {
       "tm": 33.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "devin-ai/autonomous-swe": {
       "tm": 30.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/caveman": {
       "tm": 30.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/teach": {
       "tm": 0.0,
       "grade": "ungraded",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     }
   }
 }

--- a/docs/api/v1/trending/snapshot.json
+++ b/docs/api/v1/trending/snapshot.json
@@ -1,839 +1,839 @@
 {
-  "generatedAt": "2026-06-30T16:25:29Z",
+  "generatedAt": "2026-06-30T16:58:34Z",
   "skills": {
     "garrytan/gstack": {
       "tm": 589.32,
       "grade": "S",
       "level": "5★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/ruflo": {
       "tm": 482.27,
       "grade": "S",
       "level": "5★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/skills": {
       "tm": 480.29,
       "grade": "S",
       "level": "5★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "obra/superpowers": {
       "tm": 445.15,
       "grade": "S",
       "level": "5★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/engineering": {
       "tm": 270.0,
       "grade": "A",
       "level": "4★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/agentdb": {
       "tm": 201.0,
       "grade": "A",
       "level": "4★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/ruflo-v3": {
       "tm": 186.0,
       "grade": "A",
       "level": "4★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/garrytan": {
       "tm": 156.0,
       "grade": "A",
       "level": "4★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/dual-mode": {
       "tm": 126.0,
       "grade": "A",
       "level": "4★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "pbakaus/impeccable": {
       "tm": 122.8,
       "grade": "A",
       "level": "4★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/productivity": {
       "tm": 120.0,
       "grade": "A",
       "level": "4★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/reasoningbank": {
       "tm": 118.5,
       "grade": "A",
       "level": "4★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "obra/subagent-driven-development": {
       "tm": 117.65,
       "grade": "A",
       "level": "4★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "obra/using-git-worktrees": {
       "tm": 117.65,
       "grade": "A",
       "level": "4★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "safishamsi/graphify": {
       "tm": 116.57,
       "grade": "A",
       "level": "4★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "obra/writing-plans": {
       "tm": 110.15,
       "grade": "A",
       "level": "4★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "openai/few-shot-learning": {
       "tm": 100.0,
       "grade": "A",
       "level": "4★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "openai/self-consistency": {
       "tm": 100.0,
       "grade": "A",
       "level": "4★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "stanfordnlp/dspy": {
       "tm": 100.0,
       "grade": "A",
       "level": "4★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/hive-mind-coordination": {
       "tm": 96.09,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/flow-nexus": {
       "tm": 96.0,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "obra/brainstorming": {
       "tm": 95.15,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "obra/executing-plans": {
       "tm": 95.15,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "obra/verification-before-completion": {
       "tm": 95.15,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "martin-stepanoski/nielsen-heuristics-audit": {
       "tm": 94.9,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/diagnose": {
       "tm": 90.38,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/edit-article": {
       "tm": 90.38,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/obsidian-vault": {
       "tm": 90.38,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/to-issues": {
       "tm": 90.38,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/ubiquitous-language": {
       "tm": 90.38,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "anthropic/skill-creator": {
       "tm": 90.0,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/browse": {
       "tm": 88.5,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "obra/dispatching-parallel-agents": {
       "tm": 86.0,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "addy-osmani/performance-optimization": {
       "tm": 83.2,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/retro": {
       "tm": 81.0,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "browser-use/browser-harness": {
       "tm": 73.59,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/careful": {
       "tm": 66.0,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/office-hours": {
       "tm": 66.0,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/plan-eng-review": {
       "tm": 66.0,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/github-suite": {
       "tm": 66.0,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "obra/systematic-debugging": {
       "tm": 65.15,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/benchmark": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/canary": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/cso": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/design-consultation": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/design-html": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/design-shotgun": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/document-generate": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/investigate": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/land-and-deploy": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/plan-ceo-review": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/plan-design-review": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/plan-devex-review": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/qa": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/review": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/ship": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/skillify": {
       "tm": 63.73,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/grill-me": {
       "tm": 63.71,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/grill-with-docs": {
       "tm": 63.71,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/handoff": {
       "tm": 63.71,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/to-prd": {
       "tm": 63.71,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/personal": {
       "tm": 60.0,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/setup-matt-pocock-skills": {
       "tm": 56.21,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/triage": {
       "tm": 56.21,
       "grade": "B",
       "level": "3★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/improve-codebase-architecture": {
       "tm": 45.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/write-a-skill": {
       "tm": 45.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/prototype": {
       "tm": 41.21,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "bradautomates/claude-video": {
       "tm": 37.47,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "Manavarya09/design-extract": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "addy-osmani/test-driven-development": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "anthropic/pptx": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "firecrawl/firecrawl": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/benchmark-models": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/codex": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/context-restore": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/context-save": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/design-review": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/devex-review": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/document-release": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/freeze": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/gstack-upgrade": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/guard": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/health": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/landing-report": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/learn": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/make-pdf": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/open-gstack-browser": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/pair-agent": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/plan-tune": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/qa-only": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/scrape": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/setup-browser-cookies": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/setup-deploy": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/setup-gbrain": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/sync-gbrain": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "garrytan/unfreeze": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "getagentseal/codeburn": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "huggingface/semantic-cache": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "karpathy/autoresearch": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "laravel/upgrade-laravel-v13": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mbtiongson1/gaia-audit": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mbtiongson1/gaia-curation-review": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mbtiongson1/gaia-meta-audit": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mbtiongson1/gaia-preview": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mbtiongson1/graphify-triage": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "nexu-io/open-design": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "nousresearch/feed-monitoring": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "obra/finishing-a-development-branch": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "obra/receiving-code-review": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "obra/requesting-code-review": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/agentdb-advanced": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/agentdb-memory-patterns": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/agentdb-optimization": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/agentdb-vector-search": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/agentic-jujutsu": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/dual-collect": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/dual-coordinate": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/dual-spawn": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/flow-nexus-neural": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/flow-nexus-platform": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/github-multi-repo": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/pair-programming": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/reasoningbank-intelligence": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/stream-chain": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/swarm-advanced": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/swarm-orchestration": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/v3-cli-modernization": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/v3-core-implementation": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/v3-ddd-architecture": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/v3-integration-deep": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/verification-quality": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "ruvnet/worker-integration": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "santifer/career-ops": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "spring-ai/readme-generate": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "vercel/find-skills": {
       "tm": 36.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "upsonic/unittest-generator": {
       "tm": 33.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "devin-ai/autonomous-swe": {
       "tm": 30.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/caveman": {
       "tm": 30.0,
       "grade": "C",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     },
     "mattpocock/teach": {
       "tm": 0.0,
       "grade": "ungraded",
       "level": "2★",
-      "updatedAt": "2026-06-30T16:25:29Z"
+      "updatedAt": "2026-06-30T16:58:34Z"
     }
   }
 }

--- a/docs/trending/index.html
+++ b/docs/trending/index.html
@@ -2,7 +2,7 @@
 <html lang="en" data-icon-base="../assets/icons.svg">
 
 <head>
-  <script>window.GAIA_VERSION = "5.6.0";</script>
+  <script>window.GAIA_VERSION = "5.8.2";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -23,18 +23,18 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
   <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
-  <link rel="stylesheet" href="../css/styles.css?v=5.6.0">
-  <link rel="stylesheet" href="trending.css?v=5.6.0">
+  <link rel="stylesheet" href="../css/styles.css?v=5.8.2">
+  <link rel="stylesheet" href="trending.css?v=5.8.2">
   <!-- Icon sprite helper -->
-  <script src="../js/icons.js?v=5.6.0"></script>
+  <script src="../js/icons.js?v=5.8.2"></script>
 </head>
 
 <body class="trending-page">
 
   <!-- ─── NAV ─── -->
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=5.6.0"></script>
-  <script src="../js/site-nav.js?v=5.6.0"></script>
+  <script src="../js/mounts.js?v=5.8.2"></script>
+  <script src="../js/site-nav.js?v=5.8.2"></script>
 
   <!-- ─── MAIN ─── -->
   <main class="trending-main">
@@ -116,10 +116,10 @@
 
   <!-- ─── FOOTER ─── -->
   <div id="site-footer-mount"></div>
-  <script src="../js/site-footer.js?v=5.6.0"></script>
+  <script src="../js/site-footer.js?v=5.8.2"></script>
 
   <!-- ─── PAGE SCRIPT ─── -->
-  <script src="trending.js?v=5.6.0"></script>
+  <script src="trending.js?v=5.8.2"></script>
 
 </body>
 </html>

--- a/docs/trending/index.html
+++ b/docs/trending/index.html
@@ -17,7 +17,7 @@
   <meta property="og:description" content="Skills gaining trust this week — ranked by evidence velocity, not hype.">
   <meta property="og:url" content="https://gaia.tiongson.co/trending/">
   <!-- RSS feed -->
-  <link rel="alternate" type="application/rss+xml" title="Gaia Trending" href="feed.xml">
+  <link rel="alternate" type="application/rss+xml" title="Gaia Trending Skills" href="../api/v1/trending/feed.xml">
   <!-- Web fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -61,9 +61,19 @@
     </div>
 
     <!-- Window toggle tabs -->
-    <div class="trending-tabs" role="tablist" aria-label="Time window">
-      <button class="trending-tab active" data-window="7d" role="tab" aria-selected="true">7 Days</button>
-      <button class="trending-tab" data-window="30d" role="tab" aria-selected="false">30 Days</button>
+    <div class="trending-tabs-row">
+      <div class="trending-tabs" role="tablist" aria-label="Time window">
+        <button class="trending-tab active" data-window="7d" role="tab" aria-selected="true">7 Days</button>
+        <button class="trending-tab" data-window="30d" role="tab" aria-selected="false">30 Days</button>
+      </div>
+      <a class="trending-rss-btn" href="../api/v1/trending/feed.xml" title="Subscribe to Gaia Trending RSS feed" aria-label="RSS feed">
+        <svg class="ico" width="16" height="16" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M4 11a9 9 0 0 1 9 9"/>
+          <path d="M4 4a16 16 0 0 1 16 16"/>
+          <circle cx="5" cy="19" r="1" fill="currentColor"/>
+        </svg>
+        <span>RSS</span>
+      </a>
     </div>
 
     <!-- Main trending list -->

--- a/docs/trending/trending.css
+++ b/docs/trending/trending.css
@@ -40,10 +40,19 @@
 }
 
 /* ── Window tabs ─────────────────────────────────────────────── */
+/* ── Tabs row (tabs + RSS button) ───────────────────────────── */
+.trending-tabs-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
 .trending-tabs {
   display: flex;
   gap: 0.375rem;
-  margin-bottom: 1.5rem;
+  margin-bottom: 0;
 }
 
 .trending-tab {
@@ -69,6 +78,29 @@
   background: var(--rank-2-bg);
   border-color: var(--rank-2-border);
   color: var(--rank-2);
+}
+
+/* RSS subscribe button */
+.trending-rss-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 0.375rem;
+  border: 1px solid var(--rank-1-border);
+  background: var(--rank-1-bg);
+  color: var(--rank-1);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+  flex-shrink: 0;
+}
+
+.trending-rss-btn:hover {
+  border-color: var(--grade-A);
+  background: color-mix(in srgb, var(--grade-A) 12%, var(--rank-1-bg));
+  color: var(--grade-A);
 }
 
 /* ── Loading spinners ────────────────────────────────────────── */

--- a/docs/trending/trending.css
+++ b/docs/trending/trending.css
@@ -343,6 +343,17 @@
   background: var(--rank-3-bg);
 }
 
+/* Gold accent for ascended cards */
+.ascended-card--gold {
+  border-color: var(--evidence-gold);
+  background: color-mix(in srgb, var(--evidence-gold) 6%, transparent);
+}
+
+.ascended-card--gold:hover {
+  border-color: var(--evidence-gold);
+  background: color-mix(in srgb, var(--evidence-gold) 12%, transparent);
+}
+
 .ascended-card-left {
   display: flex;
   flex-direction: column;
@@ -376,6 +387,32 @@
   font-size: 0.75rem;
   color: var(--rank-0);
   font-family: 'JetBrains Mono', monospace;
+}
+
+/* Previous → current level transition */
+.ascended-level-transition {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.ascended-prev-level {
+  font-size: 0.75rem;
+  font-family: 'JetBrains Mono', monospace;
+  color: var(--rank-0);
+  opacity: 0.65;
+  text-decoration: line-through;
+}
+
+.ascended-transition-arrow {
+  font-size: 0.75rem;
+  color: var(--evidence-gold);
+  font-weight: 600;
+}
+
+.ascended-cur-level {
+  border-color: var(--evidence-gold);
+  color: var(--evidence-gold);
 }
 
 /* ── Contested list ──────────────────────────────────────────── */
@@ -445,6 +482,25 @@
   font-weight: 600;
   font-family: 'JetBrains Mono', monospace;
   color: var(--rank-2);
+}
+
+/* Origin chip highlight */
+.contested-chip--origin {
+  border-color: var(--grade-A);
+  background: color-mix(in srgb, var(--grade-A) 10%, var(--rank-0-bg));
+}
+
+.contested-chip-origin {
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0.05rem 0.3rem;
+  border-radius: 0.2rem;
+  background: color-mix(in srgb, var(--grade-A) 20%, transparent);
+  color: var(--grade-A);
+  border: 1px solid var(--grade-A);
+  font-family: 'JetBrains Mono', monospace;
 }
 
 /* ── Result summary line ─────────────────────────────────────── */

--- a/docs/trending/trending.js
+++ b/docs/trending/trending.js
@@ -208,13 +208,27 @@
       card.className = 'ascended-card';
       card.setAttribute('role', 'listitem');
 
-      var levelBadge = skill.level
-        ? '<span class="trending-level-badge">' + esc(skill.level) + '</span>'
-        : '';
+      /* Gold accent when skill has a level badge (it ascended to something visible) */
+      var levelDisplay = '';
+      if (skill.previousLevel && skill.level) {
+        /* Show previous → current level transition */
+        levelDisplay =
+          '<span class="ascended-level-transition">' +
+            '<span class="ascended-prev-level">' + esc(skill.previousLevel) + '</span>' +
+            '<span class="ascended-transition-arrow" aria-hidden="true">→</span>' +
+            '<span class="trending-level-badge ascended-cur-level">' + esc(skill.level) + '</span>' +
+          '</span>';
+      } else if (skill.level) {
+        levelDisplay = '<span class="trending-level-badge">' + esc(skill.level) + '</span>';
+      }
+
       var gradeBadge = skill.overallTrustGrade
         ? '<span class="trending-grade-badge" data-grade="' + esc(skill.overallTrustGrade) + '">' + esc(skill.overallTrustGrade) + '</span>'
         : '';
       var dateStr = skill.ascendedAt ? formatDate(skill.ascendedAt) : '';
+
+      /* Gold accent for ascended cards */
+      card.classList.add('ascended-card--gold');
 
       card.innerHTML =
         '<div class="ascended-card-left">' +
@@ -222,7 +236,7 @@
           '<div class="ascended-card-contributor">@' + esc(skill.contributor || '') + '</div>' +
         '</div>' +
         '<div class="ascended-card-right">' +
-          levelBadge +
+          levelDisplay +
           gradeBadge +
           (dateStr ? '<span class="ascended-date">' + esc(dateStr) + '</span>' : '') +
         '</div>';
@@ -270,13 +284,20 @@
         var tm = typeof s.trustMagnitude === 'number'
           ? '<span class="contested-chip-tm">' + s.trustMagnitude.toFixed(1) + '</span>'
           : '';
-        return '<span class="contested-chip">' +
+        /* Origin highlight: highest TM implementation in the bucket */
+        var originTag = s.origin
+          ? '<span class="contested-chip-origin" aria-label="Origin implementation">origin</span>'
+          : '';
+        var chipClass = 'contested-chip' + (s.origin ? ' contested-chip--origin' : '');
+        return '<span class="' + chipClass + '">' +
           '<span class="contested-chip-id">' + esc(s.id) + '</span>' +
           tm +
           gradeBadge +
+          originTag +
           '</span>';
       }).join('');
 
+      /* Show generic skill node name prominently in header */
       bucketEl.innerHTML =
         '<div class="contested-bucket-header">' +
           '<span class="contested-bucket-name">' + esc(bucket.genericSkillRef || '') + '</span>' +

--- a/scripts/buildTrendingProjection.py
+++ b/scripts/buildTrendingProjection.py
@@ -336,7 +336,7 @@ def build_ascended(
         # e.g. "Level updated from 1★ to 4★ …"
         previous_level: str | None = None
         details = latest_event.get("details", "")
-        m_prev = re.search(r"from\s+([^\s]+(?:\s+[^t][^o]\S*)?(?:★[^\s]*)?)\s+to\s+", details)
+        m_prev = re.search(r"from\s+(\S+)\s+to\s+", details)
         if m_prev:
             previous_level = m_prev.group(1).strip()
 

--- a/scripts/buildTrendingProjection.py
+++ b/scripts/buildTrendingProjection.py
@@ -24,6 +24,7 @@ Constraint: No new scoring. TM values are read from existing API projection as-i
 from __future__ import annotations
 
 import argparse
+import email.utils
 import json
 import re
 import sys
@@ -353,6 +354,89 @@ def build_ascended(
     })
 
 
+def _write_rss(out_dir: Path, trending_7d: list[dict], generated_at: str) -> None:
+    """Write valid RSS 2.0 feed.xml for the top 20 trending skills."""
+    # Parse generated_at (ISO 8601 UTC) into RFC 2822 for <lastBuildDate>
+    try:
+        gen_dt = datetime.strptime(generated_at, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    except ValueError:
+        gen_dt = datetime.now(timezone.utc)
+
+    last_build = email.utils.format_datetime(gen_dt)
+    top20 = trending_7d[:20]
+
+    items_xml: list[str] = []
+    for skill in top20:
+        skill_id = skill.get("id", "")
+        name = skill.get("name") or skill_id
+        tm = skill.get("trustMagnitude")
+        grade = skill.get("overallTrustGrade") or ""
+        delta = skill.get("tmDelta")
+
+        # Title: "Skill Name (+5.2 TM)" or just "Skill Name"
+        if delta is not None and delta != 0.0:
+            sign = "+" if delta > 0 else ""
+            title = f"{name} ({sign}{delta:.1f} TM)"
+        else:
+            title = name
+
+        link = f"https://gaia.tiongson.co/named/#explorer/{skill_id}"
+
+        # Description: TM + grade
+        tm_str = f"{tm:.1f}" if isinstance(tm, (int, float)) else "—"
+        grade_str = f" · Grade {grade}" if grade else ""
+        description = f"Trust Magnitude: {tm_str}{grade_str}"
+
+        # pubDate — use generated_at as RFC 2822
+        pub_date = last_build
+
+        # Date part of generated_at for guid suffix (YYYY-MM-DD)
+        date_part = generated_at[:10]
+
+        guid = f"gaia-trending-{skill_id}-{date_part}"
+
+        def _xml(s: str) -> str:
+            """Escape XML special characters."""
+            return (
+                str(s)
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace('"', "&quot;")
+            )
+
+        items_xml.append(
+            f"    <item>\n"
+            f"      <title>{_xml(title)}</title>\n"
+            f"      <link>{_xml(link)}</link>\n"
+            f"      <description>{_xml(description)}</description>\n"
+            f"      <pubDate>{pub_date}</pubDate>\n"
+            f"      <guid isPermaLink=\"false\">{_xml(guid)}</guid>\n"
+            f"    </item>"
+        )
+
+    items_block = "\n".join(items_xml)
+    rss = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">\n'
+        '  <channel>\n'
+        '    <title>Gaia Trending Skills</title>\n'
+        '    <link>https://gaia.tiongson.co/trending/</link>\n'
+        '    <description>Skills gaining trust this week — ranked by evidence velocity, not hype.</description>\n'
+        '    <language>en-us</language>\n'
+        f'    <lastBuildDate>{last_build}</lastBuildDate>\n'
+        '    <atom:link href="https://gaia.tiongson.co/api/v1/trending/feed.xml"'
+        ' rel="self" type="application/rss+xml"/>\n'
+        f'{items_block}\n'
+        '  </channel>\n'
+        '</rss>\n'
+    )
+
+    feed_path = out_dir / "feed.xml"
+    feed_path.parent.mkdir(parents=True, exist_ok=True)
+    feed_path.write_text(rss, encoding="utf-8")
+
+
 def build_contested(
     out_dir: Path,
     current_skills: list[dict],
@@ -488,9 +572,13 @@ def run(out_dir: Path) -> int:
     build_ascended(trending_dir, current_skills, api_dir, generated_at)
     build_contested(trending_dir, current_skills, api_dir, generated_at)
 
+    # Build RSS feed from 7d trending list
+    trending_7d_data = json.loads((trending_dir / "7d.json").read_text(encoding="utf-8"))
+    _write_rss(trending_dir, trending_7d_data.get("skills", []), generated_at)
+
     print(f"Trending projection written to {trending_dir}/")
     print(f"  snapshot.json, history/{today}.json")
-    print(f"  7d.json, 30d.json, ascended.json, contested.json")
+    print(f"  7d.json, 30d.json, ascended.json, contested.json, feed.xml")
     return 0
 
 

--- a/scripts/buildTrendingProjection.py
+++ b/scripts/buildTrendingProjection.py
@@ -328,11 +328,20 @@ def build_ascended(
         if not ascend_events:
             continue
 
-        # Most recent event timestamp
+        # Most recent event timestamp and event
         ascended_at = max(e.get("timestamp", "") for e in ascend_events)
+        latest_event = max(ascend_events, key=lambda e: e.get("timestamp", ""))
+
+        # Extract previousLevel from event details text
+        # e.g. "Level updated from 1★ to 4★ …"
+        previous_level: str | None = None
+        details = latest_event.get("details", "")
+        m_prev = re.search(r"from\s+([^\s]+(?:\s+[^t][^o]\S*)?(?:★[^\s]*)?)\s+to\s+", details)
+        if m_prev:
+            previous_level = m_prev.group(1).strip()
 
         contributor, slug = _slug_from_id(skill_id)
-        entries.append({
+        entry: dict = {
             "id": skill_id,
             "name": skill.get("name", ""),
             "level": skill.get("level", ""),
@@ -341,7 +350,10 @@ def build_ascended(
             "overallTrustGrade": skill.get("overallTrustGrade"),
             "ascendedAt": ascended_at,
             "_links": {"self": f"/api/v1/skills/{contributor}/{slug}.json"},
-        })
+        }
+        if previous_level:
+            entry["previousLevel"] = previous_level
+        entries.append(entry)
 
     # Sort by most recent ascendedAt descending
     entries.sort(key=lambda e: e.get("ascendedAt", ""), reverse=True)
@@ -470,10 +482,13 @@ def build_contested(
     # Filter to buckets with >= 2 implementations
     contested = {ref: skills for ref, skills in buckets.items() if len(skills) >= 2}
 
-    # Build output — sort each bucket by TM descending
+    # Build output — sort each bucket by TM descending; mark origin (highest TM)
     bucket_list = []
     for ref, skills in contested.items():
         skills.sort(key=lambda s: -(s.get("trustMagnitude") or 0))
+        # Mark the top skill as origin (highest TM = most established impl)
+        for i, s in enumerate(skills):
+            s["origin"] = i == 0
         top_tm = skills[0].get("trustMagnitude", 0) if skills else 0
         bucket_list.append({
             "genericSkillRef": ref,


### PR DESCRIPTION
Resolves #852, #853

## What
- Added RSS 2.0 feed.xml generation to buildTrendingProjection.py
- Enhanced Ascended + Contested sections in /trending/ UI
- RSS alternate link + visible icon on trending page
- Graceful degradation for empty data states

## Details

### RSS Feed (feed.xml)
- Valid RSS 2.0 with `<channel>` (title: "Gaia Trending Skills", link: https://gaia.tiongson.co/trending/)
- Top 20 skills from 7d trending list as `<item>` elements
- Each item: `<title>` (skill name + delta), `<link>`, `<description>` (TM + grade), RFC 2822 `<pubDate>`, `<guid isPermaLink="false">`
- Output: `docs/api/v1/trending/feed.xml` (marked `linguist-generated=true` in .gitattributes)

### Ascended Section Enhancements
- Gold accent cards using `var(--evidence-gold)` design token
- Previous \u2192 current level transition display (extracted from timeline details)
- Strikethrough + gold arrow shows the rank progression

### Contested Section Enhancements
- Origin chip highlights the highest-TM implementation per bucket
- `origin: true` field added to contested.json for each bucket's top skill
- Origin chip styled with `var(--grade-A)` border and background

### RSS UI
- Fixed `<link rel="alternate">` href to correct path `../api/v1/trending/feed.xml`
- Added visible RSS subscribe button in trending-tabs-row
- No hex colors — all design tokens