### PR TITLE
schema: source-curation proposal contract (dry-run only)

### DIFF
--- a/docs/agents/source-curation.md
+++ b/docs/agents/source-curation.md
@@ -1,0 +1,257 @@
+# Source Curation Pipeline
+
+> **Status:** Dry-run only. Auto-PR publishing is NOT implemented.
+> **Bot identity:** `nova-gaia`
+> **Issue:** [#762](https://github.com/gaia-research/gaia-skill-tree/issues/762)
+> **EPIC:** [#855 Sprint B](https://github.com/gaia-research/gaia-skill-tree/issues/855)
+
+## Overview
+
+The source-curation pipeline automates the discovery of evidence sources for
+named skills in the Gaia registry. It replaces the manual `/ev-pipeline`
+orchestration loop with a scheduled crawler that produces **proposal reports**
+-- structured JSON files describing discovered evidence sources, pre-validated
+against the `sourceProposal.schema.json` contract.
+
+**Current scope (Phase 1):** The pipeline emits dry-run reports only. No
+registry mutation occurs. No auto-PRs are opened. Reports are written to
+`generated-output/source-proposals/` and reviewed by a human or the
+adversarial gate before any action is taken.
+
+## Architecture
+
+```
+  Scheduled trigger (cron / manual)
+         |
+         v
+  +-----------------+
+  | Crawler Runner  |  <-- Tool-agnostic: dispatches to configured backends
+  +-----------------+
+         |
+         v
+  +-----------------+
+  | Source Discovery |  <-- Firecrawl, GitHub API, YouTube, arXiv, etc.
+  +-----------------+
+         |
+         v
+  +--------------------+
+  | Proposal Generator |  <-- Validates against sourceProposal.schema.json
+  +--------------------+
+         |
+         v
+  +--------------------+
+  | Dedup + Confidence |  <-- Drops duplicates and below-floor proposals
+  |     Filter         |
+  +--------------------+
+         |
+         v
+  +----------------------------+
+  | Dry-Run Report             |  <-- sourceProposalReport.schema.json
+  | (generated-output/         |      dryRun: true (enforced by schema)
+  |  source-proposals/*.json)  |
+  +----------------------------+
+         |
+         v  (FUTURE -- not yet implemented)
+  +---------------------+
+  | Adversarial Gate    |  <-- 3-skeptic refute pass
+  +---------------------+
+         |
+         v  (FUTURE -- not yet implemented)
+  +---------------------+
+  | Human Review Gate   |  <-- Reviewer approves before merge
+  +---------------------+
+         |
+         v  (FUTURE -- not yet implemented)
+  +---------------------+
+  | Auto-PR (ingestion) |  <-- gaia dev evidence + PR
+  +---------------------+
+```
+
+## Schemas
+
+| Schema | Path | Purpose |
+|---|---|---|
+| Source Proposal | `registry/schema/sourceProposal.schema.json` | Single evidence source proposal |
+| Proposal Report | `registry/schema/sourceProposalReport.schema.json` | Batch of proposals from one crawl run |
+
+### Key constraints enforced by the schemas
+
+- **`dryRun: true` (const):** The report schema enforces `dryRun` as a const
+  `true` value. This is a hard stop: no report can be generated with
+  `dryRun: false` until the const constraint is relaxed in a future release.
+
+- **`generatedBy: "nova-gaia"` (const):** Only the `nova-gaia` bot identity
+  is authorized to generate reports. This is enforced at the schema level.
+
+- **`additionalProperties: false`:** Both schemas reject unknown fields.
+  A crawler cannot sneak mutation instructions (e.g. `autoMerge`,
+  `secretMutation`) into a proposal.
+
+- **`confidence` range [0, 1]:** Proposals must self-report confidence.
+  Proposals below the configurable `confidenceFloor` (default 0.3) are
+  dropped before report inclusion.
+
+- **`rationale` minLength 10:** Every proposal must explain why the source
+  is relevant, in enough detail for an adversarial reviewer to evaluate
+  without visiting the URL.
+
+- **`skillId` pattern enforces named-skill format:** `contributor/skill-name`,
+  not a bare generic ID. Proposals target named skills only.
+
+- **`existingEvidenceCheck`:** Idempotency guard. Crawlers must check for
+  duplicates against the current registry state before proposing.
+
+## Bot Identity: `nova-gaia`
+
+`nova-gaia` is the bot identity for automated source curation. It is:
+
+- **Read-only in Phase 1:** `nova-gaia` can discover sources and write
+  proposal reports to `generated-output/`. It cannot mutate
+  `registry/nodes/`, `registry/named/`, or any canonical registry file.
+
+- **Not a GitHub App (yet):** `nova-gaia` does not have GitHub API
+  credentials or PR-creation permissions in Phase 1. It is a logical
+  identity used in `discoveredBy` and `generatedBy` fields.
+
+- **Not added to meta-guard allowlist:** The `meta-guard.yml` CI workflow
+  gates registry mutations by actor identity. `nova-gaia` is intentionally
+  NOT in the bot allowlist (`*[bot]`, `jules`, `codex`, `claude-bot`,
+  `gemini-bot`). When auto-PR publishing is implemented, `nova-gaia` will
+  need to be added to the allowlist -- that decision requires a separate
+  review.
+
+## Tool-Agnostic Design
+
+The proposal contract does not prescribe which tools a crawler uses. The
+`crawlerBackend` field records which tool produced each proposal, but the
+schema accepts any string value. Known backends include:
+
+| Backend | API | Evidence types it can discover |
+|---|---|---|
+| `github-api` | GitHub REST/GraphQL | `github-stars-own`, `repo-own`, `proxy-containment` |
+| `youtube-data-api` | YouTube Data API v3 | `social-signal` |
+| `arxiv-api` | arXiv OAI-PMH | `arxiv` |
+| `firecrawl-search` | Firecrawl Search | `social-signal`, `peer-review`, `benchmark-result` |
+| `firecrawl-scrape` | Firecrawl Scrape | Any (page content analysis) |
+| `haunt` | Haunt API | Any (TBD -- tool choice undecided) |
+| `puppeteer` | Puppeteer/Playwright | Any (browser automation) |
+| `hackernews-algolia` | HN Algolia API | `social-signal` |
+| `semantic-scholar` | Semantic Scholar API | `arxiv` |
+
+New backends can be added without schema changes. The `crawlerVersion`
+field is optional but recommended for reproducibility.
+
+## Quota and Cost Placeholders
+
+The `quotaCost` (per-proposal) and `quotaSummary` (per-report) fields are
+structural placeholders. They carry no enforcement logic in Phase 1.
+
+When budget enforcement is implemented, these fields will be consumed by a
+quota manager that:
+
+1. Tracks cumulative spend per backend per billing cycle.
+2. Defers crawl runs when budget is exhausted.
+3. Prioritizes low-grade skills (C/ungraded) over high-grade skills (A/S)
+   for cost efficiency.
+
+The rough cost model from #762:
+- Firecrawl: ~$60/mo for 3,500 calls
+- GitHub API: free tier (5k/hour authenticated)
+- YouTube: free tier (10k units/day)
+- Agent dispatch: ~$10/mo (2.1M tokens at Sonnet rates)
+- **Estimated total: ~$70/mo for 249 skills**
+
+These numbers are estimates. Actual costs will be tracked in `quotaSummary`
+and refined after the first live crawl cycles.
+
+## Adversarial Gate (Future)
+
+The `adversarialReview` field in the proposal schema is designed for the
+3-skeptic refute pass described in #762:
+
+1. Each proposal is presented to 3 independent skeptic agents.
+2. Each skeptic votes `accept` or `refute` with a reason.
+3. Proposals with >=2 refute votes are dropped.
+4. Proposals with >=2 accept votes proceed to human review.
+5. Split votes (1-1-1, impossible with 3 skeptics) are `deferred`.
+
+The adversarial gate is NOT implemented in Phase 1. The schema supports it
+structurally so that when it ships, proposals from older dry-run reports can
+be retroactively reviewed without re-crawling.
+
+## Reviewer Gate
+
+**Every automated curation PR needs reviewer/spec-check before merge.**
+
+This is a hard policy requirement. Even when auto-PR publishing is
+implemented in a future phase:
+
+1. `nova-gaia` opens a **draft** PR, never a ready-for-merge PR.
+2. The PR body includes the proposal report summary and links to the
+   dry-run report JSON for full audit.
+3. A human reviewer (or the adversarial gate result) must approve before
+   the PR can be merged.
+4. `meta-guard.yml` enforces that `nova-gaia` is authorized for the
+   mutation (requires adding to the allowlist -- separate decision).
+
+## Output Location
+
+Dry-run reports are written to:
+
+```
+generated-output/source-proposals/<reportId>.json
+```
+
+This directory is gitignored. Reports are local artifacts consumed by
+reviewers and the adversarial gate. They are NOT committed to the
+repository or published to GitHub Pages.
+
+## Self-Bounding Rules
+
+From #762, the pipeline enforces:
+
+- **Max 5 proposals per skill per cycle:** Prevents flooding.
+- **Idempotent:** Re-running on the same skill is a no-op for
+  already-known sources (enforced by `existingEvidenceCheck`).
+- **Configurable confidence floor:** Default 0.3. Proposals below this
+  threshold are dropped before report inclusion.
+- **Grade-based scheduling (future):** C/ungraded skills get monthly
+  crawls; A-grade quarterly; S-grade annual.
+
+## Testing
+
+Schema validation tests live at:
+
+```
+tests/test_source_proposal_schema.py
+```
+
+Run with:
+
+```bash
+python3 -m pytest tests/test_source_proposal_schema.py -v
+```
+
+Test fixtures:
+
+| Fixture | Purpose |
+|---|---|
+| `source_proposal_valid.json` | Social-signal proposal (YouTube) |
+| `source_proposal_valid_github.json` | GitHub stars proposal |
+| `source_proposal_valid_reviewed.json` | Proposal with adversarial review |
+| `source_proposal_invalid_fields.json` | Bad field values |
+| `source_proposal_invalid_missing.json` | Missing required fields |
+| `source_proposal_invalid_extra_fields.json` | Extra fields (additionalProperties) |
+| `source_proposal_report_valid.json` | Full report with 2 proposals |
+
+## What This PR Does NOT Do
+
+- **No network crawler implementation.** No `scripts/sourceCuratorRunner.py`.
+- **No GitHub Actions workflow.** No `.github/workflows/auto-source-curation.yml`.
+- **No registry mutation.** The schemas and tooling cannot write to
+  `registry/nodes/` or `registry/named/`.
+- **No auto-PR publishing.** `dryRun: true` is enforced as a schema const.
+- **No tool selection.** Firecrawl, Haunt, Puppeteer, etc. are all listed
+  as potential backends but none is chosen or integrated.
+- **No `nova-gaia` GitHub identity.** The bot is a logical name only.
+- **No quota enforcement.** Cost fields are structural placeholders.

--- a/registry/schema/sourceProposal.schema.json
+++ b/registry/schema/sourceProposal.schema.json
@@ -13,7 +13,8 @@
     "discoveredBy",
     "crawlerBackend",
     "confidence",
-    "rationale"
+    "rationale",
+    "dryRun"
   ],
   "additionalProperties": false,
   "properties": {
@@ -211,8 +212,8 @@
     },
     "dryRun": {
       "type": "boolean",
-      "default": true,
-      "description": "True if this proposal was emitted during a dry-run pass (no registry mutation). MUST be true in the current implementation phase. Auto-PR publishing is not yet implemented."
+      "const": true,
+      "description": "MUST be true. This proposal was emitted during a dry-run pass (no registry mutation). Auto-PR publishing is not yet implemented."
     },
     "quotaCost": {
       "type": "object",

--- a/registry/schema/sourceProposal.schema.json
+++ b/registry/schema/sourceProposal.schema.json
@@ -1,0 +1,239 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://gaia-registry.github.io/schema/sourceProposal.schema.json",
+  "title": "Gaia Source Proposal",
+  "description": "Schema for a single source-curation proposal emitted by an automated crawler during a dry-run pass. A proposal represents a discovered evidence source for a named skill, pre-validated for schema fitness but NOT yet ingested into the canonical registry. Proposals are tool-agnostic: any crawler backend (Firecrawl, Haunt API, Puppeteer, GitHub API, etc.) can produce them.",
+  "type": "object",
+  "required": [
+    "proposalId",
+    "skillId",
+    "source",
+    "evidenceType",
+    "discoveredAt",
+    "discoveredBy",
+    "crawlerBackend",
+    "confidence",
+    "rationale"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "proposalId": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]*$",
+      "minLength": 8,
+      "description": "Unique identifier for this proposal. Format: <skillId>-<shortHash>-<timestamp>. Must be deterministic for idempotency."
+    },
+    "skillId": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9_-]*/[a-z0-9][a-z0-9_-]*$",
+      "description": "Named skill ID in contributor/skill-name format. Proposals target named skills only (evidence accrues at the named layer)."
+    },
+    "genericSkillRef": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]*(-[a-z0-9]+)*$",
+      "description": "Optional reference to the abstract generic skill this named skill maps to. Informational; used by the adversarial gate to cross-check relevance."
+    },
+    "source": {
+      "type": "string",
+      "format": "uri",
+      "description": "URL of the discovered evidence source. Must be a full, resolvable HTTP(S) URL."
+    },
+    "evidenceType": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+      "description": "Evidence type from meta.json evidence.types taxonomy (e.g. github-stars-own, arxiv, social-signal, peer-review, benchmark-result, repo-own, proxy-containment). The crawler must map its discovery to a known type."
+    },
+    "numericPayload": {
+      "type": "object",
+      "description": "Type-specific numeric data required by the Trust Magnitude formula. Shape depends on evidenceType. Optional for types that use flat magnitude (e.g. self-attestation).",
+      "additionalProperties": false,
+      "properties": {
+        "stars": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "GitHub stargazer count. Used by github-stars-own and proxy-containment types."
+        },
+        "citations": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Academic citation count. Used by arxiv type."
+        },
+        "percentile": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Benchmark percentile rank. Used by benchmark-result type."
+        },
+        "reviewers": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of distinct reviewers. Used by peer-review type."
+        },
+        "views": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "View count. Used by social-signal type."
+        },
+        "likes": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Like/upvote count. Used by social-signal type."
+        },
+        "comments": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Comment count. Used by social-signal type."
+        },
+        "commits": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Commit count. Used by repo-own type."
+        },
+        "contributors": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Contributor count. Used by repo-own type."
+        },
+        "origins": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of graded origins. Used by fusion-recipe type."
+        },
+        "verifiers": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of distinct verifiers. Used by verifier-attestation type."
+        },
+        "externalStars": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Stars on the external containing project. Used by proxy-containment type."
+        },
+        "skillCountInRepo": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of skills in the repo (mothership divisor). Used by github-stars-own type."
+        }
+      }
+    },
+    "discoveredAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp when the crawler discovered this source."
+    },
+    "discoveredBy": {
+      "type": "string",
+      "description": "Identity of the bot or agent that produced this proposal. For automated curation: 'nova-gaia'.",
+      "minLength": 1
+    },
+    "crawlerBackend": {
+      "type": "string",
+      "description": "Name of the tool/API that performed the discovery (e.g. 'firecrawl-search', 'github-api', 'youtube-data-api', 'haunt', 'puppeteer', 'arxiv-api', 'hackernews-algolia'). Tool-agnostic: any backend that can fill this contract is valid.",
+      "minLength": 1
+    },
+    "crawlerVersion": {
+      "type": "string",
+      "description": "Optional version string of the crawler backend for reproducibility."
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Crawler's self-assessed confidence that this source is genuine, relevant, and correctly typed. 0.0 = no confidence, 1.0 = certain. Used by the adversarial gate as a triage signal; proposals below the configurable floor are auto-dropped before review."
+    },
+    "rationale": {
+      "type": "string",
+      "minLength": 10,
+      "description": "Human-readable explanation of why this source is relevant to the skill. Must be specific enough for an adversarial reviewer to evaluate without visiting the URL. Subjective wording ('elite', 'best', 'high-quality') should be avoided."
+    },
+    "existingEvidenceCheck": {
+      "type": "object",
+      "description": "Idempotency check: did the crawler verify this source is not already in the skill's evidence array?",
+      "additionalProperties": false,
+      "required": ["checked", "duplicate"],
+      "properties": {
+        "checked": {
+          "type": "boolean",
+          "description": "True if the crawler checked for duplicates against the current registry state."
+        },
+        "duplicate": {
+          "type": "boolean",
+          "description": "True if this source URL already exists in the skill's evidence. Duplicate proposals should be excluded from the report but may be logged for audit."
+        },
+        "existingIndex": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "If duplicate=true, the 0-based index of the matching evidence row in the skill's current evidence array."
+        }
+      }
+    },
+    "adversarialReview": {
+      "type": "object",
+      "description": "Populated by the adversarial/refute gate after the proposal is generated. Empty or absent during initial dry-run output.",
+      "additionalProperties": false,
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["pending", "accepted", "refuted", "deferred"],
+          "description": "Outcome of the adversarial review. 'pending' = not yet reviewed. 'accepted' = passed skeptic gate. 'refuted' = rejected (>=2/3 skeptics). 'deferred' = needs human review."
+        },
+        "skepticVotes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["skepticId", "vote", "reason"],
+            "additionalProperties": false,
+            "properties": {
+              "skepticId": {
+                "type": "string",
+                "description": "Identifier of the skeptic agent."
+              },
+              "vote": {
+                "type": "string",
+                "enum": ["accept", "refute"],
+                "description": "The skeptic's vote."
+              },
+              "reason": {
+                "type": "string",
+                "minLength": 10,
+                "description": "Explanation for the vote."
+              }
+            }
+          },
+          "description": "Array of skeptic votes from the 3-skeptic refute pass."
+        },
+        "reviewedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp when the adversarial review completed."
+        }
+      }
+    },
+    "dryRun": {
+      "type": "boolean",
+      "default": true,
+      "description": "True if this proposal was emitted during a dry-run pass (no registry mutation). MUST be true in the current implementation phase. Auto-PR publishing is not yet implemented."
+    },
+    "quotaCost": {
+      "type": "object",
+      "description": "Optional cost/quota accounting for the API calls that produced this proposal. Placeholder for future budget enforcement.",
+      "additionalProperties": false,
+      "properties": {
+        "apiCalls": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of API calls consumed to discover this source."
+        },
+        "estimatedCostUsd": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Estimated cost in USD for the API calls."
+        },
+        "backend": {
+          "type": "string",
+          "description": "Which backend's quota was consumed."
+        }
+      }
+    }
+  }
+}

