### PR TITLE
meta(tenure): backfill sourceStartedAt on mattpocock/skills

### DIFF
--- a/registry/named/mattpocock/skills.md
+++ b/registry/named/mattpocock/skills.md
@@ -13,7 +13,7 @@ description: The ultimate capstone suite encompassing all of Matt Pocock's engin
 links:
   github: https://github.com/mattpocock/skills
 createdAt: '2026-05-22'
-updatedAt: '2026-06-21'
+updatedAt: '2026-07-02'
 trustMagnitude: 480.29
 overallTrustGrade: S
 apexGateStatus:
@@ -80,6 +80,11 @@ timeline:
   contributor: unknown
   details: 'Apex promotion PR stamped by Marco (founder/mbtiongson1) per #746 directive
     — mattpocock/skills qualifies for §11.12.8 (apexPromotionPrSigned)'
+- timestamp: '2026-07-01T22:21:07Z'
+  action: note
+  contributor: unknown
+  details: Backfilled evidence sourceStartedAt via gaia dev evidence --index for GitHub
+    stargazers (2026-02-03 repo creation) and arXiv source (2026-02-24 publication).
 evidence:
 - source: https://github.com/mattpocock/skills/stargazers
   evaluator: mbtiongson1
@@ -87,11 +92,12 @@ evidence:
   date: '2026-06-19'
   type: github-stars-own
   class: A
-  notes: 133,210 GitHub stars as of 2026-06-19 (verified via firecrawl validation
-    report; mothership with 19 sub-skills, divisor=4)
+  notes: 148,206 GitHub stars as of 2026-06-28 (GitHub repo created 2026-02-03T11:15:53Z;
+    mothership with 19 sub-skills, divisor=4)
   stars: 148206
   skillCountInRepo: 19
-  grade: C
+  grade: B
+  sourceStartedAt: '2026-02-03'
 - source: https://arxiv.org/abs/2602.20867
   evaluator: mbtiongson1
   date: '2026-06-19'
@@ -99,6 +105,7 @@ evidence:
   class: A
   notes: Skills/tool-use paper — ~52 citations as of 2026-06-19 (arXiv:2602.20867)
   citations: 52
+  sourceStartedAt: '2026-02-24'
 - source: https://www.youtube.com/watch?v=s5T5oQJcJ6U
   evaluator: mbtiongson1
   date: '2026-06-19'

--- a/tests/test_apex_backfill.py
+++ b/tests/test_apex_backfill.py
@@ -1,0 +1,47 @@
+import os
+import unittest
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+class TestApexTenureBackfill(unittest.TestCase):
+    """Lock the approved mattpocock/skills evidence-tenure backfill."""
+
+    def _read_frontmatter(self, filepath):
+        with open(filepath, "r", encoding="utf-8") as f:
+            content = f.read()
+        parts = content.split("---", 2)
+        if len(parts) < 3:
+            raise ValueError(f"No frontmatter found in {filepath}")
+        return yaml.safe_load(parts[1])
+
+    def test_mattpocock_skills_backfilled_rows_only(self):
+        filepath = os.path.join(
+            REPO_ROOT, "registry", "named", "mattpocock", "skills.md"
+        )
+        fm = self._read_frontmatter(filepath)
+        evidence = fm.get("evidence", [])
+
+        expected = {
+            "https://github.com/mattpocock/skills/stargazers": "2026-02-03",
+            "https://arxiv.org/abs/2602.20867": "2026-02-24",
+        }
+
+        for source, source_started_at in expected.items():
+            with self.subTest(source=source):
+                row = next((r for r in evidence if r.get("source") == source), None)
+                self.assertIsNotNone(row, f"Evidence row not found: {source}")
+                self.assertEqual(row.get("sourceStartedAt"), source_started_at)
+
+    def test_backfill_does_not_claim_apex_tenure_passed(self):
+        filepath = os.path.join(
+            REPO_ROOT, "registry", "named", "mattpocock", "skills.md"
+        )
+        fm = self._read_frontmatter(filepath)
+
+        self.assertFalse(
+            fm.get("apexGateStatus", {}).get("sourceTenureDaysGte180AorS"),
+            "Backfilled tenure dates must not flip the apex tenure gate in this PR.",
+        )


### PR DESCRIPTION
Refs #746

## Scope
Conservative evidence-tenure backfill for `mattpocock/skills` only.

Kept files changed:
- `registry/named/mattpocock/skills.md`
- `tests/test_apex_backfill.py`

Removed unrelated generated/docs drift from the PR (`docs/api/v1/*`, `docs/graph/*`, `docs/css/tokens.css`, `docs/heroes/index.html`). Class S artifacts were not regenerated/kept because this PR only updates named-skill frontmatter and a focused regression test.

## Provenance
- GitHub stargazers row: `sourceStartedAt: 2026-02-03` from `gh api repos/mattpocock/skills` → `created_at: 2026-02-03T11:15:53Z`.
- arXiv row: `sourceStartedAt: 2026-02-24` from `https://export.arxiv.org/api/query?id_list=2602.20867` → `published: 2026-02-24T13:11:38Z`.
- Stargazer notes were made internally consistent with the pre-existing row payload: `stars: 148206`, row `updatedAt: 2026-06-28`, and CLI-derived row `grade: B`.

## Audit trail
Verified `gaia dev evidence --index ... --source-started-at ...` does **not** emit a timeline event unless `--trust` is supplied. I did not hand-edit a fabricated event; I used the existing CLI-only audit path:

```bash
GAIA_OPERATOR_OVERRIDE=1 PYTHONPATH=src python3 -m gaia_cli dev timeline mattpocock/skills --action note --notes "Backfilled evidence sourceStartedAt via gaia dev evidence --index for GitHub stargazers (2026-02-03 repo creation) and arXiv source (2026-02-24 publication)." --no-build
```

Unresolved CLI audit gap: `gaia dev evidence --index` source metadata updates (`--source-started-at`, `--notes`, numeric payload changes without `--trust`) should probably emit their own evidence-update timeline event instead of requiring a separate `gaia dev timeline --action note` call.

## Validation
- `git diff --check origin/dev/sprint-b-closure...HEAD`
- `PYTHONPATH=src python3 -m pytest tests/test_apex_backfill.py`
- `GAIA_OPERATOR_OVERRIDE=1 PYTHONPATH=src python3 -m gaia_cli dev validate` (passes; retains existing non-blocking `ruvnet/hive-mind-coordination.md` named evidence warning)
