### PR TITLE
fix(sprint-d/ci): preemptive CI-green for dev/sprint-d aggregate

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,5 @@ docs/graph/*.svg  -diff linguist-generated=true
 # API projection — generated JSON, collapse in PR diffs
 docs/api/v1/**/*.json linguist-generated=true
 docs/api/v1/trending/feed.xml linguist-generated=true
+docs/sitemap.xml text eol=lf
+docs/okf/index.json text eol=lf

--- a/docs/api/v1/health.json
+++ b/docs/api/v1/health.json
@@ -1,6 +1,6 @@
 {
   "ok": true,
-  "version": "5.11.7",
+  "version": "5.11.13",
   "registryGeneratedAt": "2026-07-04",
   "namedSkillsCount": 152
 }

--- a/docs/api/v1/skills/addy-osmani/code-simplification.json
+++ b/docs/api/v1/skills/addy-osmani/code-simplification.json
@@ -43,6 +43,22 @@
       "commits": 260,
       "contributors": 36,
       "grade": "B"
+    },
+    {
+      "source": "https://github.com/gaia-research/gaia-skill-tree/blob/286e46e72631bdb1e2332b3a9745255b3ddd0bda/scripts/benchmarks/humaneval/run.py",
+      "evaluator": "unknown",
+      "date": "2026-07-05",
+      "type": "benchmark-result",
+      "benchmarkId": "humaneval@v1.0",
+      "score": 0.5,
+      "unit": "pass@1",
+      "runAt": "2026-07-05T00:00:00Z",
+      "provenance": "pending",
+      "attestor": "pending-ci-reproduction",
+      "notes": "Dogfood seed; will be promoted to ci-reproduced by the first real workflow run of benchmark-humaneval-ci.yml.",
+      "datasetHash": "244753b2a3366bfbb271e76205fdd88e939c91705093c1a18eebd60fc8a0ebf8",
+      "benchmarkInputHash": "3391b5f75da98f71962896b44acbfc37b37648d35474a10610e12b00c9e582a9",
+      "harnessUrl": "https://github.com/gaia-research/gaia-skill-tree/blob/286e46e72631bdb1e2332b3a9745255b3ddd0bda/scripts/benchmarks/humaneval/run.py"
     }
   ],
   "timeline": [
@@ -116,6 +132,12 @@
       "action": "rank_up",
       "contributor": "unknown",
       "details": "Calibrated level from 2★ to 3★"
+    },
+    {
+      "timestamp": "2026-07-04T22:20:58Z",
+      "action": "evidence_added",
+      "contributor": "unknown",
+      "details": "Added evidence from https://github.com/gaia-research/gaia-skill-tree/blob/286e46e72631bdb1e2332b3a9745255b3ddd0bda/scripts/benchmarks/humaneval/run.py (type: benchmark-result)"
     }
   ],
   "links": {

--- a/docs/api/v1/skills/anthropic/skill-creator.json
+++ b/docs/api/v1/skills/anthropic/skill-creator.json
@@ -59,6 +59,20 @@
       "class": "A",
       "notes": "Claude Code community: engineering discipline for prompt engineering praised, A/B eval harness noted for overhead on long refinement loops. Mid-2026.",
       "grade": "C"
+    },
+    {
+      "source": "https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard",
+      "evaluator": "unknown",
+      "date": "2026-07-05",
+      "type": "benchmark-result",
+      "benchmarkId": "mmlu@2024-03",
+      "score": 86.8,
+      "unit": "pct",
+      "runAt": "2024-03-01T00:00:00Z",
+      "provenance": "mirrored",
+      "attestor": "https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard",
+      "datasetHash": "ab313191b8c989dea045d52eeb8896a4646eb66140b0f7723b8f0ebebea43eb5",
+      "benchmarkInputHash": "6fa69c944f0e74add4ed3a136321e0247224eb1a8cebab1e0a85763532d6daf5"
     }
   ],
   "timeline": [
@@ -121,6 +135,12 @@
       "action": "rank_up",
       "contributor": "mbtiongson1",
       "details": "Level updated from 2★ to 3★ per G7 final rankings calibration."
+    },
+    {
+      "timestamp": "2026-07-04T22:34:14Z",
+      "action": "evidence_added",
+      "contributor": "unknown",
+      "details": "Added evidence from https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard (type: benchmark-result)"
     }
   ],
   "links": {

--- a/docs/api/v1/skills/huggingface/semantic-cache.json
+++ b/docs/api/v1/skills/huggingface/semantic-cache.json
@@ -45,6 +45,20 @@
       "contributors": 10,
       "trustNumber": 70.0,
       "grade": "B"
+    },
+    {
+      "source": "https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard",
+      "evaluator": "unknown",
+      "date": "2026-07-05",
+      "type": "benchmark-result",
+      "benchmarkId": "mmlu@2024-03",
+      "score": 63.9,
+      "unit": "pct",
+      "runAt": "2024-03-01T00:00:00Z",
+      "provenance": "mirrored",
+      "attestor": "https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard",
+      "datasetHash": "ab313191b8c989dea045d52eeb8896a4646eb66140b0f7723b8f0ebebea43eb5",
+      "benchmarkInputHash": "641e81ab9f021cec48470ee367820d5d8da81b22c92bbe31b0cf1e6d214066ac"
     }
   ],
   "timeline": [
@@ -109,6 +123,12 @@
       "action": "rank_up",
       "contributor": "mbtiongson1",
       "details": "Level updated from 1★ to 2★ per G7 final rankings calibration."
+    },
+    {
+      "timestamp": "2026-07-04T22:35:20Z",
+      "action": "evidence_added",
+      "contributor": "unknown",
+      "details": "Added evidence from https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard (type: benchmark-result)"
     }
   ]
 }

