### PR TITLE
[skill-tree] arukurmi

### DIFF
--- a/skill-trees/arukurmi/skill-tree.json
+++ b/skill-trees/arukurmi/skill-tree.json
@@ -1,0 +1,10 @@
+{
+  "userId": "arukurmi",
+  "updatedAt": "2026-07-03",
+  "unlockedSkills": [],
+  "pendingCombinations": [],
+  "stats": {
+    "totalUnlocked": 0,
+    "deepestLineage": 0
+  }
+}


### PR DESCRIPTION
## What

Adds my personal skill tree at `skill-trees/arukurmi/skill-tree.json`, per #844 ("Add yourself: create your personal skill tree").

## Details

This is the standard `gaia init` starter tree — a valid, empty tree scaffold for user `arukurmi`. It establishes my profile in the registry; skills will be promoted in follow-up contributions as they are genuinely used, keeping self-assessment honest rather than claiming unearned stars up front.

```json
{
  "userId": "arukurmi",
  "updatedAt": "2026-07-03",
  "unlockedSkills": [],
  "pendingCombinations": [],
  "stats": { "totalUnlocked": 0, "deepestLineage": 0 }
}
```

## Validation

- Validates against `registry/schema/skillTree.schema.json` (checked locally with `jsonschema`).
- Matches the canonical shape emitted by `gaia init`.
- No existing tree for this username; net-new file only, no other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)