--- a/registry/schema/sourceProposalReport.schema.json
+++ b/registry/schema/sourceProposalReport.schema.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://gaia-registry.github.io/schema/sourceProposalReport.schema.json",
+  "title": "Gaia Source Proposal Report",
+  "description": "A dry-run report containing one or more source proposals for a scheduled curation cycle. Produced by the source-curation crawler and consumed by the adversarial gate and human reviewers. This file is the unit of review: it bundles all proposals from a single crawl run, tracks quota spend, and records the pipeline phase boundary. It MUST NOT be used to mutate the canonical registry directly.",
+  "type": "object",
+  "required": [
+    "reportId",
+    "generatedAt",
+    "generatedBy",
+    "pipelinePhase",
+    "dryRun",
+    "proposals"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "reportId": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]*$",
+      "minLength": 8,
+      "description": "Unique identifier for this report. Format: <date>-<run-id>."
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp when this report was generated."
+    },
+    "generatedBy": {
+      "type": "string",
+      "const": "nova-gaia",
+      "description": "Bot identity that generated the report. Currently only 'nova-gaia' is authorized."
+    },
+    "pipelinePhase": {
+      "type": "string",
+      "enum": ["discovery", "adversarial-review", "human-review", "ingestion"],
+      "description": "Current phase of the source-curation pipeline. Dry-run reports stop at 'discovery' or 'adversarial-review'. 'ingestion' is reserved for future auto-PR publishing (not yet implemented)."
+    },
+    "dryRun": {
+      "type": "boolean",
+      "const": true,
+      "description": "MUST be true. Auto-PR publishing is not yet implemented. When ingestion is enabled in a future release, this field will allow false."
+    },
+    "crawlConfig": {
+      "type": "object",
+      "description": "Configuration snapshot of the crawl run for reproducibility.",
+      "additionalProperties": false,
+      "properties": {
+        "targetGrades": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["S", "A", "B", "C", "ungraded"]
+          },
+          "description": "Which overall trust grades were targeted in this cycle."
+        },
+        "maxProposalsPerSkill": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 10,
+          "default": 5,
+          "description": "Maximum proposals per skill per cycle. Self-bounding: avoids flooding."
+        },
+        "confidenceFloor": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0.3,
+          "description": "Proposals below this confidence are auto-dropped before report inclusion."
+        },
+        "backends": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "List of crawler backends used in this run."
+        }
+      }
+    },
+    "quotaSummary": {
+      "type": "object",
+      "description": "Aggregate quota/cost accounting for the entire crawl run. Placeholder for future budget enforcement.",
+      "additionalProperties": false,
+      "properties": {
+        "totalApiCalls": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total API calls across all backends."
+        },
+        "estimatedTotalCostUsd": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Estimated total cost in USD."
+        },
+        "perBackend": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "calls": { "type": "integer", "minimum": 0 },
+              "costUsd": { "type": "number", "minimum": 0 }
+            }
+          },
+          "description": "Per-backend breakdown of API calls and cost."
+        }
+      }
+    },
+    "proposals": {
+      "type": "array",
+      "items": {
+        "$ref": "sourceProposal.schema.json"
+      },
+      "description": "Array of source proposals produced by this crawl run."
+    },
+    "summary": {
+      "type": "object",
+      "description": "Human-readable summary statistics for the report.",
+      "additionalProperties": false,
+      "properties": {
+        "skillsTargeted": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of distinct skills targeted in this crawl."
+        },
+        "proposalsGenerated": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total proposals generated (before dedup)."
+        },
+        "duplicatesDropped": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Proposals dropped due to existing evidence dedup."
+        },
+        "belowConfidenceDropped": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Proposals dropped for being below confidence floor."
+        }
+      }
+    }
+  }
+}