--- a/docs/api/v1/skills/openai/few-shot-learning.json
+++ b/docs/api/v1/skills/openai/few-shot-learning.json
@@ -43,6 +43,20 @@
       "notes": "GPT-3 few-shot learning paper (Brown et al. 2020) — foundational, 50k+ citations",
       "citations": 50000,
       "grade": "S"
+    },
+    {
+      "source": "https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard",
+      "evaluator": "unknown",
+      "date": "2026-07-05",
+      "type": "benchmark-result",
+      "benchmarkId": "mmlu@2024-03",
+      "score": 86.4,
+      "unit": "pct",
+      "runAt": "2024-03-01T00:00:00Z",
+      "provenance": "mirrored",
+      "attestor": "https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard",
+      "datasetHash": "ab313191b8c989dea045d52eeb8896a4646eb66140b0f7723b8f0ebebea43eb5",
+      "benchmarkInputHash": "ededff463522c1793c65ce5c79411e4c1f5bbf4c7f369466a8dafbb61a9faca4"
     }
   ],
   "timeline": [
@@ -82,6 +96,12 @@
       "action": "rank_up",
       "contributor": "mbtiongson1",
       "details": "Level updated from 2★ to 4★ per G7 final rankings calibration."
+    },
+    {
+      "timestamp": "2026-07-04T22:34:46Z",
+      "action": "evidence_added",
+      "contributor": "unknown",
+      "details": "Added evidence from https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard (type: benchmark-result)"
     }
   ],
   "links": {

--- a/docs/benchmarks/index.html
+++ b/docs/benchmarks/index.html
@@ -1,6 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+  <meta http-equiv="Pragma" content="no-cache">
+  <meta http-equiv="Expires" content="0">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Benchmarks | Gaia Registry</title>
@@ -10,8 +14,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;500;600;700&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
-  <link rel="stylesheet" href="../css/tokens.css">
-  <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../css/styles.css?v=5.11.13">
 
   <script>
     window.gaiaIconBase = function () { return '../assets/icons.svg'; };
@@ -131,8 +135,8 @@
 </head>
 <body>
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js"></script>
-  <script src="../js/site-nav.js"></script>
+  <script src="../js/mounts.js?v=5.11.13"></script>
+  <script src="../js/site-nav.js?v=5.11.13"></script>
 
   <main class="benchmarks-shell">
     <header class="benchmarks-header">
@@ -182,6 +186,6 @@
   </main>
 
   <div id="site-footer"></div>
-  <script src="../js/site-footer.js"></script>
+  <script src="../js/site-footer.js?v=5.11.13"></script>
 </body>
 </html>

--- a/docs/graph/named/index.json
+++ b/docs/graph/named/index.json
@@ -1144,10 +1144,26 @@
             "commits": 260,
             "contributors": 36,
             "grade": "B"
+          },
+          {
+            "source": "https://github.com/gaia-research/gaia-skill-tree/blob/286e46e72631bdb1e2332b3a9745255b3ddd0bda/scripts/benchmarks/humaneval/run.py",
+            "evaluator": "unknown",
+            "date": "2026-07-05",
+            "type": "benchmark-result",
+            "benchmarkId": "humaneval@v1.0",
+            "score": 0.5,
+            "unit": "pass@1",
+            "runAt": "2026-07-05T00:00:00Z",
+            "provenance": "pending",
+            "attestor": "pending-ci-reproduction",
+            "notes": "Dogfood seed; will be promoted to ci-reproduced by the first real workflow run of benchmark-humaneval-ci.yml.",
+            "datasetHash": "244753b2a3366bfbb271e76205fdd88e939c91705093c1a18eebd60fc8a0ebf8",
+            "benchmarkInputHash": "3391b5f75da98f71962896b44acbfc37b37648d35474a10610e12b00c9e582a9",
+            "harnessUrl": "https://github.com/gaia-research/gaia-skill-tree/blob/286e46e72631bdb1e2332b3a9745255b3ddd0bda/scripts/benchmarks/humaneval/run.py"
           }
         ],
         "createdAt": "2026-07-03",
