### PR TITLE
feat(content-engine): weekly report 2026-28 (Sprint D orbit close)

### DIFF
--- a/docs/api/v1/reports/2026-28.json
+++ b/docs/api/v1/reports/2026-28.json
@@ -1,0 +1,257 @@
+{
+  "schemaVersion": "1.0.0",
+  "reportId": "2026-28",
+  "isoYear": 2026,
+  "isoWeek": 28,
+  "generatedAt": "2026-07-06T11:32:53Z",
+  "generator": "gaia-content-engine",
+  "generatorVersion": "5.11.16",
+  "salvageLayer": "L3",
+  "sections": {
+    "trending": {
+      "title": "Trending this week",
+      "entries": [
+        {
+          "id": "addy-osmani/agent-skills",
+          "name": "Agent Skills",
+          "contributor": "addy-osmani",
+          "level": "5★",
+          "trustMagnitude": 293.14,
+          "trustGrade": "S",
+          "trendingScore": 146.57,
+          "tmDelta": 293.14,
+          "isNew": true,
+          "url": "https://gaiaskilltree.com/named/#explorer/addy-osmani/agent-skills"
+        },
+        {
+          "id": "gsd-build/get-shit-done",
+          "name": "Get Shit Done",
+          "contributor": "gsd-build",
+          "level": "4★",
+          "trustMagnitude": 202.16,
+          "trustGrade": "A",
+          "trendingScore": 101.08,
+          "tmDelta": 202.16,
+          "isNew": true,
+          "url": "https://gaiaskilltree.com/named/#explorer/gsd-build/get-shit-done"
+        },
+        {
+          "id": "addy-osmani/performance-optimization",
+          "name": "Performance Optimization",
+          "contributor": "addy-osmani",
+          "level": "4★",
+          "trustMagnitude": 83.2,
+          "trustGrade": "B",
+          "trendingScore": 50.0,
+          "tmDelta": 0.0,
+          "isNew": false,
+          "url": "https://gaiaskilltree.com/named/#explorer/addy-osmani/performance-optimization"
+        },
+        {
+          "id": "addy-osmani/code-review-and-quality",
+          "name": "Code Review and Quality",
+          "contributor": "addy-osmani",
+          "level": "3★",
+          "trustMagnitude": 53.14,
+          "trustGrade": "B",
+          "trendingScore": 26.57,
+          "tmDelta": 53.14,
+          "isNew": true,
+          "url": "https://gaiaskilltree.com/named/#explorer/addy-osmani/code-review-and-quality"
+        },
+        {
+          "id": "addy-osmani/code-simplification",
+          "name": "Code Simplification",
+          "contributor": "addy-osmani",
+          "level": "3★",
+          "trustMagnitude": 53.14,
+          "trustGrade": "B",
+          "trendingScore": 26.57,
+          "tmDelta": 53.14,
+          "isNew": true,
+          "url": "https://gaiaskilltree.com/named/#explorer/addy-osmani/code-simplification"
+        }
+      ]
+    },
+    "ascended": {
+      "title": "Recently ascended",
+      "entries": [
+        {
+          "id": "addy-osmani/performance-optimization",
+          "name": "Performance Optimization",
+          "contributor": "addy-osmani",
+          "level": "4★",
+          "previousLevel": "3★",
+          "trustMagnitude": 83.2,
+          "trustGrade": "B",
+          "ascendedAt": "2026-07-03T19:57:07Z",
+          "url": "https://gaiaskilltree.com/named/#explorer/addy-osmani/performance-optimization"
+        },
+        {
+          "id": "addy-osmani/agent-skills",
+          "name": "Agent Skills",
+          "contributor": "addy-osmani",
+          "level": "5★",
+          "previousLevel": null,
+          "trustMagnitude": 293.14,
+          "trustGrade": "S",
+          "ascendedAt": "2026-07-02T21:46:18Z",
+          "url": "https://gaiaskilltree.com/named/#explorer/addy-osmani/agent-skills"
+        },
+        {
+          "id": "gsd-build/get-shit-done",
+          "name": "Get Shit Done",
+          "contributor": "gsd-build",
+          "level": "4★",
+          "previousLevel": "2★",
+          "trustMagnitude": 202.16,
+          "trustGrade": "A",
+          "ascendedAt": "2026-07-02T21:34:10Z",
+          "url": "https://gaiaskilltree.com/named/#explorer/gsd-build/get-shit-done"
+        },
+        {
+          "id": "gsd-build/ship",
+          "name": "GSD Ship",
+          "contributor": "gsd-build",
+          "level": "3★",
+          "previousLevel": "2★",
+          "trustMagnitude": 52.16,
+          "trustGrade": "B",
+          "ascendedAt": "2026-07-02T21:34:10Z",
+          "url": "https://gaiaskilltree.com/named/#explorer/gsd-build/ship"
+        },
+        {
+          "id": "gsd-build/execute-phase",
+          "name": "GSD Execute Phase",
+          "contributor": "gsd-build",
+          "level": "3★",
+          "previousLevel": "2★",
+          "trustMagnitude": 52.16,
+          "trustGrade": "B",
+          "ascendedAt": "2026-07-02T21:34:09Z",
+          "url": "https://gaiaskilltree.com/named/#explorer/gsd-build/execute-phase"
+        }
+      ]
+    },
+    "contested": {
+      "title": "Most contested spaces",
+      "entries": [
+        {
+          "genericSkillRef": "git-ship-done-pipeline",
+          "implementations": 2,
+          "topTM": 293.14,
+          "skills": [
+            {
+              "id": "addy-osmani/agent-skills",
+              "level": "5★",
+              "trustMagnitude": 293.14,
+              "trustGrade": "S",
+              "origin": true,
+              "url": "https://gaiaskilltree.com/named/#explorer/addy-osmani/agent-skills"
+            },
+            {
+              "id": "gsd-build/get-shit-done",
+              "level": "4★",
+              "trustMagnitude": 202.16,
+              "trustGrade": "A",
+              "origin": false,
+              "url": "https://gaiaskilltree.com/named/#explorer/gsd-build/get-shit-done"
+            }
+          ]
+        },
+        {
+          "genericSkillRef": "vertical-slice-planning",
+          "implementations": 3,
+          "topTM": 156.0,
+          "skills": [
+            {
+              "id": "garrytan/garrytan",
+              "level": "4★",
+              "trustMagnitude": 156.0,
+              "trustGrade": "A",
+              "origin": true,
+              "url": "https://gaiaskilltree.com/named/#explorer/garrytan/garrytan"
+            },
+            {
+              "id": "mattpocock/to-issues",
+              "level": "3★",
+              "trustMagnitude": 90.38,
+              "trustGrade": "B",
+              "origin": false,
+              "url": "https://gaiaskilltree.com/named/#explorer/mattpocock/to-issues"
+            },
+            {
+              "id": "addy-osmani/planning-and-task-breakdown",
+              "level": "3★",
+              "trustMagnitude": 53.14,
+              "trustGrade": "B",
+              "origin": false,
+              "url": "https://gaiaskilltree.com/named/#explorer/addy-osmani/planning-and-task-breakdown"
+            }
+          ]
+        },
+        {
+          "genericSkillRef": "ux-audit",
+          "implementations": 6,
+          "topTM": 122.8,
+          "skills": [
+            {
+              "id": "pbakaus/impeccable",
+              "level": "4★",
+              "trustMagnitude": 122.8,
+              "trustGrade": "A",
+              "origin": true,
+              "url": "https://gaiaskilltree.com/named/#explorer/pbakaus/impeccable"
+            },
+            {
+              "id": "martin-stepanoski/nielsen-heuristics-audit",
+              "level": "3★",
+              "trustMagnitude": 94.9,
+              "trustGrade": "B",
+              "origin": false,
+              "url": "https://gaiaskilltree.com/named/#explorer/martin-stepanoski/nielsen-heuristics-audit"
+            },
+            {
+              "id": "garrytan/plan-design-review",
+              "level": "3★",
+              "trustMagnitude": 63.73,
+              "trustGrade": "B",
+              "origin": false,
+              "url": "https://gaiaskilltree.com/named/#explorer/garrytan/plan-design-review"
+            },
+            {
+              "id": "garrytan/plan-devex-review",
+              "level": "3★",
+              "trustMagnitude": 63.73,
+              "trustGrade": "B",
+              "origin": false,
+              "url": "https://gaiaskilltree.com/named/#explorer/garrytan/plan-devex-review"
+            },
+            {
+              "id": "garrytan/design-review",
+              "level": "2★",
+              "trustMagnitude": 36.0,
+              "trustGrade": "C",
+              "origin": false,
+              "url": "https://gaiaskilltree.com/named/#explorer/garrytan/design-review"
+            },
+            {
+              "id": "garrytan/devex-review",
+              "level": "2★",
+              "trustMagnitude": 36.0,
+              "trustGrade": "C",
+              "origin": false,
+              "url": "https://gaiaskilltree.com/named/#explorer/garrytan/devex-review"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "urls": {
+    "canonical": "https://gaiaskilltree.com/reports/2026-28/",
+    "json": "https://gaiaskilltree.com/api/v1/reports/2026-28.json",
+    "previous": "https://gaiaskilltree.com/reports/2026-27/",
+    "archive": "https://gaiaskilltree.com/reports/"
+  }
+}

--- a/docs/api/v1/reports/index.json
+++ b/docs/api/v1/reports/index.json
@@ -1,5 +1,15 @@
 {
   "schemaVersion": "1.0.0",
-  "generatedAt": null,
-  "reports": []
+  "generatedAt": "2026-07-06T11:32:53Z",
+  "reports": [
+    {
+      "reportId": "2026-28",
+      "url": "/reports/2026-28/",
+      "json": "/api/v1/reports/2026-28.json",
+      "generatedAt": "2026-07-06T11:32:53Z",
+      "salvageLayer": "L3",
+      "isoYear": 2026,
+      "isoWeek": 28
+    }
+  ]
 }

--- a/docs/reports/2026-28/index.html
+++ b/docs/reports/2026-28/index.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en" data-icon-base="../../assets/icons.svg">
+<head>
+  <script>window.GAIA_VERSION = "5.11.16";</script>
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+  <meta http-equiv="Pragma" content="no-cache">
+  <meta http-equiv="Expires" content="0">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="generator" content="gaia-content-engine">
+  <title>Weekly Report 2026-28 — Gaia</title>
+  <meta name="description" content="Gaia weekly report for ISO week 2026-28 — trending skills, recent rank-ups, and the most contested skill spaces.">
+  <link rel="canonical" href="https://gaiaskilltree.com/reports/2026-28/">
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="Gaia Weekly Report · 2026-28">
+  <meta property="og:description" content="What's moving in the Gaia skill registry — ISO week 2026-28.">
+  <meta property="og:url" content="https://gaiaskilltree.com/reports/2026-28/">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/svg+xml" href="../../assets/marks/diamond-seal.svg">
+  <link rel="stylesheet" href="../../css/tokens.css?v=5.11.16">
+  <link rel="stylesheet" href="../../css/styles.css?v=5.11.16">
+  <link rel="alternate" type="application/json" href="https://gaiaskilltree.com/api/v1/reports/2026-28.json">
+</head>
+<body>
+  <nav id="site-nav"></nav>
+  <script src="../../js/mounts.js?v=5.11.16"></script>
+  <script src="../../js/site-nav.js?v=5.11.16"></script>
+
+  <main class="report-body" style="max-width: 72rem; margin: 2rem auto; padding: 0 1.25rem; color: var(--text); font-family: 'EB Garamond', Georgia, serif; line-height: 1.6;">
+    <div style="font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: .75rem; color: var(--muted); letter-spacing: .12em; text-transform: uppercase; margin-bottom: .5rem;">
+      Weekly Report · Salvage Layer L3
+    </div>
+    <pre class="report-markdown" style="white-space: pre-wrap; font-family: inherit; font-size: 1rem; background: transparent; padding: 0; margin: 0;"># Weekly Report · 2026-28
+
+> **Report ID:** `2026-28` · **ISO week:** 2026-W28
+> **Generated:** 2026-07-06T11:32:53Z · **Layer:** `L3` · **Generator:** gaia-content-engine v5.11.16
+
+[← Previous week](https://gaiaskilltree.com/reports/2026-27/) · [Archive](https://gaiaskilltree.com/reports/) · [Canonical JSON](https://gaiaskilltree.com/api/v1/reports/2026-28.json)
+
+## Trending this week
+
+| Rank | Skill | Contributor | Level | Trust Magnitude | Δ TM |
+| ---: | :--- | :--- | :---: | ---: | ---: |
+| 1 | [Agent Skills](https://gaiaskilltree.com/named/#explorer/addy-osmani/agent-skills) | addy-osmani | 5★ | 293.1 · S | new |
+| 2 | [Get Shit Done](https://gaiaskilltree.com/named/#explorer/gsd-build/get-shit-done) | gsd-build | 4★ | 202.2 · A | new |
+| 3 | [Performance Optimization](https://gaiaskilltree.com/named/#explorer/addy-osmani/performance-optimization) | addy-osmani | 4★ | 83.2 · B | — |
+| 4 | [Code Review and Quality](https://gaiaskilltree.com/named/#explorer/addy-osmani/code-review-and-quality) | addy-osmani | 3★ | 53.1 · B | new |
+| 5 | [Code Simplification](https://gaiaskilltree.com/named/#explorer/addy-osmani/code-simplification) | addy-osmani | 3★ | 53.1 · B | new |
+
+## Recently ascended
+
+| Skill | Contributor | Rank change | Trust Magnitude | Ascended at |
+| :--- | :--- | :---: | ---: | :--- |
+| [Performance Optimization](https://gaiaskilltree.com/named/#explorer/addy-osmani/performance-optimization) | addy-osmani | 3★ → 4★ | 83.2 · B | 2026-07-03T19:57:07Z |
+| [Agent Skills](https://gaiaskilltree.com/named/#explorer/addy-osmani/agent-skills) | addy-osmani | → 5★ | 293.1 · S | 2026-07-02T21:46:18Z |
+| [Get Shit Done](https://gaiaskilltree.com/named/#explorer/gsd-build/get-shit-done) | gsd-build | 2★ → 4★ | 202.2 · A | 2026-07-02T21:34:10Z |
+| [GSD Ship](https://gaiaskilltree.com/named/#explorer/gsd-build/ship) | gsd-build | 2★ → 3★ | 52.2 · B | 2026-07-02T21:34:10Z |
+| [GSD Execute Phase](https://gaiaskilltree.com/named/#explorer/gsd-build/execute-phase) | gsd-build | 2★ → 3★ | 52.2 · B | 2026-07-02T21:34:09Z |
+
+## Most contested spaces
+
+### `git-ship-done-pipeline` — 2 implementations
+
+_Top TM in this space: **293.1**_
+
+| Skill | Level | Trust Magnitude | Grade | Origin? |
+| :--- | :---: | ---: | :---: | :---: |
+| [addy-osmani/agent-skills](https://gaiaskilltree.com/named/#explorer/addy-osmani/agent-skills) | 5★ | 293.1 | S | ✓ |
+| [gsd-build/get-shit-done](https://gaiaskilltree.com/named/#explorer/gsd-build/get-shit-done) | 4★ | 202.2 | A | — |
+
+### `vertical-slice-planning` — 3 implementations
+
+_Top TM in this space: **156.0**_
+
+| Skill | Level | Trust Magnitude | Grade | Origin? |
+| :--- | :---: | ---: | :---: | :---: |
+| [garrytan/garrytan](https://gaiaskilltree.com/named/#explorer/garrytan/garrytan) | 4★ | 156.0 | A | ✓ |
+| [mattpocock/to-issues](https://gaiaskilltree.com/named/#explorer/mattpocock/to-issues) | 3★ | 90.4 | B | — |
+| [addy-osmani/planning-and-task-breakdown](https://gaiaskilltree.com/named/#explorer/addy-osmani/planning-and-task-breakdown) | 3★ | 53.1 | B | — |
+
+### `ux-audit` — 6 implementations
+
+_Top TM in this space: **122.8**_
+
+| Skill | Level | Trust Magnitude | Grade | Origin? |
+| :--- | :---: | ---: | :---: | :---: |
+| [pbakaus/impeccable](https://gaiaskilltree.com/named/#explorer/pbakaus/impeccable) | 4★ | 122.8 | A | ✓ |
+| [martin-stepanoski/nielsen-heuristics-audit](https://gaiaskilltree.com/named/#explorer/martin-stepanoski/nielsen-heuristics-audit) | 3★ | 94.9 | B | — |
+| [garrytan/plan-design-review](https://gaiaskilltree.com/named/#explorer/garrytan/plan-design-review) | 3★ | 63.7 | B | — |
+| [garrytan/plan-devex-review](https://gaiaskilltree.com/named/#explorer/garrytan/plan-devex-review) | 3★ | 63.7 | B | — |
+| [garrytan/design-review](https://gaiaskilltree.com/named/#explorer/garrytan/design-review) | 2★ | 36.0 | C | — |
+| [garrytan/devex-review](https://gaiaskilltree.com/named/#explorer/garrytan/devex-review) | 2★ | 36.0 | C | — |
+
+
+---
+
+_Generated mechanically by the [Gaia Content Engine](https://github.com/gaia-research/gaia-skill-tree/tree/main/scripts/contentEngine). Data flows from `/api/v1/trending/*.json` — recomputed daily by `buildTrendingProjection.py`. Salvage layer: `L3`._
+</pre>
+  </main>
+
+  <footer style="max-width: 72rem; margin: 3rem auto 2rem; padding: 1.5rem 1.25rem 0; color: var(--muted); font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: .75rem; border-top: 1px solid var(--border);">
+    <a href="https://gaiaskilltree.com/reports/" style="color: var(--muted); text-decoration: none;">← All reports</a>
+    · <a href="https://gaiaskilltree.com/api/v1/reports/2026-28.json" style="color: var(--muted); text-decoration: none;">Canonical JSON</a>
+  </footer>
+</body>
+</html>

--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "5.11.16";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -18,14 +17,6 @@
   <link rel="stylesheet" href="../css/tokens.css?v=5.11.16">
   <link rel="stylesheet" href="../css/styles.css?v=5.11.16">
   <link rel="alternate" type="application/json" href="/api/v1/reports/index.json">
-<script type="application/ld+json" data-injector="gaia-json-ld">
-{
-  "@context": "https://schema.org",
-  "@type": "WebPage",
-  "name": "Index",
-  "url": "https://gaiaskilltree.com/reports/"
-}
-</script>
 </head>
 <body>
   <nav id="site-nav"></nav>
@@ -39,7 +30,15 @@
       <p style="color: var(--muted); font-size: .95rem; margin-top: .5rem;">One report per ISO week. Trending, ascended, contested — mechanically compiled from the <a href="/api/v1/trending/" style="color: var(--evidence-gold);">trending API</a>.</p>
     </header>
 
-      <p style="color: var(--muted);">No reports published yet — the first one lands Monday 08:00 UTC.</p>
+      <ul style="list-style: none; padding: 0; margin: 0;">
+        <li style="padding: 1rem 0; border-bottom: 1px solid var(--border);">
+          <a href="/reports/2026-28/" style="color: var(--text); font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 1.1rem; text-decoration: none;">
+            2026-28
+          </a>
+          <span style="color: var(--muted); font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: .75rem; margin-left: 1rem;">ISO 2026-W28</span>
+<span style="color: var(--muted); font-size: .75rem; margin-left: 1rem;">Layer <code>L3</code></span>          <span style="color: var(--muted); font-size: .75rem; margin-left: 1rem;"><a href="/api/v1/reports/2026-28.json" style="color: var(--muted);">JSON</a></span>
+        </li>
+      </ul>
 
     <footer style="margin-top: 2rem; color: var(--muted); font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: .75rem;">
       Archive rebuilt on every publish. Machine-readable index: <a href="/api/v1/reports/index.json" style="color: var(--muted);">/api/v1/reports/index.json</a>.


### PR DESCRIPTION
Auto-generated weekly Content Engine report — first live publication via KC1+KC3 dispatch, closing the Sprint D flywheel orbit alongside KC4's fresh `addy-osmani/code-simplification` `humaneval@v1.0 = 0.75 pass@1` `ci-reproduced` row.

- Canonical JSON: `docs/api/v1/reports/2026-28.json`
- Public HTML: `docs/reports/2026-28/index.html`
- Archive rebuilt: `docs/reports/index.html` + `docs/api/v1/reports/index.json`

The salvage layer is stamped into the canonical JSON's `salvageLayer` field so a post-mortem can identify which layer produced this report.

Also includes:
- `d856a50b1` — KC4 humaneval ci-reproduced row (auto-committed by benchmark-humaneval-ci run 28785817438)
- `384caadc2` — content-engine workflow idempotency fix (force-with-lease upsert, skip PR-create if branch OPEN) so future same-week re-dispatches don't crash on stale branches

## Migration notes

- **Portable:** `scripts/contentEngine/**/*.py`, `templates/`, `tests/contentEngine/`, `.github/workflows/weekly-content-engine.yml`. Survives Sprint F.
- **Rewrites:** `docs/reports/**/*.html` and `docs/reports/index.html` — Sprint F Next.js `<Report>` page consumes `docs/api/v1/reports/YYYY-WW.json` unchanged.
- **Invariants:** URL `/reports/YYYY-WW/` FROZEN. Canonical JSON shape at `docs/api/v1/reports/YYYY-WW.json` FROZEN (SDK contract). ISO week format `%G-%V` FROZEN.

## Entrypoints

Waived — no new user-facing surface; the `/reports/YYYY-WW/` URL pattern and `/reports/` archive index are already registered (planned in EPIC #902 W1). Cache-busting for `docs/reports/2026-28/index.html` picks up automatically via `build_html_cache_busting()` at next `gaia dev docs` (already handles `docs/reports/**/*.html` wildcards).

## Follow-up

- Flip repo Settings → Actions → General → Workflow permissions → **Allow GitHub Actions to create and approve pull requests** so future weekly dispatches self-open PRs without operator handholding.

Reviewer: Marco. Sprint D flywheel: substance (KC4 ci-reproduced) ↔ megaphone (KC1+KC3 published report).