### PR TITLE
Polish apex gate reporting

### DIFF
--- a/scripts/auditApexAtG7.py
+++ b/scripts/auditApexAtG7.py
@@ -16,6 +16,7 @@ Exit code:
 from __future__ import annotations
 
 import argparse
+import datetime
 import json
 import os
 import sys
@@ -27,8 +28,9 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO_ROOT / "src"))
 
 from gaia_cli.trustMagnitude import (  # noqa: E402
+    APEX_AGRADED_ORIGINS_MIN,
+    APEX_TENURE_DAYS_MIN,
     GRADE_S_FLOOR,
-    checkAGradedOriginsGte5,
     computeTrustMagnitude,
     isApex,
     passesApexGate,
@@ -119,8 +121,14 @@ def buildRegistryState(repoRoot: Path) -> dict:
         if str(m.get("level", "")).startswith("6")
     )
 
+    # Apex predicates need to traverse both generic nodes and named suite
+    # components (suite ultimates often point at named component IDs). Keep the
+    # named map separately for grade lookups, but provide a merged lookup map to
+    # match inspectTrustMagnitude.py's predicate context.
+    mergedSkillMap = {**genericSkillMap, **namedSkillMap}
+
     return {
-        "genericSkillMap": genericSkillMap,
+        "genericSkillMap": mergedSkillMap,
         "namedSkillMap": namedSkillMap,
         "systemWideApexCount": apexCount,
     }