-        "updatedAt": "2026-07-03",
+        "updatedAt": "2026-07-05",
         "timeline": [
           {
             "timestamp": "2026-07-02T18:42:19Z",
@@ -1219,6 +1235,12 @@
             "action": "rank_up",
             "contributor": "unknown",
             "details": "Calibrated level from 2★ to 3★"
+          },
+          {
+            "timestamp": "2026-07-04T22:20:58Z",
+            "action": "evidence_added",
+            "contributor": "unknown",
+            "details": "Added evidence from https://github.com/gaia-research/gaia-skill-tree/blob/286e46e72631bdb1e2332b3a9745255b3ddd0bda/scripts/benchmarks/humaneval/run.py (type: benchmark-result)"
           }
         ],
         "suiteRef": "addy-osmani/agent-skills",
@@ -4028,10 +4050,24 @@
             "class": "A",
             "notes": "Claude Code community: engineering discipline for prompt engineering praised, A/B eval harness noted for overhead on long refinement loops. Mid-2026.",
             "grade": "C"
+          },
+          {
+            "source": "https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard",
+            "evaluator": "unknown",
+            "date": "2026-07-05",
+            "type": "benchmark-result",
+            "benchmarkId": "mmlu@2024-03",
+            "score": 86.8,
+            "unit": "pct",
+            "runAt": "2024-03-01T00:00:00Z",
+            "provenance": "mirrored",
+            "attestor": "https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard",
+            "datasetHash": "ab313191b8c989dea045d52eeb8896a4646eb66140b0f7723b8f0ebebea43eb5",
+            "benchmarkInputHash": "6fa69c944f0e74add4ed3a136321e0247224eb1a8cebab1e0a85763532d6daf5"
           }
         ],
         "createdAt": "2026-04-30",
-        "updatedAt": "2026-06-21",
+        "updatedAt": "2026-07-05",
         "timeline": [
           {
             "timestamp": "2026-06-02T23:33:00Z",
@@ -4092,6 +4128,12 @@
             "action": "rank_up",
             "contributor": "mbtiongson1",
             "details": "Level updated from 2★ to 3★ per G7 final rankings calibration."
+          },
+          {
+            "timestamp": "2026-07-04T22:34:14Z",
+            "action": "evidence_added",
+            "contributor": "unknown",
+            "details": "Added evidence from https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard (type: benchmark-result)"
           }
         ],
         "trustMagnitude": 90.0,
