### PR TITLE
schema: declare raw metric fields on evidenceEntry (#941)

### DIFF
--- a/.claude/skills/trust-methodology-consult/SKILL.md
+++ b/.claude/skills/trust-methodology-consult/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: trust-methodology-consult
+description: >
+  Consult this skill BEFORE proposing a fix to any CLI gap or schema gap that
+  touches evidence, trust magnitude, evidence types, evidence grades, or the
+  TM formula. Also read it whenever an issue mentions citations, stars,
+  commits, contributors, views, reviewers, percentile, arxiv, github-stars-own,
+  repo-own, social-signal, benchmark-result, peer-review, self-attestation,
+  fusion-recipe, verifier-attestation, or proxy-containment — those are the
+  10 canonical evidence types and the raw inputs that feed their formulas.
+  The trust methodology page at `docs/codex/trust-methodology.html` is the
+  documented source of truth for how trust is computed. It says explicitly:
+  "TM is computed at build time from a skill's evidence inventory, never
+  stored on a node." Reading it prevents proposing changes that would strip
+  the raw inputs the methodology depends on, or add fields the CLI already
+  writes and the TM engine already reads.
+---
+
+# Consult the trust methodology before touching CLI/schema evidence surface
+
+The Gaia trust surface is a three-layer contract. Skipping any layer when
+proposing a fix guarantees you either widen or narrow it incorrectly:
+
+| Layer | Source of truth |
+|---|---|
+| **Concept** — what the numbers mean and why they exist | `docs/codex/trust-methodology.html` (also mirrored in `docs/meta/2026-06-trust-methodology.md` and the G7 supersession note at `docs/meta/2026-06-17-g7-trust-magnitude-supersession.md`) |
+| **Compute** — how the numbers are actually produced | `src/gaia_cli/trustMagnitude.py` (backend); `docs/js/tm-config.js` (frontend SoT) |
+| **Persistence** — what shape the CLI writes and the schema bounds | `src/gaia_cli/commands/dev/evidence.py` (writer) + `registry/schema/skill.schema.json` + `registry/schema/namedSkill.schema.json` (bounds) |
+
+When an issue lands as "CLI gap" or "schema gap" on this surface, ONE of those
+layers is out of step with the other two. Your first job is to identify which.
+
+## The read pass — do this before writing code
+
+1. **Read the methodology page.** Open `docs/codex/trust-methodology.html`.
+   The "10 evidence types — base formula at a glance" table (search for
+   `base formula`) lists every evidence type and the raw input fields its
+   formula consumes. Confirm the field the issue names appears there.
+2. **Confirm the CLI writes it.** Grep `src/gaia_cli/commands/dev/evidence.py`
+   for the field name. If the flag exists and the writer stores it, the CLI
+   already treats that field as persistable.
+3. **Confirm the TM engine reads it.** Grep `src/gaia_cli/trustMagnitude.py`
+   for the field name via `row.get("<field>", ...)`. If the engine reads it,
+   the field is a first-class input, not a derived value.
+4. **Confirm the schema declares it.** Open the relevant `evidenceEntry`
+   definition and check the `properties` block. Because both schemas set
+   `additionalProperties: false`, any field the CLI writes but the schema
+   does not list will be rejected on the first `gaia dev validate` run —
+   which is exactly what surfaces most of these gaps.
+5. **Validate the failure locally, don't infer it.** Write a tiny probe file
+   with the field, run `jsonschema.validate(instance, schema)`, and observe
+   the exact rejection path. Do not trust an issue's diagnosis until the
+   local repro matches.
+
+## The design principle you must not violate
+
+The methodology page states, verbatim:
+
+> Trust Magnitude (TM) is the aggregate numeric signal for a skill's
+> trustworthiness. It is computed at build time from a skill's evidence
+> inventory, never stored on a node.
+
+That sentence pins the direction of every fix:
+
+- **Raw inputs are the persisted state.** Fields like `citations`, `stars`,
+  `commits`, `contributors`, `views`, `reviewers`, `percentile`, and
+  `skillCountInRepo` are the evidence inventory. They MUST be storable on an
+  evidence row so `gaia dev calibrate-evidence-grades` can re-derive grades
+  from them at any future time.
+- **Derived fields are ephemeral.** `trustMagnitude` and `overallTrustGrade`
+  are computed. They may appear on the merged graph or in reports but must
+  not become the persistence contract — otherwise you cannot recompute them
+  when the formula changes.
+- **Do not "collapse" raw inputs into `trustNumber` as a workaround.** Writing
+  only a pre-computed `trustNumber` to sidestep a schema rejection erases the
+  audit chain ("why did this row score 73?") and breaks the recompute path.
+  It is a legitimate one-off remediation when a schema fix is blocked; it is
+  never a design.
+
+## Decision matrix — what kind of gap is it?
+
+| Symptom | Most likely gap | Fix direction |
+|---|---|---|
+| CLI writes field `X`; TM engine reads field `X`; schema rejects `X` | **Schema gap** — schemas lag documented reality | Add `X` to `evidenceEntry.properties` in both `skill.schema.json` and `namedSkill.schema.json`; keep the two schemas symmetric |
+| CLI writes field `X`; TM engine ignores `X`; schema silent | **CLI over-writes** — the field is dead weight | Remove the write in `evidence.py`; document why |
+| CLI has no flag for `X`; TM engine reads `X`; schema silent | **CLI gap** — TM depends on data no operator can add | Add the flag + writer, then verify schema accepts it (add if needed) |
+| Methodology page mentions a metric not in the CLI or TM engine | **Doc drift** — treat as spec, not law | Open a discussion issue before touching any of the three layers |
+
+## The write pass — order matters
+
+The methodology page's own "if you change a formula" checklist applies, in
+this exact order. Do not skip a step or reorder them:
+
+1. `docs/js/tm-config.js` — frontend SoT for the formula
+2. `src/gaia_cli/trustMagnitude.py` — backend implementation
+3. `docs/codex/trust-methodology.html` — the doc itself
+4. `registry/schema/meta.json` — `perRowGradeThresholds` and `gradeCeiling`
+5. `tests/test_row_grading.py` + `tests/test_calibrate_evidence_grades.py`
+6. `python scripts/build_docs.py` — regenerate everything
+7. `gaia dev calibrate-evidence-grades --yes` — refresh stored grades
+
+If the gap is schema-only (as in Issue #941 — the field is already read and
+written, only the schema disagrees), most of that list does not apply —
+only steps 4-ish (extend the schema), 6 (regen docs), and 7 (rerun the
+calibration if any stored grade shifted) matter. Small schema changes still
+belong on a `schema/*` branch per the branch-scope rules.
+
+## What NOT to do
+
+- Do not "just remove the field" from the CLI when the TM engine still reads
+  it — you'll silently zero out every skill's citations-based magnitude.
+- Do not add the field to only one of the two schemas. Named and generic
+  evidence entries share the same shape; asymmetric schemas guarantee the
+  next reviewer will re-file the same issue.
+- Do not persist a pre-computed `trustNumber` in place of the raw input as a
+  "design" — see "The design principle you must not violate" above.
+- Do not re-derive the answer from memory. The methodology has been superseded
+  once already (2026-06-17, G7). Always re-read the page before acting.

--- a/registry/schema/namedSkill.schema.json
+++ b/registry/schema/namedSkill.schema.json
@@ -372,6 +372,47 @@
           "format": "date",
           "description": "ISO date the source project/repo/publication was first created or published. Optional for B/C/ungraded rows. Required at A/S tier for apex eligibility (gaia validate warns on A/S rows missing this field; hard-fail is I4's job post-cutover). Used by the sourceTenureDaysGte180AorS apex predicate."
         },
