### PR TITLE
infra(branch-scope): allow docs/ on review/meta/* branches

### DIFF
--- a/.github/workflows/branch-scope.yml
+++ b/.github/workflows/branch-scope.yml
@@ -140,13 +140,13 @@ jobs:
                 ;;
               review-meta)
                 case "$file" in
-                  registry/*|*.md) # allowed, but not schema
+                  registry/*|docs/*|*.md) # allowed, but not schema
                     case "$file" in
                       registry/schema/*) VIOLATIONS="$VIOLATIONS\n  ❌ $file (review/meta branches may not touch registry/schema/)" ;;
                       *) ;; # allowed
                     esac
                     ;;
-                  *) VIOLATIONS="$VIOLATIONS\n  ❌ $file (review/meta branches may only touch registry/ (excluding registry/schema/) or *.md files)" ;;
+                  *) VIOLATIONS="$VIOLATIONS\n  ❌ $file (review/meta branches may only touch registry/ (excluding registry/schema/), docs/, or *.md files)" ;;
                 esac
                 ;;
               jules)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,10 @@ Never push directly to main.
 
 `schema/` branches may touch `registry/schema/` **and** `src/gaia_cli/data/registry/schema/` (the bundled snapshot the pip-installed CLI reads) in addition to `*.md`. The two schema directories must move in lockstep — `scripts/validate.py` "Meta sync check" fails when they diverge — so a schema PR that only touches one side always trips CI. Codified in `.github/workflows/branch-scope.yml`; do not require `skip-scope-check` for routine schema bumps.
 
+## Branch Scope — review/meta/ allowlist
+
+`review/meta/` branches may touch `docs/` in addition to `registry/` (excluding `registry/schema/`) and `*.md`. This is required by Guard E: any change to `registry/nodes/` or `registry/named/` MUST include the regenerated Class S artifacts (`docs/graph/*`, `docs/api/v1/*`, per-user profile pages, badges) in the same PR. Codified in `.github/workflows/branch-scope.yml`; do not require `skip-scope-check` on every curation PR just to land the `gaia dev docs` output.
+
 ## Redaction Exemptions — ordained, do not re-litigate
 
 The following 8 contributor handles are **permanently exempt** from Section D badge-dir violations (`validate_redaction.py` + `build_docs.py`). Their `docs/badges/_assets/<handle>/` directories are kept intentionally. Do NOT remove them from the exemption list, do NOT delete their dirs, do NOT open issues about them. If any of them reach 2★ their dir becomes valid anyway and the exemption becomes a no-op.


### PR DESCRIPTION
## Summary
Guard E (docs-cohesion.yml) requires every registry mutation to ship with the regenerated Class S artifacts in the same PR. But \`review/meta/*\` scope only allows \`registry/\` and \`*.md\` — so every curation PR that ran \`gaia dev docs\` had to slap \`skip-scope-check\` on itself just to land the required output.

Pattern confirmed on PR #937: it had to bypass scope for 40+ Class S files (docs/api/v1/, docs/badges/, docs/graph/, docs/u/, docs/css/). Discovered while rebasing PR #939 today.

## Fix
- \`.github/workflows/branch-scope.yml\`: add \`docs/*\` to the review-meta allowlist (still excludes \`registry/schema/\`).
- \`CLAUDE.md\`: document under a new \"Branch Scope — review/meta/ allowlist\" section next to the schema/ and infra/ notes.

Same pattern as PR #944 (schema/ + bundled mirror) and the existing infra/ + docs/badges/ note. Permanent scope widening beats per-PR bypass.