@@ -13800,10 +13842,24 @@
             "contributors": 10,
             "trustNumber": 70.0,
             "grade": "B"
+          },
+          {
+            "source": "https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard",
+            "evaluator": "unknown",
+            "date": "2026-07-05",
+            "type": "benchmark-result",
+            "benchmarkId": "mmlu@2024-03",
+            "score": 63.9,
+            "unit": "pct",
+            "runAt": "2024-03-01T00:00:00Z",
+            "provenance": "mirrored",
+            "attestor": "https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard",
+            "datasetHash": "ab313191b8c989dea045d52eeb8896a4646eb66140b0f7723b8f0ebebea43eb5",
+            "benchmarkInputHash": "641e81ab9f021cec48470ee367820d5d8da81b22c92bbe31b0cf1e6d214066ac"
           }
         ],
         "createdAt": "2026-05-15",
-        "updatedAt": "2026-06-21",
+        "updatedAt": "2026-07-05",
         "timeline": [
           {
             "timestamp": "2026-06-02T23:48:18Z",
@@ -13866,6 +13922,12 @@
             "action": "rank_up",
             "contributor": "mbtiongson1",
             "details": "Level updated from 1★ to 2★ per G7 final rankings calibration."
+          },
+          {
+            "timestamp": "2026-07-04T22:35:20Z",
+            "action": "evidence_added",
+            "contributor": "unknown",
+            "details": "Added evidence from https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard (type: benchmark-result)"
           }
         ],
         "trustMagnitude": 36.0,
@@ -18668,10 +18730,24 @@
             "notes": "GPT-3 few-shot learning paper (Brown et al. 2020) — foundational, 50k+ citations",
             "citations": 50000,
             "grade": "S"
+          },
+          {
+            "source": "https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard",
+            "evaluator": "unknown",
+            "date": "2026-07-05",
+            "type": "benchmark-result",
+            "benchmarkId": "mmlu@2024-03",
+            "score": 86.4,
+            "unit": "pct",
+            "runAt": "2024-03-01T00:00:00Z",
+            "provenance": "mirrored",
+            "attestor": "https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard",
+            "datasetHash": "ab313191b8c989dea045d52eeb8896a4646eb66140b0f7723b8f0ebebea43eb5",
+            "benchmarkInputHash": "ededff463522c1793c65ce5c79411e4c1f5bbf4c7f369466a8dafbb61a9faca4"
           }
         ],
         "createdAt": "2026-05-15",
-        "updatedAt": "2026-06-21",
+        "updatedAt": "2026-07-05",
         "timeline": [
           {
             "action": "migrate_trust_magnitude",
@@ -18709,6 +18785,12 @@
             "action": "rank_up",
             "contributor": "mbtiongson1",
             "details": "Level updated from 2★ to 4★ per G7 final rankings calibration."
+          },
+          {
+            "timestamp": "2026-07-04T22:34:46Z",
+            "action": "evidence_added",
+            "contributor": "unknown",
+            "details": "Added evidence from https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard (type: benchmark-result)"
           }
         ],
         "trustMagnitude": 100.0,

--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../assets/icons.svg">
 <head>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -14,8 +15,8 @@
   <meta property="og:title" content="Weekly Reports — Gaia">
   <meta property="og:description" content="Every Monday: what changed in the Gaia skill registry, mechanically compiled from the trending API.">
   <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
-  <link rel="stylesheet" href="../css/tokens.css">
-  <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../css/styles.css?v=5.11.13">
   <link rel="alternate" type="application/json" href="/api/v1/reports/index.json">
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
@@ -28,8 +29,8 @@
 </head>
 <body>
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js"></script>
-  <script src="../js/site-nav.js"></script>
+  <script src="../js/mounts.js?v=5.11.13"></script>
+  <script src="../js/site-nav.js?v=5.11.13"></script>
 
   <main class="reports-archive" style="max-width: 72rem; margin: 2rem auto; padding: 0 1.25rem; color: var(--text); font-family: 'EB Garamond', Georgia, serif; line-height: 1.6;">
     <header style="border-bottom: 1px solid var(--border); padding-bottom: 1rem; margin-bottom: 1.5rem;">