@@ -213,30 +221,144 @@ _OFF_UNTIL = {
 
 
 def formatPredicateDetail(predicate: str, passed: Optional[bool], skill: dict, registryState: dict) -> str:
-    """Return a short parenthetical detail string for a predicate result."""
+    """Return an operator-facing detail string for a predicate result.
+
+    The apex predicates intentionally stay boolean in trustMagnitude.py. This
+    helper is the reporting layer: it explains *why* a false predicate failed
+    without mutating ranks, evidence, or gate semantics.
+    """
     if predicate == "aGradedOriginsGte5":
         genericMap = registryState.get("genericSkillMap")
         namedMap = registryState.get("namedSkillMap")
-        from gaia_cli.trustMagnitude import checkAGradedOriginsGte5
         count = _countAGradedOrigins(skill, genericMap, namedMap)
-        return f"({count} A/S-graded origins)"
+        deficit = max(0, APEX_AGRADED_ORIGINS_MIN - count)
+        if passed:
+            return f"({count}/{APEX_AGRADED_ORIGINS_MIN} A/S origins; sufficient)"
+        return f"(insufficient A/S origins: {count}/{APEX_AGRADED_ORIGINS_MIN}, needs +{deficit})"
     if predicate == "overallGradeS":
         tm = computeTrustMagnitude(skill, registryState.get("genericSkillMap"))
-        return f"(TM = {tm:.2f}, S-floor = {GRADE_S_FLOOR:.0f})"
+        if passed:
+            return f"(TM = {tm:.2f}, S-floor = {GRADE_S_FLOOR:.0f}; sufficient)"
+        return f"(TM = {tm:.2f}, S-floor = {GRADE_S_FLOOR:.0f}; below S)"
     if predicate == "sourceTenureDaysGte180AorS":
-        return "(max A/S source age >= 180 days)"
+        return _formatSourceTenureDetail(skill, passed)
     if predicate == "directNestedSuiteGte1":
-        return "(>=1 direct suite component with its own sub-components)"
+        count = _countDirectNestedSuites(skill, registryState.get("genericSkillMap") or {})
+        if passed:
+            return f"({count} direct nested suite component(s))"
+        return "(no direct suite component has its own suiteComponents)"
     if predicate == "depth2OnlyReachableGte1":
-        return "(>=1 depth-2-only fusion reachable)"
+        return _formatDepth2Detail(skill, registryState, passed)
     if predicate == "apexPromotionPrSigned":
         status = skill.get("apexGateStatus") or {}
-        if status.get("apexPromotionPrSigned"):
-            return "(apexGateStatus.apexPromotionPrSigned = true)"
-        return "(no signed promotion PR found)"
+        apexPr = skill.get("apexPromotionPr") or {}
+        if status.get("apexPromotionPrSigned") is True:
+            return "(PR-signed gate passed: apexGateStatus.apexPromotionPrSigned = true)"
+        if apexPr.get("signed"):
+            return "(PR-signed gate passed: apexPromotionPr.signed = true)"
+        return "(PR-signed gate failure: no signed apex-promotion PR annotation)"
     if predicate in _OFF_UNTIL:
         return f"({_OFF_UNTIL[predicate]})"
     return ""
+
+
+def _parseIsoDate(value: object) -> Optional[datetime.datetime]:
+    """Parse a sourceStartedAt value into UTC, returning None when absent/invalid."""
+    if not value:
+        return None
+    raw = str(value).strip()
+    if not raw:
+        return None
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        parsed = datetime.datetime.fromisoformat(raw)
+    except ValueError:
+        try:
+            parsed = datetime.datetime.strptime(raw[:10], "%Y-%m-%d")
+        except ValueError:
+            return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=datetime.timezone.utc)
+    return parsed.astimezone(datetime.timezone.utc)
+
+
+def _evidenceGrade(row: dict) -> Optional[str]:
+    grade = row.get("grade") or row.get("class")
+    return grade if grade in {"S", "A", "B", "C"} else None
+
+
+def _formatSourceTenureDetail(skill: dict, passed: Optional[bool]) -> str:
+    now = datetime.datetime.now(datetime.timezone.utc)
+    aOrSRows = [
+        row for row in skill.get("evidence") or []
+        if isinstance(row, dict) and _evidenceGrade(row) in {"A", "S"}
+    ]
+    if not aOrSRows:
+        return "(missing A/S provenance: no A/S evidence rows to age)"
+
+    datedRows: list[tuple[int, str]] = []
+    missingRows = 0
+    invalidRows = 0
+    for row in aOrSRows:
+        rawStartedAt = row.get("sourceStartedAt")
+        parsed = _parseIsoDate(rawStartedAt)
+        if parsed is None:
+            if rawStartedAt:
+                invalidRows += 1
+            else:
+                missingRows += 1
+            continue
+        source = row.get("source") or row.get("url") or row.get("sourceUrl") or "unknown source"
+        datedRows.append(((now - parsed).days, str(source)))
+
+    if not datedRows:
+        missingBits = []
+        if missingRows:
+            missingBits.append(f"missing sourceStartedAt on {missingRows}/{len(aOrSRows)} A/S row(s)")
+        if invalidRows:
+            missingBits.append(f"invalid sourceStartedAt on {invalidRows}/{len(aOrSRows)} A/S row(s)")
+        return "(" + "; ".join(missingBits) + "; max age = 0d)"
+
+    maxAge, source = max(datedRows, key=lambda item: item[0])
+    suffix = []
+    if missingRows:
+        suffix.append(f"{missingRows} missing sourceStartedAt")
+    if invalidRows:
+        suffix.append(f"{invalidRows} invalid sourceStartedAt")
+    suffixText = "; " + "; ".join(suffix) if suffix else ""
+    if passed:
+        return f"(oldest A/S source age {maxAge}d >= {APEX_TENURE_DAYS_MIN}d: {source}{suffixText})"
+    return f"(insufficient tenure: oldest A/S source age {maxAge}d < {APEX_TENURE_DAYS_MIN}d: {source}{suffixText})"
+
+
+def _countDirectNestedSuites(skill: dict, genericSkillMap: dict) -> int:
+    count = 0
+    for cid in skill.get("suiteComponents") or []:
+        node = genericSkillMap.get(cid) or {}
+        if node.get("suiteComponents"):
+            count += 1
+    return count
+
+
+def _formatDepth2Detail(skill: dict, registryState: dict, passed: Optional[bool]) -> str:
+    from gaia_cli.trustMagnitude import _fusionAndSuiteOriginIds
+
+    genericMap = registryState.get("genericSkillMap") or {}
+    namedMap = registryState.get("namedSkillMap") or {}
+    skillId = skill.get("id") or skill.get("skillId")
+    depth1 = set(_fusionAndSuiteOriginIds(skill, genericMap, namedMap))
+    depth2: set[str] = set()
+    for d1id in depth1:
+        node = namedMap.get(d1id) or genericMap.get(d1id) or {}
+        for d2id in _fusionAndSuiteOriginIds(node, genericMap, namedMap):
+            if d2id != skillId:
+                depth2.add(d2id)
+    if passed:
+        return f"(depth2 passed: {len(depth2)} depth-2 node(s) via {len(depth1)} depth-1 origin(s))"
+    if not depth1:
+        return "(depth2 failure: no fusion origins or suiteComponents at depth 1)"
+    return f"(depth2 failure: {len(depth1)} depth-1 origin(s), 0 depth-2 node(s))"
 
 
 def _countAGradedOrigins(skill: dict, genericSkillMap: Optional[dict], namedSkillMap: Optional[dict]) -> int:

--- a/scripts/inspectTrustMagnitude.py
+++ b/scripts/inspectTrustMagnitude.py
@@ -25,6 +25,7 @@ sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "src"))
 
 from gaia_cli.trustMagnitude import (  # noqa: E402
+    APEX_AGRADED_ORIGINS_MIN,
     GRADE_A_FLOOR,
     GRADE_B_FLOOR,
     GRADE_C_FLOOR,
@@ -35,6 +36,7 @@ from gaia_cli.trustMagnitude import (  # noqa: E402
     passesApexGate,
     isApex,
 )
+from auditApexAtG7 import formatPredicateDetail  # noqa: E402
 
 NAMED_DIR = REPO_ROOT / "registry" / "named"
 NODES_DIR = REPO_ROOT / "registry" / "nodes"
@@ -70,7 +72,7 @@ STARS_ORDER: dict[str, int] = {
 
 # Human-readable labels for apex gate predicates (RFC §11.12)
 APEX_GATE_LABELS: dict[str, str] = {
-    "aGradedOriginsGte5":          "§11.12.5  >=8 A-graded origins in transitive closure",
+    "aGradedOriginsGte5":          f"§11.12.5  >={APEX_AGRADED_ORIGINS_MIN} A/S-graded origins in transitive closure",
     "sourceTenureDaysGte180AorS":  "§11.12.7  Tenure >= 180 days at A-or-S",
     "directNestedSuiteGte1":       "§11.12.2  >=1 direct component with suiteComponents",
     "depth2OnlyReachableGte1":     "§11.12.3  >=1 node reachable only at depth >= 2",
@@ -204,7 +206,9 @@ def formatApexGateLines(skill: dict, mergedMap: dict, namedSkillMap: dict) -> li
     lines.append(f"  {'─'*64}")
     for key, val in results.items():
         mark = "PASS" if val is True else ("FAIL" if val is False else "OFF ")
-        lines.append(f"    {mark}  {APEX_GATE_LABELS.get(key, key)}")
+        detail = formatPredicateDetail(key, val, skill, state)
+        suffix = f"  {detail}" if detail else ""
+        lines.append(f"    {mark}  {APEX_GATE_LABELS.get(key, key)}{suffix}")
     lines.append(f"  {'─'*64}")
     return lines
 
@@ -303,6 +307,7 @@ def leaderboardMode() -> int:
             "g7Stars": g7Stars,
             "flag": flag,
             "apexResults": apexResults,
+            "skill": fm,
         })
 
     rows.sort(key=lambda r: -r["tm"])
@@ -359,7 +364,9 @@ def leaderboardMode() -> int:
                 for key, val in r["apexResults"].items():
                     mark = "PASS" if val is True else ("FAIL" if val is False else "OFF ")
                     label = APEX_GATE_LABELS.get(key, key)
-                    print(f"         {' '*49}  {mark}  {label}")
+                    detail = formatPredicateDetail(key, val, r["skill"], apexState)
+                    suffix = f"  {detail}" if detail else ""
+                    print(f"         {' '*49}  {mark}  {label}{suffix}")
                 print()
                 pos += 1
         else:

--- a/tests/test_apex_reporting.py
+++ b/tests/test_apex_reporting.py
@@ -1,0 +1,98 @@
+"""Focused tests for apex gate operator-facing reporting."""
+
+from __future__ import annotations
+
+import datetime
+import importlib.util
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def importScript(name: str):
+    path = _REPO_ROOT / "scripts" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_source_tenure_detail_distinguishes_missing_source_started_at():
+    audit = importScript("auditApexAtG7")
+    skill = {
+        "evidence": [
+            {"type": "verifier-attestation", "grade": "A", "source": "https://example.test/a"},
+            {"type": "arxiv", "grade": "S", "source": "https://example.test/s"},
+        ]
+    }
+
+    detail = audit.formatPredicateDetail("sourceTenureDaysGte180AorS", False, skill, {})
+
+    assert "missing sourceStartedAt" in detail
+    assert "2/2 A/S row" in detail
+    assert "max age = 0d" in detail
+
+
+def test_source_tenure_detail_distinguishes_insufficient_tenure():
+    audit = importScript("auditApexAtG7")
+    recent = (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=30)).date().isoformat()
+    skill = {
+        "evidence": [
+            {
+                "type": "verifier-attestation",
+                "grade": "A",
+                "source": "https://example.test/recent",
+                "sourceStartedAt": recent,
+            }
+        ]
+    }
+
+    detail = audit.formatPredicateDetail("sourceTenureDaysGte180AorS", False, skill, {})
+
+    assert "insufficient tenure" in detail
+    assert "< 180d" in detail
+    assert "missing sourceStartedAt" not in detail
+
+
+def test_a_graded_origins_detail_reports_deficit():
+    audit = importScript("auditApexAtG7")
+    skill = {"suiteComponents": ["origin-a", "origin-b"]}
+    registryState = {
+        "genericSkillMap": {
+            "origin-a": {"overallTrustGrade": "A"},
+            "origin-b": {"overallTrustGrade": "B"},
+        },
+        "namedSkillMap": {},
+    }
+
+    detail = audit.formatPredicateDetail("aGradedOriginsGte5", False, skill, registryState)
+
+    assert "insufficient A/S origins" in detail
+    assert "1/5" in detail
+    assert "needs +4" in detail
+
+
+def test_depth2_detail_reports_depth2_failure():
+    audit = importScript("auditApexAtG7")
+    skill = {"id": "ultimate", "suiteComponents": ["child"]}
+    registryState = {
+        "genericSkillMap": {"child": {"id": "child", "suiteComponents": []}},
+        "namedSkillMap": {},
+    }
+
+    detail = audit.formatPredicateDetail("depth2OnlyReachableGte1", False, skill, registryState)
+
+    assert "depth2 failure" in detail
+    assert "1 depth-1 origin" in detail
+    assert "0 depth-2 node" in detail
+
+
+def test_pr_signed_detail_reports_gate_failure():
+    audit = importScript("auditApexAtG7")
+    skill = {"apexGateStatus": {"apexPromotionPrSigned": False}}
+
+    detail = audit.formatPredicateDetail("apexPromotionPrSigned", False, skill, {})
+
+    assert "PR-signed gate failure" in detail
+    assert "no signed apex-promotion PR" in detail


### PR DESCRIPTION
## Summary
- Clarify apex audit/TM output for missing `sourceStartedAt` provenance vs insufficient tenure.
- Add predicate details for A/S origin deficits, depth2 traversal, direct nested suites, S-grade TM, and PR-signed gate state.
- Align `auditApexAtG7.py` registry lookup context with `inspectTrustMagnitude.py` so named suite components are visible during reporting.

Refs #746

## Tests
- `python3 -m pytest tests/test_apex_reporting.py tests/test_meta_guard.py -q`
- `python3 -m pytest -q`

## Reviewer checklist
- [ ] Confirm output distinguishes missing `sourceStartedAt` from tenure <180d.
- [ ] Confirm no rank changes or evidence mutations are included.
- [ ] Confirm apex audit output remains operator-facing and script-scoped.
