### PR TITLE
fix(sprint-d): W1 archive template cache-busting (adversarial review HIGH)

### DIFF
--- a/scripts/contentEngine/generate_weekly_report.py
+++ b/scripts/contentEngine/generate_weekly_report.py
@@ -357,6 +357,7 @@ def _rebuildArchive(
     archiveJsonPath: Path,
     archiveHtmlPath: Path,
     generatedAt: str,
+    version: str,
 ) -> None:
     """Rebuild (not append) docs/api/v1/reports/index.json + docs/reports/index.html.
 
@@ -401,7 +402,7 @@ def _rebuildArchive(
     tpl = env.get_template("archive.html.j2")
     archiveHtmlPath.parent.mkdir(parents=True, exist_ok=True)
     archiveHtmlPath.write_text(
-        tpl.render(reports=entries, generatedAt=generatedAt),
+        tpl.render(reports=entries, generatedAt=generatedAt, version=version),
         encoding="utf-8",
     )
 
@@ -480,6 +481,7 @@ def run(
             targets["archiveJson"],
             targets["archiveHtml"],
             generatedAt,
+            version,
         )
         print(
             f"[content-engine] published: "

--- a/scripts/contentEngine/templates/archive.html.j2
+++ b/scripts/contentEngine/templates/archive.html.j2
@@ -14,14 +14,14 @@
   <meta property="og:title" content="Weekly Reports — Gaia">
   <meta property="og:description" content="Every Monday: what changed in the Gaia skill registry, mechanically compiled from the trending API.">
   <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
-  <link rel="stylesheet" href="../css/tokens.css">
-  <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="../css/tokens.css?v={{ version }}">
+  <link rel="stylesheet" href="../css/styles.css?v={{ version }}">
   <link rel="alternate" type="application/json" href="/api/v1/reports/index.json">
 </head>
 <body>
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js"></script>
-  <script src="../js/site-nav.js"></script>
+  <script src="../js/mounts.js?v={{ version }}"></script>
+  <script src="../js/site-nav.js?v={{ version }}"></script>
 
   <main class="reports-archive" style="max-width: 72rem; margin: 2rem auto; padding: 0 1.25rem; color: var(--text); font-family: 'EB Garamond', Georgia, serif; line-height: 1.6;">
     <header style="border-bottom: 1px solid var(--border); padding-bottom: 1rem; margin-bottom: 1.5rem;">


### PR DESCRIPTION
Fixes the HIGH finding from PR #950 adversarial review. archive.html.j2 rendered CSS hrefs unversioned; the weekly cron auto-PR would commit these and the live site would serve stale tokens.css for up to a week until the next human-triggered gaia dev docs run.

Mirrors the pattern already in report.html.j2 (per adversarial review).

Closes no issue — follow-up on merged PR #950.