--- a/docs/u/0xdarkmatter/index.html
+++ b/docs/u/0xdarkmatter/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@0xdarkmatter — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -167,14 +167,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/Manavarya09/index.html
+++ b/docs/u/Manavarya09/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@Manavarya09 — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -167,14 +167,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/Taoidle/index.html
+++ b/docs/u/Taoidle/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@Taoidle — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -167,14 +167,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/addy-osmani/index.html
+++ b/docs/u/addy-osmani/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@addy-osmani — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -175,14 +175,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/anthropic/index.html
+++ b/docs/u/anthropic/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@anthropic — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -168,14 +168,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/bradautomates/index.html
+++ b/docs/u/bradautomates/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@bradautomates — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -167,14 +167,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/browser-use/index.html
+++ b/docs/u/browser-use/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@browser-use — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -167,14 +167,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/browserbase/index.html
+++ b/docs/u/browserbase/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@browserbase — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -167,14 +167,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/changkun/index.html
+++ b/docs/u/changkun/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@changkun — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -167,14 +167,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/devin-ai/index.html
+++ b/docs/u/devin-ai/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@devin-ai — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -167,14 +167,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/firecrawl/index.html
+++ b/docs/u/firecrawl/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@firecrawl — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -167,14 +167,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/gaiabot/index.html
+++ b/docs/u/gaiabot/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@gaiabot — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -168,14 +168,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/garrytan/index.html
+++ b/docs/u/garrytan/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@garrytan — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -213,14 +213,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/getagentseal/index.html
+++ b/docs/u/getagentseal/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@getagentseal — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -167,14 +167,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/glincker/index.html
+++ b/docs/u/glincker/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@glincker — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -167,14 +167,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/google-deepmind/index.html
+++ b/docs/u/google-deepmind/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@google-deepmind — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -203,14 +203,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/gooseworks/index.html
+++ b/docs/u/gooseworks/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@gooseworks — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -167,14 +167,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/gsd-build/index.html
+++ b/docs/u/gsd-build/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@gsd-build — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -172,14 +172,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/huggingface/index.html
+++ b/docs/u/huggingface/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@huggingface — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -173,14 +173,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/intelligentcode-ai/index.html
+++ b/docs/u/intelligentcode-ai/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@intelligentcode-ai — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -174,14 +174,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/karpathy/index.html
+++ b/docs/u/karpathy/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@karpathy — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -167,14 +167,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/langgenius/index.html
+++ b/docs/u/langgenius/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@langgenius — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -171,14 +171,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/laravel/index.html
+++ b/docs/u/laravel/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@laravel — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -167,14 +167,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/martin-stepanoski/index.html
+++ b/docs/u/martin-stepanoski/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@martin-stepanoski — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -167,14 +167,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/mattpocock/index.html
+++ b/docs/u/mattpocock/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@mattpocock — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -200,14 +200,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/mbtiongson1/index.html
+++ b/docs/u/mbtiongson1/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@mbtiongson1 — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -178,14 +178,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/nexu-io/index.html
+++ b/docs/u/nexu-io/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@nexu-io — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -167,14 +167,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/nousresearch/index.html
+++ b/docs/u/nousresearch/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@nousresearch — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -167,14 +167,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/obra/index.html
+++ b/docs/u/obra/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@obra — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -178,14 +178,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/openai/index.html
+++ b/docs/u/openai/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@openai — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -168,14 +168,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/pbakaus/index.html
+++ b/docs/u/pbakaus/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@pbakaus — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -167,14 +167,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/pexp13/index.html
+++ b/docs/u/pexp13/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@pexp13 — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -168,14 +168,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/ruvnet/index.html
+++ b/docs/u/ruvnet/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@ruvnet — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -214,14 +214,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/safishamsi/index.html
+++ b/docs/u/safishamsi/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@safishamsi — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -167,14 +167,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/santifer/index.html
+++ b/docs/u/santifer/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@santifer — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -167,14 +167,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/sickn33/index.html
+++ b/docs/u/sickn33/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@sickn33 — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -169,14 +169,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/spring-ai/index.html
+++ b/docs/u/spring-ai/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@spring-ai — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -167,14 +167,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/stanfordnlp/index.html
+++ b/docs/u/stanfordnlp/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@stanfordnlp — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -167,14 +167,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/upsonic/index.html
+++ b/docs/u/upsonic/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@upsonic — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -167,14 +167,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/vercel/index.html
+++ b/docs/u/vercel/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@vercel — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -167,14 +167,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/xquik-dev/index.html
+++ b/docs/u/xquik-dev/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@xquik-dev — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -167,14 +167,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/yonatangross/index.html
+++ b/docs/u/yonatangross/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@yonatangross — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -167,14 +167,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/docs/u/yundu-ai/index.html
+++ b/docs/u/yundu-ai/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.4";</script>
+  <script>window.GAIA_VERSION = "5.11.13";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>@yundu-ai — Gaia Skill Registry</title>
@@ -16,18 +16,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/styles.css?v=5.11.4">
-  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.4">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.13">
+  <link rel="stylesheet" href="../../css/plaque.css?v=5.11.13">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../../js/icons.js?v=5.11.4"></script>
+  <script src="../../js/icons.js?v=5.11.13"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../../js/rank-badge.js?v=5.11.4"></script>
+  <script src="../../js/rank-badge.js?v=5.11.13"></script>
   <!-- Stage 3 — TM config (single source of truth for formulas/RFC), before plaque. -->
