### PR TITLE
infra(branch-scope): add bundled schema mirror to schema/* allowlist

### DIFF
--- a/.github/workflows/branch-scope.yml
+++ b/.github/workflows/branch-scope.yml
@@ -110,8 +110,8 @@ jobs:
             case "$PREFIX" in
               schema)
                 case "$file" in
-                  registry/schema/*|*.md) ;; # allowed
-                  *) VIOLATIONS="$VIOLATIONS\n  ❌ $file (schema/ branches may only touch registry/schema/ or *.md files)" ;;
+                  registry/schema/*|src/gaia_cli/data/registry/schema/*|*.md) ;; # allowed
+                  *) VIOLATIONS="$VIOLATIONS\n  ❌ $file (schema/ branches may only touch registry/schema/, src/gaia_cli/data/registry/schema/, or *.md files)" ;;
                 esac
                 ;;
               cli)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,10 @@ Never push directly to main.
 
 `infra/` branches may touch `docs/badges/` (registry.json, _assets/) in addition to the standard `.github/`, `scripts/`, `*.md`, `docs/*.html`. This is codified in `.github/workflows/branch-scope.yml` and applies permanently — badge restore/guard commits belong on `infra/` branches and must not require `skip-scope-check` every time.
 
+## Branch Scope — schema/ allowlist
+
+`schema/` branches may touch `registry/schema/` **and** `src/gaia_cli/data/registry/schema/` (the bundled snapshot the pip-installed CLI reads) in addition to `*.md`. The two schema directories must move in lockstep — `scripts/validate.py` "Meta sync check" fails when they diverge — so a schema PR that only touches one side always trips CI. Codified in `.github/workflows/branch-scope.yml`; do not require `skip-scope-check` for routine schema bumps.
+
 ## Redaction Exemptions — ordained, do not re-litigate
 
 The following 8 contributor handles are **permanently exempt** from Section D badge-dir violations (`validate_redaction.py` + `build_docs.py`). Their `docs/badges/_assets/<handle>/` directories are kept intentionally. Do NOT remove them from the exemption list, do NOT delete their dirs, do NOT open issues about them. If any of them reach 2★ their dir becomes valid anyway and the exemption becomes a no-op.


### PR DESCRIPTION
## Summary
The canonical schemas at \`registry/schema/\` have a bundled mirror at \`src/gaia_cli/data/registry/schema/\` — \`scripts/validate.py\` \"Meta sync check\" fails when they diverge. Every schema/* PR that touches the canonical side must also update the mirror, but the branch-scope allowlist rejects the mirror path, forcing either a two-PR split or a \`skip-scope-check\` label on every routine schema bump.

Discovered while landing PR #942 (Issue #941). Applies to every future schema change.

## Fix
- \`.github/workflows/branch-scope.yml\`: allow \`src/gaia_cli/data/registry/schema/*\` alongside \`registry/schema/*\` on schema branches.
- \`CLAUDE.md\`: document under a new "Branch Scope — schema/ allowlist" section, mirroring the existing infra/* + docs/badges/ note.

Symmetric with the \`infra/*\` allowlist widening for \`docs/badges/\` — the two dirs are one logical unit, permanent scope widening is right, per-PR bypass is not.