+        "citations": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Raw academic citation count for arxiv-type evidence. Consumed by the arxiv magnitude formula: citations / 5 (capped at 100). Persisted so `gaia dev calibrate-evidence-grades` can re-derive the grade if the formula changes."
+        },
+        "stars": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Raw GitHub star count for github-stars-own / proxy-containment / repo-own evidence. Consumed by the github-stars-own formula: min(200, stars/1000) / min(skillCountInRepo, 4)."
+        },
+        "commits": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Raw commit count for repo-own evidence. Consumed by the repo-own formula: (commits/200) + (contributors² × 2), capped at 60."
+        },
+        "contributors": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Distinct contributor count for repo-own evidence. Consumed alongside `commits` in the repo-own formula."
+        },
+        "views": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "View count for social-signal evidence. Consumed by the social-signal formula: log₁₀(views) × 8 × creator_mult × engagement_ratio. Views below 1000 score 0 (floor)."
+        },
+        "reviewers": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Peer reviewer count for peer-review evidence. Consumed by the peer-review formula: 25 × reviewers."
+        },
+        "percentile": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Benchmark placement percentile (0–100) for benchmark-result evidence. Directly consumed by the benchmark-result formula (magnitude = percentile). Required by the CLI when --type benchmark-result."
+        },
+        "skillCountInRepo": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of skills that share the source repo for github-stars-own / proxy-containment evidence. Used as the divisor in the github-stars-own 'mothership discount' — the star pool is split across all skills in the repo up to a cap of 4."
+        },
         "unverified": {
           "type": "boolean",
           "description": "Interim flag for proxy-containment entries whose claim has not yet been validated by the proxy-containment validator (RFC §11.2). Entry counts at full magnitude while flagged; surfaced in gaia evidence listings and audit reports."

--- a/registry/schema/skill.schema.json
+++ b/registry/schema/skill.schema.json
@@ -323,6 +323,47 @@
           "format": "date",
           "description": "ISO date the source project/repo/publication was first created or published. Optional for B/C/ungraded rows. Required at A/S tier for apex eligibility (gaia validate warns on A/S rows missing this field; hard-fail is I4's job post-cutover). Used by the sourceTenureDaysGte180AorS apex predicate."
         },
