### PR TITLE
feat(cli): add add/link/named preflights Refs #759

### DIFF
--- a/src/gaia_cli/commands/dev/build.py
+++ b/src/gaia_cli/commands/dev/build.py
@@ -15,6 +15,7 @@ from gaia_cli.commands.dev.helpers import (
     _run_dev_preflights,
     preflightAddCommand,
     preflightLinkCommand,
+    parseCommaSeparatedIds,
 )
 
 
@@ -52,8 +53,8 @@ def meta_add_command(args):
             "contributor": contributor,
             "origin": False,
             "genericSkillRef": getattr(args, "generic_ref", "unknown"),
-            "status": "named",
-            "level": getattr(args, "level", "2★"),
+            "status": getattr(args, "status", None) or "named",
+            "level": getattr(args, "level", None) or "2★",
             "description": desc,
             "createdAt": datetime.date.today().isoformat(),
             "updatedAt": datetime.date.today().isoformat(),
@@ -212,7 +213,7 @@ def meta_link_command(args):
     ])
     registry_path = args.registry
     target_id = args.target.lstrip("/")
-    prereqs = [p.strip() for p in args.prereqs.split(",")]
+    prereqs = parseCommaSeparatedIds(args.prereqs, "prerequisite")
 
     nodes_dir = Path(registry_nodes_dir(registry_path))
     target_file = None

--- a/src/gaia_cli/commands/dev/build.py
+++ b/src/gaia_cli/commands/dev/build.py
@@ -12,6 +12,9 @@ from gaia_cli.commands.dev.helpers import (
     _confirm_destructive,
     _get_contributor,
     _run_docs_build,
+    _run_dev_preflights,
+    preflightAddCommand,
+    preflightLinkCommand,
 )
 
 
@@ -23,6 +26,9 @@ def meta_build_command(args):
 
 
 def meta_add_command(args):
+    _run_dev_preflights([
+        lambda: preflightAddCommand(args),
+    ])
     registry_path = args.registry
     skill_name = args.name
     skill_id = args.id or skill_name.lower().replace(" ", "-")
@@ -201,6 +207,9 @@ def meta_remove_command(args):
 
 
 def meta_link_command(args):
+    _run_dev_preflights([
+        lambda: preflightLinkCommand(args),
+    ])
     registry_path = args.registry
     target_id = args.target.lstrip("/")
     prereqs = [p.strip() for p in args.prereqs.split(",")]

--- a/src/gaia_cli/commands/dev/helpers.py
+++ b/src/gaia_cli/commands/dev/helpers.py
@@ -333,11 +333,25 @@ def namedSkillExists(registryPath: str, contributor: str, skillId: str) -> bool:
     return destFile.exists()
 
 
+def parseCommaSeparatedIds(rawValue: str | None, label: str) -> list[str]:
+    """Parse a comma-separated ID list and reject empty entries."""
+    if rawValue is None or rawValue == "":
+        return []
+    entries = [entry.strip() for entry in rawValue.split(",")]
+    emptyPositions = [str(index + 1) for index, entry in enumerate(entries) if not entry]
+    if emptyPositions:
+        _fail_dev_preflight(
+            f"Empty {label} entries are not allowed at position(s): {', '.join(emptyPositions)}.",
+            fix=f"Remove extra commas from the {label} list."
+        )
+    return entries
+
+
 def preflightSuiteComponents(registryPath: str, suiteComponentsStr: str | None) -> None:
     """Validate suite components exist and have no duplicates."""
-    if not suiteComponentsStr:
+    components = parseCommaSeparatedIds(suiteComponentsStr, "suite component")
+    if not components:
         return
-    components = [c.strip() for c in suiteComponentsStr.split(",") if c.strip()]
     seen = set()
     duplicates = []
     for comp in components:
@@ -366,28 +380,27 @@ def preflightGithubLink(githubLink: str | None) -> None:
     import re
     if not githubLink:
         return
