### PR TITLE
meta(timeline): audit apex tenure provenance backfill

### DIFF
--- a/registry/named/mattpocock/skills.md
+++ b/registry/named/mattpocock/skills.md
@@ -85,6 +85,14 @@ timeline:
   contributor: unknown
   details: Backfilled evidence sourceStartedAt via gaia dev evidence --index for GitHub
     stargazers (2026-02-03 repo creation) and arXiv source (2026-02-24 publication).
+- timestamp: '2026-07-02T08:25:19Z'
+  action: note
+  contributor: unknown
+  details: 'Post-#918 audit follow-up for #901: sourceStartedAt provenance was backfilled
+    on evidence #0 (https://github.com/mattpocock/skills/stargazers, sourceStartedAt
+    2026-02-03, repo creation date) and evidence #1 (https://arxiv.org/abs/2602.20867,
+    sourceStartedAt 2026-02-24, arXiv publication date). Metadata-only provenance
+    audit note; no rank, star, Trust Magnitude, grade, or apex-gate status changed.'
 evidence:
 - source: https://github.com/mattpocock/skills/stargazers
   evaluator: mbtiongson1


### PR DESCRIPTION
## Summary
- Adds a follow-up `note` timeline/audit event for the #901 historical `sourceStartedAt` backfill on `mattpocock/skills`.
- The note explicitly identifies the two affected evidence rows:
  - evidence #0: `https://github.com/mattpocock/skills/stargazers`, `sourceStartedAt: 2026-02-03` (repo creation date)
  - evidence #1: `https://arxiv.org/abs/2602.20867`, `sourceStartedAt: 2026-02-24` (arXiv publication date)
- The note states this was metadata-only provenance and did not change rank, stars, Trust Magnitude, grade, or apex-gate status.

Refs #746
Refs #918

## CLI command used
```bash
PYTHONPATH=src python3 -m gaia_cli dev timeline mattpocock/skills \
  --action note \
  --notes "Post-#918 audit follow-up for #901: sourceStartedAt provenance was backfilled on evidence #0 (https://github.com/mattpocock/skills/stargazers, sourceStartedAt 2026-02-03, repo creation date) and evidence #1 (https://arxiv.org/abs/2602.20867, sourceStartedAt 2026-02-24, arXiv publication date). Metadata-only provenance audit note; no rank, star, Trust Magnitude, grade, or apex-gate status changed." \
  --no-build
```

## Why this is accurate
- #918 makes future `gaia dev evidence --index --source-started-at ...` metadata updates emit accurate audit details, but #901 already applied the historical metadata values.
- Re-running evidence updates would be a no-op and would not emit an event; changing evidence fields just to force an audit event would be inaccurate.
- `gaia dev timeline --action note` is therefore the only CLI route that accurately records a historical metadata/provenance audit event without claiming rank/star/apex changes.

## Tests
- Generated local gitignored `registry/named-skills.json` from `docs/graph/gaia.json` so timeline validation could run locally.
- `PYTHONPATH=src pytest -q tests/test_dev_timeline.py tests/test_dev_evidence.py tests/test_apex_backfill.py tests/test_timelines.py`
- `PYTHONPATH=src python3 -m gaia_cli dev validate`
