### PR TITLE
feat(source-curation): add GitHub discovery adapter

### DIFF
--- a/docs/agents/source-curation.md
+++ b/docs/agents/source-curation.md
@@ -142,6 +142,28 @@ schema accepts any string value. Known backends include:
 New backends can be added without schema changes. The `crawlerVersion`
 field is optional but recommended for reproducibility.
 
+### GitHub discovery adapter
+
+`src/gaia_cli/sourceCuration.py` includes a GitHub discovery adapter for the
+Phase 1 dry-run runner:
+
+- **Default mode is offline fixture discovery.** Running
+  `scripts/sourceCuratorRunner.py` with no flags emits deterministic
+  `github-fixture` proposals and makes zero network calls.
+- **Live GitHub API reads are opt-in only.** Pass `--github-live` or set
+  `GAIA_SOURCE_CURATION_LIVE_GITHUB=1` to refresh fixture repo metadata via
+  the GitHub REST API. `GITHUB_TOKEN` is used if present. Tests do not enable
+  live mode.
+- **Skill-file sources must be `blob/<branch>/<subpath>` URLs.** The adapter
+  strips query strings and fragments from GitHub blob URLs and rejects
+  `tree/` directory URLs instead of guessing a file path.
+- **Same-source proposals are deduped.** The report drops repeated canonical
+  source URLs even when the incoming seed does not mark them as existing
+  evidence duplicates.
+- **Quota accounting is explicit.** Fixture proposals carry
+  `quotaCost.apiCalls: 0`; live GitHub reads increment per-proposal and report
+  `quotaSummary` call counts.
+
 ## Quota and Cost Placeholders
 
 The `quotaCost` (per-proposal) and `quotaSummary` (per-report) fields are
