### PR TITLE
fix(ci): branch-scope guard survives all-bot commit windows

### DIFF
--- a/.github/workflows/branch-scope.yml
+++ b/.github/workflows/branch-scope.yml
@@ -79,9 +79,15 @@ jobs:
           # Merge commits and github-actions[bot] commits (auto-regen, sync) are
           # intentionally excluded so automated maintenance does not trigger false
           # scope violations on otherwise-clean branches.
+          #
+          # NOTE: `grep -v` returns exit 1 when it filters out EVERY line (i.e.
+          # 100% of commits are bot-authored — the case for weekly-content-engine
+          # cron branches). With `set -euo pipefail`, that would kill the script
+          # silently with no violation output. `|| true` on the grep + a safe
+          # awk fallback keep the pipeline zero-exit in that case.
           HUMAN_COMMITS=$(
             git log --no-merges --format="%H %ae" "$MERGE_BASE..HEAD" \
-              | grep -v 'github-actions\[bot\]' \
+              | { grep -v 'github-actions\[bot\]' || true; } \
               | awk '{print $1}'
           )
 


### PR DESCRIPTION
## Why

Weekly-content-engine cron produces branches with 100% `github-actions[bot]` commits. The scope-check pipeline:

```
git log ... | grep -v 'github-actions[bot]' | awk ...
```

Under `set -euo pipefail`, `grep -v` exits 1 when it filters out every line, `pipefail` cascades, script dies with no violation output. First surfaced on PR #966 today (weekly report 2026-28), but the Monday cron will hit the same class of failure every week going forward.

## Fix

Wrap the `grep` in braces with `|| true` so zero-line output is treated as 'no human commits, nothing to check' rather than an uncaught pipeline failure. The downstream `if [ -z "$HUMAN_COMMITS" ]; then ...` already handles the empty case cleanly — this just lets execution reach it.

## Scope

- `.github/workflows/branch-scope.yml` — 7 insertions, 1 deletion. Adds `|| true` and a 6-line comment explaining the failure mode.

Behavior unchanged for any branch with at least one human commit. Pre-existing scope violations still fail-loud as before.

## Entrypoints

Waived — CI-only fix, no user-facing surface.