### PR TITLE
feat(source-curation): add dry-run proposal runner

### DIFF
--- a/docs/agents/source-curation.md
+++ b/docs/agents/source-curation.md
@@ -15,8 +15,8 @@ against the `sourceProposal.schema.json` contract.
 
 **Current scope (Phase 1):** The pipeline emits dry-run reports only. No
 registry mutation occurs. No auto-PRs are opened. Reports are written to
-`generated-output/source-proposals/` and reviewed by a human or the
-adversarial gate before any action is taken.
+`generated-output/source-curation/<run-id>/report.json` and reviewed by a
+human or the adversarial gate before any action is taken.
 
 ## Architecture
 
@@ -48,7 +48,8 @@ adversarial gate before any action is taken.
   +----------------------------+
   | Dry-Run Report             |  <-- sourceProposalReport.schema.json
   | (generated-output/         |      dryRun: true (enforced by schema)
-  |  source-proposals/*.json)  |
+  |  source-curation/<run-id>/ |
+  |  report.json)             |
   +----------------------------+
          |
          v  (FUTURE -- not yet implemented)
@@ -199,12 +200,23 @@ implemented in a future phase:
 Dry-run reports are written to:
 
 ```
-generated-output/source-proposals/<reportId>.json
+generated-output/source-curation/<run-id>/report.json
 ```
 
 This directory is gitignored. Reports are local artifacts consumed by
 reviewers and the adversarial gate. They are NOT committed to the
 repository or published to GitHub Pages.
+
+Run the deterministic dry-run runner with:
+
+```bash
+python3 scripts/sourceCuratorRunner.py --run-id 20260702-dry-run --generated-at 2026-07-02T14:00:00Z
+```
+
+By default the runner uses fixture discovery only: no live network calls, no
+registry mutation, `dryRun: true`, and `generatedBy: "nova-gaia"`. Pass
+`--input seed.json` to supply a local JSON array or an object with a `seeds`
+/ `proposals` array.
 
 ## Self-Bounding Rules
 
@@ -246,7 +258,7 @@ Test fixtures:
 
 ## What This PR Does NOT Do
 
-- **No network crawler implementation.** No `scripts/sourceCuratorRunner.py`.
+- **No network crawler implementation.** `scripts/sourceCuratorRunner.py` is dry-run fixture/seed driven only.
 - **No GitHub Actions workflow.** No `.github/workflows/auto-source-curation.yml`.
 - **No registry mutation.** The schemas and tooling cannot write to
   `registry/nodes/` or `registry/named/`.

--- a/scripts/sourceCuratorRunner.py
+++ b/scripts/sourceCuratorRunner.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Dry-run source-curation runner.
+
+No network calls are made. No registry files are mutated. The runner writes a
+schema-valid proposal report for review.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from gaia_cli.sourceCuration import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/gaia_cli/sourceCuration.py
+++ b/src/gaia_cli/sourceCuration.py
@@ -61,12 +61,27 @@ def schemaStore(schemaDir: Path) -> dict[str, dict[str, Any]]:
     return store
 
 
+def formatChecker() -> jsonschema.FormatChecker:
+    checker = jsonschema.FormatChecker()
+
+    if "date-time" not in checker.checkers:
+        @checker.checks("date-time", raises=ValueError)
+        def isDateTime(value: object) -> bool:
+            if not isinstance(value, str):
+                return True
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            return parsed.tzinfo is not None
+
+    return checker
+
+
 def validateReport(report: dict[str, Any], rootDir: Path | None = None) -> None:
     root = rootDir or repoRoot()
     schemaDir = root / "registry" / "schema"
     schema = loadJson(schemaDir / "sourceProposalReport.schema.json")
     resolver = jsonschema.RefResolver("file://" + str(schemaDir) + "/", {}, store=schemaStore(schemaDir))
-    jsonschema.validate(report, schema, resolver=resolver)
+    validator = jsonschema.Draft7Validator(schema, resolver=resolver, format_checker=formatChecker())
+    validator.validate(report)
 
 
 def safeId(value: str) -> str:
@@ -192,6 +207,17 @@ def defaultOutputPath(rootDir: Path, runId: str) -> Path:
     return rootDir / "generated-output" / "source-curation" / runId / "report.json"
 
 
+def resolveOutputPath(rootDir: Path, runId: str, outputPath: str | None = None) -> Path:
+    allowedDir = (rootDir / "generated-output" / "source-curation").resolve()
+    path = Path(outputPath) if outputPath else defaultOutputPath(rootDir, runId)
+    if not path.is_absolute():
+        path = rootDir / path
+    resolved = path.resolve()
+    if not resolved.is_relative_to(allowedDir):
+        raise ValueError(f"Output path must stay under {allowedDir}")
+    return resolved
+
+
 def runDryRun(
     rootDir: Path | None = None,
     runId: str | None = None,
@@ -207,7 +233,7 @@ def runDryRun(
     seeds = loadSeeds(inputPath)
     report = buildReport(seeds, reportId, stamp, confidenceFloor, maxProposalsPerSkill)
     validateReport(report, root)
-    path = Path(outputPath) if outputPath else defaultOutputPath(root, reportId)
+    path = resolveOutputPath(root, reportId, outputPath)
     writeJson(path, report)
     return report, path
 

--- a/src/gaia_cli/sourceCuration.py
+++ b/src/gaia_cli/sourceCuration.py
@@ -1,0 +1,242 @@
+"""Dry-run source curation report runner.
+
+This module intentionally performs no network calls and no registry writes. It
+emits schema-validated proposal reports for human review only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+
+BOT_IDENTITY = "nova-gaia"
+PIPELINE_PHASE = "discovery"
+DEFAULT_CONFIDENCE_FLOOR = 0.3
+DEFAULT_MAX_PROPOSALS_PER_SKILL = 5
+DEFAULT_BACKENDS = ["fixture-discovery"]
+
+
+def repoRoot() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def utcNowStamp() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def todayRunId(nowStamp: str | None = None) -> str:
+    stamp = nowStamp or utcNowStamp()
+    return stamp[:10].replace("-", "") + "-dry-run"
+
+
+def loadJson(path: str | os.PathLike[str]) -> Any:
+    with open(path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def writeJson(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def schemaStore(schemaDir: Path) -> dict[str, dict[str, Any]]:
+    store: dict[str, dict[str, Any]] = {}
+    for schemaPath in schemaDir.glob("*.schema.json"):
+        schema = loadJson(schemaPath)
+        schemaId = schema.get("$id")
+        if schemaId:
+            store[schemaId] = schema
+        store[schemaPath.name] = schema
+    return store
+
+
+def validateReport(report: dict[str, Any], rootDir: Path | None = None) -> None:
+    root = rootDir or repoRoot()
+    schemaDir = root / "registry" / "schema"
+    schema = loadJson(schemaDir / "sourceProposalReport.schema.json")
+    resolver = jsonschema.RefResolver("file://" + str(schemaDir) + "/", {}, store=schemaStore(schemaDir))
+    jsonschema.validate(report, schema, resolver=resolver)
+
+
+def safeId(value: str) -> str:
+    value = value.lower().replace("/", "-")
+    value = re.sub(r"[^a-z0-9-]+", "-", value)
+    value = re.sub(r"-+", "-", value).strip("-")
+    return value or "proposal"
+
+
+def proposalId(seed: dict[str, Any], datePart: str) -> str:
+    basis = "|".join([seed.get("skillId", ""), seed.get("source", ""), seed.get("evidenceType", "")])
+    digest = hashlib.sha256(basis.encode("utf-8")).hexdigest()[:8]
+    return f"{safeId(seed.get('skillId', 'unknown-skill'))}-{digest}-{datePart}"
+
+
+def defaultSeeds() -> list[dict[str, Any]]:
+    return [
+        {
+            "skillId": "mattpocock/grill-me",
+            "genericSkillRef": "code-review-automation",
+            "source": "https://example.com/source-curation/grill-me-demo",
+            "evidenceType": "social-signal",
+            "numericPayload": {"views": 2400, "likes": 120, "comments": 18},
+            "crawlerBackend": "fixture-discovery",
+            "confidence": 0.74,
+            "rationale": "Deterministic fixture describing a public demonstration relevant to the grill-me named skill.",
+            "existingEvidenceCheck": {"checked": True, "duplicate": False},
+        },
+        {
+            "skillId": "karpathy/autoresearch",
+            "genericSkillRef": "autonomous-research",
+            "source": "https://example.com/source-curation/autoresearch-repo",
+            "evidenceType": "repo-own",
+            "numericPayload": {"commits": 42, "contributors": 3},
+            "crawlerBackend": "fixture-discovery",
+            "confidence": 0.81,
+            "rationale": "Deterministic fixture describing repository activity relevant to the autoresearch named skill.",
+            "existingEvidenceCheck": {"checked": True, "duplicate": False},
+        },
+    ]
+
+
+def loadSeeds(inputPath: str | None) -> list[dict[str, Any]]:
+    if not inputPath:
+        return defaultSeeds()
+    payload = loadJson(inputPath)
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict) and isinstance(payload.get("proposals"), list):
+        return payload["proposals"]
+    if isinstance(payload, dict) and isinstance(payload.get("seeds"), list):
+        return payload["seeds"]
+    raise ValueError("Input seed file must be a JSON array, or an object with proposals/seeds array")
+
+
+def normalizeProposal(seed: dict[str, Any], generatedAt: str) -> dict[str, Any]:
+    proposal = copy.deepcopy(seed)
+    datePart = generatedAt[:10].replace("-", "")
+    proposal.setdefault("proposalId", proposalId(proposal, datePart))
+    proposal.setdefault("discoveredAt", generatedAt)
+    proposal["discoveredBy"] = BOT_IDENTITY
+    proposal.setdefault("crawlerBackend", "fixture-discovery")
+    proposal["dryRun"] = True
+    return proposal
+
+
+def buildReport(
+    seeds: list[dict[str, Any]],
+    runId: str,
+    generatedAt: str,
+    confidenceFloor: float = DEFAULT_CONFIDENCE_FLOOR,
+    maxProposalsPerSkill: int = DEFAULT_MAX_PROPOSALS_PER_SKILL,
+) -> dict[str, Any]:
+    countsBySkill: dict[str, int] = {}
+    proposals: list[dict[str, Any]] = []
+    duplicatesDropped = 0
+    belowConfidenceDropped = 0
+    skillsTargeted = {seed.get("skillId") for seed in seeds if seed.get("skillId")}
+
+    for seed in seeds:
+        if seed.get("existingEvidenceCheck", {}).get("duplicate") is True:
+            duplicatesDropped += 1
+            continue
+        if float(seed.get("confidence", 0)) < confidenceFloor:
+            belowConfidenceDropped += 1
+            continue
+        skillId = seed.get("skillId", "")
+        if countsBySkill.get(skillId, 0) >= maxProposalsPerSkill:
+            continue
+        proposal = normalizeProposal(seed, generatedAt)
+        proposals.append(proposal)
+        countsBySkill[skillId] = countsBySkill.get(skillId, 0) + 1
+
+    backends = sorted({proposal.get("crawlerBackend", "fixture-discovery") for proposal in proposals}) or DEFAULT_BACKENDS
+    return {
+        "reportId": runId,
+        "generatedAt": generatedAt,
+        "generatedBy": BOT_IDENTITY,
+        "pipelinePhase": PIPELINE_PHASE,
+        "dryRun": True,
+        "crawlConfig": {
+            "targetGrades": ["C", "ungraded"],
+            "maxProposalsPerSkill": maxProposalsPerSkill,
+            "confidenceFloor": confidenceFloor,
+            "backends": backends,
+        },
+        "quotaSummary": {
+            "totalApiCalls": 0,
+            "estimatedTotalCostUsd": 0,
+            "perBackend": {backend: {"calls": 0, "costUsd": 0} for backend in backends},
+        },
+        "proposals": proposals,
+        "summary": {
+            "skillsTargeted": len(skillsTargeted),
+            "proposalsGenerated": len(proposals),
+            "duplicatesDropped": duplicatesDropped,
+            "belowConfidenceDropped": belowConfidenceDropped,
+        },
+    }
+
+
+def defaultOutputPath(rootDir: Path, runId: str) -> Path:
+    return rootDir / "generated-output" / "source-curation" / runId / "report.json"
+
+
+def runDryRun(
+    rootDir: Path | None = None,
+    runId: str | None = None,
+    generatedAt: str | None = None,
+    inputPath: str | None = None,
+    outputPath: str | None = None,
+    confidenceFloor: float = DEFAULT_CONFIDENCE_FLOOR,
+    maxProposalsPerSkill: int = DEFAULT_MAX_PROPOSALS_PER_SKILL,
+) -> tuple[dict[str, Any], Path]:
+    root = rootDir or repoRoot()
+    stamp = generatedAt or utcNowStamp()
+    reportId = runId or todayRunId(stamp)
+    seeds = loadSeeds(inputPath)
+    report = buildReport(seeds, reportId, stamp, confidenceFloor, maxProposalsPerSkill)
+    validateReport(report, root)
+    path = Path(outputPath) if outputPath else defaultOutputPath(root, reportId)
+    writeJson(path, report)
+    return report, path
+
+
+def buildParser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Emit a dry-run nova-gaia source-curation proposal report.")
+    parser.add_argument("--input", help="Optional JSON seed file. Defaults to deterministic fixture discovery.")
+    parser.add_argument("--output", help="Output report path. Defaults to generated-output/source-curation/<run-id>/report.json")
+    parser.add_argument("--run-id", help="Deterministic report ID. Defaults to <yyyymmdd>-dry-run")
+    parser.add_argument("--generated-at", help="ISO 8601 timestamp for deterministic runs. Defaults to current UTC time.")
+    parser.add_argument("--confidence-floor", type=float, default=DEFAULT_CONFIDENCE_FLOOR)
+    parser.add_argument("--max-proposals-per-skill", type=int, default=DEFAULT_MAX_PROPOSALS_PER_SKILL)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = buildParser().parse_args(argv)
+    report, path = runDryRun(
+        runId=args.run_id,
+        generatedAt=args.generated_at,
+        inputPath=args.input,
+        outputPath=args.output,
+        confidenceFloor=args.confidence_floor,
+        maxProposalsPerSkill=args.max_proposals_per_skill,
+    )
+    print(f"Wrote dry-run source-curation report: {path}")
+    print(f"reportId={report['reportId']} proposals={len(report['proposals'])} generatedBy={report['generatedBy']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_source_curator_runner.py
+++ b/tests/test_source_curator_runner.py
@@ -95,6 +95,33 @@ def test_dry_run_runner_rejects_report_if_identity_is_changed(tmp_path):
         sourceCuration.validateReport(report, root)
 
 
+def test_dry_run_runner_rejects_invalid_generated_at_format(tmp_path):
+    root = makeRoot(tmp_path)
+    report = sourceCuration.buildReport(
+        sourceCuration.defaultSeeds(),
+        "20260702-invalid-generated-at",
+        "not-a-date-time",
+    )
+
+    with pytest.raises(jsonschema.ValidationError):
+        sourceCuration.validateReport(report, root)
+
+
+def test_dry_run_runner_rejects_output_path_outside_source_curation_dir(tmp_path):
+    root = makeRoot(tmp_path)
+    forbidden = root / "registry" / "named" / "bad.md"
+
+    with pytest.raises(ValueError):
+        sourceCuration.runDryRun(
+            rootDir=root,
+            runId="20260702-bad-output",
+            generatedAt="2026-07-02T14:00:00Z",
+            outputPath="registry/named/bad.md",
+        )
+
+    assert not forbidden.exists()
+
+
 def test_dry_run_runner_filters_duplicates_and_low_confidence(tmp_path):
     root = makeRoot(tmp_path)
     seeds = [

--- a/tests/test_source_curator_runner.py
+++ b/tests/test_source_curator_runner.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+import jsonschema
+
+from gaia_cli import sourceCuration
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def makeRoot(tmpPath: Path) -> Path:
+    root = tmpPath / "repo"
+    schemaDir = root / "registry" / "schema"
+    schemaDir.mkdir(parents=True)
+    for schemaPath in (REPO_ROOT / "registry" / "schema").glob("*.schema.json"):
+        shutil.copy(schemaPath, schemaDir / schemaPath.name)
+    return root
+
+
+def test_dry_run_runner_emits_deterministic_schema_valid_report(tmp_path):
+    root = makeRoot(tmp_path)
+
+    report, path = sourceCuration.runDryRun(
+        rootDir=root,
+        runId="20260702-dry-run-test",
+        generatedAt="2026-07-02T14:00:00Z",
+    )
+
+    assert path == root / "generated-output" / "source-curation" / "20260702-dry-run-test" / "report.json"
+    assert json.loads(path.read_text(encoding="utf-8")) == report
+    assert report["reportId"] == "20260702-dry-run-test"
+    assert report["generatedAt"] == "2026-07-02T14:00:00Z"
+    assert report["generatedBy"] == "nova-gaia"
+    assert report["dryRun"] is True
+    assert report["pipelinePhase"] == "discovery"
+    assert len(report["proposals"]) == 2
+    assert [proposal["proposalId"] for proposal in report["proposals"]] == [
+        "mattpocock-grill-me-90af940b-20260702",
+        "karpathy-autoresearch-02e79a9c-20260702",
+    ]
+
+    sourceCuration.validateReport(report, root)
+
+
+def test_dry_run_runner_forces_nova_gaia_and_dry_run_from_seed_file(tmp_path):
+    root = makeRoot(tmp_path)
+    seedPath = tmp_path / "seed.json"
+    seedPath.write_text(
+        json.dumps(
+            [
+                {
+                    "skillId": "alice/research-helper",
+                    "source": "https://example.com/research-helper",
+                    "evidenceType": "social-signal",
+                    "crawlerBackend": "fixture-discovery",
+                    "confidence": 0.9,
+                    "rationale": "Seeded dry-run source that should remain review-only.",
+                    "dryRun": False,
+                    "discoveredBy": "rogue-bot",
+                    "existingEvidenceCheck": {"checked": True, "duplicate": False},
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    report, _ = sourceCuration.runDryRun(
+        rootDir=root,
+        runId="20260702-seed-test",
+        generatedAt="2026-07-02T14:00:00Z",
+        inputPath=str(seedPath),
+    )
+
+    proposal = report["proposals"][0]
+    assert report["generatedBy"] == "nova-gaia"
+    assert report["dryRun"] is True
+    assert proposal["discoveredBy"] == "nova-gaia"
+    assert proposal["dryRun"] is True
+
+
+def test_dry_run_runner_rejects_report_if_identity_is_changed(tmp_path):
+    root = makeRoot(tmp_path)
+    report = sourceCuration.buildReport(
+        sourceCuration.defaultSeeds(),
+        "20260702-invalid-identity",
+        "2026-07-02T14:00:00Z",
+    )
+    report["generatedBy"] = "rogue-bot"
+
+    with pytest.raises(jsonschema.ValidationError):
+        sourceCuration.validateReport(report, root)
+
+
+def test_dry_run_runner_filters_duplicates_and_low_confidence(tmp_path):
+    root = makeRoot(tmp_path)
+    seeds = [
+        {
+            "skillId": "alice/research-helper",
+            "source": "https://example.com/duplicate",
+            "evidenceType": "social-signal",
+            "crawlerBackend": "fixture-discovery",
+            "confidence": 0.8,
+            "rationale": "Duplicate seed should be dropped before the report is written.",
+            "existingEvidenceCheck": {"checked": True, "duplicate": True, "existingIndex": 0},
+        },
+        {
+            "skillId": "alice/research-helper",
+            "source": "https://example.com/weak",
+            "evidenceType": "social-signal",
+            "crawlerBackend": "fixture-discovery",
+            "confidence": 0.1,
+            "rationale": "Low confidence seed should be dropped before the report is written.",
+            "existingEvidenceCheck": {"checked": True, "duplicate": False},
+        },
+    ]
+    seedPath = tmp_path / "seed.json"
+    seedPath.write_text(json.dumps(seeds), encoding="utf-8")
+
+    report, _ = sourceCuration.runDryRun(
+        rootDir=root,
+        runId="20260702-filter-test",
+        generatedAt="2026-07-02T14:00:00Z",
+        inputPath=str(seedPath),
+    )
+
+    assert report["proposals"] == []
+    assert report["summary"]["duplicatesDropped"] == 1
+    assert report["summary"]["belowConfidenceDropped"] == 1
+    sourceCuration.validateReport(report, root)
+
+
+def test_dry_run_runner_does_not_mutate_registry_files(tmp_path):
+    root = makeRoot(tmp_path)
+    namedDir = root / "registry" / "named" / "alice"
+    namedDir.mkdir(parents=True)
+    sentinel = namedDir / "skill.md"
+    sentinel.write_text("original registry content\n", encoding="utf-8")
+
+    before = sentinel.read_text(encoding="utf-8")
+    report, path = sourceCuration.runDryRun(
+        rootDir=root,
+        runId="20260702-no-mutation",
+        generatedAt="2026-07-02T14:00:00Z",
+    )
+
+    assert sentinel.read_text(encoding="utf-8") == before
+    assert path.is_file()
+    assert path.is_relative_to(root / "generated-output" / "source-curation")
+    assert report["generatedBy"] == "nova-gaia"


### PR DESCRIPTION
## Summary
- Add a no-network dry-run source-curation runner that emits schema-valid proposal reports under generated-output/source-curation/<run-id>/report.json
- Add deterministic fixture/seed-file discovery, confidence/duplicate filtering, quota summary placeholders, and schema validation
- Document the dry-run runner and add tests for nova-gaia identity, dryRun enforcement, deterministic output, and no registry mutation

Refs #762

## Tests
- python3 -m pytest tests/test_source_curator_runner.py tests/test_source_proposal_schema.py -q
- python3 scripts/sourceCuratorRunner.py --run-id 20260702-cli-smoke --generated-at 2026-07-02T14:00:00Z
- python3 -m pytest -q