### PR TITLE
feat(dev): preflight structural mutations

### DIFF
--- a/src/gaia_cli/commands/dev/build.py
+++ b/src/gaia_cli/commands/dev/build.py
@@ -15,6 +15,8 @@ from gaia_cli.commands.dev.helpers import (
     _run_dev_preflights,
     preflightAddCommand,
     preflightLinkCommand,
+    preflightRemoveCommand,
+    preflightReclassifyCommand,
     parseCommaSeparatedIds,
 )
 
@@ -147,6 +149,9 @@ def meta_add_command(args):
 
 
 def meta_remove_command(args):
+    _run_dev_preflights([
+        lambda: preflightRemoveCommand(args),
+    ])
     registry_path = args.registry
     skill_id = args.skill_id.lstrip("/")
 
@@ -257,6 +262,9 @@ def meta_link_command(args):
 
 
 def meta_reclassify_command(args):
+    _run_dev_preflights([
+        lambda: preflightReclassifyCommand(args),
+    ])
     registry_path = args.registry
     skill_id = args.skill_id.lstrip("/")
     new_type = args.new_type

--- a/src/gaia_cli/commands/dev/helpers.py
+++ b/src/gaia_cli/commands/dev/helpers.py
@@ -325,6 +325,216 @@ def genericSkillExists(registryPath: str, skillId: str) -> bool:
     return False
 
 
