### PR TITLE
feat(dev): preflight remaining mutating verbs

### DIFF
--- a/src/gaia_cli/commands/dev/calibrate.py
+++ b/src/gaia_cli/commands/dev/calibrate.py
@@ -15,6 +15,7 @@ from gaia_cli.commands.dev.helpers import (
     _confirm_destructive,
     _run_dev_preflights,
     _preflight_starbar_blob_link,
+    _fail_dev_preflight,
 )
 
 
@@ -94,6 +95,34 @@ def calibrate_evidence_grades_command(args):
     if not per_row_thresholds:
         print("Error: perRowGradeThresholds not found in meta.json. Cannot proceed.", file=sys.stderr)
         sys.exit(1)
+
+    def _preflight_target_skill_exists() -> None:
+        if not target_skill:
+            return
+        nodes_dir_check = Path(registry_nodes_dir(registry_path))
+        for node_file in nodes_dir_check.rglob("*.json"):
+            try:
+                with open(node_file, "r", encoding="utf-8") as f:
+                    skill = json.load(f)
+            except Exception:
+                continue
+            if skill.get("id") == target_skill:
+                return
+        named_dir_check = Path(named_skills_dir(registry_path))
+        if named_dir_check.exists():
+            for md_file in named_dir_check.rglob("*.md"):
+                try:
+                    meta_fm, _ = _parse_md(md_file)
+                except Exception:
+                    continue
+                if meta_fm.get("id") == target_skill or meta_fm.get("genericSkillRef") == target_skill:
+                    return
+        _fail_dev_preflight(
+            f"--skill target '{target_skill}' was not found in generic or named registry data.",
+            fix="Pass an existing generic ref or named skill ID, or omit --skill to process the selected scope.",
+        )
+
+    _run_dev_preflights([_preflight_target_skill_exists])
 
     if not dry_run:
         _confirm_destructive(

--- a/src/gaia_cli/commands/dev/evidence.py
+++ b/src/gaia_cli/commands/dev/evidence.py
@@ -16,6 +16,7 @@ from gaia_cli.commands.dev.helpers import (
     _run_dev_preflights,
     _preflight_evidence_static,
     _preflight_evidence_index_bounds,
+    _preflight_duplicate_evidence_source,
 )
 
 
@@ -208,6 +209,7 @@ def meta_evidence_command(args):
         meta, body = _parse_md(named_file)
         _run_dev_preflights([
             lambda: _preflight_evidence_index_bounds(skill_id, meta.get("evidence") or [], index),
+            lambda: _preflight_duplicate_evidence_source(skill_id, meta.get("evidence") or [], args.source),
         ])
         result_entry = _apply(meta.setdefault("evidence", []))
         # Stamp tenure baseline on the first evidence-add only.
@@ -238,6 +240,7 @@ def meta_evidence_command(args):
             data = json.load(f)
         _run_dev_preflights([
             lambda: _preflight_evidence_index_bounds(skill_id, data.get("evidence") or [], index),
+            lambda: _preflight_duplicate_evidence_source(skill_id, data.get("evidence") or [], args.source),
         ])
         result_entry = _apply(data.setdefault("evidence", []))
         # Stamp tenure baseline on the first evidence-add only.

--- a/src/gaia_cli/commands/dev/helpers.py
+++ b/src/gaia_cli/commands/dev/helpers.py
@@ -6,6 +6,7 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Iterable
+from urllib.parse import urlparse
 
 from gaia_cli.registry import (
     registry_graph_path,
@@ -112,27 +113,83 @@ def _preflight_starbar_blob_link(skill_id: str, skill_data: dict, level: str) ->
     )
 
 
+def _preflight_url(value: str | None, flag: str) -> None:
+    if not value:
+        return
+    parsed = urlparse(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        _fail_dev_preflight(
+            f"{flag} must be an absolute http(s) URL; got {value!r}.",
+            fix="Pass a full evidence URL such as https://example.com/path.",
+        )
+
+
+def _preflight_iso_timestamp(value: str | None, flag: str = "--timestamp") -> None:
+    if value is None:
+        return
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.datetime.fromisoformat(normalized)
+    except ValueError:
+        _fail_dev_preflight(
+            f"{flag} must be ISO 8601 (for example 2026-03-01T00:00:00Z); got {value!r}."
+        )
+    if parsed.tzinfo is None:
+        _fail_dev_preflight(
+            f"{flag} must include a timezone (use Z for UTC); got {value!r}."
+        )
+
+
+def _preflight_non_negative(value, flag: str, *, allow_zero: bool = True) -> None:
+    if value is None:
+        return
+    if value < 0 or (value == 0 and not allow_zero):
+        comparator = ">= 0" if allow_zero else "> 0"
+        _fail_dev_preflight(f"{flag} must be {comparator}; got {value!r}.")
+
+
 def _preflight_evidence_static(args, valid_types: set[str] | list[str] | tuple[str, ...]) -> None:
     evidence_type = getattr(args, "evidence_type", None)
-    if evidence_type is not None and evidence_type not in valid_types:
-        valid_list = ", ".join(valid_types)
+    valid_type_set = set(valid_types)
+    if evidence_type is not None and evidence_type not in valid_type_set:
+        valid_list = ", ".join(sorted(valid_type_set))
         _fail_dev_preflight(
             f"unknown evidence type '{evidence_type}'.",
             fix=f"Use one of: {valid_list}",
         )
 
+    _preflight_url(getattr(args, "source", None), "source")
+
+    trust_number = getattr(args, "trust", None)
+    _preflight_non_negative(trust_number, "--trust")
+
+    numeric_fields = (
+        ("stars", "--stars", True),
+        ("views", "--views", True),
+        ("citations", "--citations", True),
+        ("reviewers", "--reviewers", False),
+        ("commits", "--commits", True),
+        ("contributors", "--contributors", True),
+        ("skill_count_in_repo", "--skill-count-in-repo", False),
+    )
+    for attr, flag, allow_zero in numeric_fields:
+        _preflight_non_negative(getattr(args, attr, None), flag, allow_zero=allow_zero)
+
     percentile = getattr(args, "percentile", None)
-    if evidence_type == "benchmark-result":
-        if percentile is None:
+    if percentile is not None and not (0 <= int(percentile) <= 100):
+        _fail_dev_preflight(f"`--percentile` must be in range 0-100; got {percentile!r}.")
+
+    required_payloads = {
+        "benchmark-result": (("percentile", "--percentile <0-100>"),),
+        "peer-review": (("reviewers", "--reviewers <count>"),),
+    }
+    if evidence_type in required_payloads:
+        missing = [flag for attr, flag in required_payloads[evidence_type] if getattr(args, attr, None) is None]
+        if missing:
             _fail_dev_preflight(
-                "`--type benchmark-result` requires `--percentile <0-100>`.",
-                fix=(
-                    "Pass `--percentile <int>` (0-100 inclusive). If the percentile is unknown, "
-                    "use `--type peer-review` with `--reviewers` instead for a gradeable entry."
-                ),
+                f"`--type {evidence_type}` requires {', '.join(missing)}.",
+                fix="Provide the required numeric payload so the evidence row can produce a non-zero artifact score.",
             )
-        if not (0 <= int(percentile) <= 100):
-            _fail_dev_preflight(f"`--percentile` must be in range 0-100; got {percentile!r}.")
 
     for attr, flag in (("date", "--date"), ("source_started_at", "--source-started-at")):
         value = getattr(args, attr, None)
@@ -174,6 +231,36 @@ def _preflight_evidence_index_bounds(skill_id: str, ev_list: list, index: int | 
         _fail_dev_preflight(
             f"Evidence index {index} out of range for skill '{skill_id}' ({len(ev_list)} entries).",
             fix="Use a valid zero-based --index value or omit --index to append new evidence.",
+        )
+
+
+def _preflight_duplicate_evidence_source(skill_id: str, ev_list: list, source: str | None) -> None:
+    if not source:
+        return
+    duplicates = [entry for entry in (ev_list or []) if entry.get("source") == source]
+    if duplicates:
+        plural = "entry" if len(duplicates) == 1 else "entries"
+        print(
+            f"Warning: {skill_id} already has {len(duplicates)} evidence {plural} at {source}; "
+            "same-source dedup may collapse Trust Magnitude contribution.",
+            file=sys.stderr,
+        )
+
+
+def _preflight_verify_evidence(skill_id: str, ev_list: list, index: int, *, is_dispute: bool, source: str | None) -> None:
+    _preflight_evidence_index_bounds(skill_id, ev_list, index)
+    _preflight_url(source, "--source")
+    entry = ev_list[index]
+    if is_dispute:
+        if entry.get("disputed") is True:
+            _fail_dev_preflight(
+                f"Evidence index {index} for '{skill_id}' is already disputed.",
+                fix="Choose a different evidence index or omit duplicate dispute attempts.",
+            )
+    elif entry.get("verified") is True and entry.get("disputed") is not True:
+        _fail_dev_preflight(
+            f"Evidence index {index} for '{skill_id}' is already verified.",
+            fix="Use --dispute to change the status, or choose an unverified evidence row.",
         )
 
 

--- a/src/gaia_cli/commands/dev/timeline.py
+++ b/src/gaia_cli/commands/dev/timeline.py
@@ -1,5 +1,62 @@
 import sys
-from gaia_cli.commands.dev.helpers import _get_contributor, _run_docs_build
+from pathlib import Path
+
+from gaia_cli.commands.dev.helpers import (
+    _get_contributor,
+    _run_docs_build,
+    _run_dev_preflights,
+    _fail_dev_preflight,
+    _preflight_iso_timestamp,
+)
+
+
+def _registry_timeline_target_exists(skill_id: str, registry_path: str) -> bool:
+    from gaia_cli.registry import registry_nodes_dir, named_skills_dir
+    from gaia_cli.commands.dev.helpers import _find_named_file
+
+    nodes_dir = Path(registry_nodes_dir(registry_path))
+    for node_file in nodes_dir.glob("**/*.json"):
+        try:
+            import json
+            data = json.loads(node_file.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if data.get("id") == skill_id:
+            return True
+
+    named_dir = Path(named_skills_dir(registry_path))
+    return _find_named_file(named_dir, skill_id) is not None
+
+
+def _preflight_timeline_command(args) -> None:
+    skill_id = args.skill_id.lstrip("/")
+    user = getattr(args, "user", None)
+    timestamp = getattr(args, "timestamp", None)
+    _preflight_iso_timestamp(timestamp)
+
+    if user:
+        from gaia_cli.treeManager import load_tree
+        try:
+            tree_data = load_tree(user, args.registry)
+        except ValueError as exc:
+            _fail_dev_preflight(str(exc))
+        if tree_data is None:
+            _fail_dev_preflight(
+                f"User tree skill-trees/{user}/skill-tree.json does not exist.",
+                fix="Run `gaia init` for that user or pass the correct --user value before appending a user-tree timeline event.",
+            )
+        return
+
+    if timestamp:
+        _fail_dev_preflight(
+            "--timestamp is only supported with --user skill-tree timeline events.",
+            fix="Pass --user <username> for historical user-tree backfills, or omit --timestamp for registry timelines.",
+        )
+    if not _registry_timeline_target_exists(skill_id, args.registry):
+        _fail_dev_preflight(
+            f"Timeline target '{skill_id}' was not found in registry nodes or named skills.",
+            fix="Use an existing generic or named skill ID, or pass --user when targeting a user skill tree.",
+        )
 
 
 def meta_timeline_command(args):
@@ -11,26 +68,22 @@ def meta_timeline_command(args):
     user = getattr(args, "user", None)
     timestamp = getattr(args, "timestamp", None)
 
+    _run_dev_preflights([
+        lambda: _preflight_timeline_command(args),
+    ])
+
     if user:
-        # Check if skill_id refers to a named skill first; if so write there.
-        from gaia_cli.timeline import _named_skill_file
-        named_file = _named_skill_file(skill_id, registry_path)
-        if named_file:
-            from gaia_cli.timeline import append_skill_event
-            append_skill_event(skill_id, action, user, notes, registry_path=registry_path)
-            print(f"Appended '{action}' event for '{skill_id}' to named skill file.")
-        else:
-            from gaia_cli.timeline import append_skill_tree_event
-            append_skill_tree_event(
-                user,
-                skill_id,
-                action,
-                notes,
-                registry_path=registry_path,
-                timestamp=timestamp,
-            )
-            marker = f" (at {timestamp})" if timestamp else ""
-            print(f"Appended '{action}' event for '{skill_id}' to skill-trees/{user}/skill-tree.json{marker}.")
+        from gaia_cli.timeline import append_skill_tree_event
+        append_skill_tree_event(
+            user,
+            skill_id,
+            action,
+            notes,
+            registry_path=registry_path,
+            timestamp=timestamp,
+        )
+        marker = f" (at {timestamp})" if timestamp else ""
+        print(f"Appended '{action}' event for '{skill_id}' to skill-trees/{user}/skill-tree.json{marker}.")
     else:
         from gaia_cli.timeline import append_skill_event
         append_skill_event(

--- a/src/gaia_cli/commands/dev/verify.py
+++ b/src/gaia_cli/commands/dev/verify.py
@@ -13,6 +13,8 @@ from gaia_cli.commands.dev.helpers import (
     _is_verifier,
     _get_contributor,
     _run_docs_build,
+    _run_dev_preflights,
+    _preflight_verify_evidence,
 )
 
 
@@ -70,11 +72,15 @@ def meta_verify_command(args):
 
     if node_file:
         evidence = skill_data.get("evidence", [])
-        if evidence_index >= len(evidence):
-            print(
-                f"Error: Evidence index {evidence_index} out of range (total {len(evidence)})."
-            )
-            sys.exit(1)
+        _run_dev_preflights([
+            lambda: _preflight_verify_evidence(
+                skill_id,
+                evidence,
+                evidence_index,
+                is_dispute=is_dispute,
+                source=v_source,
+            ),
+        ])
 
         ev = evidence[evidence_index]
         ev["verified"] = not is_dispute
@@ -110,11 +116,15 @@ def meta_verify_command(args):
 
         meta, body = _parse_md(target_file)
         evidence = meta.get("evidence", [])
-        if evidence_index >= len(evidence):
-            print(
-                f"Error: Evidence index {evidence_index} out of range (total {len(evidence)})."
-            )
-            sys.exit(1)
+        _run_dev_preflights([
+            lambda: _preflight_verify_evidence(
+                skill_id,
+                evidence,
+                evidence_index,
+                is_dispute=is_dispute,
+                source=v_source,
+            ),
+        ])
 
         ev = evidence[evidence_index]
         ev["verified"] = not is_dispute

--- a/tests/test_calibrate_evidence_grades.py
+++ b/tests/test_calibrate_evidence_grades.py
@@ -293,3 +293,17 @@ def test_stale_grade_cleared_when_score_below_floor(tmp_path):
     calibrate_evidence_grades_command(_args(root))
     ev = _load_node(root)["evidence"]
     assert "grade" not in ev[0]
+
+
+def test_missing_skill_filter_exits_before_write(tmp_path, capsys):
+    root = _build_registry(tmp_path, [
+        {"type": "arxiv", "source": "https://arxiv.org/abs/test", "grade": "B", "trustNumber": 5},
+    ])
+    before = _load_node(root)
+
+    with pytest.raises(SystemExit) as exc:
+        calibrate_evidence_grades_command(_args(root, skill="missing-skill"))
+
+    assert exc.value.code != 0
+    assert _load_node(root) == before
+    assert "--skill target 'missing-skill' was not found" in capsys.readouterr().err

--- a/tests/test_dev_evidence.py
+++ b/tests/test_dev_evidence.py
@@ -35,6 +35,7 @@ def _make_registry(tmp_path: Path, evidence: list | None = None) -> str:
                     {"id": "peer-review", "gradeCeiling": "S"},
                     {"id": "benchmark-result", "gradeCeiling": "A"},
                     {"id": "github-stars-own", "gradeCeiling": "B"},
+                    {"id": "social-signal", "gradeCeiling": "A"},
                 ],
                 "perRowGradeThresholds": {},
             }
@@ -107,7 +108,7 @@ def test_append_adds_evidence(tmp_path):
 
 def test_append_with_type(tmp_path):
     root = _make_registry(tmp_path)
-    meta_evidence_command(_args(root, evidence_type="repo-own", trust=120.0))
+    meta_evidence_command(_args(root, evidence_type="repo-own", trust=120.0, commits=50, contributors=2))
     ev = _load_node(root)["evidence"]
     assert ev[0]["type"] == "repo-own"
 
@@ -211,9 +212,47 @@ def test_percentile_out_of_range_exits(tmp_path):
 def test_non_benchmark_type_no_percentile_required(tmp_path):
     """Other types do not require --percentile."""
     root = _make_registry(tmp_path)
-    meta_evidence_command(_args(root, evidence_type="repo-own", trust=80.0))
+    meta_evidence_command(_args(root, evidence_type="peer-review", trust=80.0, reviewers=2))
     ev = _load_node(root)["evidence"]
     assert len(ev) == 1
+
+
+def test_peer_review_requires_reviewers_before_write(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    before = _load_node(root)
+
+    with pytest.raises(SystemExit) as exc:
+        meta_evidence_command(_args(root, evidence_type="peer-review", trust=80.0))
+
+    assert exc.value.code != 0
+    assert _load_node(root) == before
+    err = capsys.readouterr().err
+    assert "--type peer-review" in err
+    assert "--reviewers" in err
+
+
+def test_negative_numeric_payload_rejected_before_write(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    before = _load_node(root)
+
+    with pytest.raises(SystemExit) as exc:
+        meta_evidence_command(_args(root, evidence_type="social-signal", views=-1))
+
+    assert exc.value.code != 0
+    assert _load_node(root) == before
+    assert "--views must be >= 0" in capsys.readouterr().err
+
+
+def test_invalid_source_url_rejected_before_write(tmp_path, capsys):
+    root = _make_registry(tmp_path)
+    before = _load_node(root)
+
+    with pytest.raises(SystemExit) as exc:
+        meta_evidence_command(_args(root, source="not-a-url", trust=20.0))
+
+    assert exc.value.code != 0
+    assert _load_node(root) == before
+    assert "absolute http(s) URL" in capsys.readouterr().err
 
 
 # ---------------------------------------------------------------------------
@@ -299,5 +338,5 @@ def test_preflight_benchmark_with_percentile_passes():
 
 
 def test_preflight_non_benchmark_passes():
-    ns = SimpleNamespace(evidence_type="repo-own", percentile=None)
+    ns = SimpleNamespace(evidence_type="repo-own", percentile=None, commits=1, contributors=1)
     _preflight_benchmark_percentile(ns)  # must not raise

--- a/tests/test_dev_timeline.py
+++ b/tests/test_dev_timeline.py
@@ -34,6 +34,15 @@ def _make_registry(tmp_path: Path) -> str:
     return str(tmp_path)
 
 
+def _write_tree(root: str, user: str = "alice") -> None:
+    tree_dir = Path(root) / "skill-trees" / user
+    tree_dir.mkdir(parents=True, exist_ok=True)
+    (tree_dir / "skill-tree.json").write_text(
+        json.dumps({"userId": user, "unlockedSkills": [], "timeline": []}),
+        encoding="utf-8",
+    )
+
+
 def _args(root: str, skill_id: str = "demo-skill", action: str = "note",
           notes: str = "Test note.", **kw) -> SimpleNamespace:
     base = dict(registry=root, skill_id=skill_id, action=action, notes=notes,
@@ -85,6 +94,7 @@ def test_timeline_capsys_shows_completion(tmp_path, capsys):
 def test_timeline_with_user_routes_to_tree(tmp_path, monkeypatch):
     """With --user, event is routed to the user skill-tree."""
     root = _make_registry(tmp_path)
+    _write_tree(root, "alice")
     tree_events = []
     monkeypatch.setattr(
         "gaia_cli.timeline.append_skill_tree_event",
@@ -108,6 +118,7 @@ def test_timeline_with_user_routes_to_tree(tmp_path, monkeypatch):
 
 def test_timestamp_forwarded_to_tree_event(tmp_path, monkeypatch):
     root = _make_registry(tmp_path)
+    _write_tree(root, "alice")
     timestamps = []
     monkeypatch.setattr(
         "gaia_cli.timeline.append_skill_tree_event",
@@ -119,3 +130,52 @@ def test_timestamp_forwarded_to_tree_event(tmp_path, monkeypatch):
     monkeypatch.setattr("gaia_cli.timeline.append_skill_event", lambda *a, **kw: None)
     meta_timeline_command(_args(root, user="alice", timestamp="2026-01-01T00:00:00Z"))
     assert timestamps[0] == "2026-01-01T00:00:00Z"
+
+
+def test_invalid_timestamp_exits_before_tree_write(tmp_path, monkeypatch, capsys):
+    root = _make_registry(tmp_path)
+    _write_tree(root, "alice")
+    tree_events = []
+    monkeypatch.setattr(
+        "gaia_cli.timeline.append_skill_tree_event",
+        lambda *a, **kw: tree_events.append(a),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        meta_timeline_command(_args(root, user="alice", timestamp="not-a-date"))
+
+    assert exc.value.code != 0
+    assert tree_events == []
+    assert "--timestamp must be ISO 8601" in capsys.readouterr().err
+
+
+def test_timestamp_without_user_rejected_before_registry_write(tmp_path, monkeypatch, capsys):
+    root = _make_registry(tmp_path)
+    events = []
+    monkeypatch.setattr(
+        "gaia_cli.timeline.append_skill_event",
+        lambda *a, **kw: events.append(a),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        meta_timeline_command(_args(root, timestamp="2026-01-01T00:00:00Z"))
+
+    assert exc.value.code != 0
+    assert events == []
+    assert "--timestamp is only supported with --user" in capsys.readouterr().err
+
+
+def test_missing_user_tree_rejected_before_write(tmp_path, monkeypatch, capsys):
+    root = _make_registry(tmp_path)
+    tree_events = []
+    monkeypatch.setattr(
+        "gaia_cli.timeline.append_skill_tree_event",
+        lambda *a, **kw: tree_events.append(a),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        meta_timeline_command(_args(root, user="missing"))
+
+    assert exc.value.code != 0
+    assert tree_events == []
+    assert "skill-trees/missing/skill-tree.json does not exist" in capsys.readouterr().err

--- a/tests/test_dev_verify_preflights.py
+++ b/tests/test_dev_verify_preflights.py
@@ -1,0 +1,123 @@
+"""Preflight coverage for gaia dev verify."""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from gaia_cli.commands.dev.verify import meta_verify_command
+
+pytestmark = [pytest.mark.integration]
+
+
+def _make_registry(tmp_path: Path, evidence: list) -> str:
+    nodes = tmp_path / "registry" / "nodes" / "basic"
+    nodes.mkdir(parents=True)
+    schema = tmp_path / "registry" / "schema"
+    schema.mkdir(parents=True)
+    (schema / "meta.json").write_text(json.dumps({}), encoding="utf-8")
+    (nodes / "demo-skill.json").write_text(
+        json.dumps(
+            {
+                "id": "demo-skill",
+                "name": "Demo Skill",
+                "type": "basic",
+                "description": "A demo skill for verify tests.",
+                "evidence": evidence,
+                "timeline": [],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return str(tmp_path)
+
+
+def _load_node(root: str) -> dict:
+    return json.loads(
+        (Path(root) / "registry" / "nodes" / "basic" / "demo-skill.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+
+def _args(root: str, **kw) -> SimpleNamespace:
+    base = dict(
+        registry=root,
+        skill_id="demo-skill",
+        index=0,
+        dispute=False,
+        notes=None,
+        source=None,
+        no_build=True,
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+@pytest.fixture(autouse=True)
+def _patches(monkeypatch):
+    monkeypatch.setattr("gaia_cli.commands.dev.verify._get_contributor", lambda: "verifier")
+    monkeypatch.setattr("gaia_cli.commands.dev.verify._is_verifier", lambda *a, **kw: True)
+    monkeypatch.setattr("gaia_cli.commands.dev.verify._run_docs_build", lambda *a, **kw: None)
+    monkeypatch.setattr("gaia_cli.commands.dev.verify.append_skill_event", lambda *a, **kw: None)
+
+
+def test_verify_negative_index_exits_before_write(tmp_path, capsys):
+    root = _make_registry(tmp_path, [{"source": "https://example.com/a"}])
+    before = _load_node(root)
+
+    with pytest.raises(SystemExit) as exc:
+        meta_verify_command(_args(root, index=-1))
+
+    assert exc.value.code != 0
+    assert _load_node(root) == before
+    assert "Evidence index -1 out of range" in capsys.readouterr().err
+
+
+def test_verify_invalid_source_url_exits_before_write(tmp_path, capsys):
+    root = _make_registry(tmp_path, [{"source": "https://example.com/a"}])
+    before = _load_node(root)
+
+    with pytest.raises(SystemExit) as exc:
+        meta_verify_command(_args(root, source="not-a-url"))
+
+    assert exc.value.code != 0
+    assert _load_node(root) == before
+    assert "absolute http(s) URL" in capsys.readouterr().err
+
+
+def test_verify_rejects_already_verified_before_write(tmp_path, capsys):
+    root = _make_registry(tmp_path, [{"source": "https://example.com/a", "verified": True}])
+    before = _load_node(root)
+
+    with pytest.raises(SystemExit) as exc:
+        meta_verify_command(_args(root))
+
+    assert exc.value.code != 0
+    assert _load_node(root) == before
+    assert "already verified" in capsys.readouterr().err
+
+
+def test_dispute_rejects_already_disputed_before_write(tmp_path, capsys):
+    root = _make_registry(tmp_path, [{"source": "https://example.com/a", "disputed": True}])
+    before = _load_node(root)
+
+    with pytest.raises(SystemExit) as exc:
+        meta_verify_command(_args(root, dispute=True))
+
+    assert exc.value.code != 0
+    assert _load_node(root) == before
+    assert "already disputed" in capsys.readouterr().err
+
+
+def test_verify_happy_path_marks_verified(tmp_path):
+    root = _make_registry(tmp_path, [{"source": "https://example.com/a"}])
+
+    meta_verify_command(_args(root, source="https://example.com/review"))
+
+    entry = _load_node(root)["evidence"][0]
+    assert entry["verified"] is True
+    assert entry["disputed"] is False
+    assert entry["verificationSource"] == "https://example.com/review"

--- a/tests/test_timeline_routing.py
+++ b/tests/test_timeline_routing.py
@@ -137,7 +137,7 @@ class TestAppendSkillEventRouting:
 
 
 # ---------------------------------------------------------------------------
-# Test: meta_timeline_command with --user routes to named file for named skill
+# Test: meta_timeline_command with --user routes to user tree even for named skill
 # ---------------------------------------------------------------------------
 
 class TestMetaTimelineCommandRouting:
@@ -152,12 +152,20 @@ class TestMetaTimelineCommandRouting:
         args.no_build = no_build
         return args
 
-    def test_timeline_with_user_routes_to_named_file_when_named_skill(self, tmp_path):
-        """meta_timeline_command with --user must write to named .md when skill is named."""
+    def test_timeline_with_user_routes_to_user_tree_when_skill_is_named(self, tmp_path):
+        """meta_timeline_command with --user must write to the user tree, even for named IDs."""
         from gaia_cli.commands.dev import meta_timeline_command
 
         root = _make_registry(tmp_path)
         named_md = root / "registry" / "named" / "testuser" / "myskill.md"
+        before_named = named_md.read_text(encoding="utf-8")
+        user_tree_dir = root / "skill-trees" / "mbtiongson1"
+        user_tree_dir.mkdir(parents=True)
+        user_tree = user_tree_dir / "skill-tree.json"
+        user_tree.write_text(
+            json.dumps({"username": "mbtiongson1", "unlockedSkills": [], "timeline": []}),
+            encoding="utf-8",
+        )
 
         args = self._make_args(
             skill_id="testuser/myskill",
@@ -170,13 +178,12 @@ class TestMetaTimelineCommandRouting:
 
         meta_timeline_command(args)
 
-        updated_content = named_md.read_text(encoding="utf-8")
-        assert "timeline:" in updated_content
-        assert "demote" in updated_content
-
-        # User tree must NOT be created/touched
-        user_tree = root / "skill-trees" / "mbtiongson1" / "skill-tree.json"
-        assert not user_tree.exists()
+        assert named_md.read_text(encoding="utf-8") == before_named
+        tree_data = json.loads(user_tree.read_text(encoding="utf-8"))
+        assert any(
+            ev.get("action") == "demote" and ev.get("skillId") == "testuser/myskill"
+            for ev in tree_data.get("timeline", [])
+        )
 
     def test_timeline_with_user_routes_to_user_tree_for_generic_skill(self, tmp_path):
         """meta_timeline_command with --user must write to user tree for generic skill IDs."""


### PR DESCRIPTION
## Summary

Refs #759.

Implements the remaining `gaia dev` preflight coverage for Sprint B closure:

- strengthens evidence validation for URL shape, numeric ranges, required benchmark/peer-review payloads, index patch fields, and duplicate-source warnings before write
- adds verify preflights for evidence index bounds (including negative indices), verification source URLs, and duplicate verified/disputed transitions before write
- fixes timeline `--user` routing so it always targets `skill-trees/<user>/skill-tree.json`, with timestamp/user-tree/registry-target preflights before write
- adds `calibrate-evidence-grades --skill` target existence preflight before destructive rewrites
- expands tests to assert no-write behavior for the newly covered failure paths

## Dev verb coverage matrix

| `gaia dev` verb | Classification | Preflight/status |
|---|---:|---|
| `list` | read-only | No verifier gate; unchanged. |
| `audit` | read-only | No verifier gate; unchanged. |
| `diff` | read-only | No verifier gate; unchanged. |
| `validate` | read-only | No verifier gate; unchanged. |
| `test` | read-only | No verifier gate; unchanged. |
| `mcp` | daemon management/read-mostly | Not in mutating dev registry set; unchanged. |
| `hook` | internal | Not in mutating dev registry set; unchanged. |
| `docs` | mutating via `docs build` path | Existing command path; not part of registry mutation preflight set. |
| `add` | mutating | Covered by prior preflights (description, ids, duplicates, named identity/generic ref/status/level). Regression tests retained. |
| `merge` | mutating | Covered by prior structural preflights (target/source existence, duplicates, type mixing). Regression tests retained. |
| `split` | mutating | Covered by prior structural preflights (source existence, target id validity/collisions). Regression tests retained. |
| `rename` | mutating | Covered by prior structural preflights (id validity/existence/collisions). Regression tests retained. |
| `calibrate` | mutating | Covered by named-only/level validation plus 3★+ Star Bar blob-link preflight. Regression tests retained. |
| `calibrate-evidence-grades` | mutating unless `--dry-run` | New: `--skill` must resolve to a generic ref, named id, or named generic ref before any rewrite. |
| `evidence` | mutating | New/strengthened: source URL, evidence type, trust/numeric ranges, benchmark percentile, peer-review reviewers, date formats, index update fields, index bounds, duplicate source warning before write. |
| `rm-evidence` | mutating | Existing index/source selection and bounds happen before writes; destructive confirmation remains. |
| `link` | mutating | Covered by prior preflights (target/prereq existence, self-link, duplicate list, duplicate relationship). Regression tests retained. |
| `reclassify` | mutating | Covered by prior preflights (type, existence, destination collision). Regression tests retained. |
| `update-named` | mutating | Covered by prior named preflights (named identity, suite components, GitHub blob link, generic ref). Regression tests retained. |
| `timeline` | mutating | New: timestamp ISO+timezone validation, `--timestamp` only with `--user`, existing user tree required, registry target exists when no `--user`; `--user` always routes to user tree. |
| `rm` | mutating | Covered by prior preflights (generic existence, no `genericSkillRef`/`suiteRef` users). Regression tests retained. |
| `verify` | mutating | New: evidence index bounds including negative values, verification source URL, reject duplicate verified/disputed transitions before write. |
| `verify-tier` | mutating | Existing target load fails before write; recompute is deterministic. |
| `build` | mutating generated artifacts | No schema/data invariant to preflight; docs build remains the operation and failure surface. |
| `release` | mutating git/version operation | Existing release workflow handles lockstep/version checks; out of registry-verb preflight scope. |

## Tests

- `python3 -m py_compile src/gaia_cli/commands/dev/helpers.py src/gaia_cli/commands/dev/evidence.py src/gaia_cli/commands/dev/verify.py src/gaia_cli/commands/dev/timeline.py src/gaia_cli/commands/dev/calibrate.py`
- `git diff --check`
- `PYTHONPATH=src pytest tests/test_dev_*.py tests/test_calibrate_evidence_grades.py tests/test_evidence_regrade.py tests/test_grading.py::TestEvidenceCLI::test_trust_derives_grade_a tests/test_timeline_routing.py` — 145 passed
- `PYTHONPATH=src pytest` — 1425 passed, 2 skipped, 1 failure: `tests/test_packaging.py::test_wheel_install_smoke_tests_console_script` fails because the temporary venv lacks `venv/bin/gaia` after wheel install. This appears unrelated to this PR's dev preflight changes.

## Notes / uncertainties

- Kept legacy `--trust` fallback behavior for evidence types like `arxiv`/`repo-own` to avoid breaking existing regrade and grading workflows; strict required payloads are enforced for `benchmark-result` and `peer-review` where missing fields are known to produce bad rows.
- `gaia dev timeline --user` now follows the documented closed-gap behavior: `--user` always writes to the user tree, not to named frontmatter even if the skill id is named.