-  <script src="../../js/tm-config.js?v=5.11.4"></script>
+  <script src="../../js/tm-config.js?v=5.11.13"></script>
   <!-- Stage 4 — plaque component family, loaded after tm-config.js. -->
-  <script src="../../js/plaque.js?v=5.11.4"></script>
-  <script src="../../js/ui.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque.js?v=5.11.13"></script>
+  <script src="../../js/ui.js?v=5.11.13" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 <body class="profile-page">
 
   <nav id="site-nav"></nav>
-<script src="../../js/mounts.js?v=5.11.4"></script>
-<script src="../../js/site-nav.js?v=5.11.4"></script>
+<script src="../../js/mounts.js?v=5.11.13"></script>
+<script src="../../js/site-nav.js?v=5.11.13"></script>
 
   <div class="profile-grid-container">
     <main class="profile-main">
@@ -167,14 +167,14 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../../js/site-footer.js?v=5.11.4"></script>
+<script src="../../js/site-footer.js?v=5.11.13"></script>
 
-  <script src="../../js/plaque-reveal.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-timeline.js?v=5.11.4" defer></script>
-  <script src="../../js/profile-filter.js?v=5.11.4" defer></script>
-  <script src="../../js/named-skills.js?v=5.11.4" defer></script>
-  <script src="../../js/skill-explorer.js?v=5.11.4" defer></script>
-  <script src="../../js/hoh-modal.js?v=5.11.4" defer></script>
+  <script src="../../js/plaque-reveal.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-timeline.js?v=5.11.13" defer></script>
+  <script src="../../js/profile-filter.js?v=5.11.13" defer></script>
+  <script src="../../js/named-skills.js?v=5.11.13" defer></script>
+  <script src="../../js/skill-explorer.js?v=5.11.13" defer></script>
+  <script src="../../js/hoh-modal.js?v=5.11.13" defer></script>
 
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
     <svg class="ico" width="20" height="20" aria-hidden="true"><use href="../../assets/icons.svg#arrow-up"/></svg>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
+    "jinja2>=3.0",
     "jsonschema>=4.17.0",
     "pyyaml>=6.0",
     "questionary>=2.0.0",

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -724,7 +724,7 @@ def build_docs_named_index(check: bool) -> bool:
 
 # Files that live in docs/api/v1/ but are hand-authored (not emitted by
 # buildApiProjection.py).  They must be preserved across every regen cycle.
-_API_HAND_AUTHORED = ["openapi.json", "trending"]
+_API_HAND_AUTHORED = ["openapi.json", "trending", "benchmarks", "reports"]
 
 
 def build_trust_ledger(check: bool) -> bool:

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -961,6 +961,26 @@ def build_profile_pages(check: bool) -> bool:
                 _apply_cache_busting(gen_index.read_text(encoding="utf-8"), version),
                 encoding="utf-8",
             )
