### PR TITLE
fix(sprint-d): W2b honest KC4 attestor + superseded-pending validator (adversarial review HIGH+MEDIUM)

### DIFF
--- a/registry/named/addy-osmani/code-simplification.md
+++ b/registry/named/addy-osmani/code-simplification.md
@@ -87,8 +87,9 @@ evidence:
   score: 0.5
   unit: pass@1
   runAt: '2026-07-05T00:00:00Z'
-  provenance: ci-reproduced
-  attestor: https://github.com/gaia-research/gaia-skill-tree/actions/runs/w2b-kc4-bootstrap@286e46e72631bdb1e2332b3a9745255b3ddd0bda
+  provenance: pending
+  attestor: pending-ci-reproduction
+  notes: 'Dogfood seed; will be promoted to ci-reproduced by the first real workflow run of benchmark-humaneval-ci.yml.'
   datasetHash: 244753b2a3366bfbb271e76205fdd88e939c91705093c1a18eebd60fc8a0ebf8
   benchmarkInputHash: 3391b5f75da98f71962896b44acbfc37b37648d35474a10610e12b00c9e582a9
   harnessUrl: https://github.com/gaia-research/gaia-skill-tree/blob/286e46e72631bdb1e2332b3a9745255b3ddd0bda/scripts/benchmarks/humaneval/run.py

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -386,9 +386,11 @@ def validate_benchmark_provenance(graph, strict=False):
 
     Reject self-attested rows always (schema also blocks this at Draft-07
     level; kept as defence-in-depth for pre-migration corpus rows). Reject
-    pending rows when strict is on (main-merge protection). Warn on mirrored
-    rows so operators know their entry is citation-only and excluded from
-    Trust Magnitude.
+    pending rows when strict is on (main-merge protection), UNLESS a later
+    ci-reproduced or verifier-attested row exists for the same skill +
+    benchmarkId (superseded-pending carve-out). Warn on mirrored rows so
+    operators know their entry is citation-only and excluded from Trust
+    Magnitude.
 
     Returns a list of error strings; the caller merges these into all_errors.
     Prints mirrored warnings directly to stdout.
@@ -398,7 +400,9 @@ def validate_benchmark_provenance(graph, strict=False):
     skills = graph.get("skills", []) if isinstance(graph, dict) else graph
     for skill in skills:
         skill_id = skill.get("id", "<unknown>")
-        for idx, row in enumerate(skill.get("evidence") or []):
+        evidence_list = skill.get("evidence") or []
+        
+        for idx, row in enumerate(evidence_list):
             if row.get("type") != "benchmark-result":
                 continue
             provenance = row.get("provenance")
@@ -409,15 +413,29 @@ def validate_benchmark_provenance(graph, strict=False):
                     f"verifier-attested, mirrored, or pending."
                 )
             elif provenance == "pending":
-                message = (
-                    f"Skill '{skill_id}' evidence[{idx}] has provenance='pending' "
-                    f"— must be promoted to ci-reproduced or verifier-attested "
-                    f"before landing on main."
-                )
-                if strict:
-                    errors.append(message)
-                else:
-                    mirrored_warnings.append("(pending) " + message)
+                # Superseded-pending carve-out (Sprint D W2b #905): a pending row is
+                # allowed on main if a later row for the same skill + benchmarkId exists
+                # with provenance in ('ci-reproduced', 'verifier-attested').
+                benchmark_id = row.get("benchmarkId")
+                is_superseded = False
+                if benchmark_id:
+                    for later_row in evidence_list[idx+1:]:
+                        if (later_row.get("type") == "benchmark-result" and
+                            later_row.get("benchmarkId") == benchmark_id and
+                            later_row.get("provenance") in ("ci-reproduced", "verifier-attested")):
+                            is_superseded = True
+                            break
+                
+                if not is_superseded:
+                    message = (
+                        f"Skill '{skill_id}' evidence[{idx}] has provenance='pending' "
+                        f"— must be promoted to ci-reproduced or verifier-attested "
+                        f"before landing on main."
+                    )
+                    if strict:
+                        errors.append(message)
+                    else:
+                        mirrored_warnings.append("(pending) " + message)
             elif provenance == "mirrored":
                 mirrored_warnings.append(
                     f"Skill '{skill_id}' evidence[{idx}] is mirrored — "


### PR DESCRIPTION
Fixes the HIGH (dishonest ci-reproduced attestor on KC4 dogfood row) and MEDIUM (validator strict-mode blocks superseded pending rows) findings from PR #953 adversarial review.

**Commit 1 (HIGH):** demotes the KC4 row on addy-osmani/code-simplification.md to provenance: pending with an honest 'pending-ci-reproduction' attestor. First real workflow run of benchmark-humaneval-ci.yml will promote it correctly.

**Commit 2 (MEDIUM):** validator now respects superseded pending rows — a pending row is allowed on main if a later ci-reproduced/verifier-attested row exists for the same skill+benchmarkId. This prevents the CI workflow's append-without-prune pattern from tripping strict-mode validation.

Closes no issue — follow-up on merged PR #953.