### PR TITLE
Add shared dev preflight plumbing

### DIFF
--- a/src/gaia_cli/commands/dev/calibrate.py
+++ b/src/gaia_cli/commands/dev/calibrate.py
@@ -13,33 +13,9 @@ from gaia_cli.commands.dev.helpers import (
     _get_contributor,
     _run_docs_build,
     _confirm_destructive,
+    _run_dev_preflights,
+    _preflight_starbar_blob_link,
 )
-
-
-def _preflight_starbar(skill_data: dict, level: str) -> None:
-    """Reject calibrations to 3★+ when the skill lacks a verified blob URL.
-
-    Per META.md §2.4 "Star Bar": a named skill at 3★ or above must have a
-    verified `links.github` pointing to a `blob/` URL. Without it the skill
-    is uninstallable and fails the Star Bar gate.
-
-    Raises SystemExit(1) if the invariant is violated.
-    """
-    three_star_plus = {"3★", "4★", "5★", "6★"}
-    if level not in three_star_plus:
-        return
-    github_url = (skill_data.get("links") or {}).get("github", "")
-    if not github_url or "/blob/" not in github_url:
-        print(
-            f"Error: Cannot calibrate to {level} — `links.github` is missing or not a "
-            f"`blob/` URL. The Star Bar (META.md §2.4) requires a verified GitHub blob URL "
-            f"for 3★+ skills.\n"
-            f"  Current value: {github_url!r}\n"
-            f"  Fix: `gaia dev update-named <skill> --github-link "
-            f"https://github.com/<owner>/<repo>/blob/<branch>/<path-to-skill>`",
-            file=sys.stderr,
-        )
-        sys.exit(1)
 
 
 def meta_calibrate_command(args):
@@ -69,7 +45,9 @@ def meta_calibrate_command(args):
         sys.exit(1)
 
     skill_data, body = _parse_md(node_file)
-    _preflight_starbar(skill_data, level)
+    _run_dev_preflights([
+        lambda: _preflight_starbar_blob_link(skill_id, skill_data, level),
+    ])
     old_level = skill_data.get("level", "2★")
     skill_data["level"] = level
     skill_data["updatedAt"] = datetime.date.today().isoformat()

--- a/src/gaia_cli/commands/dev/evidence.py
+++ b/src/gaia_cli/commands/dev/evidence.py
@@ -13,38 +13,17 @@ from gaia_cli.commands.dev.helpers import (
     _get_contributor,
     _run_docs_build,
     _confirm_destructive,
+    _run_dev_preflights,
+    _preflight_evidence_static,
+    _preflight_evidence_index_bounds,
 )
 
 
 def _preflight_benchmark_percentile(args) -> None:
-    """Require --percentile when --type benchmark-result is used.
-
-    Without a percentile value the magnitude formula returns 0 and the
-    evidence entry is left ungraded. Per CLAUDE.md curation §5 ("benchmark-result
-    requires `percentile` field"), we reject the command before any write.
-
-    Raises SystemExit(1) if the invariant is violated.
-    """
-    if getattr(args, "evidence_type", None) != "benchmark-result":
-        return
-    percentile = getattr(args, "percentile", None)
-    if percentile is None:
-        print(
-            "Error: `--type benchmark-result` requires `--percentile <0-100>`.\n"
-            "Without a percentile value the Trust Magnitude formula yields 0 and the "
-            "evidence entry will be ungraded. Pass `--percentile <int>` (0–100 inclusive) "
-            "to record the benchmark result's performance percentile.\n"
-            "If the percentile is unknown, use `--type peer-review` with `--reviewers` "
-            "instead for a gradeable entry.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-    if not (0 <= int(percentile) <= 100):
-        print(
-            f"Error: `--percentile` must be in range 0-100; got {percentile!r}.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
+    """Backward-compatible wrapper for the shared evidence preflight."""
+    _run_dev_preflights([
+        lambda: _preflight_evidence_static(args, ("benchmark-result", "repo-own")),
+    ])
 
 
 def meta_evidence_command(args):
@@ -63,31 +42,12 @@ def meta_evidence_command(args):
     trust_number = getattr(args, "trust", None)
     evidence_type = getattr(args, "evidence_type", None)
 
-    # Validate --type against meta.json evidence.types
-    if evidence_type is not None:
-        valid_types = load_evidence_types(registry_path)
-        if evidence_type not in valid_types:
-            print(
-                f"Error: unknown evidence type '{evidence_type}'. "
-                f"Valid types: {', '.join(valid_types)}",
-                file=sys.stderr,
-            )
-            sys.exit(1)
+    valid_types = load_evidence_types(registry_path)
+    _run_dev_preflights([
+        lambda: _preflight_evidence_static(args, valid_types),
+    ])
 
-    # Pre-flight: benchmark-result requires --percentile (magnitude formula uses it)
-    _preflight_benchmark_percentile(args)
-
-    # Validate --source-started-at as ISO YYYY-MM-DD; reject bad input loudly.
     source_started_at = getattr(args, "source_started_at", None)
-    if source_started_at is not None:
-        try:
-            datetime.date.fromisoformat(source_started_at)
-        except ValueError:
-            print(
-                f"Error: --source-started-at must be ISO YYYY-MM-DD; got '{source_started_at}'.",
-                file=sys.stderr,
-            )
-            sys.exit(1)
 
     # Derive grade from trust number (legacy fallback used when no type+artifact info available)
     derived_grade: str | None = None
@@ -98,16 +58,6 @@ def meta_evidence_command(args):
     # --index re-grades an existing entry in place (class→grade backfill);
     # otherwise a new entry is appended.
     index = getattr(args, "index", None)
-
-    if index is not None and trust_number is None and evidence_type is None and (
-        not getattr(args, "notes", None)
-    ) and source_started_at is None:
-        print(
-            "Error: --index requires at least one of --trust, --type, --notes, "
-            "or --source-started-at to update on the existing entry.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
 
     evidence: dict = {
         "source": args.source,
@@ -256,6 +206,9 @@ def meta_evidence_command(args):
             print(f"Error: Named skill '{skill_id}' not found.")
             sys.exit(1)
         meta, body = _parse_md(named_file)
+        _run_dev_preflights([
+            lambda: _preflight_evidence_index_bounds(skill_id, meta.get("evidence") or [], index),
+        ])
         result_entry = _apply(meta.setdefault("evidence", []))
         # Stamp tenure baseline on the first evidence-add only.
         if index is None:
@@ -283,6 +236,9 @@ def meta_evidence_command(args):
 
         with open(node_file, "r", encoding="utf-8") as f:
             data = json.load(f)
+        _run_dev_preflights([
+            lambda: _preflight_evidence_index_bounds(skill_id, data.get("evidence") or [], index),
+        ])
         result_entry = _apply(data.setdefault("evidence", []))
         # Stamp tenure baseline on the first evidence-add only.
         if index is None:

--- a/src/gaia_cli/commands/dev/helpers.py
+++ b/src/gaia_cli/commands/dev/helpers.py
@@ -3,7 +3,9 @@ import os
 import json
 import datetime
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Callable, Iterable
 
 from gaia_cli.registry import (
     registry_graph_path,
@@ -41,6 +43,138 @@ _VERSION_FILES = {
     "registry/gaia.json",
     "docs/graph/gaia.json",
 }
+
+
+@dataclass(frozen=True)
+class DevPreflightError(Exception):
+    """A mutating `gaia dev` command would violate an invariant before writing."""
+
+    message: str
+    fix: str | None = None
+
+
+def _format_dev_preflight_error(error: DevPreflightError) -> str:
+    lines = [f"Error: {error.message}"]
+    if error.fix:
+        lines.append(f"Fix: {error.fix}")
+    return "\n".join(lines)
+
+
+def _fail_dev_preflight(message: str, *, fix: str | None = None) -> None:
+    raise DevPreflightError(message=message, fix=fix)
+
+
+def _run_dev_preflights(checks: Iterable[Callable[[], None]]) -> None:
+    """Run invariant checks and abort before any write if one fails."""
+    try:
+        for check in checks:
+            check()
+    except DevPreflightError as error:
+        print(_format_dev_preflight_error(error), file=sys.stderr)
+        sys.exit(1)
+
+
+def _preflight_named_status_identity(skill_id: str, meta: dict, args) -> None:
+    new_status = getattr(args, "status", None)
+    if new_status != "named":
+        return
+    if (
+        meta.get("title")
+        or meta.get("catalogRef")
+        or getattr(args, "title", None)
+        or getattr(args, "catalog_ref", None)
+    ):
+        return
+    _fail_dev_preflight(
+        f"status='named' requires 'title' or 'catalogRef' on {skill_id}.",
+        fix=(
+            f"Re-run `gaia dev update-named {skill_id} --status named "
+            f"--title \"<lore title>\"` (or `--catalog-ref <slug>`) to satisfy "
+            f"the schema constraint."
+        ),
+    )
+
+
+def _preflight_starbar_blob_link(skill_id: str, skill_data: dict, level: str) -> None:
+    three_star_plus = {"3★", "4★", "5★", "6★"}
+    if level not in three_star_plus:
+        return
+    github_url = (skill_data.get("links") or {}).get("github", "")
+    if github_url and "/blob/" in github_url:
+        return
+    _fail_dev_preflight(
+        f"Cannot calibrate {skill_id} to {level}: `links.github` is missing or not a `blob/` URL.",
+        fix=(
+            "The Star Bar (META.md §2.4) requires a verified GitHub blob URL for 3★+ skills. "
+            f"Current value: {github_url!r}. Re-run `gaia dev update-named {skill_id} "
+            "--github-link https://github.com/<owner>/<repo>/blob/<branch>/<path-to-skill>`."
+        ),
+    )
+
+
+def _preflight_evidence_static(args, valid_types: set[str] | list[str] | tuple[str, ...]) -> None:
+    evidence_type = getattr(args, "evidence_type", None)
+    if evidence_type is not None and evidence_type not in valid_types:
+        valid_list = ", ".join(valid_types)
+        _fail_dev_preflight(
+            f"unknown evidence type '{evidence_type}'.",
+            fix=f"Use one of: {valid_list}",
+        )
+
+    percentile = getattr(args, "percentile", None)
+    if evidence_type == "benchmark-result":
+        if percentile is None:
+            _fail_dev_preflight(
+                "`--type benchmark-result` requires `--percentile <0-100>`.",
+                fix=(
+                    "Pass `--percentile <int>` (0-100 inclusive). If the percentile is unknown, "
+                    "use `--type peer-review` with `--reviewers` instead for a gradeable entry."
+                ),
+            )
+        if not (0 <= int(percentile) <= 100):
+            _fail_dev_preflight(f"`--percentile` must be in range 0-100; got {percentile!r}.")
+
+    for attr, flag in (("date", "--date"), ("source_started_at", "--source-started-at")):
+        value = getattr(args, attr, None)
+        if value is None:
+            continue
+        try:
+            datetime.date.fromisoformat(value)
+        except ValueError:
+            _fail_dev_preflight(f"{flag} must be ISO YYYY-MM-DD; got '{value}'.")
+
+    index = getattr(args, "index", None)
+    patch_fields = (
+        "trust",
+        "evidence_type",
+        "notes",
+        "evaluator",
+        "date",
+        "stars",
+        "views",
+        "citations",
+        "reviewers",
+        "commits",
+        "contributors",
+        "skill_count_in_repo",
+        "percentile",
+        "source_started_at",
+    )
+    if index is not None and not any(getattr(args, field, None) is not None for field in patch_fields):
+        _fail_dev_preflight(
+            "--index requires at least one update field.",
+            fix="Pass one of --trust, --type, --notes, --date, --source-started-at, or a numeric payload flag.",
+        )
+
+
+def _preflight_evidence_index_bounds(skill_id: str, ev_list: list, index: int | None) -> None:
+    if index is None:
+        return
+    if index < 0 or index >= len(ev_list):
+        _fail_dev_preflight(
+            f"Evidence index {index} out of range for skill '{skill_id}' ({len(ev_list)} entries).",
+            fix="Use a valid zero-based --index value or omit --index to append new evidence.",
+        )
 
 
 def _run_docs_build(registry_path) -> None:

--- a/src/gaia_cli/commands/dev/named.py
+++ b/src/gaia_cli/commands/dev/named.py
@@ -11,6 +11,8 @@ from gaia_cli.commands.dev.helpers import (
     _replace_section,
     _get_contributor,
     _run_docs_build,
+    _run_dev_preflights,
+    _preflight_named_status_identity,
 )
 
 
@@ -30,22 +32,12 @@ def meta_update_named_command(args):
     changed = False
     status_promoted_to_named = False
 
+    _run_dev_preflights([
+        lambda: _preflight_named_status_identity(skill_id, meta, args),
+    ])
+
     if getattr(args, "status", None):
         new_status = args.status
-        # Schema rule: status=named requires title or catalogRef. Block premature promotion
-        # so I13-style intake bugs don't slip past validation again.
-        if new_status == "named" and not (
-            meta.get("title")
-            or meta.get("catalogRef")
-            or getattr(args, "title", None)
-            or getattr(args, "catalog_ref", None)
-        ):
-            print(
-                f"Error: status='named' requires 'title' or 'catalogRef' on {skill_id}. "
-                f"Re-run with --title \"<lore title>\" (or --catalog-ref <slug>) to satisfy "
-                f"the schema constraint."
-            )
-            sys.exit(1)
         if prior_status != "named" and new_status == "named":
             status_promoted_to_named = True
         meta["status"] = new_status

--- a/tests/test_dev_calibrate.py
+++ b/tests/test_dev_calibrate.py
@@ -123,13 +123,21 @@ def test_missing_named_skill_exits(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_starbar_rejects_missing_github_link(tmp_path, monkeypatch):
+def test_starbar_rejects_missing_github_link_before_write(tmp_path, monkeypatch, capsys):
     """Calibrating to 3★ without links.github raises SystemExit(1)."""
     root = _make_registry(tmp_path)  # no github_link
+    md_path = tmp_path / "registry" / "named" / "alice" / "test-skill.md"
+    before = md_path.read_text(encoding="utf-8")
     monkeypatch.setattr("gaia_cli.commands.dev.calibrate._run_docs_build", lambda *a, **kw: None)
+
     with pytest.raises(SystemExit) as exc:
         meta_calibrate_command(_args(root, level="3★"))
+
     assert exc.value.code != 0
+    assert md_path.read_text(encoding="utf-8") == before
+    err = capsys.readouterr().err
+    assert "links.github" in err
+    assert "gaia dev update-named alice/test-skill --github-link" in err
 
 
 def test_starbar_rejects_tree_url(tmp_path, monkeypatch, capsys):
@@ -139,9 +147,14 @@ def test_starbar_rejects_tree_url(tmp_path, monkeypatch, capsys):
         github_link="https://github.com/alice/repo/tree/main/skills/test-skill",
     )
     monkeypatch.setattr("gaia_cli.commands.dev.calibrate._run_docs_build", lambda *a, **kw: None)
+    md_path = tmp_path / "registry" / "named" / "alice" / "test-skill.md"
+    before = md_path.read_text(encoding="utf-8")
+
     with pytest.raises(SystemExit) as exc:
         meta_calibrate_command(_args(root, level="4★"))
+
     assert exc.value.code != 0
+    assert md_path.read_text(encoding="utf-8") == before
     err = capsys.readouterr().err
     assert "blob/" in err
 

--- a/tests/test_dev_evidence.py
+++ b/tests/test_dev_evidence.py
@@ -143,18 +143,32 @@ def test_index_updates_trust(tmp_path):
     assert len(_load_node(root)["evidence"]) == 1
 
 
-def test_index_out_of_range_exits(tmp_path):
+def test_index_out_of_range_exits_before_write(tmp_path, capsys):
     root = _make_registry(tmp_path, [{"source": "https://x"}])
+    before = _load_node(root)
+
     with pytest.raises(SystemExit) as exc:
         meta_evidence_command(_args(root, index=5, trust=80.0))
+
     assert exc.value.code != 0
+    assert _load_node(root) == before
+    err = capsys.readouterr().err
+    assert "Evidence index 5 out of range" in err
+    assert "--index" in err
 
 
-def test_index_with_no_update_field_exits(tmp_path):
+def test_index_with_no_update_field_exits_before_write(tmp_path, capsys):
     root = _make_registry(tmp_path, [{"source": "https://x"}])
+    before = _load_node(root)
+
     with pytest.raises(SystemExit) as exc:
         meta_evidence_command(_args(root, index=0))
+
     assert exc.value.code != 0
+    assert _load_node(root) == before
+    err = capsys.readouterr().err
+    assert "--index requires at least one update field" in err
+    assert "--trust" in err
 
 
 # ---------------------------------------------------------------------------
@@ -162,11 +176,18 @@ def test_index_with_no_update_field_exits(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_benchmark_without_percentile_exits(tmp_path):
+def test_benchmark_without_percentile_exits_before_write(tmp_path, capsys):
     root = _make_registry(tmp_path)
+    before = _load_node(root)
+
     with pytest.raises(SystemExit) as exc:
         meta_evidence_command(_args(root, evidence_type="benchmark-result", trust=80.0))
+
     assert exc.value.code != 0
+    assert _load_node(root) == before
+    err = capsys.readouterr().err
+    assert "--type benchmark-result" in err
+    assert "--percentile" in err
 
 
 def test_benchmark_with_percentile_succeeds(tmp_path):
@@ -221,11 +242,44 @@ def test_existing_class_field_preserved_on_regrade(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_invalid_type_exits(tmp_path):
+def test_invalid_type_exits_before_write(tmp_path, capsys):
     root = _make_registry(tmp_path)
+    before = _load_node(root)
+
     with pytest.raises(SystemExit) as exc:
         meta_evidence_command(_args(root, evidence_type="not-a-real-type", trust=50.0))
+
     assert exc.value.code != 0
+    assert _load_node(root) == before
+    err = capsys.readouterr().err
+    assert "unknown evidence type 'not-a-real-type'" in err
+    assert "repo-own" in err
+
+
+def test_invalid_date_exits_before_write(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    before = _load_node(root)
+
+    with pytest.raises(SystemExit) as exc:
+        meta_evidence_command(_args(root, trust=50.0, date="2026/07/01"))
+
+    assert exc.value.code != 0
+    assert _load_node(root) == before
+    err = capsys.readouterr().err
+    assert "--date must be ISO YYYY-MM-DD" in err
+
+
+def test_invalid_source_started_at_exits_before_write(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    before = _load_node(root)
+
+    with pytest.raises(SystemExit) as exc:
+        meta_evidence_command(_args(root, trust=50.0, source_started_at="July 1"))
+
+    assert exc.value.code != 0
+    assert _load_node(root) == before
+    err = capsys.readouterr().err
+    assert "--source-started-at must be ISO YYYY-MM-DD" in err
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dev_named.py
+++ b/tests/test_dev_named.py
@@ -107,13 +107,21 @@ def test_update_named_missing_skill_exits(tmp_path):
     assert exc.value.code != 0
 
 
-def test_update_named_status_named_requires_title(tmp_path):
+def test_update_named_status_named_requires_title(tmp_path, capsys):
     """Setting status=named on a skill without a title/catalogRef must be rejected."""
     root = _make_registry(tmp_path, title="")
     # Remove title from the file
     path = Path(root) / "registry" / "named" / "alice" / "test-skill.md"
     content = path.read_text(encoding="utf-8").replace("title: \n", "").replace("title:\n", "")
     path.write_text(content, encoding="utf-8")
+    before = path.read_text(encoding="utf-8")
+
     with pytest.raises(SystemExit) as exc:
         meta_update_named_command(_args(root, status="named"))
+
     assert exc.value.code != 0
+    assert path.read_text(encoding="utf-8") == before
+    err = capsys.readouterr().err
+    assert "status='named' requires 'title' or 'catalogRef'" in err
+    assert "--title" in err
+    assert "--catalog-ref" in err


### PR DESCRIPTION
Refs #759

## Summary
- Add shared `gaia dev` preflight error/plumbing helpers that abort before writes.
- Migrate existing update-named identity, evidence type/date/index/benchmark percentile, and calibrate Star Bar checks onto the common helper.
- Expand tests to assert rejection messages, no writes on preflight failure, and existing happy paths.

## Tests
- `python3 -m py_compile src/gaia_cli/commands/dev/helpers.py src/gaia_cli/commands/dev/named.py src/gaia_cli/commands/dev/evidence.py src/gaia_cli/commands/dev/calibrate.py`
- `PYTHONPATH=src pytest -q tests/test_dev_named.py tests/test_dev_evidence.py tests/test_dev_calibrate.py`
- `PYTHONPATH=src pytest -q` (fails: existing packaging smoke test cannot find generated venv `bin/gaia` console script under local Python 3.14; 1329 passed, 2 skipped before failure)

## Reviewer checklist
- [ ] Preflight failures happen before any filesystem write.
- [ ] Error messages name the missing flag/value and the right CLI fix.
- [ ] Existing update-named, evidence, and calibrate happy paths still pass.
- [ ] Scope stays limited to PR 1 core plumbing; no new dev verbs broadened.