-    if "github.com" in githubLink or githubLink.startswith("https://github.com/"):
-        if not githubLink.startswith("https://github.com/"):
-            _fail_dev_preflight(
-                f"GitHub link must start with 'https://github.com/'; got {githubLink!r}.",
-                fix="Ensure the URL is a valid GitHub URL."
-            )
-        if "/tree/" in githubLink:
-            _fail_dev_preflight(
-                f"GitHub URL uses '/tree/' which is not supported: {githubLink!r}.",
-                fix="Convert the '/tree/' segment to '/blob/' and specify the path to the skill file/directory."
-            )
-        if "/blob/" not in githubLink:
-            _fail_dev_preflight(
-                f"GitHub URL is missing the '/blob/' segment: {githubLink!r}.",
-                fix="Ensure the URL uses the 'blob/<branch>/<subpath>' format rather than a bare repository URL."
-            )
-        match = re.match(r"^https://github\.com/([^/]+)/([^/]+)/blob/([^/]+)/(.+)$", githubLink)
-        if not match:
-            _fail_dev_preflight(
-                f"GitHub URL must match 'https://github.com/<owner>/<repo>/blob/<branch>/<subpath>'; got {githubLink!r}.",
-                fix="Provide a complete URL including the owner, repo, branch, and subpath."
-            )
+    if not githubLink.startswith("https://github.com/"):
+        _fail_dev_preflight(
+            f"GitHub link must start with 'https://github.com/'; got {githubLink!r}.",
+            fix="Use https://github.com/<owner>/<repo>/blob/<branch>/<subpath>."
+        )
+    if "/tree/" in githubLink:
+        _fail_dev_preflight(
+            f"GitHub URL uses '/tree/' which is not supported: {githubLink!r}.",
+            fix="Convert the '/tree/' segment to '/blob/' and specify the path to the skill file/directory."
+        )
+    if "/blob/" not in githubLink:
+        _fail_dev_preflight(
+            f"GitHub URL is missing the '/blob/' segment: {githubLink!r}.",
+            fix="Ensure the URL uses the 'blob/<branch>/<subpath>' format rather than a bare repository URL."
+        )
+    match = re.match(r"^https://github\.com/([^/]+)/([^/]+)/blob/([^/]+)/(.+)$", githubLink)
+    if not match:
+        _fail_dev_preflight(
+            f"GitHub URL must match 'https://github.com/<owner>/<repo>/blob/<branch>/<subpath>'; got {githubLink!r}.",
+            fix="Provide a complete URL including the owner, repo, branch, and subpath."
+        )
 
 
 def preflightAddCommand(args) -> None:
@@ -507,7 +520,7 @@ def preflightLinkCommand(args) -> None:
     import json
     registryPath = args.registry
     targetId = args.target.lstrip("/")