+        # JSON-LD injection (scripts/injectJsonLd.py) runs in a separate
+        # build_docs step AFTER profile pages are written to disk. In check
+        # mode the tempdir pages lack JSON-LD blocks, causing perpetual drift
+        # against the committed pages which have JSON-LD already injected.
+        # Apply the same injection here so the comparison is like-for-like.
+        # NOTE: out_dir = <tmp>/u  →  inject_file classifies relative to the
+        # parent of out_dir so paths appear as u/<handle>/index.html (3 parts),
+        # matching the _classify(parts[0] == "u") branch.
+        try:
+            import importlib.util as _ilu
+            _spec = _ilu.spec_from_file_location(
+                "injectJsonLd", SCRIPTS / "injectJsonLd.py"
+            )
+            _ild = _ilu.module_from_spec(_spec)  # type: ignore[arg-type]
+            _spec.loader.exec_module(_ild)  # type: ignore[union-attr]
+            _ild.DOCS_DIR = out_dir.parent  # parent so rel = u/<handle>/index.html
+            for _hp in sorted(out_dir.rglob("*.html")):
+                _ild.inject_file(_hp, check=False)
+        except Exception:
+            pass  # JSON-LD injection is best-effort in check mode
         if not committed.exists():
             if check:
                 print("diff docs/u/ (missing)")

--- a/scripts/generateSitemap.py
+++ b/scripts/generateSitemap.py
@@ -163,9 +163,23 @@ def main(argv: list[str] | None = None) -> int:
             print("docs/sitemap.xml missing — run generateSitemap.py to create it")
             return 1
         existing = out_path.read_text(encoding="utf-8")
-        if existing == rendered:
+        # Normalize line endings when comparing to avoid Windows CRLF vs Linux LF
+        # false positives across platforms.
+        if existing.replace("\r\n", "\n") == rendered.replace("\r\n", "\n"):
             return 0
         print("docs/sitemap.xml is stale — run generateSitemap.py to regenerate")
+        # Print a small unified diff so future CI failures are debuggable.
+        import difflib
+        diff = list(difflib.unified_diff(
+            existing.splitlines(keepends=False)[:100],
+            rendered.splitlines(keepends=False)[:100],
+            lineterm="",
+            fromfile="committed",
+            tofile="regenerated",
+            n=1,
+        ))
+        for line in diff[:40]:
+            print(line)
         return 1
 
     # Write mode


### PR DESCRIPTION
Preemptive CI-fix child PR into dev/sprint-d, opened before the aggregate dev/sprint-d → main PR. Fixes:

- jinja2 promoted from [dev] to core runtime deps (W1 Content Engine needs it in the cron path).
- Class S artifacts regenerated for W1's /reports/, W2a's /benchmarks/, and the /skills/ + /u/ profile surfaces.
- Cache-bust version stamps aligned (5.11.4 → 5.11.13 across all Sprint-D pages).
- API skill projections updated with W3/W4 benchmark evidence rows.
- **Root cause fix #1**: Added `benchmarks` and `reports` to `_API_HAND_AUTHORED` in `scripts/build_docs.py` — `buildApiProjection.py` was silently deleting these Sprint-D-owned dirs on every `gaia dev docs` run.
- **Root cause fix #2**: Apply JSON-LD injection to the profile pages tempdir in `--check` mode — W5's `injectJsonLd.py` adds JSON-LD blocks to committed profile pages, but `build_profile_pages --check` was not simulating that step before comparison, causing perpetual drift on all 43 contributor profile pages.

After this + W4 (#958) merge, the aggregate dev/sprint-d → main PR opens with a clean CI slate.

## Commits

- `97a05a9` fix(sprint-d/ci): promote jinja2 to core runtime dependency  
- `521c641` chore(sprint-d/ci): regenerate Class S docs artifacts for Sprint D surfaces  
- `d18c3cb` fix(sprint-d/ci): apply JSON-LD injection in build_profile_pages --check mode