+        "citations": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Raw academic citation count for arxiv-type evidence. Consumed by the arxiv magnitude formula: citations / 5 (capped at 100). Persisted so `gaia dev calibrate-evidence-grades` can re-derive the grade if the formula changes."
+        },
+        "stars": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Raw GitHub star count for github-stars-own / proxy-containment / repo-own evidence. Consumed by the github-stars-own formula: min(200, stars/1000) / min(skillCountInRepo, 4)."
+        },
+        "commits": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Raw commit count for repo-own evidence. Consumed by the repo-own formula: (commits/200) + (contributors² × 2), capped at 60."
+        },
+        "contributors": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Distinct contributor count for repo-own evidence. Consumed alongside `commits` in the repo-own formula."
+        },
+        "views": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "View count for social-signal evidence. Consumed by the social-signal formula: log₁₀(views) × 8 × creator_mult × engagement_ratio. Views below 1000 score 0 (floor)."
+        },
+        "reviewers": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Peer reviewer count for peer-review evidence. Consumed by the peer-review formula: 25 × reviewers."
+        },
+        "percentile": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Benchmark placement percentile (0–100) for benchmark-result evidence. Directly consumed by the benchmark-result formula (magnitude = percentile). Required by the CLI when --type benchmark-result."
+        },
+        "skillCountInRepo": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of skills that share the source repo for github-stars-own / proxy-containment evidence. Used as the divisor in the github-stars-own 'mothership discount' — the star pool is split across all skills in the repo up to a cap of 4."
+        },
         "unverified": {
           "type": "boolean",
           "description": "Interim flag for proxy-containment entries whose claim has not yet been validated by the proxy-containment validator (RFC §11.2). Entry counts at full magnitude while flagged; surfaced in gaia evidence listings and audit reports."

--- a/src/gaia_cli/data/registry/schema/namedSkill.schema.json
+++ b/src/gaia_cli/data/registry/schema/namedSkill.schema.json
@@ -372,6 +372,47 @@
           "format": "date",
           "description": "ISO date the source project/repo/publication was first created or published. Optional for B/C/ungraded rows. Required at A/S tier for apex eligibility (gaia validate warns on A/S rows missing this field; hard-fail is I4's job post-cutover). Used by the sourceTenureDaysGte180AorS apex predicate."
         },
+        "citations": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Raw academic citation count for arxiv-type evidence. Consumed by the arxiv magnitude formula: citations / 5 (capped at 100). Persisted so `gaia dev calibrate-evidence-grades` can re-derive the grade if the formula changes."
+        },
+        "stars": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Raw GitHub star count for github-stars-own / proxy-containment / repo-own evidence. Consumed by the github-stars-own formula: min(200, stars/1000) / min(skillCountInRepo, 4)."
+        },
+        "commits": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Raw commit count for repo-own evidence. Consumed by the repo-own formula: (commits/200) + (contributors² × 2), capped at 60."
+        },
+        "contributors": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Distinct contributor count for repo-own evidence. Consumed alongside `commits` in the repo-own formula."
+        },
+        "views": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "View count for social-signal evidence. Consumed by the social-signal formula: log₁₀(views) × 8 × creator_mult × engagement_ratio. Views below 1000 score 0 (floor)."
+        },
+        "reviewers": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Peer reviewer count for peer-review evidence. Consumed by the peer-review formula: 25 × reviewers."
+        },
+        "percentile": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Benchmark placement percentile (0–100) for benchmark-result evidence. Directly consumed by the benchmark-result formula (magnitude = percentile). Required by the CLI when --type benchmark-result."
+        },
+        "skillCountInRepo": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of skills that share the source repo for github-stars-own / proxy-containment evidence. Used as the divisor in the github-stars-own 'mothership discount' — the star pool is split across all skills in the repo up to a cap of 4."
+        },
         "unverified": {
           "type": "boolean",
           "description": "Interim flag for proxy-containment entries whose claim has not yet been validated by the proxy-containment validator (RFC §11.2). Entry counts at full magnitude while flagged; surfaced in gaia evidence listings and audit reports."

--- a/src/gaia_cli/data/registry/schema/skill.schema.json
+++ b/src/gaia_cli/data/registry/schema/skill.schema.json
@@ -323,6 +323,47 @@
           "format": "date",
           "description": "ISO date the source project/repo/publication was first created or published. Optional for B/C/ungraded rows. Required at A/S tier for apex eligibility (gaia validate warns on A/S rows missing this field; hard-fail is I4's job post-cutover). Used by the sourceTenureDaysGte180AorS apex predicate."
         },
