### PR TITLE
fix(ui): v6.0.2 fast-follow polish — hero CTAs, footer dedupe, drawer parity, em-dash prune

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -226,6 +226,8 @@
       <div class="hero-pills">
         <button class="field-trigger" type="button" id="hudToggleBtn" aria-pressed="false" aria-label="Toggle field view"><svg class="ico" width="14" height="14" aria-hidden="true"><use href="assets/icons.svg#hud-toggle"/></svg> Field view</button>
         <a class="field-trigger" href="trust/ledger/" aria-label="Trust Ledger" style="text-decoration:none;">◆ Trust Ledger</a>
+        <a class="field-trigger" href="benchmarks/" aria-label="Benchmarks" style="text-decoration:none;">▲ Benchmarks</a>
+        <a class="field-trigger" href="reports/" aria-label="Weekly Reports" style="text-decoration:none;">◇ Weekly Reports</a>
       </div>
       <h1 class="hero-title">
         Skills are catalogued.<br>
@@ -664,7 +666,7 @@
        Per-rank colour comes from .rank-badge[data-level="N"] tokens. -->
   <section id="ascension" class="reveal ascension-section" data-section="ascension">
     <h2>The Ascension Cycle</h2>
-    <p class="section-sub">Skills advance through evidence — not declaration. Each rank unlocks the next.</p>
+    <p class="section-sub">Skills advance through evidence, not declaration. Each rank unlocks the next.</p>
     <div class="ascension-track" data-pattern="journey">
       <div class="asc-stage">
         <div class="asc-node">
@@ -721,7 +723,7 @@
        .grade-bar / .grade-segment from styles.css L10281+. -->
   <section id="evidence-cycle" class="reveal evidence-cycle-section" data-section="evidence-cycle">
     <h2>Evidence Grade</h2>
-    <p class="section-sub">A skill earns its Overall Trust Grade by the strength of the evidence behind it. Four tiers — Bronze, Silver, Gold, Platinum — mark the aggregate Trust Magnitude that a skill's evidence pool reaches.</p>
+    <p class="section-sub">A skill earns its Overall Trust Grade by the strength of the evidence behind it. Four tiers (Bronze, Silver, Gold, Platinum) mark the aggregate Trust Magnitude that a skill's evidence pool reaches.</p>
     <div class="grade-bar">
       <div class="grade-row">
         <div class="grade-segment grade-plat"><span class="grade-label">Platinum (S) ≥ 250 trust</span></div>
@@ -791,7 +793,7 @@
           <a href="meta/reports/2026-06-20-gaia-trust-infrastructure-a-june-2026-retrospective.html" class="pmq-post">
             <span class="pmq-label">Trust Model</span>
             <h4 class="pmq-title">GAIA Trust Infrastructure: A June 2026 Retrospective <span class="meta-peek-arrow" style="float: right;">↗</span></h4>
-            <p class="pmq-summary">Phase 1 baseline through Phase 1.5 ratification — G7 RFC, Trust Magnitude formula, apex gate, public Trust Ledger. Now includes the Phase 1.5 closeout addendum on per-evidence grade calibration and the Trust Ledger May/June rollout.</p>
+            <p class="pmq-summary">Phase 1 baseline through Phase 1.5 ratification: G7 RFC, Trust Magnitude formula, apex gate, public Trust Ledger. Now includes the Phase 1.5 closeout addendum on per-evidence grade calibration and the Trust Ledger May/June rollout.</p>
           </a>
           <!-- gaia-posts-end -->
       <button type="button" class="pmq-changelog-btn" id="metaChangelogBtnPath">Open Meta Changelog →</button>

--- a/docs/js/site-footer.js
+++ b/docs/js/site-footer.js
@@ -45,7 +45,7 @@
               <li><a href="${r}index.html">Skill Tree</a></li>
               <li><a href="${r}index.html?field=1">Skill Graph</a></li>
               <li><a href="${r}starless.html">Starless</a></li>