-    prereqsList = [p.strip() for p in args.prereqs.split(",") if p.strip()]
+    prereqsList = parseCommaSeparatedIds(args.prereqs, "prerequisite")
     if not prereqsList:
         _fail_dev_preflight(
             "No prerequisite skills specified.",

--- a/src/gaia_cli/commands/dev/helpers.py
+++ b/src/gaia_cli/commands/dev/helpers.py
@@ -313,3 +313,253 @@ def _parse_named_frontmatter(content):
             key, _, val = line.partition(":")
             meta[key.strip()] = val.strip().strip("'\"")
     return meta
+
+
+def genericSkillExists(registryPath: str, skillId: str) -> bool:
+    """Check if a generic skill with the given ID exists."""
+    from gaia_cli.registry import registry_nodes_dir
+    nodesDir = Path(registry_nodes_dir(registryPath))
+    for p in nodesDir.glob("**/*.json"):
+        if p.stem == skillId:
+            return True
+    return False
+
+
+def namedSkillExists(registryPath: str, contributor: str, skillId: str) -> bool:
+    """Check if a named skill with the given ID exists."""
+    from gaia_cli.registry import named_skills_dir
+    namedDir = Path(named_skills_dir(registryPath))
+    destFile = namedDir / contributor / f"{skillId}.md"
+    return destFile.exists()
+
+
+def preflightSuiteComponents(registryPath: str, suiteComponentsStr: str | None) -> None:
+    """Validate suite components exist and have no duplicates."""
+    if not suiteComponentsStr:
+        return
+    components = [c.strip() for c in suiteComponentsStr.split(",") if c.strip()]
+    seen = set()
+    duplicates = []
+    for comp in components:
+        if comp in seen:
+            duplicates.append(comp)
+        else:
+            seen.add(comp)
+    if duplicates:
+        duplicateList = ", ".join(duplicates)
+        _fail_dev_preflight(
+            f"Duplicate suite components are not allowed: {duplicateList}.",
+            fix="Remove the duplicates from the --suite-components list."
+        )
+    from gaia_cli.registry import named_skills_dir
+    namedDir = Path(named_skills_dir(registryPath))
+    for comp in components:
+        if not _find_named_file(namedDir, comp):
+            _fail_dev_preflight(
+                f"Suite component '{comp}' does not exist in the registry.",
+                fix=f"Ensure the named skill '{comp}' is added to the registry before referencing it as a suite component."
+            )
+
+
+def preflightGithubLink(githubLink: str | None) -> None:
+    """Validate GitHub link uses the blob/<branch>/<subpath> format."""
+    import re
+    if not githubLink:
+        return
+    if "github.com" in githubLink or githubLink.startswith("https://github.com/"):
+        if not githubLink.startswith("https://github.com/"):
+            _fail_dev_preflight(
+                f"GitHub link must start with 'https://github.com/'; got {githubLink!r}.",
+                fix="Ensure the URL is a valid GitHub URL."
+            )
+        if "/tree/" in githubLink:
+            _fail_dev_preflight(
+                f"GitHub URL uses '/tree/' which is not supported: {githubLink!r}.",
+                fix="Convert the '/tree/' segment to '/blob/' and specify the path to the skill file/directory."
+            )
+        if "/blob/" not in githubLink:
+            _fail_dev_preflight(
+                f"GitHub URL is missing the '/blob/' segment: {githubLink!r}.",
+                fix="Ensure the URL uses the 'blob/<branch>/<subpath>' format rather than a bare repository URL."
+            )
+        match = re.match(r"^https://github\.com/([^/]+)/([^/]+)/blob/([^/]+)/(.+)$", githubLink)
+        if not match:
+            _fail_dev_preflight(
+                f"GitHub URL must match 'https://github.com/<owner>/<repo>/blob/<branch>/<subpath>'; got {githubLink!r}.",
+                fix="Provide a complete URL including the owner, repo, branch, and subpath."
+            )
+
+
+def preflightAddCommand(args) -> None:
+    """Validate arguments for the add command."""
+    import re
+    import json
+    registryPath = args.registry
+    skillName = args.name
+    isNamed = getattr(args, "named", False)
+    skillId = args.id or skillName.lower().replace(" ", "-")
+    descriptionText = (getattr(args, "description", None) or "").strip()
+    if len(descriptionText) < 10:
+        _fail_dev_preflight(
+            f"Skill description must be at least 10 characters; got {len(descriptionText)}.",
+            fix="Provide a longer, more descriptive --description."
+        )
+    if isNamed:
+        contributorVal = getattr(args, "contributor", "gaiabot")
+        if contributorVal is None:
+            contributorVal = "gaiabot"
+        if not re.match(r"^[a-zA-Z0-9][a-zA-Z0-9_-]*$", contributorVal):
+            _fail_dev_preflight(
+                f"Contributor username '{contributorVal}' is invalid.",
+                fix="Use only alphanumeric characters, underscores, or hyphens."
+            )
+        fullId = f"{contributorVal}/{skillId}"
+        if not re.match(r"^[a-z0-9][a-z0-9_-]*/[a-z0-9][a-z0-9_-]*$", fullId):
+            _fail_dev_preflight(
+                f"Named skill ID '{fullId}' is invalid.",
+                fix="Ensure both the contributor username and skill ID are valid lowercase slug patterns."
+            )
+        if namedSkillExists(registryPath, contributorVal, skillId):
+            _fail_dev_preflight(
+                f"Named skill '{fullId}' already exists.",
+                fix="Use a different ID or update the existing skill using `gaia dev update-named`."
+            )
+        levelVal = getattr(args, "level", "2★")
+        if levelVal is None:
+            levelVal = "2★"
+        validLevels = {"1★", "2★", "3★", "4★", "5★", "6★"}
+        if levelVal not in validLevels:
+            _fail_dev_preflight(
+                f"Level '{levelVal}' is invalid.",
+                fix=f"Level must be one of: {', '.join(sorted(validLevels))}"
+            )
+        statusVal = getattr(args, "status", "named")
+        if statusVal is None:
+            statusVal = "named"
+        validStatuses = {"awakened", "named"}
+        if statusVal not in validStatuses:
+            _fail_dev_preflight(
+                f"Status '{statusVal}' is invalid for named skill.",
+                fix="Status must be 'awakened' or 'named'."
+            )
+        titleVal = getattr(args, "title", None)
+        catalogRefVal = None
+        extraFieldsStr = getattr(args, "extra_fields", None)
+        if extraFieldsStr:
+            try:
+                extra = json.loads(extraFieldsStr)
+                if isinstance(extra, dict):
+                    catalogRefVal = extra.get("catalogRef")
+            except json.JSONDecodeError:
+                pass
+        if statusVal == "named" and not titleVal and not catalogRefVal:
+            _fail_dev_preflight(
+                f"status='named' requires 'title' or 'catalogRef' on {fullId}.",
+                fix="Pass --title '<lore title>' or include catalogRef in --extra-fields."
+            )
+        genericRef = getattr(args, "generic_ref", "unknown")
+        if genericRef is None:
+            genericRef = "unknown"
+        if genericRef != "unknown":
+            if not re.match(r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$", genericRef):
+                _fail_dev_preflight(
+                    f"Generic skill reference '{genericRef}' has an invalid ID pattern.",
+                    fix="Use a valid lowercase, hyphenated slug pattern."
+                )
+            if not genericSkillExists(registryPath, genericRef):
+                _fail_dev_preflight(
+                    f"Referenced generic skill '{genericRef}' does not exist.",
+                    fix="Ensure the generic skill exists before referencing it as genericSkillRef."
+                )
+    else:
+        if not re.match(r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$", skillId):
+            _fail_dev_preflight(
+                f"Generic skill ID '{skillId}' is invalid.",
+                fix="Use a valid lowercase, hyphenated slug pattern matching '^[a-z][a-z0-9]*(-[a-z0-9]+)*$'."
+            )
+        if genericSkillExists(registryPath, skillId):
+            _fail_dev_preflight(
+                f"Generic skill '{skillId}' already exists.",
+                fix="Use a different ID or edit the existing skill file directly."
+            )
+        typeVal = getattr(args, "type", "basic")
+        if typeVal is None:
+            typeVal = "basic"
+        validTypes = {"basic", "extra", "ultimate", "unique"}
+        if typeVal not in validTypes:
+            _fail_dev_preflight(
+                f"Type '{typeVal}' is invalid.",
+                fix=f"Type must be one of: {', '.join(sorted(validTypes))}"
+            )
+        statusVal = getattr(args, "status", "provisional")
+        if statusVal is None:
+            statusVal = "provisional"
+        validStatuses = {"provisional", "validated", "disputed", "deprecated"}
+        if statusVal not in validStatuses:
+            _fail_dev_preflight(
+                f"Status '{statusVal}' is invalid for generic skill.",
+                fix=f"Status must be one of: {', '.join(sorted(validStatuses))}"
+            )
+
+
+def preflightLinkCommand(args) -> None:
+    """Validate arguments for the link command."""
+    import json
+    registryPath = args.registry
+    targetId = args.target.lstrip("/")
+    prereqsList = [p.strip() for p in args.prereqs.split(",") if p.strip()]
+    if not prereqsList:
+        _fail_dev_preflight(
+            "No prerequisite skills specified.",
+            fix="Provide a comma-separated list of prerequisite skill IDs."
+        )
+    if not genericSkillExists(registryPath, targetId):
+        _fail_dev_preflight(
+            f"Target skill '{targetId}' does not exist.",
+            fix="Ensure the target skill exists before adding prerequisites to it."
+        )
+    for prereqId in prereqsList:
+        if not genericSkillExists(registryPath, prereqId):
+            _fail_dev_preflight(
+                f"Prerequisite skill '{prereqId}' does not exist.",
+                fix=f"Ensure the prerequisite skill '{prereqId}' exists in the registry first."
+            )
+    for prereqId in prereqsList:
+        if prereqId == targetId:
+            _fail_dev_preflight(
+                f"Cannot link skill '{targetId}' to itself.",
+                fix="Remove the target skill ID from the prerequisite list."
+            )
+    seen = set()
+    duplicatesInList = []
+    for prereqId in prereqsList:
+        if prereqId in seen:
+            duplicatesInList.append(prereqId)
+        else:
+            seen.add(prereqId)
+    if duplicatesInList:
+        dupListStr = ", ".join(duplicatesInList)
+        _fail_dev_preflight(
+            f"Duplicate prerequisite IDs are not allowed in the link list: {dupListStr}.",
+            fix="Remove duplicate IDs from the prerequisite list."
+        )
+    if not getattr(args, "reset", False):
+        from gaia_cli.registry import registry_nodes_dir
+        nodesDir = Path(registry_nodes_dir(registryPath))
+        targetPrereqs = []
+        for p in nodesDir.glob("**/*.json"):
+            if p.stem == targetId:
+                with open(p, "r", encoding="utf-8") as f:
+                    try:
+                        data = json.load(f)
+                        targetPrereqs = data.get("prerequisites", [])
+                    except Exception:
+                        pass
+                break
+        existingDups = [p for p in prereqsList if p in targetPrereqs]
+        if existingDups:
+            dupRelStr = ", ".join(existingDups)
+            _fail_dev_preflight(
+                f"Relationship already exists: {targetId} is already linked to prerequisite(s): {dupRelStr}.",
+                fix="Remove the already-linked prerequisite(s) from the list, or use --reset to overwrite them."
+            )

--- a/src/gaia_cli/commands/dev/named.py
+++ b/src/gaia_cli/commands/dev/named.py
@@ -15,6 +15,7 @@ from gaia_cli.commands.dev.helpers import (
     _preflight_named_status_identity,
     preflightSuiteComponents,
     preflightGithubLink,
+    parseCommaSeparatedIds,
 )
 
 
@@ -60,7 +61,7 @@ def meta_update_named_command(args):
         changed = True
 
     if getattr(args, "suite_components", None):
-        meta["suiteComponents"] = [s.strip() for s in args.suite_components.split(",")]
+        meta["suiteComponents"] = parseCommaSeparatedIds(args.suite_components, "suite component")
         changed = True
 
     if getattr(args, "suite_ref", None):
@@ -97,7 +98,7 @@ def meta_update_named_command(args):
             meta["origin"] = target_val
             changed = True
             origin_changed = True
-            
+
             # Uniqueness constraint: if we're setting origin=True, strip it from others in the same bucket
             if target_val and meta.get("genericSkillRef"):
                 bucket_ref = meta["genericSkillRef"]

--- a/src/gaia_cli/commands/dev/named.py
+++ b/src/gaia_cli/commands/dev/named.py
@@ -13,6 +13,8 @@ from gaia_cli.commands.dev.helpers import (
     _run_docs_build,
     _run_dev_preflights,
     _preflight_named_status_identity,
+    preflightSuiteComponents,
+    preflightGithubLink,
 )
 
 
@@ -34,6 +36,8 @@ def meta_update_named_command(args):
 
     _run_dev_preflights([
         lambda: _preflight_named_status_identity(skill_id, meta, args),
+        lambda: preflightSuiteComponents(registry_path, getattr(args, "suite_components", None)),
+        lambda: preflightGithubLink(getattr(args, "github_link", None)),
     ])
 
     if getattr(args, "status", None):

--- a/tests/test_dev_build.py
+++ b/tests/test_dev_build.py
@@ -239,6 +239,16 @@ def test_add_rejects_named_status_missing_title(tmp_path, capsys):
     assert "status='named' requires 'title' or 'catalogRef'" in err
 
 
+def test_add_awakened_named_does_not_require_title_and_writes_status(tmp_path):
+    root = _make_registry(tmp_path)
+    meta_add_command(_add_args(root, id="my-skill", named=True, status="awakened"))
+    new_file = Path(root) / "registry" / "named" / "gaiabot" / "my-skill.md"
+    assert new_file.exists()
+    md = new_file.read_text(encoding="utf-8")
+    assert "status: awakened" in md
+    assert "title:" not in md
+
+
 def test_add_rejects_nonexistent_generic_ref(tmp_path, capsys):
     root = _make_registry(tmp_path)
     with pytest.raises(SystemExit) as exc:
@@ -298,7 +308,7 @@ def test_link_rejects_duplicate_relationship(tmp_path, capsys):
     meta_add_command(_add_args(root, name="Other Skill", id="other-skill"))
     # link them once (works)
     meta_link_command(_link_args(root, target="existing-skill", prereqs="other-skill"))
-    
+
     # try linking again, should reject
     with pytest.raises(SystemExit) as exc:
         meta_link_command(_link_args(root, target="existing-skill", prereqs="other-skill"))
@@ -307,11 +317,26 @@ def test_link_rejects_duplicate_relationship(tmp_path, capsys):
     assert "Relationship already exists" in err
 
 
+def test_link_rejects_empty_prereq_entry_before_write(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    meta_add_command(_add_args(root, name="Other Skill", id="other-skill"))
+    target_file = Path(root) / "registry" / "nodes" / "basic" / "existing-skill.json"
+    before = target_file.read_text(encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc:
+        meta_link_command(_link_args(root, target="existing-skill", prereqs="other-skill,"))
+
+    assert exc.value.code != 0
+    assert target_file.read_text(encoding="utf-8") == before
+    err = capsys.readouterr().err
+    assert "Empty prerequisite entries are not allowed" in err
+
+
 def test_link_happy_path(tmp_path):
     root = _make_registry(tmp_path)
     meta_add_command(_add_args(root, name="Other Skill", id="other-skill"))
     meta_link_command(_link_args(root, target="existing-skill", prereqs="other-skill"))
-    
+
     newFile = Path(root) / "registry" / "nodes" / "basic" / "existing-skill.json"
     data = json.loads(newFile.read_text(encoding="utf-8"))
     assert "other-skill" in data["prerequisites"]
@@ -321,12 +346,12 @@ def test_link_happy_path_with_reset(tmp_path):
     root = _make_registry(tmp_path)
     meta_add_command(_add_args(root, name="Other Skill", id="other-skill"))
     meta_add_command(_add_args(root, name="Another Skill", id="another-skill"))
-    
+
     # link once
     meta_link_command(_link_args(root, target="existing-skill", prereqs="other-skill"))
     # link with reset
     meta_link_command(_link_args(root, target="existing-skill", prereqs="another-skill", reset=True))
-    
+
     newFile = Path(root) / "registry" / "nodes" / "basic" / "existing-skill.json"
     data = json.loads(newFile.read_text(encoding="utf-8"))
     assert data["prerequisites"] == ["another-skill"]

--- a/tests/test_dev_build.py
+++ b/tests/test_dev_build.py
@@ -355,4 +355,3 @@ def test_link_happy_path_with_reset(tmp_path):
     newFile = Path(root) / "registry" / "nodes" / "basic" / "existing-skill.json"
     data = json.loads(newFile.read_text(encoding="utf-8"))
     assert data["prerequisites"] == ["another-skill"]
-

--- a/tests/test_dev_build.py
+++ b/tests/test_dev_build.py
@@ -10,6 +10,7 @@ from gaia_cli.commands.dev.build import (
     meta_build_command,
     meta_add_command,
     meta_remove_command,
+    meta_link_command,
 )
 pytestmark = [pytest.mark.integration]
 
@@ -44,6 +45,20 @@ def _make_registry(tmp_path: Path) -> str:
     return str(tmp_path)
 
 
+def _write_named(tmp_path: Path, slug: str, name: str = "Test Skill", level: str = "2★") -> None:
+    contributor, skillId = slug.split("/", 1)
+    namedDir = tmp_path / "registry" / "named" / contributor
+    namedDir.mkdir(parents=True, exist_ok=True)
+    path = namedDir / f"{skillId}.md"
+    path.write_text(
+        f"---\nid: {slug}\nname: {name}\ncontributor: {contributor}\n"
+        f"origin: false\ngenericSkillRef: unknown\nstatus: named\n"
+        f"level: {level}\ntitle: Epithet\n"
+        f"description: A named skill description here.\n---\n",
+        encoding="utf-8"
+    )
+
+
 def _add_args(root: str, name: str = "New Skill",
               description: str = "A brand new skill description here.",
               **kw) -> SimpleNamespace:
@@ -68,6 +83,12 @@ def _add_args(root: str, name: str = "New Skill",
 
 def _rm_args(root: str, skill_id: str = "existing-skill", **kw) -> SimpleNamespace:
     base = dict(registry=root, skill_id=skill_id, yes=True, no_build=True)
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def _link_args(root: str, target: str, prereqs: str, **kw) -> SimpleNamespace:
+    base = dict(registry=root, target=target, prereqs=prereqs, reset=False, no_build=True)
     base.update(kw)
     return SimpleNamespace(**base)
 
@@ -147,3 +168,166 @@ def test_remove_missing_skill_exits(tmp_path):
     with pytest.raises(SystemExit) as exc:
         meta_remove_command(_rm_args(root, skill_id="nonexistent"))
     assert exc.value.code != 0
+
+
+# ---------------------------------------------------------------------------
+# Preflight tests for add and link commands
+# ---------------------------------------------------------------------------
+
+
+def test_add_rejects_duplicate_generic_id(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    with pytest.raises(SystemExit) as exc:
+        meta_add_command(_add_args(root, id="existing-skill"))
+    assert exc.value.code != 0
+    err = capsys.readouterr().err
+    assert "Generic skill 'existing-skill' already exists" in err
+
+
+def test_add_rejects_invalid_generic_id(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    with pytest.raises(SystemExit) as exc:
+        meta_add_command(_add_args(root, id="Invalid_ID"))
+    assert exc.value.code != 0
+    err = capsys.readouterr().err
+    assert "Generic skill ID 'Invalid_ID' is invalid" in err
+
+
+def test_add_rejects_duplicate_named_id(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    _write_named(Path(root), "alice/my-skill")
+    with pytest.raises(SystemExit) as exc:
+        meta_add_command(_add_args(root, id="my-skill", named=True, contributor="alice"))
+    assert exc.value.code != 0
+    err = capsys.readouterr().err
+    assert "Named skill 'alice/my-skill' already exists" in err
+
+
+def test_add_rejects_invalid_named_id(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    with pytest.raises(SystemExit) as exc:
+        meta_add_command(_add_args(root, id="Invalid_ID", named=True, contributor="alice"))
+    assert exc.value.code != 0
+    err = capsys.readouterr().err
+    assert "Named skill ID 'alice/Invalid_ID' is invalid" in err
+
+
+def test_add_rejects_invalid_level(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    with pytest.raises(SystemExit) as exc:
+        meta_add_command(_add_args(root, id="my-skill", named=True, level="10★"))
+    assert exc.value.code != 0
+    err = capsys.readouterr().err
+    assert "Level '10★' is invalid" in err
+
+
+def test_add_rejects_invalid_status(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    with pytest.raises(SystemExit) as exc:
+        meta_add_command(_add_args(root, id="my-skill", named=True, status="invalid-status"))
+    assert exc.value.code != 0
+    err = capsys.readouterr().err
+    assert "Status 'invalid-status' is invalid for named skill" in err
+
+
+def test_add_rejects_named_status_missing_title(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    with pytest.raises(SystemExit) as exc:
+        meta_add_command(_add_args(root, id="my-skill", named=True, status="named"))
+    assert exc.value.code != 0
+    err = capsys.readouterr().err
+    assert "status='named' requires 'title' or 'catalogRef'" in err
+
+
+def test_add_rejects_nonexistent_generic_ref(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    with pytest.raises(SystemExit) as exc:
+        meta_add_command(_add_args(root, id="my-skill", named=True, generic_ref="nonexistent-skill", title="Epithet"))
+    assert exc.value.code != 0
+    err = capsys.readouterr().err
+    assert "Referenced generic skill 'nonexistent-skill' does not exist" in err
+
+
+def test_add_happy_path_named(tmp_path):
+    root = _make_registry(tmp_path)
+    meta_add_command(_add_args(root, id="my-skill", named=True, generic_ref="existing-skill", title="Epithet"))
+    assert (Path(root) / "registry" / "named" / "gaiabot" / "my-skill.md").exists()
+
+
+def test_link_rejects_nonexistent_target(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    with pytest.raises(SystemExit) as exc:
+        meta_link_command(_link_args(root, target="nonexistent-target", prereqs="existing-skill"))
+    assert exc.value.code != 0
+    err = capsys.readouterr().err
+    assert "Target skill 'nonexistent-target' does not exist" in err
+
+
+def test_link_rejects_nonexistent_prereq(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    with pytest.raises(SystemExit) as exc:
+        meta_link_command(_link_args(root, target="existing-skill", prereqs="nonexistent-prereq"))
+    assert exc.value.code != 0
+    err = capsys.readouterr().err
+    assert "Prerequisite skill 'nonexistent-prereq' does not exist" in err
+
+
+def test_link_rejects_self_link(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    with pytest.raises(SystemExit) as exc:
+        meta_link_command(_link_args(root, target="existing-skill", prereqs="existing-skill"))
+    assert exc.value.code != 0
+    err = capsys.readouterr().err
+    assert "Cannot link skill 'existing-skill' to itself" in err
+
+
+def test_link_rejects_duplicate_prereqs_in_list(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    # create another skill
+    meta_add_command(_add_args(root, name="Other Skill", id="other-skill"))
+    with pytest.raises(SystemExit) as exc:
+        meta_link_command(_link_args(root, target="existing-skill", prereqs="other-skill,other-skill"))
+    assert exc.value.code != 0
+    err = capsys.readouterr().err
+    assert "Duplicate prerequisite IDs are not allowed in the link list: other-skill" in err
+
+
+def test_link_rejects_duplicate_relationship(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    # create other skill
+    meta_add_command(_add_args(root, name="Other Skill", id="other-skill"))
+    # link them once (works)
+    meta_link_command(_link_args(root, target="existing-skill", prereqs="other-skill"))
+    
+    # try linking again, should reject
+    with pytest.raises(SystemExit) as exc:
+        meta_link_command(_link_args(root, target="existing-skill", prereqs="other-skill"))
+    assert exc.value.code != 0
+    err = capsys.readouterr().err
+    assert "Relationship already exists" in err
+
+
+def test_link_happy_path(tmp_path):
+    root = _make_registry(tmp_path)
+    meta_add_command(_add_args(root, name="Other Skill", id="other-skill"))
+    meta_link_command(_link_args(root, target="existing-skill", prereqs="other-skill"))
+    
+    newFile = Path(root) / "registry" / "nodes" / "basic" / "existing-skill.json"
+    data = json.loads(newFile.read_text(encoding="utf-8"))
+    assert "other-skill" in data["prerequisites"]
+
+
+def test_link_happy_path_with_reset(tmp_path):
+    root = _make_registry(tmp_path)
+    meta_add_command(_add_args(root, name="Other Skill", id="other-skill"))
+    meta_add_command(_add_args(root, name="Another Skill", id="another-skill"))
+    
+    # link once
+    meta_link_command(_link_args(root, target="existing-skill", prereqs="other-skill"))
+    # link with reset
+    meta_link_command(_link_args(root, target="existing-skill", prereqs="another-skill", reset=True))
+    
+    newFile = Path(root) / "registry" / "nodes" / "basic" / "existing-skill.json"
+    data = json.loads(newFile.read_text(encoding="utf-8"))
+    assert data["prerequisites"] == ["another-skill"]
+

--- a/tests/test_dev_named.py
+++ b/tests/test_dev_named.py
@@ -152,6 +152,19 @@ def test_update_named_suite_components_rejects_duplicates(tmp_path, capsys):
     assert "Duplicate suite components are not allowed: alice/other-skill." in err
 
 
+def test_update_named_suite_components_rejects_empty_entry_before_write(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    _write_named(Path(root) / "registry" / "named", slug="alice/other-skill")
+    path = Path(root) / "registry" / "named" / "alice" / "test-skill.md"
+    before = path.read_text(encoding="utf-8")
+    with pytest.raises(SystemExit) as exc:
+        meta_update_named_command(_args(root, suite_components="alice/other-skill,"))
+    assert exc.value.code != 0
+    assert path.read_text(encoding="utf-8") == before
+    err = capsys.readouterr().err
+    assert "Empty suite component entries are not allowed" in err
+
+
 def test_update_named_suite_components_happy_path(tmp_path):
     root = _make_registry(tmp_path)
     _write_named(Path(root) / "registry" / "named", slug="alice/other-skill")
@@ -184,6 +197,18 @@ def test_update_named_github_link_rejects_bare(tmp_path, capsys):
     assert path.read_text(encoding="utf-8") == before
     err = capsys.readouterr().err
     assert "missing the '/blob/' segment" in err
+
+
+def test_update_named_github_link_rejects_non_github_url(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    path = Path(root) / "registry" / "named" / "alice" / "test-skill.md"
+    before = path.read_text(encoding="utf-8")
+    with pytest.raises(SystemExit) as exc:
+        meta_update_named_command(_args(root, github_link="https://example.com/alice/repo/blob/main/skill.md"))
+    assert exc.value.code != 0
+    assert path.read_text(encoding="utf-8") == before
+    err = capsys.readouterr().err
+    assert "GitHub link must start with 'https://github.com/'" in err
 
 
 def test_update_named_github_link_happy_path(tmp_path):

--- a/tests/test_dev_named.py
+++ b/tests/test_dev_named.py
@@ -218,4 +218,3 @@ def test_update_named_github_link_happy_path(tmp_path):
     from gaia_cli.commands.dev.helpers import _parse_md
     meta, _ = _parse_md(path)
     assert meta["links"]["github"] == "https://github.com/alice/repo/blob/main/skills/test-skill/SKILL.md"
-

--- a/tests/test_dev_named.py
+++ b/tests/test_dev_named.py
@@ -125,3 +125,72 @@ def test_update_named_status_named_requires_title(tmp_path, capsys):
     assert "status='named' requires 'title' or 'catalogRef'" in err
     assert "--title" in err
     assert "--catalog-ref" in err
+
+
+def test_update_named_suite_components_rejects_nonexistent(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    path = Path(root) / "registry" / "named" / "alice" / "test-skill.md"
+    before = path.read_text(encoding="utf-8")
+    with pytest.raises(SystemExit) as exc:
+        meta_update_named_command(_args(root, suite_components="alice/nonexistent"))
+    assert exc.value.code != 0
+    assert path.read_text(encoding="utf-8") == before
+    err = capsys.readouterr().err
+    assert "Suite component 'alice/nonexistent' does not exist in the registry." in err
+
+
+def test_update_named_suite_components_rejects_duplicates(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    _write_named(Path(root) / "registry" / "named", slug="alice/other-skill")
+    path = Path(root) / "registry" / "named" / "alice" / "test-skill.md"
+    before = path.read_text(encoding="utf-8")
+    with pytest.raises(SystemExit) as exc:
+        meta_update_named_command(_args(root, suite_components="alice/other-skill,alice/other-skill"))
+    assert exc.value.code != 0
+    assert path.read_text(encoding="utf-8") == before
+    err = capsys.readouterr().err
+    assert "Duplicate suite components are not allowed: alice/other-skill." in err
+
+
+def test_update_named_suite_components_happy_path(tmp_path):
+    root = _make_registry(tmp_path)
+    _write_named(Path(root) / "registry" / "named", slug="alice/other-skill")
+    path = Path(root) / "registry" / "named" / "alice" / "test-skill.md"
+    meta_update_named_command(_args(root, suite_components="alice/other-skill"))
+    from gaia_cli.commands.dev.helpers import _parse_md
+    meta, _ = _parse_md(path)
+    assert meta["suiteComponents"] == ["alice/other-skill"]
+
+
+def test_update_named_github_link_rejects_tree(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    path = Path(root) / "registry" / "named" / "alice" / "test-skill.md"
+    before = path.read_text(encoding="utf-8")
+    with pytest.raises(SystemExit) as exc:
+        meta_update_named_command(_args(root, github_link="https://github.com/alice/repo/tree/main/skills/test-skill"))
+    assert exc.value.code != 0
+    assert path.read_text(encoding="utf-8") == before
+    err = capsys.readouterr().err
+    assert "uses '/tree/' which is not supported" in err
+
+
+def test_update_named_github_link_rejects_bare(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    path = Path(root) / "registry" / "named" / "alice" / "test-skill.md"
+    before = path.read_text(encoding="utf-8")
+    with pytest.raises(SystemExit) as exc:
+        meta_update_named_command(_args(root, github_link="https://github.com/alice/repo"))
+    assert exc.value.code != 0
+    assert path.read_text(encoding="utf-8") == before
+    err = capsys.readouterr().err
+    assert "missing the '/blob/' segment" in err
+
+
+def test_update_named_github_link_happy_path(tmp_path):
+    root = _make_registry(tmp_path)
+    path = Path(root) / "registry" / "named" / "alice" / "test-skill.md"
+    meta_update_named_command(_args(root, github_link="https://github.com/alice/repo/blob/main/skills/test-skill/SKILL.md"))
+    from gaia_cli.commands.dev.helpers import _parse_md
+    meta, _ = _parse_md(path)
+    assert meta["links"]["github"] == "https://github.com/alice/repo/blob/main/skills/test-skill/SKILL.md"
+


### PR DESCRIPTION
Implement PR 2 of #759. Adds preflight checks for dev add, dev link, and dev update-named. Includes unit tests for both happy and reject paths.

Token spend log:
2026-07-02 Claude 3.5 Sonnet: 30k in, 8k out. ~/bin/bash.20