@@ -213,10 +235,12 @@ Run the deterministic dry-run runner with:
 python3 scripts/sourceCuratorRunner.py --run-id 20260702-dry-run --generated-at 2026-07-02T14:00:00Z
 ```
 
-By default the runner uses fixture discovery only: no live network calls, no
-registry mutation, `dryRun: true`, and `generatedBy: "nova-gaia"`. Pass
-`--input seed.json` to supply a local JSON array or an object with a `seeds`
-/ `proposals` array.
+By default the runner uses GitHub fixture discovery only: no live network
+calls, no registry mutation, `dryRun: true`, and `generatedBy: "nova-gaia"`.
+Pass `--input seed.json` to supply a local JSON array or an object with a
+`seeds` / `proposals` array. Pass `--github-live` (or set
+`GAIA_SOURCE_CURATION_LIVE_GITHUB=1`) only when an operator explicitly wants
+live GitHub API reads.
 
 ## Self-Bounding Rules
 
@@ -258,7 +282,7 @@ Test fixtures:
 
 ## What This PR Does NOT Do
 
-- **No network crawler implementation.** `scripts/sourceCuratorRunner.py` is dry-run fixture/seed driven only.
+- **No default network crawler execution.** `scripts/sourceCuratorRunner.py` is dry-run GitHub fixture/seed driven by default; live GitHub reads require explicit opt-in and still only write local reports.
 - **No GitHub Actions workflow.** No `.github/workflows/auto-source-curation.yml`.
 - **No registry mutation.** The schemas and tooling cannot write to
   `registry/nodes/` or `registry/named/`.

--- a/scripts/sourceCuratorRunner.py
+++ b/scripts/sourceCuratorRunner.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Dry-run source-curation runner.
 
-No network calls are made. No registry files are mutated. The runner writes a
-schema-valid proposal report for review.
+The default mode uses offline GitHub fixtures and makes no network calls. Live
+GitHub reads require explicit opt-in. No registry files are mutated; the runner
+writes a schema-valid proposal report for review.
 """
 
 import sys

--- a/src/gaia_cli/sourceCuration.py
+++ b/src/gaia_cli/sourceCuration.py
@@ -110,6 +110,12 @@ def proposalId(seed: dict[str, Any], datePart: str) -> str:
     return f"{safeId(seed.get('skillId', 'unknown-skill'))}-{digest}-{datePart}"
 
 
+def isGithubHost(url: str) -> bool:
+    parsed = urllib.parse.urlparse(url)
+    host = (parsed.hostname or "").lower()
+    return host in {"github.com", "www.github.com"}
+
+
 def canonicalizeGithubBlobUrl(url: str) -> str:
     """Return a canonical GitHub blob URL, rejecting directory tree URLs.
 
@@ -121,16 +127,18 @@ def canonicalizeGithubBlobUrl(url: str) -> str:
     """
 
     parsed = urllib.parse.urlparse(url)
-    if parsed.scheme not in {"http", "https"} or parsed.netloc.lower() != "github.com":
+    host = (parsed.hostname or "").lower()
+    if parsed.scheme.lower() != "https" or host not in {"github.com", "www.github.com"}:
         raise GithubUrlError("GitHub source must be an https://github.com/... URL")
 
     parts = [urllib.parse.unquote(part) for part in parsed.path.split("/") if part]
     if len(parts) < 5:
         raise GithubUrlError("GitHub skill-file source must include /blob/<branch>/<path>")
     owner, repo, view, branch, *subpath = parts
-    if view == "tree":
+    viewType = view.lower()
+    if viewType == "tree":
         raise GithubUrlError("GitHub tree/ URLs are directory views; use a blob/<branch>/<file> source")
-    if view != "blob":
+    if viewType != "blob":
         raise GithubUrlError("GitHub skill-file source must use /blob/<branch>/<path>")
     if not owner or not repo or not branch or not subpath:
         raise GithubUrlError("GitHub blob URL is missing owner, repo, branch, or file path")
@@ -229,7 +237,7 @@ def loadSeeds(inputPath: str | None, liveGithub: bool = False, token: str | None
 def normalizeProposal(seed: dict[str, Any], generatedAt: str) -> dict[str, Any]:
     proposal = copy.deepcopy(seed)
     datePart = generatedAt[:10].replace("-", "")
-    if proposal.get("source", "").startswith("https://github.com/"):
+    if isGithubHost(proposal.get("source", "")):
         proposal["source"] = canonicalizeGithubBlobUrl(proposal["source"])
     proposal.setdefault("proposalId", proposalId(proposal, datePart))
     proposal.setdefault("discoveredAt", generatedAt)
@@ -275,13 +283,13 @@ def buildReport(
         if proposal.get("existingEvidenceCheck", {}).get("duplicate") is True or source in seenSources:
             duplicatesDropped += 1
             continue
-        seenSources.add(source)
         if float(proposal.get("confidence", 0)) < confidenceFloor:
             belowConfidenceDropped += 1
             continue
         skillId = proposal.get("skillId", "")
         if countsBySkill.get(skillId, 0) >= maxProposalsPerSkill:
             continue
+        seenSources.add(source)
         proposals.append(proposal)
         countsBySkill[skillId] = countsBySkill.get(skillId, 0) + 1
 

--- a/src/gaia_cli/sourceCuration.py
+++ b/src/gaia_cli/sourceCuration.py
@@ -1,7 +1,8 @@
 """Dry-run source curation report runner.
 
-This module intentionally performs no network calls and no registry writes. It
-emits schema-validated proposal reports for human review only.
+This module defaults to offline fixture discovery. Live GitHub API reads are
+available only when explicitly enabled and still stop at schema-valid dry-run
+reports: no registry writes and no PR publishing.
 """
 
 from __future__ import annotations
@@ -12,6 +13,9 @@ import hashlib
 import json
 import os
 import re
+import urllib.error
+import urllib.parse
+import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -22,7 +26,16 @@ BOT_IDENTITY = "nova-gaia"
 PIPELINE_PHASE = "discovery"
 DEFAULT_CONFIDENCE_FLOOR = 0.3
 DEFAULT_MAX_PROPOSALS_PER_SKILL = 5
-DEFAULT_BACKENDS = ["fixture-discovery"]
+GITHUB_FIXTURE_BACKEND = "github-fixture"
+GITHUB_API_BACKEND = "github-api"
+DEFAULT_BACKENDS = [GITHUB_FIXTURE_BACKEND]
+GITHUB_LIVE_ENV = "GAIA_SOURCE_CURATION_LIVE_GITHUB"
+GITHUB_TOKEN_ENV = "GITHUB_TOKEN"
+GITHUB_ADAPTER_VERSION = "github-discovery-v1"
+
+
+class GithubUrlError(ValueError):
+    """Raised when a GitHub source URL is not acceptable for a proposal."""
 
 
 def repoRoot() -> Path:
@@ -97,36 +110,112 @@ def proposalId(seed: dict[str, Any], datePart: str) -> str:
     return f"{safeId(seed.get('skillId', 'unknown-skill'))}-{digest}-{datePart}"
 
 
-def defaultSeeds() -> list[dict[str, Any]]:
+def canonicalizeGithubBlobUrl(url: str) -> str:
+    """Return a canonical GitHub blob URL, rejecting directory tree URLs.
+
+    Source-curation proposals that point at a skill file must be installable and
+    reviewable as a concrete file. GitHub directory-view URLs use `/tree/`; the
+    installer policy requires `/blob/<branch>/<subpath>` for file sources, so
+    tree URLs are rejected instead of silently rewritten to a possibly-wrong
+    file path.
+    """
+
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in {"http", "https"} or parsed.netloc.lower() != "github.com":
+        raise GithubUrlError("GitHub source must be an https://github.com/... URL")
+
+    parts = [urllib.parse.unquote(part) for part in parsed.path.split("/") if part]
+    if len(parts) < 5:
+        raise GithubUrlError("GitHub skill-file source must include /blob/<branch>/<path>")
+    owner, repo, view, branch, *subpath = parts
+    if view == "tree":
+        raise GithubUrlError("GitHub tree/ URLs are directory views; use a blob/<branch>/<file> source")
+    if view != "blob":
+        raise GithubUrlError("GitHub skill-file source must use /blob/<branch>/<path>")
+    if not owner or not repo or not branch or not subpath:
+        raise GithubUrlError("GitHub blob URL is missing owner, repo, branch, or file path")
+
+    quotedParts = [urllib.parse.quote(part, safe="") for part in [owner, repo, "blob", branch, *subpath]]
+    return "https://github.com/" + "/".join(quotedParts)
+
+
+def githubFixtureDiscoveries() -> list[dict[str, Any]]:
     return [
         {
             "skillId": "mattpocock/grill-me",
             "genericSkillRef": "code-review-automation",
-            "source": "https://example.com/source-curation/grill-me-demo",
-            "evidenceType": "social-signal",
-            "numericPayload": {"views": 2400, "likes": 120, "comments": 18},
-            "crawlerBackend": "fixture-discovery",
-            "confidence": 0.74,
-            "rationale": "Deterministic fixture describing a public demonstration relevant to the grill-me named skill.",
-            "existingEvidenceCheck": {"checked": True, "duplicate": False},
+            "source": "https://github.com/mattpocock/grill-me/blob/main/SKILL.md",
+            "evidenceType": "github-stars-own",
+            "numericPayload": {"stars": 1280, "skillCountInRepo": 1},
+            "confidence": 0.86,
+            "rationale": "Offline GitHub fixture for a concrete SKILL.md file associated with the grill-me named skill.",
         },
         {
             "skillId": "karpathy/autoresearch",
             "genericSkillRef": "autonomous-research",
-            "source": "https://example.com/source-curation/autoresearch-repo",
+            "source": "https://github.com/karpathy/autoresearch/blob/main/skills/autoresearch/SKILL.md",
             "evidenceType": "repo-own",
             "numericPayload": {"commits": 42, "contributors": 3},
-            "crawlerBackend": "fixture-discovery",
             "confidence": 0.81,
-            "rationale": "Deterministic fixture describing repository activity relevant to the autoresearch named skill.",
-            "existingEvidenceCheck": {"checked": True, "duplicate": False},
+            "rationale": "Offline GitHub fixture for repository activity relevant to the autoresearch named skill.",
         },
     ]
 
 
-def loadSeeds(inputPath: str | None) -> list[dict[str, Any]]:
+def githubRepoApiUrl(blobUrl: str) -> str:
+    parsed = urllib.parse.urlparse(blobUrl)
+    parts = [part for part in parsed.path.split("/") if part]
+    owner, repo = parts[0], parts[1]
+    return f"https://api.github.com/repos/{owner}/{repo}"
+
+
+def fetchGithubRepo(repoApiUrl: str, token: str | None = None) -> dict[str, Any]:
+    headers = {"Accept": "application/vnd.github+json", "User-Agent": "nova-gaia-source-curation"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(repoApiUrl, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as error:
+        raise RuntimeError(f"GitHub API request failed for {repoApiUrl}: {error}") from error
+
+
+def discoverGithubSeeds(liveGithub: bool = False, token: str | None = None) -> list[dict[str, Any]]:
+    """Discover GitHub-backed source proposals.
+
+    Fixture mode is the default and consumes zero quota. Live mode refreshes the
+    fixture repositories through the GitHub REST API only when explicitly
+    enabled by CLI flag or environment variable.
+    """
+
+    backend = GITHUB_API_BACKEND if liveGithub else GITHUB_FIXTURE_BACKEND
+    seeds: list[dict[str, Any]] = []
+    for raw in githubFixtureDiscoveries():
+        seed = copy.deepcopy(raw)
+        seed["source"] = canonicalizeGithubBlobUrl(seed["source"])
+        seed["crawlerBackend"] = backend
+        seed["crawlerVersion"] = GITHUB_ADAPTER_VERSION
+        seed["existingEvidenceCheck"] = {"checked": True, "duplicate": False}
+        seed["quotaCost"] = {"apiCalls": 0, "estimatedCostUsd": 0, "backend": backend}
+        if liveGithub:
+            repoPayload = fetchGithubRepo(githubRepoApiUrl(seed["source"]), token=token)
+            seed["quotaCost"]["apiCalls"] = 1
+            if seed["evidenceType"] == "github-stars-own":
+                seed.setdefault("numericPayload", {})["stars"] = int(repoPayload.get("stargazers_count", 0))
+            if seed["evidenceType"] == "repo-own":
+                seed.setdefault("numericPayload", {})["contributors"] = int(seed["numericPayload"].get("contributors", 0))
+        seeds.append(seed)
+    return seeds
+
+
+def defaultSeeds(liveGithub: bool = False, token: str | None = None) -> list[dict[str, Any]]:
+    return discoverGithubSeeds(liveGithub=liveGithub, token=token)
+
+
+def loadSeeds(inputPath: str | None, liveGithub: bool = False, token: str | None = None) -> list[dict[str, Any]]:
     if not inputPath:
-        return defaultSeeds()
+        return defaultSeeds(liveGithub=liveGithub, token=token)
     payload = loadJson(inputPath)
     if isinstance(payload, list):
         return payload
@@ -140,12 +229,30 @@ def loadSeeds(inputPath: str | None) -> list[dict[str, Any]]:
 def normalizeProposal(seed: dict[str, Any], generatedAt: str) -> dict[str, Any]:
     proposal = copy.deepcopy(seed)
     datePart = generatedAt[:10].replace("-", "")
+    if proposal.get("source", "").startswith("https://github.com/"):
+        proposal["source"] = canonicalizeGithubBlobUrl(proposal["source"])
     proposal.setdefault("proposalId", proposalId(proposal, datePart))
     proposal.setdefault("discoveredAt", generatedAt)
     proposal["discoveredBy"] = BOT_IDENTITY
-    proposal.setdefault("crawlerBackend", "fixture-discovery")
+    proposal.setdefault("crawlerBackend", GITHUB_FIXTURE_BACKEND)
+    proposal.setdefault("quotaCost", {"apiCalls": 0, "estimatedCostUsd": 0, "backend": proposal["crawlerBackend"]})
     proposal["dryRun"] = True
     return proposal
+
+
+def quotaSummary(proposals: list[dict[str, Any]], backends: list[str]) -> dict[str, Any]:
+    perBackend = {backend: {"calls": 0, "costUsd": 0} for backend in backends}
+    for proposal in proposals:
+        cost = proposal.get("quotaCost", {})
+        backend = cost.get("backend") or proposal.get("crawlerBackend", GITHUB_FIXTURE_BACKEND)
+        perBackend.setdefault(backend, {"calls": 0, "costUsd": 0})
+        perBackend[backend]["calls"] += int(cost.get("apiCalls", 0))
+        perBackend[backend]["costUsd"] += float(cost.get("estimatedCostUsd", 0))
+    return {
+        "totalApiCalls": sum(item["calls"] for item in perBackend.values()),
+        "estimatedTotalCostUsd": sum(item["costUsd"] for item in perBackend.values()),
+        "perBackend": perBackend,
+    }
 
 
 def buildReport(
@@ -156,26 +263,29 @@ def buildReport(
     maxProposalsPerSkill: int = DEFAULT_MAX_PROPOSALS_PER_SKILL,
 ) -> dict[str, Any]:
     countsBySkill: dict[str, int] = {}
+    seenSources: set[str] = set()
     proposals: list[dict[str, Any]] = []
     duplicatesDropped = 0
     belowConfidenceDropped = 0
     skillsTargeted = {seed.get("skillId") for seed in seeds if seed.get("skillId")}
 
     for seed in seeds:
-        if seed.get("existingEvidenceCheck", {}).get("duplicate") is True:
+        proposal = normalizeProposal(seed, generatedAt)
+        source = proposal.get("source", "")
+        if proposal.get("existingEvidenceCheck", {}).get("duplicate") is True or source in seenSources:
             duplicatesDropped += 1
             continue
-        if float(seed.get("confidence", 0)) < confidenceFloor:
+        seenSources.add(source)
+        if float(proposal.get("confidence", 0)) < confidenceFloor:
             belowConfidenceDropped += 1
             continue
-        skillId = seed.get("skillId", "")
+        skillId = proposal.get("skillId", "")
         if countsBySkill.get(skillId, 0) >= maxProposalsPerSkill:
             continue
-        proposal = normalizeProposal(seed, generatedAt)
         proposals.append(proposal)
         countsBySkill[skillId] = countsBySkill.get(skillId, 0) + 1
 
-    backends = sorted({proposal.get("crawlerBackend", "fixture-discovery") for proposal in proposals}) or DEFAULT_BACKENDS
+    backends = sorted({proposal.get("crawlerBackend", GITHUB_FIXTURE_BACKEND) for proposal in proposals}) or DEFAULT_BACKENDS
     return {
         "reportId": runId,
         "generatedAt": generatedAt,
@@ -188,11 +298,7 @@ def buildReport(
             "confidenceFloor": confidenceFloor,
             "backends": backends,
         },
-        "quotaSummary": {
-            "totalApiCalls": 0,
-            "estimatedTotalCostUsd": 0,
-            "perBackend": {backend: {"calls": 0, "costUsd": 0} for backend in backends},
-        },
+        "quotaSummary": quotaSummary(proposals, backends),
         "proposals": proposals,
         "summary": {
             "skillsTargeted": len(skillsTargeted),
@@ -218,6 +324,10 @@ def resolveOutputPath(rootDir: Path, runId: str, outputPath: str | None = None) 
     return resolved
 
 
+def envEnablesLiveGithub() -> bool:
+    return os.environ.get(GITHUB_LIVE_ENV, "").lower() in {"1", "true", "yes", "on"}
+
+
 def runDryRun(
     rootDir: Path | None = None,
     runId: str | None = None,
@@ -226,11 +336,13 @@ def runDryRun(
     outputPath: str | None = None,
     confidenceFloor: float = DEFAULT_CONFIDENCE_FLOOR,
     maxProposalsPerSkill: int = DEFAULT_MAX_PROPOSALS_PER_SKILL,
+    liveGithub: bool | None = None,
 ) -> tuple[dict[str, Any], Path]:
     root = rootDir or repoRoot()
     stamp = generatedAt or utcNowStamp()
     reportId = runId or todayRunId(stamp)
-    seeds = loadSeeds(inputPath)
+    githubLive = envEnablesLiveGithub() if liveGithub is None else liveGithub
+    seeds = loadSeeds(inputPath, liveGithub=githubLive, token=os.environ.get(GITHUB_TOKEN_ENV))
     report = buildReport(seeds, reportId, stamp, confidenceFloor, maxProposalsPerSkill)
     validateReport(report, root)
     path = resolveOutputPath(root, reportId, outputPath)
@@ -240,12 +352,17 @@ def runDryRun(
 
 def buildParser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Emit a dry-run nova-gaia source-curation proposal report.")
-    parser.add_argument("--input", help="Optional JSON seed file. Defaults to deterministic fixture discovery.")
+    parser.add_argument("--input", help="Optional JSON seed file. Defaults to deterministic GitHub fixture discovery.")
     parser.add_argument("--output", help="Output report path. Defaults to generated-output/source-curation/<run-id>/report.json")
     parser.add_argument("--run-id", help="Deterministic report ID. Defaults to <yyyymmdd>-dry-run")
     parser.add_argument("--generated-at", help="ISO 8601 timestamp for deterministic runs. Defaults to current UTC time.")
     parser.add_argument("--confidence-floor", type=float, default=DEFAULT_CONFIDENCE_FLOOR)
     parser.add_argument("--max-proposals-per-skill", type=int, default=DEFAULT_MAX_PROPOSALS_PER_SKILL)
+    parser.add_argument(
+        "--github-live",
+        action="store_true",
+        help=f"Opt in to live GitHub API reads. Fixture mode is used unless this flag or {GITHUB_LIVE_ENV}=1 is set.",
+    )
     return parser
 
 
@@ -258,6 +375,7 @@ def main(argv: list[str] | None = None) -> int:
         outputPath=args.output,
         confidenceFloor=args.confidence_floor,
         maxProposalsPerSkill=args.max_proposals_per_skill,
+        liveGithub=True if args.github_live else None,
     )
     print(f"Wrote dry-run source-curation report: {path}")
     print(f"reportId={report['reportId']} proposals={len(report['proposals'])} generatedBy={report['generatedBy']}")

--- a/tests/test_source_curator_runner.py
+++ b/tests/test_source_curator_runner.py
@@ -150,9 +150,45 @@ def test_github_url_canonicalization_rejects_tree_urls():
     assert sourceCuration.canonicalizeGithubBlobUrl(
         "https://github.com/owner/repo/blob/main/skills/example/SKILL.md?plain=1#L1"
     ) == "https://github.com/owner/repo/blob/main/skills/example/SKILL.md"
+    assert sourceCuration.canonicalizeGithubBlobUrl(
+        "https://www.GitHub.com/owner/repo/blob/main/skills/example/SKILL.md?plain=1#L1"
+    ) == "https://github.com/owner/repo/blob/main/skills/example/SKILL.md"
 
     with pytest.raises(sourceCuration.GithubUrlError):
         sourceCuration.canonicalizeGithubBlobUrl("https://github.com/owner/repo/tree/main/skills/example")
+    with pytest.raises(sourceCuration.GithubUrlError):
+        sourceCuration.canonicalizeGithubBlobUrl("http://github.com/owner/repo/tree/main/skills/example")
+    with pytest.raises(sourceCuration.GithubUrlError):
+        sourceCuration.canonicalizeGithubBlobUrl("http://github.com/owner/repo/blob/main/skills/example/SKILL.md")
+    with pytest.raises(sourceCuration.GithubUrlError):
+        sourceCuration.canonicalizeGithubBlobUrl("https://www.github.com/owner/repo/tree/main/skills/example")
+
+
+def test_dry_run_runner_canonicalizes_www_github_urls(tmp_path):
+    root = makeRoot(tmp_path)
+    seeds = [
+        {
+            "skillId": "alice/research-helper",
+            "source": "https://www.GitHub.com/alice/research-helper/blob/main/SKILL.md?plain=1#L4",
+            "evidenceType": "repo-own",
+            "crawlerBackend": "github-fixture",
+            "confidence": 0.8,
+            "rationale": "www GitHub hosts should be detected and normalized for dedupe and installability.",
+            "existingEvidenceCheck": {"checked": True, "duplicate": False},
+        },
+    ]
+    seedPath = tmp_path / "seed.json"
+    seedPath.write_text(json.dumps(seeds), encoding="utf-8")
+
+    report, _ = sourceCuration.runDryRun(
+        rootDir=root,
+        runId="20260702-www-github-canonicalize",
+        generatedAt="2026-07-02T14:00:00Z",
+        inputPath=str(seedPath),
+    )
+
+    assert report["proposals"][0]["source"] == "https://github.com/alice/research-helper/blob/main/SKILL.md"
+    sourceCuration.validateReport(report, root)
 
 
 def test_dry_run_runner_dedupes_same_source_url(tmp_path):
@@ -189,6 +225,45 @@ def test_dry_run_runner_dedupes_same_source_url(tmp_path):
 
     assert len(report["proposals"]) == 1
     assert report["summary"]["duplicatesDropped"] == 1
+    sourceCuration.validateReport(report, root)
+
+
+def test_dry_run_runner_allows_high_confidence_duplicate_after_low_confidence_drop(tmp_path):
+    root = makeRoot(tmp_path)
+    seeds = [
+        {
+            "skillId": "alice/research-helper",
+            "source": "https://github.com/alice/research-helper/blob/main/SKILL.md",
+            "evidenceType": "repo-own",
+            "crawlerBackend": "github-fixture",
+            "confidence": 0.1,
+            "rationale": "Low-confidence duplicate should be dropped without marking the source seen.",
+            "existingEvidenceCheck": {"checked": True, "duplicate": False},
+        },
+        {
+            "skillId": "alice/research-helper",
+            "source": "https://github.com/alice/research-helper/blob/main/SKILL.md",
+            "evidenceType": "repo-own",
+            "crawlerBackend": "github-fixture",
+            "confidence": 0.9,
+            "rationale": "High-confidence duplicate should still be emitted after the weak seed is filtered.",
+            "existingEvidenceCheck": {"checked": True, "duplicate": False},
+        },
+    ]
+    seedPath = tmp_path / "seed.json"
+    seedPath.write_text(json.dumps(seeds), encoding="utf-8")
+
+    report, _ = sourceCuration.runDryRun(
+        rootDir=root,
+        runId="20260702-low-confidence-before-duplicate",
+        generatedAt="2026-07-02T14:00:00Z",
+        inputPath=str(seedPath),
+    )
+
+    assert len(report["proposals"]) == 1
+    assert report["proposals"][0]["confidence"] == 0.9
+    assert report["summary"]["duplicatesDropped"] == 0
+    assert report["summary"]["belowConfidenceDropped"] == 1
     sourceCuration.validateReport(report, root)
 
 

--- a/tests/test_source_curator_runner.py
+++ b/tests/test_source_curator_runner.py
@@ -39,9 +39,14 @@ def test_dry_run_runner_emits_deterministic_schema_valid_report(tmp_path):
     assert report["pipelinePhase"] == "discovery"
     assert len(report["proposals"]) == 2
     assert [proposal["proposalId"] for proposal in report["proposals"]] == [
-        "mattpocock-grill-me-90af940b-20260702",
-        "karpathy-autoresearch-02e79a9c-20260702",
+        "mattpocock-grill-me-bd19fdf3-20260702",
+        "karpathy-autoresearch-c1a7d8ea-20260702",
     ]
+    assert {proposal["crawlerBackend"] for proposal in report["proposals"]} == {"github-fixture"}
+    assert all(proposal["source"].startswith("https://github.com/") for proposal in report["proposals"])
+    assert all("/blob/" in proposal["source"] for proposal in report["proposals"])
+    assert all(proposal["quotaCost"]["apiCalls"] == 0 for proposal in report["proposals"])
+    assert report["quotaSummary"]["totalApiCalls"] == 0
 
     sourceCuration.validateReport(report, root)
 
@@ -120,6 +125,71 @@ def test_dry_run_runner_rejects_output_path_outside_source_curation_dir(tmp_path
         )
 
     assert not forbidden.exists()
+
+
+def test_github_fixture_discovery_does_not_call_network_by_default(tmp_path, monkeypatch):
+    root = makeRoot(tmp_path)
+
+    def failNetwork(*_args, **_kwargs):
+        raise AssertionError("default source-curation discovery must not call the network")
+
+    monkeypatch.setattr(sourceCuration.urllib.request, "urlopen", failNetwork)
+
+    report, _ = sourceCuration.runDryRun(
+        rootDir=root,
+        runId="20260702-fixture-no-network",
+        generatedAt="2026-07-02T14:00:00Z",
+    )
+
+    assert len(report["proposals"]) == 2
+    assert report["crawlConfig"]["backends"] == ["github-fixture"]
+    assert report["quotaSummary"]["perBackend"] == {"github-fixture": {"calls": 0, "costUsd": 0}}
+
+
+def test_github_url_canonicalization_rejects_tree_urls():
+    assert sourceCuration.canonicalizeGithubBlobUrl(
+        "https://github.com/owner/repo/blob/main/skills/example/SKILL.md?plain=1#L1"
+    ) == "https://github.com/owner/repo/blob/main/skills/example/SKILL.md"
+
+    with pytest.raises(sourceCuration.GithubUrlError):
+        sourceCuration.canonicalizeGithubBlobUrl("https://github.com/owner/repo/tree/main/skills/example")
+
+
+def test_dry_run_runner_dedupes_same_source_url(tmp_path):
+    root = makeRoot(tmp_path)
+    seeds = [
+        {
+            "skillId": "alice/research-helper",
+            "source": "https://github.com/alice/research-helper/blob/main/SKILL.md",
+            "evidenceType": "repo-own",
+            "crawlerBackend": "github-fixture",
+            "confidence": 0.8,
+            "rationale": "First proposal for the same GitHub source file should remain.",
+            "existingEvidenceCheck": {"checked": True, "duplicate": False},
+        },
+        {
+            "skillId": "alice/research-helper",
+            "source": "https://github.com/alice/research-helper/blob/main/SKILL.md",
+            "evidenceType": "repo-own",
+            "crawlerBackend": "github-fixture",
+            "confidence": 0.9,
+            "rationale": "Second proposal for the same GitHub source file should be deduped.",
+            "existingEvidenceCheck": {"checked": True, "duplicate": False},
+        },
+    ]
+    seedPath = tmp_path / "seed.json"
+    seedPath.write_text(json.dumps(seeds), encoding="utf-8")
+
+    report, _ = sourceCuration.runDryRun(
+        rootDir=root,
+        runId="20260702-source-dedupe",
+        generatedAt="2026-07-02T14:00:00Z",
+        inputPath=str(seedPath),
+    )
+
+    assert len(report["proposals"]) == 1
+    assert report["summary"]["duplicatesDropped"] == 1
+    sourceCuration.validateReport(report, root)
 
 
 def test_dry_run_runner_filters_duplicates_and_low_confidence(tmp_path):


### PR DESCRIPTION
## Summary

Refs #762.

Implements PR 10 of the source-curation sprint: a GitHub discovery adapter for dry-run reports.

- Adds offline `github-fixture` discovery as the default runner backend.
- Keeps live GitHub REST reads behind explicit `--github-live` / `GAIA_SOURCE_CURATION_LIVE_GITHUB=1` opt-in.
- Canonicalizes GitHub skill-file proposal sources to `blob/<branch>/<subpath>` and rejects `tree/` directory URLs.
- Dedupes repeated canonical source URLs before report emission.
- Adds per-proposal `quotaCost` and aggregate `quotaSummary` accounting, with fixture mode costing zero calls.
- Updates source-curation docs and runner docstring to clarify dry-run/no-network defaults.

## Reviewer checklist

- [ ] Confirm default runner mode makes no network calls.
- [ ] Confirm `--github-live` / env opt-in is acceptable as the only live API path.
- [ ] Confirm GitHub `tree/` URL rejection matches installer/source policy.
- [ ] Confirm emitted proposals remain valid under `sourceProposal.schema.json` and report schema.
- [ ] Confirm this PR stops at dry-run reports and does not add auto-PR publishing or registry mutation.

## Tests

- `PYTHONPATH=src pytest tests/test_source_curator_runner.py -q`
- `PYTHONPATH=src pytest tests/test_source_curator_runner.py tests/test_source_proposal_schema.py -q`
- `python3 -m py_compile src/gaia_cli/sourceCuration.py scripts/sourceCuratorRunner.py`
- `PYTHONPATH=src pytest -q` *(1 unrelated packaging failure: `tests/test_packaging.py::test_wheel_install_smoke_tests_console_script` could not find venv `bin/gaia`; 1394 passed, 2 skipped before failure)*

## Notes

No registry files or generated source-curation reports are committed.