-              <li><a href="${r}meta.html">Meta Reports</a></li>
+              <li><a href="${r}meta.html">Meta Changelog</a></li>
             </ul>
           </div>
 
@@ -54,7 +54,6 @@
             <ul>
               <li><a href="${r}codex.html">The Codex</a></li>
               <li><a href="${r}named/">Named Skills</a></li>
-              <li><a href="${r}index.html#hall-of-heroes">Hall of Heroes</a></li>
               <li><a href="${r}u/">Named Contributors</a></li>
               <li><a href="${r}badges/">GitHub Badges</a></li>
             </ul>

--- a/docs/js/site-nav.js
+++ b/docs/js/site-nav.js
@@ -188,6 +188,7 @@
         '<li><a href="' + root + 'evidence/" style="color:var(--rank-3)">Evidence Library</a></li>' +
         '<li><a href="' + root + 'reports/" style="color:var(--evidence-gold)">Weekly Reports</a></li>' +
         '<li><a href="' + root + 'benchmarks/" style="color:var(--evidence-gold)">Benchmarks</a></li>' +
+        '<li><a href="' + root + 'skills/" style="color:var(--tier-basic)">Skill Index</a></li>' +
       '</ul>' +
     '</div>';
 


### PR DESCRIPTION
v6.0.2 fast-follow polish queued against #969. Four scoped UI tweaks, no schema / lockfile / data changes.

### 1. Surface Benchmarks + Reports CTAs nearer the fold
`docs/index.html` — added two pills to `.hero-pills` alongside the existing Trust Ledger pill:

- `▲ Benchmarks` → `benchmarks/`
- `◇ Weekly Reports` → `reports/`

Previously the Benchmarks CTA lived down in the Evidence Grade section (well below the fold) and Weekly Reports had no homepage entrypoint at all (footer only). Now both are one click from the hero.

### 2. Drop duplicate Hall of Heroes from Discover footer column
`docs/js/site-footer.js` — the Discover column and the Evidence column both linked to Hall of Heroes. Kept the Evidence-column link (`heroes/`, which is the canonical page) and removed the Discover-column anchor to `index.html#hall-of-heroes`. Discover now reads: Codex · Named Skills · Named Contributors · GitHub Badges.

### 3. Add Skill Index to mobile nav drawer
`docs/js/site-nav.js` — the More dropdown on desktop already included Skill Index (`skills/`) but the flat mobile drawer skipped it. Added `Skill Index` after Benchmarks so the drawer is inventory-parity with desktop.

### 4. Em-dash prune + Registry column rename
`docs/index.html`:
- Ascension section sub: `evidence — not declaration` → `evidence, not declaration`
- Evidence Grade sub: `Four tiers — Bronze, Silver, Gold, Platinum — mark` → `Four tiers (Bronze, Silver, Gold, Platinum) mark`
- Meta report summary: `ratification — G7 RFC, …` → `ratification: G7 RFC, …`

`docs/js/site-footer.js`:
- Registry column `Meta Reports` → `Meta Changelog` to disambiguate from Evidence column `Weekly Reports`. The `meta.html` page title/H1 are unchanged; only the footer nav label moves.

The task ticket said "3 em-dashes" but L724 had a bracketing pair, so the parens rewrite drops 4 dashes in total. `grep -c '—' docs/index.html` is now 0.

### Verification
- Local server: `python -m http.server 8765` from `docs/`, verified hero pills render, footer columns render, mobile drawer includes Skill Index, zero em-dashes in prose.
- No JSON / schema / lock changes. `packages/api-client-ts/node_modules/` and its lock file are untracked artifacts unrelated to this PR.

### Version
Tagging this as v6.0.2 (UI polish, no behavior change). Happy to fold into a broader v6.0.2 batch if others are queued.

Closes: v6.0.1 fast-follow items on #969.