+        "citations": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Raw academic citation count for arxiv-type evidence. Consumed by the arxiv magnitude formula: citations / 5 (capped at 100). Persisted so `gaia dev calibrate-evidence-grades` can re-derive the grade if the formula changes."
+        },
+        "stars": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Raw GitHub star count for github-stars-own / proxy-containment / repo-own evidence. Consumed by the github-stars-own formula: min(200, stars/1000) / min(skillCountInRepo, 4)."
+        },
+        "commits": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Raw commit count for repo-own evidence. Consumed by the repo-own formula: (commits/200) + (contributors² × 2), capped at 60."
+        },
+        "contributors": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Distinct contributor count for repo-own evidence. Consumed alongside `commits` in the repo-own formula."
+        },
+        "views": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "View count for social-signal evidence. Consumed by the social-signal formula: log₁₀(views) × 8 × creator_mult × engagement_ratio. Views below 1000 score 0 (floor)."
+        },
+        "reviewers": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Peer reviewer count for peer-review evidence. Consumed by the peer-review formula: 25 × reviewers."
+        },
+        "percentile": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Benchmark placement percentile (0–100) for benchmark-result evidence. Directly consumed by the benchmark-result formula (magnitude = percentile). Required by the CLI when --type benchmark-result."
+        },
+        "skillCountInRepo": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of skills that share the source repo for github-stars-own / proxy-containment evidence. Used as the divisor in the github-stars-own 'mothership discount' — the star pool is split across all skills in the repo up to a cap of 4."
+        },
         "unverified": {
           "type": "boolean",
           "description": "Interim flag for proxy-containment entries whose claim has not yet been validated by the proxy-containment validator (RFC §11.2). Entry counts at full magnitude while flagged; surfaced in gaia evidence listings and audit reports."


### PR DESCRIPTION
## Summary
Closes #941. Blocker for #939.

Both \`skill.schema.json\` and \`namedSkill.schema.json\` set \`additionalProperties: false\` on \`evidenceEntry\` but do not declare the raw metric fields that the CLI writes and the TM engine reads. Any file that got its evidence via \`gaia dev evidence\` was silently at risk — and PR #939 tripped it.

Adds to \`evidenceEntry.properties\` in BOTH schemas:
- \`citations\` (arxiv formula)
- \`stars\` (github-stars-own, proxy-containment, repo-own)
- \`commits\` (repo-own)
- \`contributors\` (repo-own)
- \`views\` (social-signal)
- \`reviewers\` (peer-review)
- \`percentile\` (benchmark-result)
- \`skillCountInRepo\` (github-stars-own mothership discount)

Each field's description cross-references the formula that consumes it, per the trust methodology page's own audit contract.

## Design pin
Reason for adding fields (not stripping them from the CLI): the trust methodology page says explicitly that TM is \"computed at build time from a skill's evidence inventory, never stored on a node.\" That means the raw inputs ARE the persisted state and \`trustNumber\` is a derived value. Stripping the raw inputs would break the recompute path (\`gaia dev calibrate-evidence-grades\`) and erase the audit chain.

## Also lands
\`.claude/skills/trust-methodology-consult/SKILL.md\` — a consult-first skill that tells future agents to read the methodology before proposing changes to this surface. If this issue had triggered it, we would have gone straight to option 1 and skipped a round-trip.

## Verification
- \`jsonschema.validate\` on PR #939's failing \`registry/nodes/basic/sentiment-analysis.json\` now passes.
- \`scripts/validate.py\` reports \"All validation checks passed.\" against the entire live registry.
- No CLI code changes; no data migration needed.

## Token spend
2026-07-04 Opus 4.8 (extra-high) — logged on merge.