+def loadGenericNodes(registryPath: str) -> list[tuple[Path, dict]]:
+    """Load all parseable generic registry nodes once for dev preflights."""
+    nodesDir = Path(registry_nodes_dir(registryPath))
+    nodes = []
+    for p in nodesDir.glob("**/*.json"):
+        with open(p, "r", encoding="utf-8") as f:
+            try:
+                data = json.load(f)
+            except json.JSONDecodeError:
+                continue
+        nodes.append((p, data))
+    return nodes
+
+
+def indexGenericNodes(nodes: list[tuple[Path, dict]]) -> dict[str, list[tuple[Path, dict]]]:
+    """Return node rows grouped by id so callers can detect collisions."""
+    byId: dict[str, list[tuple[Path, dict]]] = {}
+    for path, data in nodes:
+        nodeId = data.get("id")
+        if nodeId:
+            byId.setdefault(nodeId, []).append((path, data))
+    return byId
+
+
+def _require_single_generic(byId: dict[str, list[tuple[Path, dict]]], skillId: str, label: str) -> tuple[Path, dict]:
+    matches = byId.get(skillId, [])
+    if not matches:
+        _fail_dev_preflight(f"{label} skill '{skillId}' does not exist.")
+    if len(matches) > 1:
+        locations = ", ".join(str(path) for path, _ in matches)
+        _fail_dev_preflight(
+            f"{label} skill '{skillId}' is duplicated in registry nodes.",
+            fix=f"Resolve the ID collision before mutating it. Matches: {locations}",
+        )
+    return matches[0]
+
+
+def _reject_duplicate_values(values: list[str], label: str) -> None:
+    seen = set()
+    duplicates = []
+    for value in values:
+        if value in seen and value not in duplicates:
+            duplicates.append(value)
+        seen.add(value)
+    if duplicates:
+        _fail_dev_preflight(
+            f"Duplicate {label} IDs are not allowed: {', '.join(duplicates)}.",
+            fix=f"Remove duplicate IDs from the {label} list.",
+        )
+
+
+def _valid_generic_id(skillId: str) -> bool:
+    import re
+    return bool(re.match(r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$", skillId))
+
+
+def preflightMergeCommand(args) -> None:
+    registryPath = args.registry
+    targetId = args.target.lstrip("/")
+    sources = [source.lstrip("/") for source in args.sources]
+    if not sources:
+        _fail_dev_preflight("Merge requires at least one source skill.")
+    _reject_duplicate_values(sources, "source")
+    if targetId in sources:
+        _fail_dev_preflight(
+            f"Target skill '{targetId}' cannot also be a source skill.",
+            fix="Remove the target from the source list or choose a different target.",
+        )
+
+    if "/" in targetId:
+        namedDir = Path(named_skills_dir(registryPath))
+        if not _find_named_file(namedDir, targetId):
+            _fail_dev_preflight(f"Target named skill '{targetId}' does not exist.")
+        for sourceId in sources:
+            if "/" not in sourceId:
+                _fail_dev_preflight(
+                    f"Cannot merge generic source '{sourceId}' into named target '{targetId}'.",
+                    fix="Use all named IDs or all generic IDs in one merge.",
+                )
+            if not _find_named_file(namedDir, sourceId):
+                _fail_dev_preflight(f"Source named skill '{sourceId}' does not exist.")
+        return
+
+    for sourceId in sources:
+        if "/" in sourceId:
+            _fail_dev_preflight(
+                f"Cannot merge named source '{sourceId}' into generic target '{targetId}'.",
+                fix="Use all named IDs or all generic IDs in one merge.",
+            )
+    nodes = loadGenericNodes(registryPath)
+    byId = indexGenericNodes(nodes)
+    _require_single_generic(byId, targetId, "Target")
+    for sourceId in sources:
+        _require_single_generic(byId, sourceId, "Source")
+
+
+def preflightSplitCommand(args) -> None:
+    registryPath = args.registry
+    sourceId = args.source.lstrip("/")
+    targets = [target.lstrip("/") for target in args.targets]
+    if not targets:
+        _fail_dev_preflight("Split requires at least one target skill ID.")
+    _reject_duplicate_values(targets, "split target")
+    if sourceId in targets:
+        _fail_dev_preflight(
+            f"Split source '{sourceId}' cannot also be a target.",
+            fix="Choose new target IDs that do not match the source.",
+        )
+    for targetId in targets:
+        if not _valid_generic_id(targetId):
+            _fail_dev_preflight(
+                f"Split target ID '{targetId}' is invalid.",
+                fix="Use a valid lowercase, hyphenated generic skill slug.",
+            )
+
+    nodes = loadGenericNodes(registryPath)
+    byId = indexGenericNodes(nodes)
+    sourcePath, _ = _require_single_generic(byId, sourceId, "Source")
+    for targetId in targets:
+        if targetId in byId:
+            _fail_dev_preflight(f"Split target '{targetId}' already exists in registry.")
+        targetPath = sourcePath.parent / f"{targetId}.json"
+        if targetPath.exists():
+            _fail_dev_preflight(
+                f"Split target '{targetId}' already exists on disk at {targetPath}.",
+                fix="Choose a new target ID or remove the stale file first.",
+            )
+
+
+def preflightRenameCommand(args) -> None:
+    registryPath = args.registry
+    oldId = args.old_id.lstrip("/")
+    newId = args.new_id.lstrip("/")
+    if oldId == newId:
+        _fail_dev_preflight(
+            f"Cannot rename skill '{oldId}' to itself.",
+            fix="Choose a distinct new ID.",
+        )
+    if not _valid_generic_id(newId):
+        _fail_dev_preflight(
+            f"New skill ID '{newId}' is invalid.",
+            fix="Use a valid lowercase, hyphenated generic skill slug.",
+        )
+    nodes = loadGenericNodes(registryPath)
+    byId = indexGenericNodes(nodes)
+    oldPath, _ = _require_single_generic(byId, oldId, "Source")
+    if newId in byId:
+        _fail_dev_preflight(f"Skill with id '{newId}' already exists in registry.")
+    newPath = oldPath.parent / f"{newId}.json"
+    if newPath.exists():
+        _fail_dev_preflight(
+            f"'{newId}' already exists on disk at {newPath}.",
+            fix="Choose a new ID or remove the stale file before renaming.",
+        )
+
+
+def preflightRemoveCommand(args) -> None:
+    registryPath = args.registry
+    skillId = args.skill_id.lstrip("/")
+    nodes = loadGenericNodes(registryPath)
+    byId = indexGenericNodes(nodes)
+    _require_single_generic(byId, skillId, "Generic")
+
+    namedDir = Path(named_skills_dir(registryPath))
+    genericRefUsers = []
+    suiteRefUsers = []
+    for p in namedDir.glob("**/*.md"):
+        meta, _ = _parse_md(p)
+        namedId = meta.get("id") or str(p)
+        if meta.get("genericSkillRef") == skillId:
+            genericRefUsers.append(namedId)
+        if meta.get("suiteRef") == skillId:
+            suiteRefUsers.append(namedId)
+    if genericRefUsers:
+        _fail_dev_preflight(
+            f"Cannot remove generic skill '{skillId}' while named skills reference it as genericSkillRef: {', '.join(genericRefUsers)}.",
+            fix="Repoint those named skills with `gaia dev update-named --generic-ref` before removing the generic skill.",
+        )
+    if suiteRefUsers:
+        _fail_dev_preflight(
+            f"Cannot remove skill '{skillId}' while named skills reference it as suiteRef: {', '.join(suiteRefUsers)}.",
+            fix="Clear or repoint those suiteRef values before removing the skill.",
+        )
+
+
+def preflightReclassifyCommand(args) -> None:
+    registryPath = args.registry
+    skillId = args.skill_id.lstrip("/")
+    newType = args.new_type
+    validTypes = {"basic", "extra", "ultimate", "unique"}
+    if newType not in validTypes:
+        _fail_dev_preflight(
+            f"Type '{newType}' is invalid.",
+            fix=f"Type must be one of: {', '.join(sorted(validTypes))}",
+        )
+    nodes = loadGenericNodes(registryPath)
+    byId = indexGenericNodes(nodes)
+    nodePath, data = _require_single_generic(byId, skillId, "Skill")
+    oldType = data.get("type", "basic")
+    if oldType == newType:
+        return
+    nodesDir = Path(registry_nodes_dir(registryPath))
+    newPath = nodesDir / newType / f"{skillId}.json"
+    if newPath.exists() and newPath != nodePath:
+        _fail_dev_preflight(
+            f"Cannot reclassify '{skillId}' to {newType}: destination file already exists at {newPath}.",
+            fix="Resolve the destination collision before reclassifying.",
+        )
+
+
 def namedSkillExists(registryPath: str, contributor: str, skillId: str) -> bool:
     """Check if a named skill with the given ID exists."""
     from gaia_cli.registry import named_skills_dir

--- a/src/gaia_cli/commands/dev/merge.py
+++ b/src/gaia_cli/commands/dev/merge.py
@@ -14,10 +14,16 @@ from gaia_cli.commands.dev.helpers import (
     _get_contributor,
     _update_named_skill_ref,
     _run_docs_build,
+    _run_dev_preflights,
+    preflightMergeCommand,
+    preflightSplitCommand,
 )
 
 
 def meta_merge_command(args):
+    _run_dev_preflights([
+        lambda: preflightMergeCommand(args),
+    ])
     registry_path = args.registry
     target_id = args.target.lstrip("/")
     sources = [s.lstrip("/") for s in args.sources]
@@ -220,6 +226,9 @@ def meta_merge_command(args):
 
 
 def meta_split_command(args):
+    _run_dev_preflights([
+        lambda: preflightSplitCommand(args),
+    ])
     registry_path = args.registry
     source_id = args.source.lstrip("/")
     targets = [t.lstrip("/") for t in args.targets]

--- a/src/gaia_cli/commands/dev/rename.py
+++ b/src/gaia_cli/commands/dev/rename.py
@@ -10,10 +10,15 @@ from gaia_cli.commands.dev.helpers import (
     _update_named_skill_ref,
     _get_contributor,
     _run_docs_build,
+    _run_dev_preflights,
+    preflightRenameCommand,
 )
 
 
 def meta_rename_command(args):
+    _run_dev_preflights([
+        lambda: preflightRenameCommand(args),
+    ])
     registry_path = args.registry
     old_id = args.old_id.lstrip("/")
     new_id = args.new_id.lstrip("/")

--- a/tests/test_dev_build.py
+++ b/tests/test_dev_build.py
@@ -11,6 +11,7 @@ from gaia_cli.commands.dev.build import (
     meta_add_command,
     meta_remove_command,
     meta_link_command,
+    meta_reclassify_command,
 )
 pytestmark = [pytest.mark.integration]
 
@@ -83,6 +84,12 @@ def _add_args(root: str, name: str = "New Skill",
 
 def _rm_args(root: str, skill_id: str = "existing-skill", **kw) -> SimpleNamespace:
     base = dict(registry=root, skill_id=skill_id, yes=True, no_build=True)
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def _reclassify_args(root: str, skill_id: str = "existing-skill", new_type: str = "extra", **kw) -> SimpleNamespace:
+    base = dict(registry=root, skill_id=skill_id, new_type=new_type, no_build=True)
     base.update(kw)
     return SimpleNamespace(**base)
 
@@ -168,6 +175,84 @@ def test_remove_missing_skill_exits(tmp_path):
     with pytest.raises(SystemExit) as exc:
         meta_remove_command(_rm_args(root, skill_id="nonexistent"))
     assert exc.value.code != 0
+
+
+def test_remove_rejects_named_generic_ref_before_write(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    _write_named(Path(root), "alice/my-skill")
+    named_file = Path(root) / "registry" / "named" / "alice" / "my-skill.md"
+    text = named_file.read_text(encoding="utf-8")
+    text = text.replace("genericSkillRef: unknown", "genericSkillRef: existing-skill")
+    named_file.write_text(text, encoding="utf-8")
+    node_file = Path(root) / "registry" / "nodes" / "basic" / "existing-skill.json"
+    before = node_file.read_text(encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc:
+        meta_remove_command(_rm_args(root))
+
+    assert exc.value.code != 0
+    assert node_file.exists()
+    assert node_file.read_text(encoding="utf-8") == before
+    err = capsys.readouterr().err
+    assert "genericSkillRef" in err
+
+
+def test_remove_rejects_suite_ref_before_write(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    _write_named(Path(root), "alice/my-skill")
+    named_file = Path(root) / "registry" / "named" / "alice" / "my-skill.md"
+    text = named_file.read_text(encoding="utf-8")
+    text = text.replace("title: Epithet\n", "title: Epithet\nsuiteRef: existing-skill\n")
+    named_file.write_text(text, encoding="utf-8")
+    node_file = Path(root) / "registry" / "nodes" / "basic" / "existing-skill.json"
+    before = node_file.read_text(encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc:
+        meta_remove_command(_rm_args(root))
+
+    assert exc.value.code != 0
+    assert node_file.exists()
+    assert node_file.read_text(encoding="utf-8") == before
+    err = capsys.readouterr().err
+    assert "suiteRef" in err
+
+
+# ---------------------------------------------------------------------------
+# meta_reclassify_command
+# ---------------------------------------------------------------------------
+
+
+def test_reclassify_moves_skill_file(tmp_path):
+    root = _make_registry(tmp_path)
+    meta_reclassify_command(_reclassify_args(root))
+    assert not (Path(root) / "registry" / "nodes" / "basic" / "existing-skill.json").exists()
+    assert (Path(root) / "registry" / "nodes" / "extra" / "existing-skill.json").exists()
+
+
+def test_reclassify_missing_skill_exits(tmp_path):
+    root = _make_registry(tmp_path)
+    with pytest.raises(SystemExit) as exc:
+        meta_reclassify_command(_reclassify_args(root, skill_id="nonexistent"))
+    assert exc.value.code != 0
+
+
+def test_reclassify_destination_collision_exits_before_write(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    dest_dir = Path(root) / "registry" / "nodes" / "extra"
+    dest_dir.mkdir(parents=True)
+    dest_file = dest_dir / "existing-skill.json"
+    dest_file.write_text('{"id":"stale"}\n', encoding="utf-8")
+    source_file = Path(root) / "registry" / "nodes" / "basic" / "existing-skill.json"
+    before = source_file.read_text(encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc:
+        meta_reclassify_command(_reclassify_args(root))
+
+    assert exc.value.code != 0
+    assert source_file.read_text(encoding="utf-8") == before
+    assert dest_file.read_text(encoding="utf-8") == '{"id":"stale"}\n'
+    err = capsys.readouterr().err
+    assert "destination file already exists" in err
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dev_merge.py
+++ b/tests/test_dev_merge.py
@@ -113,6 +113,36 @@ def test_merge_missing_target_exits(tmp_path):
     assert exc.value.code != 0
 
 
+def test_merge_missing_source_exits_before_write(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    target_file = Path(root) / "registry" / "nodes" / "basic" / "skill-a.json"
+    before = target_file.read_text(encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc:
+        meta_merge_command(_merge_args(root, "skill-a", ["nonexistent"]))
+
+    assert exc.value.code != 0
+    assert target_file.read_text(encoding="utf-8") == before
+    assert (Path(root) / "registry" / "nodes" / "basic" / "skill-b.json").exists()
+    err = capsys.readouterr().err
+    assert "Source skill 'nonexistent' does not exist" in err
+
+
+def test_merge_duplicate_sources_exit_before_write(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    target_file = Path(root) / "registry" / "nodes" / "basic" / "skill-a.json"
+    before = target_file.read_text(encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc:
+        meta_merge_command(_merge_args(root, "skill-a", ["skill-b", "skill-b"]))
+
+    assert exc.value.code != 0
+    assert target_file.read_text(encoding="utf-8") == before
+    assert (Path(root) / "registry" / "nodes" / "basic" / "skill-b.json").exists()
+    err = capsys.readouterr().err
+    assert "Duplicate source IDs" in err
+
+
 # ---------------------------------------------------------------------------
 # Split — happy path
 # ---------------------------------------------------------------------------
@@ -141,3 +171,48 @@ def test_split_missing_source_exits(tmp_path):
     with pytest.raises(SystemExit) as exc:
         meta_split_command(_split_args(root, "nonexistent", ["skill-d"]))
     assert exc.value.code != 0
+
+
+def test_split_duplicate_targets_exit_before_write(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    source_file = Path(root) / "registry" / "nodes" / "basic" / "skill-a.json"
+    before = source_file.read_text(encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc:
+        meta_split_command(_split_args(root, "skill-a", ["skill-d", "skill-d"]))
+
+    assert exc.value.code != 0
+    assert source_file.exists()
+    assert source_file.read_text(encoding="utf-8") == before
+    assert not (Path(root) / "registry" / "nodes" / "basic" / "skill-d.json").exists()
+    err = capsys.readouterr().err
+    assert "Duplicate split target IDs" in err
+
+
+def test_split_source_as_target_exits_before_write(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    source_file = Path(root) / "registry" / "nodes" / "basic" / "skill-a.json"
+    before = source_file.read_text(encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc:
+        meta_split_command(_split_args(root, "skill-a", ["skill-a", "skill-d"]))
+
+    assert exc.value.code != 0
+    assert source_file.read_text(encoding="utf-8") == before
+    err = capsys.readouterr().err
+    assert "cannot also be a target" in err
+
+
+def test_split_existing_target_exits_before_write(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    source_file = Path(root) / "registry" / "nodes" / "basic" / "skill-a.json"
+    before = source_file.read_text(encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc:
+        meta_split_command(_split_args(root, "skill-a", ["skill-b", "skill-d"]))
+
+    assert exc.value.code != 0
+    assert source_file.read_text(encoding="utf-8") == before
+    assert not (Path(root) / "registry" / "nodes" / "basic" / "skill-d.json").exists()
+    err = capsys.readouterr().err
+    assert "already exists" in err

--- a/tests/test_dev_rename.py
+++ b/tests/test_dev_rename.py
@@ -99,3 +99,31 @@ def test_rename_to_existing_id_exits(tmp_path):
     with pytest.raises(SystemExit) as exc:
         meta_rename_command(_args(root, new_id="skill-existing"))
     assert exc.value.code != 0
+
+
+def test_rename_to_self_exits_before_write(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    old_file = Path(root) / "registry" / "nodes" / "basic" / "skill-old.json"
+    before = old_file.read_text(encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc:
+        meta_rename_command(_args(root, new_id="skill-old"))
+
+    assert exc.value.code != 0
+    assert old_file.read_text(encoding="utf-8") == before
+    err = capsys.readouterr().err
+    assert "Cannot rename skill 'skill-old' to itself" in err
+
+
+def test_rename_invalid_new_id_exits_before_write(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    old_file = Path(root) / "registry" / "nodes" / "basic" / "skill-old.json"
+    before = old_file.read_text(encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc:
+        meta_rename_command(_args(root, new_id="Invalid_ID"))
+
+    assert exc.value.code != 0
+    assert old_file.read_text(encoding="utf-8") == before
+    err = capsys.readouterr().err
+    assert "New skill ID 'Invalid_ID' is invalid" in err


### PR DESCRIPTION
## Summary
- Adds shared structural preflight helpers for generic node existence/collision checks.
- Gates `gaia dev merge`, `split`, `rm`, `rename`, and `reclassify` before destructive writes.
- Rejects missing sources/targets, duplicate inputs, self operations, target collisions, unsafe `genericSkillRef`/`suiteRef` removals, invalid split/rename IDs, and reclassify destination collisions.

Refs #759

## Tests
- `python3 -m pytest tests/test_dev_merge.py tests/test_dev_build.py tests/test_dev_rename.py`
- `python3 -m pytest` (1404 passed, 2 skipped; warnings only)
- `git diff --check`

## Reviewer checklist
- [ ] Confirm preflight failures happen before file writes/unlinks.
- [ ] Confirm `dev rm` rejection for named-skill `genericSkillRef` / `suiteRef` references is the desired safety boundary.
- [ ] Confirm successful behavior for merge/split/rm/rename/reclassify remains unchanged except safer rejection.

## Token spend
2026-07-02 worker-gpt: ~65k in, ~9k out. Cost unknown.