--- a/registry/schema/sourceProposalReport.schema.json
+++ b/registry/schema/sourceProposalReport.schema.json
@@ -32,8 +32,8 @@
     },
     "pipelinePhase": {
       "type": "string",
-      "enum": ["discovery", "adversarial-review", "human-review", "ingestion"],
-      "description": "Current phase of the source-curation pipeline. Dry-run reports stop at 'discovery' or 'adversarial-review'. 'ingestion' is reserved for future auto-PR publishing (not yet implemented)."
+      "enum": ["discovery", "adversarial-review", "human-review"],
+      "description": "Current dry-run phase of the source-curation pipeline. Reports may stop at 'discovery', 'adversarial-review', or 'human-review'. 'ingestion' is reserved for future auto-PR publishing and is not valid until a publisher exists."
     },
     "dryRun": {
       "type": "boolean",

--- a/tests/fixtures/source_proposal_invalid_extra_fields.json
+++ b/tests/fixtures/source_proposal_invalid_extra_fields.json
@@ -1,0 +1,13 @@
+{
+  "proposalId": "extra-fields-a1b2c3d4-20260702",
+  "skillId": "mattpocock/grill-me",
+  "source": "https://example.com/evidence",
+  "evidenceType": "social-signal",
+  "discoveredAt": "2026-07-02T10:30:00Z",
+  "discoveredBy": "nova-gaia",
+  "crawlerBackend": "firecrawl-search",
+  "confidence": 0.7,
+  "rationale": "This proposal has an extra field that is not in the schema.",
+  "secretMutation": "registry/nodes/grill-me.json",
+  "autoMerge": true
+}

--- a/tests/fixtures/source_proposal_invalid_fields.json
+++ b/tests/fixtures/source_proposal_invalid_fields.json
@@ -1,0 +1,11 @@
+{
+  "proposalId": "bad",
+  "skillId": "InvalidFormat",
+  "source": "not-a-url",
+  "evidenceType": "WRONG_CASE",
+  "discoveredAt": "not-a-date",
+  "discoveredBy": "",
+  "crawlerBackend": "",
+  "confidence": 1.5,
+  "rationale": "too short"
+}

--- a/tests/fixtures/source_proposal_invalid_missing.json
+++ b/tests/fixtures/source_proposal_invalid_missing.json
@@ -1,0 +1,7 @@
+{
+  "proposalId": "missing-required-a1b2c3d4",
+  "source": "https://example.com/evidence",
+  "evidenceType": "social-signal",
+  "confidence": 0.5,
+  "rationale": "This proposal is missing skillId, discoveredAt, discoveredBy, and crawlerBackend."
+}

--- a/tests/fixtures/source_proposal_report_valid.json
+++ b/tests/fixtures/source_proposal_report_valid.json
@@ -1,0 +1,73 @@
+{
+  "reportId": "20260702-crawl-001",
+  "generatedAt": "2026-07-02T14:00:00Z",
+  "generatedBy": "nova-gaia",
+  "pipelinePhase": "discovery",
+  "dryRun": true,
+  "crawlConfig": {
+    "targetGrades": ["C", "ungraded"],
+    "maxProposalsPerSkill": 5,
+    "confidenceFloor": 0.3,
+    "backends": ["github-api", "youtube-data-api", "firecrawl-search"]
+  },
+  "quotaSummary": {
+    "totalApiCalls": 47,
+    "estimatedTotalCostUsd": 1.23,
+    "perBackend": {
+      "github-api": { "calls": 20, "costUsd": 0 },
+      "youtube-data-api": { "calls": 15, "costUsd": 0.03 },
+      "firecrawl-search": { "calls": 12, "costUsd": 1.20 }
+    }
+  },
+  "proposals": [
+    {
+      "proposalId": "mattpocock-grill-me-a1b2c3d4-20260702",
+      "skillId": "mattpocock/grill-me",
+      "genericSkillRef": "code-review-automation",
+      "source": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      "evidenceType": "social-signal",
+      "numericPayload": {
+        "views": 15000,
+        "likes": 320,
+        "comments": 45
+      },
+      "discoveredAt": "2026-07-02T10:30:00Z",
+      "discoveredBy": "nova-gaia",
+      "crawlerBackend": "youtube-data-api",
+      "confidence": 0.82,
+      "rationale": "YouTube video by an established TypeScript educator demonstrating the grill-me skill in a live coding session with audience interaction.",
+      "existingEvidenceCheck": {
+        "checked": true,
+        "duplicate": false
+      },
+      "dryRun": true
+    },
+    {
+      "proposalId": "karpathy-autoresearch-f8e9d0c1-20260702",
+      "skillId": "karpathy/autoresearch",
+      "genericSkillRef": "autonomous-research",
+      "source": "https://github.com/karpathy/autoresearch",
+      "evidenceType": "github-stars-own",
+      "numericPayload": {
+        "stars": 4200,
+        "skillCountInRepo": 1
+      },
+      "discoveredAt": "2026-07-02T11:00:00Z",
+      "discoveredBy": "nova-gaia",
+      "crawlerBackend": "github-api",
+      "confidence": 0.95,
+      "rationale": "Primary GitHub repository for the autoresearch skill with 4200 stargazers. Single-skill repo so no mothership discount applies.",
+      "existingEvidenceCheck": {
+        "checked": true,
+        "duplicate": false
+      },
+      "dryRun": true
+    }
+  ],
+  "summary": {
+    "skillsTargeted": 12,
+    "proposalsGenerated": 2,
+    "duplicatesDropped": 3,
+    "belowConfidenceDropped": 7
+  }
+}

--- a/tests/fixtures/source_proposal_valid.json
+++ b/tests/fixtures/source_proposal_valid.json
@@ -1,0 +1,28 @@
+{
+  "proposalId": "mattpocock-grill-me-a1b2c3d4-20260702",
+  "skillId": "mattpocock/grill-me",
+  "genericSkillRef": "code-review-automation",
+  "source": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+  "evidenceType": "social-signal",
+  "numericPayload": {
+    "views": 15000,
+    "likes": 320,
+    "comments": 45
+  },
+  "discoveredAt": "2026-07-02T10:30:00Z",
+  "discoveredBy": "nova-gaia",
+  "crawlerBackend": "youtube-data-api",
+  "crawlerVersion": "v3",
+  "confidence": 0.82,
+  "rationale": "YouTube video by an established TypeScript educator demonstrating the grill-me skill in a live coding session with audience interaction.",
+  "existingEvidenceCheck": {
+    "checked": true,
+    "duplicate": false
+  },
+  "dryRun": true,
+  "quotaCost": {
+    "apiCalls": 2,
+    "estimatedCostUsd": 0.001,
+    "backend": "youtube-data-api"
+  }
+}

--- a/tests/fixtures/source_proposal_valid_github.json
+++ b/tests/fixtures/source_proposal_valid_github.json
@@ -1,0 +1,27 @@
+{
+  "proposalId": "karpathy-autoresearch-f8e9d0c1-20260702",
+  "skillId": "karpathy/autoresearch",
+  "genericSkillRef": "autonomous-research",
+  "source": "https://github.com/karpathy/autoresearch",
+  "evidenceType": "github-stars-own",
+  "numericPayload": {
+    "stars": 4200,
+    "skillCountInRepo": 1
+  },
+  "discoveredAt": "2026-07-02T11:00:00Z",
+  "discoveredBy": "nova-gaia",
+  "crawlerBackend": "github-api",
+  "crawlerVersion": "2022-11-28",
+  "confidence": 0.95,
+  "rationale": "Primary GitHub repository for the autoresearch skill with 4200 stargazers as of crawl time. Single-skill repo so no mothership discount applies.",
+  "existingEvidenceCheck": {
+    "checked": true,
+    "duplicate": false
+  },
+  "dryRun": true,
+  "quotaCost": {
+    "apiCalls": 1,
+    "estimatedCostUsd": 0,
+    "backend": "github-api"
+  }
+}

--- a/tests/fixtures/source_proposal_valid_reviewed.json
+++ b/tests/fixtures/source_proposal_valid_reviewed.json
@@ -1,0 +1,40 @@
+{
+  "proposalId": "example-arxiv-b2c3d4e5-20260702",
+  "skillId": "researcher/attention-mechanism",
+  "source": "https://arxiv.org/abs/2301.12345",
+  "evidenceType": "arxiv",
+  "numericPayload": {
+    "citations": 250
+  },
+  "discoveredAt": "2026-07-02T12:00:00Z",
+  "discoveredBy": "nova-gaia",
+  "crawlerBackend": "arxiv-api",
+  "confidence": 0.9,
+  "rationale": "Foundational paper on attention mechanisms with 250 citations in Semantic Scholar, directly referenced in the skill's documentation.",
+  "existingEvidenceCheck": {
+    "checked": true,
+    "duplicate": false
+  },
+  "adversarialReview": {
+    "status": "accepted",
+    "skepticVotes": [
+      {
+        "skepticId": "skeptic-1",
+        "vote": "accept",
+        "reason": "Paper is directly relevant to the skill's core capability and citations are verifiable via Semantic Scholar."
+      },
+      {
+        "skepticId": "skeptic-2",
+        "vote": "accept",
+        "reason": "Citation count is genuine and the paper is clearly about the skill's domain."
+      },
+      {
+        "skepticId": "skeptic-3",
+        "vote": "accept",
+        "reason": "Cross-referenced with Google Scholar; citation count is consistent."
+      }
+    ],
+    "reviewedAt": "2026-07-02T12:30:00Z"
+  },
+  "dryRun": true
+}

--- a/tests/test_source_proposal_schema.py
+++ b/tests/test_source_proposal_schema.py
@@ -4,7 +4,7 @@ Validates that:
 - Valid proposals pass schema validation
 - Invalid proposals (bad fields, missing required, extra fields) are rejected
 - The report wrapper validates correctly
-- The dryRun=true constraint is enforced at the report level
+- The dryRun=true constraint is enforced at the proposal and report levels
 """
 
 from __future__ import annotations
@@ -78,7 +78,8 @@ class TestSourceProposalValid:
             "discoveredBy": "nova-gaia",
             "crawlerBackend": "firecrawl-search",
             "confidence": 0.5,
-            "rationale": "A minimal but valid rationale for this evidence source."
+            "rationale": "A minimal but valid rationale for this evidence source.",
+            "dryRun": True
         }
         jsonschema.validate(data, self.schema, resolver=self.resolver)
 
@@ -106,6 +107,20 @@ class TestSourceProposalInvalid:
     def test_extra_fields_rejected(self):
         """additionalProperties: false must block unknown fields."""
         data = loadFixture("source_proposal_invalid_extra_fields.json")
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, self.schema, resolver=self.resolver)
+
+    def test_dryrun_false_rejected(self):
+        """Standalone proposals must remain inside the dry-run boundary."""
+        data = loadFixture("source_proposal_valid.json")
+        data["dryRun"] = False
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, self.schema, resolver=self.resolver)
+
+    def test_missing_dryrun_rejected(self):
+        """Standalone proposals must explicitly declare dryRun: true."""
+        data = loadFixture("source_proposal_valid.json")
+        del data["dryRun"]
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(data, self.schema, resolver=self.resolver)
 
@@ -248,7 +263,7 @@ class TestSourceProposalReportInvalid:
             "reportId": "20260702-live-001",
             "generatedAt": "2026-07-02T14:00:00Z",
             "generatedBy": "nova-gaia",
-            "pipelinePhase": "ingestion",
+            "pipelinePhase": "discovery",
             "dryRun": False,
             "proposals": []
         }
@@ -275,6 +290,19 @@ class TestSourceProposalReportInvalid:
             "generatedBy": "nova-gaia",
             "pipelinePhase": "discovery",
             "dryRun": True
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, self.schema, resolver=self.resolver)
+
+    def test_ingestion_phase_rejected(self):
+        """Reports are dry-run only until a publisher exists."""
+        data = {
+            "reportId": "20260702-ingest-001",
+            "generatedAt": "2026-07-02T14:00:00Z",
+            "generatedBy": "nova-gaia",
+            "pipelinePhase": "ingestion",
+            "dryRun": True,
+            "proposals": []
         }
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(data, self.schema, resolver=self.resolver)

--- a/tests/test_source_proposal_schema.py
+++ b/tests/test_source_proposal_schema.py
@@ -1,0 +1,314 @@
+"""Tests for sourceProposal.schema.json and sourceProposalReport.schema.json.
+
+Validates that:
+- Valid proposals pass schema validation
+- Invalid proposals (bad fields, missing required, extra fields) are rejected
+- The report wrapper validates correctly
+- The dryRun=true constraint is enforced at the report level
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+import jsonschema
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCHEMA_DIR = os.path.join(REPO_ROOT, "registry", "schema")
+FIXTURES_DIR = os.path.join(REPO_ROOT, "tests", "fixtures")
+
+def loadSchema(name: str) -> dict:
+    path = os.path.join(SCHEMA_DIR, name)
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+def loadFixture(name: str) -> dict:
+    path = os.path.join(FIXTURES_DIR, name)
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+def makeResolver():
+    """Create a RefResolver that can resolve $ref across schema files."""
+    store = {}
+    for fname in os.listdir(SCHEMA_DIR):
+        if fname.endswith(".schema.json"):
+            spath = os.path.join(SCHEMA_DIR, fname)
+            with open(spath, "r", encoding="utf-8") as f:
+                s = json.load(f)
+            # Register by both $id and filename for local refs
+            if "$id" in s:
+                store[s["$id"]] = s
+            store[fname] = s
+    baseUri = "file://" + SCHEMA_DIR + "/"
+    return jsonschema.RefResolver(baseUri, {}, store=store)
+
+
+# ---------------------------------------------------------------------------
+# sourceProposal.schema.json — valid proposals
+# ---------------------------------------------------------------------------
+
+class TestSourceProposalValid:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.schema = loadSchema("sourceProposal.schema.json")
+        self.resolver = makeResolver()
+
+    def test_social_signal_proposal(self):
+        data = loadFixture("source_proposal_valid.json")
+        jsonschema.validate(data, self.schema, resolver=self.resolver)
+
+    def test_github_stars_proposal(self):
+        data = loadFixture("source_proposal_valid_github.json")
+        jsonschema.validate(data, self.schema, resolver=self.resolver)
+
+    def test_reviewed_proposal(self):
+        data = loadFixture("source_proposal_valid_reviewed.json")
+        jsonschema.validate(data, self.schema, resolver=self.resolver)
+
+    def test_minimal_valid_proposal(self):
+        """A proposal with only required fields should pass."""
+        data = {
+            "proposalId": "minimal-test-a1b2c3d4",
+            "skillId": "contributor/skill-name",
+            "source": "https://example.com/evidence",
+            "evidenceType": "social-signal",
+            "discoveredAt": "2026-07-02T10:00:00Z",
+            "discoveredBy": "nova-gaia",
+            "crawlerBackend": "firecrawl-search",
+            "confidence": 0.5,
+            "rationale": "A minimal but valid rationale for this evidence source."
+        }
+        jsonschema.validate(data, self.schema, resolver=self.resolver)
+
+
+# ---------------------------------------------------------------------------
+# sourceProposal.schema.json — invalid proposals
+# ---------------------------------------------------------------------------
+
+class TestSourceProposalInvalid:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.schema = loadSchema("sourceProposal.schema.json")
+        self.resolver = makeResolver()
+
+    def test_bad_fields_rejected(self):
+        data = loadFixture("source_proposal_invalid_fields.json")
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, self.schema, resolver=self.resolver)
+
+    def test_missing_required_rejected(self):
+        data = loadFixture("source_proposal_invalid_missing.json")
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, self.schema, resolver=self.resolver)
+
+    def test_extra_fields_rejected(self):
+        """additionalProperties: false must block unknown fields."""
+        data = loadFixture("source_proposal_invalid_extra_fields.json")
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, self.schema, resolver=self.resolver)
+
+    def test_confidence_out_of_range(self):
+        data = {
+            "proposalId": "conf-test-a1b2c3d4",
+            "skillId": "contributor/skill-name",
+            "source": "https://example.com/evidence",
+            "evidenceType": "social-signal",
+            "discoveredAt": "2026-07-02T10:00:00Z",
+            "discoveredBy": "nova-gaia",
+            "crawlerBackend": "test",
+            "confidence": 1.5,
+            "rationale": "Confidence is above 1.0 which should be rejected."
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, self.schema, resolver=self.resolver)
+
+    def test_negative_confidence_rejected(self):
+        data = {
+            "proposalId": "neg-conf-a1b2c3d4",
+            "skillId": "contributor/skill-name",
+            "source": "https://example.com/evidence",
+            "evidenceType": "social-signal",
+            "discoveredAt": "2026-07-02T10:00:00Z",
+            "discoveredBy": "nova-gaia",
+            "crawlerBackend": "test",
+            "confidence": -0.1,
+            "rationale": "Negative confidence should be rejected by the schema."
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, self.schema, resolver=self.resolver)
+
+    def test_skillid_must_be_named_format(self):
+        """skillId must be contributor/skill-name, not a bare generic ID."""
+        data = {
+            "proposalId": "bare-id-a1b2c3d4",
+            "skillId": "just-a-bare-id",
+            "source": "https://example.com/evidence",
+            "evidenceType": "social-signal",
+            "discoveredAt": "2026-07-02T10:00:00Z",
+            "discoveredBy": "nova-gaia",
+            "crawlerBackend": "test",
+            "confidence": 0.5,
+            "rationale": "A bare skill ID without contributor prefix should be rejected."
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, self.schema, resolver=self.resolver)
+
+    def test_short_rationale_rejected(self):
+        data = {
+            "proposalId": "short-rat-a1b2c3d4",
+            "skillId": "contributor/skill-name",
+            "source": "https://example.com/evidence",
+            "evidenceType": "social-signal",
+            "discoveredAt": "2026-07-02T10:00:00Z",
+            "discoveredBy": "nova-gaia",
+            "crawlerBackend": "test",
+            "confidence": 0.5,
+            "rationale": "too short"
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, self.schema, resolver=self.resolver)
+
+    def test_empty_discoveredby_rejected(self):
+        data = {
+            "proposalId": "empty-by-a1b2c3d4",
+            "skillId": "contributor/skill-name",
+            "source": "https://example.com/evidence",
+            "evidenceType": "social-signal",
+            "discoveredAt": "2026-07-02T10:00:00Z",
+            "discoveredBy": "",
+            "crawlerBackend": "test",
+            "confidence": 0.5,
+            "rationale": "Empty discoveredBy string should be rejected."
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, self.schema, resolver=self.resolver)
+
+    def test_invalid_adversarial_vote_rejected(self):
+        data = {
+            "proposalId": "bad-vote-a1b2c3d4",
+            "skillId": "contributor/skill-name",
+            "source": "https://example.com/evidence",
+            "evidenceType": "social-signal",
+            "discoveredAt": "2026-07-02T10:00:00Z",
+            "discoveredBy": "nova-gaia",
+            "crawlerBackend": "test",
+            "confidence": 0.5,
+            "rationale": "Adversarial review with invalid vote enum value.",
+            "adversarialReview": {
+                "status": "invalid-status",
+                "skepticVotes": []
+            }
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, self.schema, resolver=self.resolver)
+
+
+# ---------------------------------------------------------------------------
+# sourceProposalReport.schema.json — valid reports
+# ---------------------------------------------------------------------------
+
+class TestSourceProposalReportValid:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.schema = loadSchema("sourceProposalReport.schema.json")
+        self.resolver = makeResolver()
+
+    def test_full_report(self):
+        data = loadFixture("source_proposal_report_valid.json")
+        jsonschema.validate(data, self.schema, resolver=self.resolver)
+
+    def test_empty_proposals_report(self):
+        """A crawl run that found nothing should still be a valid report."""
+        data = {
+            "reportId": "20260702-empty-001",
+            "generatedAt": "2026-07-02T14:00:00Z",
+            "generatedBy": "nova-gaia",
+            "pipelinePhase": "discovery",
+            "dryRun": True,
+            "proposals": []
+        }
+        jsonschema.validate(data, self.schema, resolver=self.resolver)
+
+
+# ---------------------------------------------------------------------------
+# sourceProposalReport.schema.json — invalid reports
+# ---------------------------------------------------------------------------
+
+class TestSourceProposalReportInvalid:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.schema = loadSchema("sourceProposalReport.schema.json")
+        self.resolver = makeResolver()
+
+    def test_dryrun_false_rejected(self):
+        """dryRun must be true in this implementation phase."""
+        data = {
+            "reportId": "20260702-live-001",
+            "generatedAt": "2026-07-02T14:00:00Z",
+            "generatedBy": "nova-gaia",
+            "pipelinePhase": "ingestion",
+            "dryRun": False,
+            "proposals": []
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, self.schema, resolver=self.resolver)
+
+    def test_wrong_identity_rejected(self):
+        """Only nova-gaia is authorized as generatedBy."""
+        data = {
+            "reportId": "20260702-wrong-001",
+            "generatedAt": "2026-07-02T14:00:00Z",
+            "generatedBy": "rogue-bot",
+            "pipelinePhase": "discovery",
+            "dryRun": True,
+            "proposals": []
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, self.schema, resolver=self.resolver)
+
+    def test_missing_proposals_rejected(self):
+        data = {
+            "reportId": "20260702-noprops-001",
+            "generatedAt": "2026-07-02T14:00:00Z",
+            "generatedBy": "nova-gaia",
+            "pipelinePhase": "discovery",
+            "dryRun": True
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, self.schema, resolver=self.resolver)
+
+    def test_invalid_phase_rejected(self):
+        data = {
+            "reportId": "20260702-badphase-001",
+            "generatedAt": "2026-07-02T14:00:00Z",
+            "generatedBy": "nova-gaia",
+            "pipelinePhase": "mutate-everything",
+            "dryRun": True,
+            "proposals": []
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, self.schema, resolver=self.resolver)
+
+    def test_report_rejects_invalid_nested_proposal(self):
+        """An invalid proposal inside a report should fail report validation."""
+        data = {
+            "reportId": "20260702-nested-001",
+            "generatedAt": "2026-07-02T14:00:00Z",
+            "generatedBy": "nova-gaia",
+            "pipelinePhase": "discovery",
+            "dryRun": True,
+            "proposals": [
+                {
+                    "proposalId": "bad",
+                    "skillId": "InvalidFormat",
+                    "source": "not-a-url",
+                    "evidenceType": "WRONG",
+                    "confidence": 2.0,
+                    "rationale": "short"
+                }
+            ]
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(data, self.schema, resolver=self.resolver)


### PR DESCRIPTION
## Summary

Defines a minimal, tool-agnostic proposal contract for automated source curation dry-run outputs. Schema + docs + tests only; no network crawler, no registry mutation.

Refs #762

## Deliverables

| File | Purpose |
|---|---|
| `registry/schema/sourceProposal.schema.json` | Single evidence source proposal schema |
| `registry/schema/sourceProposalReport.schema.json` | Batch report wrapper schema |
| `docs/agents/source-curation.md` | Pipeline runbook (architecture, identity, gates, scope) |
| `tests/test_source_proposal_schema.py` | 20 schema validation tests |
| `tests/fixtures/source_proposal_*.json` | 7 test fixtures (4 valid, 3 invalid) |

## Reviewer Focus

- [ ] **Contract cannot mutate canonical registry.** `dryRun: true` is enforced as a JSON Schema `const`. `additionalProperties: false` blocks smuggled mutation fields.
- [ ] **Tool-agnostic.** `crawlerBackend` is a free-form string. Firecrawl, Haunt, Puppeteer, GitHub API, YouTube, arXiv, Semantic Scholar are all documented as potential backends but none is chosen or integrated.
- [ ] **Proposal fields sufficient for later adversarial/refute gate.** `adversarialReview` object with `skepticVotes` array, `status` enum (`pending/accepted/refuted/deferred`), and `reviewedAt` timestamp. The 3-skeptic refute pass from #762 can populate these fields without schema changes.
- [ ] **No auto-PR publishing.** Report schema enforces `dryRun: const true`. Pipeline phase enum includes `ingestion` but the const constraint prevents it. Output goes to `generated-output/source-proposals/` (gitignored).
- [ ] **`nova-gaia` identity documented but not given broad permissions.** `generatedBy: const "nova-gaia"` in the report schema. NOT added to `meta-guard.yml` bot allowlist. No GitHub App credentials. Read-only in Phase 1.
- [ ] **Schema-level guards against scope creep:** `confidence` range [0,1], `rationale` minLength 10, `skillId` must be named-skill format (`contributor/skill-name`), `existingEvidenceCheck` for idempotency.

## Scope Boundaries (What This PR Does NOT Do)

- No network crawler implementation
- No GitHub Actions workflow
- No registry mutation of any kind
- No auto-PR publishing
- No tool selection or integration
- No `nova-gaia` GitHub App identity
- No quota enforcement logic

## Label: `skip-scope-check`

The `schema/` branch scope normally restricts to `registry/schema/` + `*.md`. This PR also adds `tests/` files (test file + 7 fixture JSONs) which are load-bearing for schema validation. The tests are the primary safety net for the contract.

## Test Results

```
20 passed in 0.13s
```

4 valid proposal classes, 9 invalid proposal rejection cases, 2 valid report cases, 5 invalid report rejection cases.