### PR TITLE
infra(build_docs): normalize bare version stamp in --check (unblocks PR churn)

### DIFF
--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -529,6 +529,13 @@ _VOLATILE_DATE_PATTERNS = (
     # JSON: "generatedAt", "registryGeneratedAt", or trending "updatedAt": "2026-06-13" | "...T..Z" → value blanked
     (re.compile(r'("(?:\w+)?(?:g|G)eneratedAt"\s*:\s*)"[^"]*"'), r'\1"<normalized>"'),
     (re.compile(r'("updatedAt"\s*:\s*)"\d{4}-\d{2}-\d{2}T[^"]*Z"'), r'\1"<normalized>"'),
+    # JSON: "version": "5.11.5" — bare semver stamp on generated API projections
+    # (docs/api/v1/health.json, ledger/data.json). The value is deterministically
+    # regenerated from pyproject.toml on every build; every PR opened between a
+    # release and its next auto-sync commit tripped `--check` on this field
+    # before this normalizer. Sibling patterns already cover the same drift in
+    # ?v= cache-bust strings and window.GAIA_VERSION.
+    (re.compile(r'("version"\s*:\s*)"\d+\.\d+\.\d+"'), r'\1"<normalized>"'),
     # docs/tree.md provenance lines, both forms:
     #   "GAIA SKILL TREE … · generated 2026-06-13"   (banner header)
     #   "Generated from gaia.json on 2026-06-13. …"  (footer)


### PR DESCRIPTION
## Summary
Every PR opened between a release and its next auto-sync commit currently trips \`build_docs.py --check\` on \`docs/api/v1/health.json\` and \`docs/graph/ledger/data.json\` because those files bake a \`\"version\": \"5.11.5\"\` string that gets bumped independently by the release process. The value is deterministically regenerated from \`pyproject.toml\` — the drift is meaningless — but the existing normalizer only covered HTML \`?v=\` and \`window.GAIA_VERSION\` (PR #780 / Issue #807), not bare JSON stamps.

This blocked PR #940 and PR #942 during the current session. Fixing the CI check itself is the right move — the code comments at build_docs.py:519–527 already identified this class of drift as the dominant source of post-#780 churn.

## Change
One line added to \`_VOLATILE_DATE_PATTERNS\`:

\`\`\`python
(re.compile(r'(\"version\"\s*:\s*)\"\d+\.\d+\.\d+\"'), r'\1\"<normalized>\"'),
\`\`\`

## Safety
- \`docs/api/v1/openapi.json\` contains bare \`\"version\"\` fields but is HAND-AUTHORED — build_docs copies the committed file into the tempdir before diffing, so the normalizer applies to nothing there in practice.
- \`docs/graph/gaia.json\` has per-skill \`\"version\"\` fields that ARE structural (bumped when a skill's data changes). That file is synced by \`syncDocsGraphAssets.py\`, which does NOT go through \`_normalize_dates\`. So real skill-version drift is still detected.
- \`docs/graph/ledger/data.json\` uses structural JSON compare and already strips version/generatedAt in its own path.

## Verified locally
- Two health.json blobs differing only on \`\"version\"\` — \`_equal_ignoring_dates()\` returns True (was False).
- Same shape with a real content change (\`namedSkillsCount\` diff) — still returns False, real drift is still flagged.