### PR TITLE
design(v6.1.1): entrypoint polish for /benchmarks/ + /reports/ (post-EPIC #902)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,50 @@ Do **not** apply the pattern to hide unfinished work that has no sprint home. Th
 
 See `scripts/contentEngine/templates/report.html.j2` (added in PR #972, tracking issue #973 for Sprint F rendering-layer rewrite). The banner CSS is inline in the template `<style>` block; the markup sits between the `<nav>` and `<main>` elements.
 
+## Fixed-nav clearance — every top-level page container must clear ~58px
+
+**Every page-level container that sits directly under `<body>` MUST provide its own top clearance to sit below the fixed nav.** The site nav (`<nav>` in `docs/js/site-nav.js`, rule at `docs/css/styles.css` L299–315) is `position: fixed` with `padding: .9rem 2rem` + a 1px border, giving it an effective height of ~58px. Nothing in the layout compensates for that automatically. Every page-level container fixes this on its own, and every design pass on a new surface must apply the pattern from the start. Codified after the v6.1.1 review, where the `.wip-banner` on the per-report page and the `.trending-main` on `/trending/` both shipped with insufficient top padding and got cut off by the nav.
+
+### The pattern (use this exact value ladder)
+
+```css
+.some-page-shell {
+  padding: 5rem 1.5rem 6rem;   /* top: 5rem (80px) clears the ~58px nav with 22px breathing room */
+  max-width: 62rem;
+  margin: 0 auto;
+}
+@media (min-width: 768px) {
+  .some-page-shell { padding: 8rem 2rem 7rem; }   /* or padding-top: 6rem for compact strips */
+}
+```
+
+Base clearance is **5rem (80px)**. Desktop clearance is **6rem (96px) for thin strips** (banners, notices) or **8rem (128px) for full page shells** (hero-carrying containers where a bit more breathing room is warranted). Do not invent other values; consistency across surfaces is the point.
+
+### Existing reference implementations
+
+Every current site surface uses this ladder. When adding a new page, copy one of these:
+
+- `.bench-shell` (`docs/benchmarks/index.html` inline `<style>`) — canonical full-page shell, `5rem`/`8rem`
+- `.reports-shell` (`scripts/contentEngine/templates/archive.html.j2` inline `<style>`) — full-page shell, `5rem`/`8rem`
+- `.trending-main` (`docs/trending/trending.css` L7–16) — full-page shell, `5rem`/`6rem` (added in PR #972 after cutoff regression)
+- `.wip-banner` (`scripts/contentEngine/templates/report.html.j2` inline `<style>`) — thin strip, `5rem`/`6rem`
+
+### Anti-patterns (refuse and rewrite)
+
+- **`padding-top: 0` on a body-child container.** The default. Will cut off content. Every page-level container needs an explicit top pad; there is no global `body { padding-top: ... }` and there won't be one (the fixed nav is a scroll-persistent surface, not a document flow element, and a global body offset would break the hero which is intentionally full-bleed under the nav).
+- **The `margin-top: -Npx` + `padding-top: calc(... + Npx)` trick** (as seen on `.profile-back-row` at `docs/css/styles.css` L1109–1122). Pulls the element into negative layout space to "pretend" the nav isn't there. Fragile: any preceding sibling with margin breaks the offset math, and the descendants inherit the compressed vertical origin. Legacy; do not extend to new surfaces.
+- **Inline `style="margin: 2rem auto"` or similar on `<main>`.** Was the pattern on the pre-Sprint-D bridge-state per-report page. `2rem` (32px) < nav height (58px), so the top of `<main>` sits under the nav. Same failure mode as the `.wip-banner` regression.
+- **Adding padding-top only to a nested child** (e.g. the hero inside a page shell). Works for that hero but breaks any subsequent design change that swaps or removes the hero. Put the clearance on the outermost body-child container so it's a property of the surface, not of one section.
+
+### Verification during design pass
+
+Before closing any PR that adds a new page or moves a top-level container:
+
+1. Load the page in a browser, scroll to absolute top (Ctrl+Home).
+2. The first content pixel below the nav should have visible breathing room, not touch the nav border.
+3. Confirm at both breakpoints (<768px and ≥768px).
+4. If a WIP-banner sits above the main content, verify the banner clears the nav AND the main content clears the banner.
+
 ## Testing
 
 Always run the test suite after making changes and fix any regressions before reporting completion.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,40 @@ The PR description must include an "Entrypoints" section listing which of the ab
 
 **Rule of thumb:** if a user landing on `gaiaskilltree.com/` with fresh eyes cannot discover the new feature within 30 seconds of scanning, the entrypoints are broken.
 
+## Deferred-surface convention — ship the bridge state, disclose the bridge state
+
+**When a surface ships to satisfy a kill criterion but its design register is explicitly slated for a later sprint, the interim state MUST be disclosed on the surface itself with a WIP banner linking to the tracking issue.** Codified after the v6.0.1 review, where the archive landing at `/reports/` was correctly redesigned but the per-report page at `/reports/YYYY-WW/` shipped as the L3-mechanical `<pre>{{ markdownBody }}</pre>` fallback and confused a reviewer into thinking the leaderboard rendering was missing (it wasn't; it was Sprint F scope).
+
+### When this applies
+
+Apply the pattern when **all three** conditions hold:
+
+1. The surface is user-visible and reachable from the homepage or main nav.
+2. Its current rendering satisfies its ratified kill criterion (URL exists, JSON contract shipped, cron produces output, etc.) but is visibly below the design bar of adjacent surfaces.
+3. `founder/GAIA_ROADMAP v*.md` explicitly slates the rendering-layer work for a named later sprint, OR a tracking issue exists with that sprint tag.
+
+Do **not** apply the pattern to hide unfinished work that has no sprint home. That's not a bridge state, that's a defect. File it and fix it.
+
+### What ships
+
+1. **A `.wip-banner` element** at the top of the surface (inside `<main>`, before content). Uses the shared class from the content-engine template pass, or an equivalent local styled element that matches:
+   - `--font-mono`, `0.78rem`, subtle `--evidence-gold` tint background + border
+   - Two spans: `<span class="wip-tag">◇ Interim rendering</span>` (or an equivalent short label) + `<span class="wip-body">` with one sentence of what's provisional, one sentence of what's frozen, and a link to the tracking issue.
+   - `role="note"` + `aria-label` describing the notice.
+2. **A tracking issue** with the target sprint label (e.g. `sprint-f`) and an explicit `## Non-goals` section noting the WIP banner is removed by the port. Reference sprint scope from `founder/GAIA_ROADMAP v*.md` by line number.
+3. **A note in the shipping PR body** under a `## Deferred surfaces` section listing which surfaces carry the banner and their tracking issues.
+
+### What NOT to do
+
+- Do not silently ship the bridge state and hope reviewers infer the sprint schedule. That was the v6.0.1 failure mode; the fix is disclosure.
+- Do not add a WIP banner without a tracking issue. The banner exists to point somewhere; without a link, it's decoration.
+- Do not use the banner to defer trivial polish (missing padding, wrong color, one label). Polish gets fixed in the same PR. The banner is for cross-sprint rendering-layer or infrastructure boundaries.
+- Do not stack multiple WIP banners on one surface. If a surface has more than one deferred concern, consolidate them into one tracking issue and one banner.
+
+### Reference implementation
+
+See `scripts/contentEngine/templates/report.html.j2` (added in PR #972, tracking issue #973 for Sprint F rendering-layer rewrite). The banner CSS is inline in the template `<style>` block; the markup sits between the `<nav>` and `<main>` elements.
+
 ## Testing
 
 Always run the test suite after making changes and fix any regressions before reporting completion.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -202,6 +202,8 @@ is retained ONLY as the background fill for the floating hero CTA pills (`◆ Op
 
 **Deferred-surface WIP banner** — when a user-visible surface ships in an intentional bridge state that a later sprint will replace (per `founder/GAIA_ROADMAP v*.md`), disclose the state with a `.wip-banner` element between `<nav>` and `<main>`. Uses `--font-mono` at `0.78rem`, a subtle `rgba(var(--evidence-gold-rgb), 0.06)` tint on `rgba(var(--evidence-gold-rgb), 0.28)` border, one uppercase `.wip-tag` label (`◇ Interim rendering` or equivalent), and one prose `.wip-body` sentence linking to the tracking issue and naming what is frozen (typically the JSON contract) versus what is provisional (the rendering layer). Full policy in `CLAUDE.md` § Deferred-surface convention; reference implementation in `scripts/contentEngine/templates/report.html.j2`. The banner is removed by the port; do not treat it as permanent chrome.
 
+**Fixed-nav clearance** — the site nav is `position: fixed` at ~58px tall (rule at `docs/css/styles.css` L299–315). Every top-level page container that sits directly under `<body>` provides its own top clearance using the value ladder `padding-top: 5rem` at base and `6rem` (thin strips) or `8rem` (full page shells) at `>= 768px`. Nothing offsets automatically. Reference implementations: `.bench-shell`, `.reports-shell`, `.trending-main`, `.wip-banner`. Full policy in `CLAUDE.md` § Fixed-nav clearance. Anti-pattern: the `margin-top: -Npx + padding-top: calc(... + Npx)` trick on `.profile-back-row`; do not extend it to new surfaces.
+
 ---
 
 ## Skill Explorer

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -200,6 +200,8 @@ is retained ONLY as the background fill for the floating hero CTA pills (`◆ Op
 
 **Hall share modal** — the Hall share/download modal is shared between the homepage and `/heroes/` page. It renders the OG plaque in a fullscreen stage with compact icon controls, an identity confirmation pill, optional README badge overlay, and PNG/SVG download choices. Treat this as a production component family, not a decorative overlay: focus states, `aria-label`s, reduced-motion behavior, and path-depth differences (`assets/icons.svg` vs `../assets/icons.svg`) must remain intact.
 
+**Deferred-surface WIP banner** — when a user-visible surface ships in an intentional bridge state that a later sprint will replace (per `founder/GAIA_ROADMAP v*.md`), disclose the state with a `.wip-banner` element between `<nav>` and `<main>`. Uses `--font-mono` at `0.78rem`, a subtle `rgba(var(--evidence-gold-rgb), 0.06)` tint on `rgba(var(--evidence-gold-rgb), 0.28)` border, one uppercase `.wip-tag` label (`◇ Interim rendering` or equivalent), and one prose `.wip-body` sentence linking to the tracking issue and naming what is frozen (typically the JSON contract) versus what is provisional (the rendering layer). Full policy in `CLAUDE.md` § Deferred-surface convention; reference implementation in `scripts/contentEngine/templates/report.html.j2`. The banner is removed by the port; do not treat it as permanent chrome.
+
 ---
 
 ## Skill Explorer

--- a/docs/index.html
+++ b/docs/index.html
@@ -81,9 +81,69 @@
     border-radius: 12px;
     overflow: hidden;
     font-family: var(--font-mono, ui-monospace, monospace);
-    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2);
+    /* Defined 8px blur elevation — pairs with the 1px border to read as a
+       framed terminal panel, not a diffuse ghost card. Was 0 4px 24px. */
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.24);
     display: flex;
     flex-direction: column;
+  }
+
+  /* ── Hero ledger flash ─────────────────────────────────────────────
+     Thin above-the-fold entrypoint pair for /reports/ and /benchmarks/.
+     Sits between #hero and #hall-of-heroes so the two Sprint-D headline
+     artifacts are reachable in the first two viewports. Preserves the
+     canonical #evidence-cycle CTAs; this is an additional entrypoint,
+     not a move. Ledger typography (JetBrains Mono, subdued separator)
+     matches the in-hero .ledger-strip register. */
+  .hero-ledger-flash {
+    max-width: 62rem;
+    margin: 0 auto;
+    padding: 1.25rem 1.5rem 0;
+    display: flex;
+    align-items: baseline;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 0.75rem 1.25rem;
+    font-family: var(--font-mono, ui-monospace, monospace);
+    font-size: 0.82rem;
+    letter-spacing: 0.02em;
+  }
+  .hlf-link {
+    color: var(--text);
+    text-decoration: none;
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.4em;
+    padding: 0.25rem 0;
+    border-bottom: 1px solid transparent;
+    transition: border-color 160ms ease-out, color 160ms ease-out;
+  }
+  .hlf-link:hover,
+  .hlf-link:focus-visible {
+    color: var(--evidence-gold);
+    border-bottom-color: var(--evidence-gold);
+    outline: none;
+  }
+  .hlf-glyph {
+    color: var(--evidence-gold);
+    font-size: 0.9em;
+  }
+  .hlf-tail {
+    color: var(--muted);
+    transition: color 160ms ease-out, transform 160ms ease-out;
+  }
+  .hlf-link:hover .hlf-tail,
+  .hlf-link:focus-visible .hlf-tail {
+    color: var(--evidence-gold);
+    transform: translateX(2px);
+  }
+  .hlf-sep {
+    color: var(--border);
+    user-select: none;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .hlf-link, .hlf-tail { transition: none; }
+    .hlf-link:hover .hlf-tail, .hlf-link:focus-visible .hlf-tail { transform: none; }
   }
 
   .review-sim-header {
@@ -276,6 +336,24 @@
       <svg class="ico" aria-hidden="true"><use href="assets/icons.svg#chevron-down"/></svg>
     </div>
   </section>
+
+  <!-- ─── HERO LEDGER FLASH ─── -->
+  <!-- Above-the-fold entrypoint for Weekly Reports + Benchmarks. Two links,
+       one line, ledger typography. Additive to the canonical CTAs in
+       #evidence-cycle further down; this is the near-the-fold surface. -->
+  <aside class="hero-ledger-flash" aria-label="Latest evidence">
+    <a href="reports/" class="hlf-link">
+      <span class="hlf-glyph" aria-hidden="true">◇</span>
+      <span>Latest weekly report</span>
+      <span class="hlf-tail" aria-hidden="true">→</span>
+    </a>
+    <span class="hlf-sep" aria-hidden="true">/</span>
+    <a href="benchmarks/" class="hlf-link">
+      <span class="hlf-glyph" aria-hidden="true">▲</span>
+      <span>Benchmarks leaderboard</span>
+      <span class="hlf-tail" aria-hidden="true">→</span>
+    </a>
+  </aside>
 
   <!-- ─── HALL OF HEROES ─── -->
   <section id="hall-of-heroes" class="reveal hoh-section hoh-section--mini" data-section="hoh" aria-labelledby="hohTitle">
@@ -664,7 +742,7 @@
        Per-rank colour comes from .rank-badge[data-level="N"] tokens. -->
   <section id="ascension" class="reveal ascension-section" data-section="ascension">
     <h2>The Ascension Cycle</h2>
-    <p class="section-sub">Skills advance through evidence — not declaration. Each rank unlocks the next.</p>
+    <p class="section-sub">Skills advance through evidence, not declaration. Each rank unlocks the next.</p>
     <div class="ascension-track" data-pattern="journey">
       <div class="asc-stage">
         <div class="asc-node">
@@ -721,7 +799,7 @@
        .grade-bar / .grade-segment from styles.css L10281+. -->
   <section id="evidence-cycle" class="reveal evidence-cycle-section" data-section="evidence-cycle">
     <h2>Evidence Grade</h2>
-    <p class="section-sub">A skill earns its Overall Trust Grade by the strength of the evidence behind it. Four tiers — Bronze, Silver, Gold, Platinum — mark the aggregate Trust Magnitude that a skill's evidence pool reaches.</p>
+    <p class="section-sub">A skill earns its Overall Trust Grade by the strength of the evidence behind it. Four tiers (Bronze, Silver, Gold, Platinum) mark the aggregate Trust Magnitude that a skill's evidence pool reaches.</p>
     <div class="grade-bar">
       <div class="grade-row">
         <div class="grade-segment grade-plat"><span class="grade-label">Platinum (S) ≥ 250 trust</span></div>
@@ -739,7 +817,7 @@
         <div class="grade-segment grade-ungraded"><span class="grade-label">Ungraded</span></div>
       </div>
     </div>
-    <p class="section-sub" style="max-width:680px;margin:1.5rem auto 0;font-size:14px;opacity:0.85;">Each piece of evidence (a repo, a benchmark, a peer-reviewed paper) earns its own per-row Evidence Grade. The numbers above are the aggregate Trust Magnitude thresholds the rows must combine to clear. See the methodology report for the full formula.</p>
+    <p class="section-sub" style="max-width:680px;margin:1.5rem auto 0;font-size:14px;">Each piece of evidence (a repo, a benchmark, a peer-reviewed paper) earns its own per-row Evidence Grade. The numbers above are the aggregate Trust Magnitude thresholds the rows must combine to clear. See the methodology report for the full formula.</p>
     <div style="margin-top:2.5rem;text-align:center;display:flex;gap:1rem;justify-content:center;flex-wrap:wrap;">
       <a href="evidence/" class="btn btn-ghost"
         style="text-decoration:none;font-size:13px;display:inline-flex;align-items:center;gap:0.4rem;">
@@ -763,6 +841,14 @@
           <use href="assets/icons.svg#sort-arrows"></use>
         </svg>
         Benchmarks →
+      </a>
+      <a href="reports/"
+        class="btn btn-ghost"
+        style="text-decoration:none;font-size:13px;display:inline-flex;align-items:center;gap:0.4rem;">
+        <svg class="ico" width="13" height="13" aria-hidden="true">
+          <use href="assets/icons.svg#info"></use>
+        </svg>
+        Weekly Reports →
       </a>
     </div>
   </section>
@@ -791,7 +877,7 @@
           <a href="meta/reports/2026-06-20-gaia-trust-infrastructure-a-june-2026-retrospective.html" class="pmq-post">
             <span class="pmq-label">Trust Model</span>
             <h4 class="pmq-title">GAIA Trust Infrastructure: A June 2026 Retrospective <span class="meta-peek-arrow" style="float: right;">↗</span></h4>
-            <p class="pmq-summary">Phase 1 baseline through Phase 1.5 ratification — G7 RFC, Trust Magnitude formula, apex gate, public Trust Ledger. Now includes the Phase 1.5 closeout addendum on per-evidence grade calibration and the Trust Ledger May/June rollout.</p>
+            <p class="pmq-summary">Phase 1 baseline through Phase 1.5 ratification: G7 RFC, Trust Magnitude formula, apex gate, public Trust Ledger. Now includes the Phase 1.5 closeout addendum on per-evidence grade calibration and the Trust Ledger May/June rollout.</p>
           </a>
           <!-- gaia-posts-end -->
       <button type="button" class="pmq-changelog-btn" id="metaChangelogBtnPath">Open Meta Changelog →</button>

--- a/docs/index.html
+++ b/docs/index.html
@@ -478,6 +478,12 @@
           <path d="M5 10 L15 10 M11 6 L15 10 L11 14" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
       </a>
+      <a class="trust-preview-cta-link trust-preview-cta-link--ghost" href="trending/">
+        <span>Trending this week</span>
+        <svg aria-hidden="true" viewBox="0 0 20 20" width="16" height="16">
+          <path d="M5 10 L15 10 M11 6 L15 10 L11 14" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </a>
       <a class="trust-preview-cta-link trust-preview-cta-link--ghost" href="trust/leaderboard/">
         <span>Trust Leaderboard</span>
         <svg aria-hidden="true" viewBox="0 0 20 20" width="16" height="16">
@@ -754,35 +760,35 @@
       <div class="asc-stage">
         <div class="asc-node">
           <span class="asc-label">Named</span>
-          <span class="asc-sub"><span class="rank-badge" data-level="2" data-variant="chip" role="img" aria-label="Rank 2 of 6"><span class="rank-badge__chip">2★</span></span> · Class C</span>
+          <span class="asc-sub"><span class="rank-badge" data-level="2" data-variant="chip" role="img" aria-label="Rank 2 of 6"><span class="rank-badge__chip">2★</span></span></span>
         </div>
         <span class="asc-arrow">→</span>
       </div>
       <div class="asc-stage">
         <div class="asc-node">
           <span class="asc-label">Evolved</span>
-          <span class="asc-sub"><span class="rank-badge" data-level="3" data-variant="chip" role="img" aria-label="Rank 3 of 6"><span class="rank-badge__chip">3★</span></span> · Class B</span>
+          <span class="asc-sub"><span class="rank-badge" data-level="3" data-variant="chip" role="img" aria-label="Rank 3 of 6"><span class="rank-badge__chip">3★</span></span></span>
         </div>
         <span class="asc-arrow">→</span>
       </div>
       <div class="asc-stage">
         <div class="asc-node">
           <span class="asc-label">Hardened</span>
-          <span class="asc-sub"><span class="rank-badge" data-level="4" data-variant="chip" role="img" aria-label="Rank 4 of 6"><span class="rank-badge__chip">4★</span></span> · Class B/A</span>
+          <span class="asc-sub"><span class="rank-badge" data-level="4" data-variant="chip" role="img" aria-label="Rank 4 of 6"><span class="rank-badge__chip">4★</span></span></span>
         </div>
         <span class="asc-arrow">→</span>
       </div>
       <div class="asc-stage">
         <div class="asc-node">
           <span class="asc-label">Transcendent</span>
-          <span class="asc-sub"><span class="rank-badge" data-level="5" data-variant="chip" role="img" aria-label="Rank 5 of 6"><span class="rank-badge__chip">5★</span></span> · Class B/A</span>
+          <span class="asc-sub"><span class="rank-badge" data-level="5" data-variant="chip" role="img" aria-label="Rank 5 of 6"><span class="rank-badge__chip">5★</span></span></span>
         </div>
         <span class="asc-arrow">→</span>
       </div>
       <div class="asc-stage">
         <div class="asc-node is-apex">
           <span class="asc-label">Apex</span>
-          <span class="asc-sub"><span class="rank-badge" data-level="6" data-variant="chip" role="img" aria-label="Rank 6 of 6"><span class="rank-badge__chip">6★</span></span> · Class A</span>
+          <span class="asc-sub"><span class="rank-badge" data-level="6" data-variant="chip" role="img" aria-label="Rank 6 of 6"><span class="rank-badge__chip">6★</span></span></span>
         </div>
       </div>
     </div>

--- a/docs/js/site-footer.js
+++ b/docs/js/site-footer.js
@@ -45,7 +45,7 @@
               <li><a href="${r}index.html">Skill Tree</a></li>
               <li><a href="${r}index.html?field=1">Skill Graph</a></li>
               <li><a href="${r}starless.html">Starless</a></li>
-              <li><a href="${r}meta.html">Meta Reports</a></li>
+              <li><a href="${r}meta.html">Meta Changelog</a></li>
             </ul>
           </div>
 
@@ -54,7 +54,6 @@
             <ul>
               <li><a href="${r}codex.html">The Codex</a></li>
               <li><a href="${r}named/">Named Skills</a></li>
-              <li><a href="${r}index.html#hall-of-heroes">Hall of Heroes</a></li>
               <li><a href="${r}u/">Named Contributors</a></li>
               <li><a href="${r}badges/">GitHub Badges</a></li>
             </ul>

--- a/docs/js/site-nav.js
+++ b/docs/js/site-nav.js
@@ -188,6 +188,7 @@
         '<li><a href="' + root + 'evidence/" style="color:var(--rank-3)">Evidence Library</a></li>' +
         '<li><a href="' + root + 'reports/" style="color:var(--evidence-gold)">Weekly Reports</a></li>' +
         '<li><a href="' + root + 'benchmarks/" style="color:var(--evidence-gold)">Benchmarks</a></li>' +
+        '<li><a href="' + root + 'skills/" style="color:var(--tier-basic)">Skill Index</a></li>' +
       '</ul>' +
     '</div>';
 

--- a/docs/reports/2026-28/index.html
+++ b/docs/reports/2026-28/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "6.0.1";</script>
+  <script>window.GAIA_VERSION = "6.1.0";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -17,33 +17,71 @@
   <meta property="og:url" content="https://gaiaskilltree.com/reports/2026-28/">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="icon" type="image/svg+xml" href="../../assets/marks/diamond-seal.svg">
-  <link rel="stylesheet" href="../../css/tokens.css?v=6.0.1">
-  <link rel="stylesheet" href="../../css/styles.css?v=6.0.1">
+  <link rel="stylesheet" href="../../css/tokens.css?v=6.1.0">
+  <link rel="stylesheet" href="../../css/styles.css?v=6.1.0">
   <link rel="alternate" type="application/json" href="https://gaiaskilltree.com/api/v1/reports/2026-28.json">
-<script type="application/ld+json" data-injector="gaia-json-ld">
-{
-  "@context": "https://schema.org",
-  "@type": "Article",
-  "headline": "Gaia Weekly Report — 2026-28",
-  "url": "https://gaiaskilltree.com/reports/2026-28/",
-  "publisher": {
-    "@type": "Organization",
-    "name": "Gaia Skill Tree",
-    "url": "https://gaiaskilltree.com/"
-  }
-}
-{
-  "@context": "https://schema.org",
-  "@type": "NewsArticle",
-  "headline": "Gaia Weekly Report — 2026-28",
-  "url": "https://gaiaskilltree.com/reports/2026-28/"
-}
-</script>
+
+  <style>
+    /* ── Deferred-surface WIP banner ──────────────────────────────────────
+       Discloses that this surface renders in its L3-mechanical bridge
+       state pending the Sprint F rendering-layer rewrite (issue #973).
+       Follows the deferred-surface convention in CLAUDE.md §Deferred
+       surface convention. Removed by the port. */
+    .wip-banner {
+      max-width: 62rem;
+      /* Clear the fixed nav (~58px). Matches the 5rem/6rem top-clearance
+         pattern used by .bench-shell and .reports-shell. */
+      margin: 5rem auto 0;
+      padding: 0.75rem 1.5rem;
+      display: flex;
+      align-items: baseline;
+      flex-wrap: wrap;
+      gap: 0.5rem 0.9rem;
+      font-family: var(--font-mono);
+      font-size: 0.78rem;
+      line-height: 1.55;
+      color: var(--text);
+      background: rgba(var(--evidence-gold-rgb), 0.06);
+      border: 1px solid rgba(var(--evidence-gold-rgb), 0.28);
+      border-radius: 6px;
+      letter-spacing: 0.02em;
+    }
+    @media (min-width: 768px) {
+      .wip-banner { margin-top: 6rem; }
+    }
+    .wip-banner .wip-tag {
+      color: var(--evidence-gold);
+      font-weight: 500;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      font-size: 0.72rem;
+    }
+    .wip-banner .wip-body { color: var(--text); opacity: 0.86; }
+    .wip-banner a {
+      color: var(--evidence-gold);
+      text-decoration: none;
+      border-bottom: 1px solid rgba(var(--evidence-gold-rgb), 0.45);
+      transition: border-color 160ms ease-out;
+    }
+    .wip-banner a:hover,
+    .wip-banner a:focus-visible {
+      border-bottom-color: var(--evidence-gold);
+      outline: none;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .wip-banner a { transition: none; }
+    }
+  </style>
 </head>
 <body>
   <nav id="site-nav"></nav>
-  <script src="../../js/mounts.js?v=6.0.1"></script>
-  <script src="../../js/site-nav.js?v=6.0.1"></script>
+  <script src="../../js/mounts.js?v=6.1.0"></script>
+  <script src="../../js/site-nav.js?v=6.1.0"></script>
+
+  <aside class="wip-banner" role="note" aria-label="Interim rendering notice">
+    <span class="wip-tag">◇ Interim rendering</span>
+    <span class="wip-body">Tables render as source markdown in this bridge state. Leaderboard view lands in Sprint F (<a href="https://github.com/gaia-research/gaia-skill-tree/issues/973">#973</a>). The <a href="https://gaiaskilltree.com/api/v1/reports/2026-28.json">canonical JSON</a> is frozen and permanent.</span>
+  </aside>
 
   <main class="report-body" style="max-width: 72rem; margin: 2rem auto; padding: 0 1.25rem; color: var(--text); font-family: 'EB Garamond', Georgia, serif; line-height: 1.6;">
     <div style="font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: .75rem; color: var(--muted); letter-spacing: .12em; text-transform: uppercase; margin-bottom: .5rem;">
@@ -52,7 +90,7 @@
     <pre class="report-markdown" style="white-space: pre-wrap; font-family: inherit; font-size: 1rem; background: transparent; padding: 0; margin: 0;"># Weekly Report · 2026-28
 
 > **Report ID:** `2026-28` · **ISO week:** 2026-W28
-> **Generated:** 2026-07-06T13:29:36Z · **Layer:** `L3` · **Generator:** gaia-content-engine v6.0.1
+> **Generated:** 2026-07-06T13:29:36Z · **Layer:** `L3` · **Generator:** gaia-content-engine v6.1.0
 
 [← Previous week](https://gaiaskilltree.com/reports/2026-27/) · [Archive](https://gaiaskilltree.com/reports/) · [Canonical JSON](https://gaiaskilltree.com/api/v1/reports/2026-28.json)
 
@@ -60,21 +98,21 @@
 
 | Rank | Skill | Contributor | Level | Trust Magnitude | Δ TM |
 | ---: | :--- | :--- | :---: | ---: | ---: |
-| 1 | [Agent Skills](https://gaiaskilltree.com/named/#explorer/addy-osmani/agent-skills) | addy-osmani | 5★ | 293.1 · S | new |
-| 2 | [Get Shit Done](https://gaiaskilltree.com/named/#explorer/gsd-build/get-shit-done) | gsd-build | 4★ | 202.2 · A | new |
-| 3 | [Performance Optimization](https://gaiaskilltree.com/named/#explorer/addy-osmani/performance-optimization) | addy-osmani | 4★ | 83.2 · B | — |
-| 4 | [Code Review and Quality](https://gaiaskilltree.com/named/#explorer/addy-osmani/code-review-and-quality) | addy-osmani | 3★ | 53.1 · B | new |
-| 5 | [Code Simplification](https://gaiaskilltree.com/named/#explorer/addy-osmani/code-simplification) | addy-osmani | 3★ | 53.1 · B | new |
+| 1 | [Agent Skills](https://gaiaskilltree.com/named/#explorer/addy-osmani/agent-skills) | addy-osmani | 5â˜… | 293.1 · S | new |
+| 2 | [Get Shit Done](https://gaiaskilltree.com/named/#explorer/gsd-build/get-shit-done) | gsd-build | 4â˜… | 202.2 · A | new |
+| 3 | [Performance Optimization](https://gaiaskilltree.com/named/#explorer/addy-osmani/performance-optimization) | addy-osmani | 4â˜… | 83.2 · B | — |
+| 4 | [Code Review and Quality](https://gaiaskilltree.com/named/#explorer/addy-osmani/code-review-and-quality) | addy-osmani | 3â˜… | 53.1 · B | new |
+| 5 | [Code Simplification](https://gaiaskilltree.com/named/#explorer/addy-osmani/code-simplification) | addy-osmani | 3â˜… | 53.1 · B | new |
 
 ## Recently ascended
 
 | Skill | Contributor | Rank change | Trust Magnitude | Ascended at |
 | :--- | :--- | :---: | ---: | :--- |
-| [Performance Optimization](https://gaiaskilltree.com/named/#explorer/addy-osmani/performance-optimization) | addy-osmani | 3★ → 4★ | 83.2 · B | 2026-07-03T19:57:07Z |
-| [Agent Skills](https://gaiaskilltree.com/named/#explorer/addy-osmani/agent-skills) | addy-osmani | → 5★ | 293.1 · S | 2026-07-02T21:46:18Z |
-| [Get Shit Done](https://gaiaskilltree.com/named/#explorer/gsd-build/get-shit-done) | gsd-build | 2★ → 4★ | 202.2 · A | 2026-07-02T21:34:10Z |
-| [GSD Ship](https://gaiaskilltree.com/named/#explorer/gsd-build/ship) | gsd-build | 2★ → 3★ | 52.2 · B | 2026-07-02T21:34:10Z |
-| [GSD Execute Phase](https://gaiaskilltree.com/named/#explorer/gsd-build/execute-phase) | gsd-build | 2★ → 3★ | 52.2 · B | 2026-07-02T21:34:09Z |
+| [Performance Optimization](https://gaiaskilltree.com/named/#explorer/addy-osmani/performance-optimization) | addy-osmani | 3â˜… → 4â˜… | 83.2 · B | 2026-07-03T19:57:07Z |
+| [Agent Skills](https://gaiaskilltree.com/named/#explorer/addy-osmani/agent-skills) | addy-osmani | → 5â˜… | 293.1 · S | 2026-07-02T21:46:18Z |
+| [Get Shit Done](https://gaiaskilltree.com/named/#explorer/gsd-build/get-shit-done) | gsd-build | 2â˜… → 4â˜… | 202.2 · A | 2026-07-02T21:34:10Z |
+| [GSD Ship](https://gaiaskilltree.com/named/#explorer/gsd-build/ship) | gsd-build | 2â˜… → 3â˜… | 52.2 · B | 2026-07-02T21:34:10Z |
+| [GSD Execute Phase](https://gaiaskilltree.com/named/#explorer/gsd-build/execute-phase) | gsd-build | 2â˜… → 3â˜… | 52.2 · B | 2026-07-02T21:34:09Z |
 
 ## Most contested spaces
 
@@ -84,8 +122,8 @@ _Top TM in this space: **293.1**_
 
 | Skill | Level | Trust Magnitude | Grade | Origin? |
 | :--- | :---: | ---: | :---: | :---: |
-| [addy-osmani/agent-skills](https://gaiaskilltree.com/named/#explorer/addy-osmani/agent-skills) | 5★ | 293.1 | S | ✓ |
-| [gsd-build/get-shit-done](https://gaiaskilltree.com/named/#explorer/gsd-build/get-shit-done) | 4★ | 202.2 | A | — |
+| [addy-osmani/agent-skills](https://gaiaskilltree.com/named/#explorer/addy-osmani/agent-skills) | 5â˜… | 293.1 | S | ✓ |
+| [gsd-build/get-shit-done](https://gaiaskilltree.com/named/#explorer/gsd-build/get-shit-done) | 4â˜… | 202.2 | A | — |
 
 ### `vertical-slice-planning` — 3 implementations
 
@@ -93,9 +131,9 @@ _Top TM in this space: **156.0**_
 
 | Skill | Level | Trust Magnitude | Grade | Origin? |
 | :--- | :---: | ---: | :---: | :---: |
-| [garrytan/garrytan](https://gaiaskilltree.com/named/#explorer/garrytan/garrytan) | 4★ | 156.0 | A | ✓ |
-| [mattpocock/to-issues](https://gaiaskilltree.com/named/#explorer/mattpocock/to-issues) | 3★ | 90.4 | B | — |
-| [addy-osmani/planning-and-task-breakdown](https://gaiaskilltree.com/named/#explorer/addy-osmani/planning-and-task-breakdown) | 3★ | 53.1 | B | — |
+| [garrytan/garrytan](https://gaiaskilltree.com/named/#explorer/garrytan/garrytan) | 4â˜… | 156.0 | A | ✓ |
+| [mattpocock/to-issues](https://gaiaskilltree.com/named/#explorer/mattpocock/to-issues) | 3â˜… | 90.4 | B | — |
+| [addy-osmani/planning-and-task-breakdown](https://gaiaskilltree.com/named/#explorer/addy-osmani/planning-and-task-breakdown) | 3â˜… | 53.1 | B | — |
 
 ### `ux-audit` — 6 implementations
 
@@ -103,12 +141,12 @@ _Top TM in this space: **122.8**_
 
 | Skill | Level | Trust Magnitude | Grade | Origin? |
 | :--- | :---: | ---: | :---: | :---: |
-| [pbakaus/impeccable](https://gaiaskilltree.com/named/#explorer/pbakaus/impeccable) | 4★ | 122.8 | A | ✓ |
-| [martin-stepanoski/nielsen-heuristics-audit](https://gaiaskilltree.com/named/#explorer/martin-stepanoski/nielsen-heuristics-audit) | 3★ | 94.9 | B | — |
-| [garrytan/plan-design-review](https://gaiaskilltree.com/named/#explorer/garrytan/plan-design-review) | 3★ | 63.7 | B | — |
-| [garrytan/plan-devex-review](https://gaiaskilltree.com/named/#explorer/garrytan/plan-devex-review) | 3★ | 63.7 | B | — |
-| [garrytan/design-review](https://gaiaskilltree.com/named/#explorer/garrytan/design-review) | 2★ | 36.0 | C | — |
-| [garrytan/devex-review](https://gaiaskilltree.com/named/#explorer/garrytan/devex-review) | 2★ | 36.0 | C | — |
+| [pbakaus/impeccable](https://gaiaskilltree.com/named/#explorer/pbakaus/impeccable) | 4â˜… | 122.8 | A | ✓ |
+| [martin-stepanoski/nielsen-heuristics-audit](https://gaiaskilltree.com/named/#explorer/martin-stepanoski/nielsen-heuristics-audit) | 3â˜… | 94.9 | B | — |
+| [garrytan/plan-design-review](https://gaiaskilltree.com/named/#explorer/garrytan/plan-design-review) | 3â˜… | 63.7 | B | — |
+| [garrytan/plan-devex-review](https://gaiaskilltree.com/named/#explorer/garrytan/plan-devex-review) | 3â˜… | 63.7 | B | — |
+| [garrytan/design-review](https://gaiaskilltree.com/named/#explorer/garrytan/design-review) | 2â˜… | 36.0 | C | — |
+| [garrytan/devex-review](https://gaiaskilltree.com/named/#explorer/garrytan/devex-review) | 2â˜… | 36.0 | C | — |
 
 
 ---

--- a/docs/reports/2026-28/index.html
+++ b/docs/reports/2026-28/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "6.1.0";</script>
+  <script>window.GAIA_VERSION = "6.1.1";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -17,8 +17,8 @@
   <meta property="og:url" content="https://gaiaskilltree.com/reports/2026-28/">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="icon" type="image/svg+xml" href="../../assets/marks/diamond-seal.svg">
-  <link rel="stylesheet" href="../../css/tokens.css?v=6.1.0">
-  <link rel="stylesheet" href="../../css/styles.css?v=6.1.0">
+  <link rel="stylesheet" href="../../css/tokens.css?v=6.1.1">
+  <link rel="stylesheet" href="../../css/styles.css?v=6.1.1">
   <link rel="alternate" type="application/json" href="https://gaiaskilltree.com/api/v1/reports/2026-28.json">
 
   <style>
@@ -94,8 +94,8 @@
 </head>
 <body>
   <nav id="site-nav"></nav>
-  <script src="../../js/mounts.js?v=6.1.0"></script>
-  <script src="../../js/site-nav.js?v=6.1.0"></script>
+  <script src="../../js/mounts.js?v=6.1.1"></script>
+  <script src="../../js/site-nav.js?v=6.1.1"></script>
 
   <aside class="wip-banner" role="note" aria-label="Interim rendering notice">
     <span class="wip-tag">◇ Interim rendering</span>
@@ -109,7 +109,7 @@
     <pre class="report-markdown" style="white-space: pre-wrap; font-family: inherit; font-size: 1rem; background: transparent; padding: 0; margin: 0;"># Weekly Report · 2026-28
 
 > **Report ID:** `2026-28` · **ISO week:** 2026-W28
-> **Generated:** 2026-07-06T13:29:36Z · **Layer:** `L3` · **Generator:** gaia-content-engine v6.1.0
+> **Generated:** 2026-07-06T13:29:36Z · **Layer:** `L3` · **Generator:** gaia-content-engine v6.1.1
 
 [← Previous week](https://gaiaskilltree.com/reports/2026-27/) · [Archive](https://gaiaskilltree.com/reports/) · [Canonical JSON](https://gaiaskilltree.com/api/v1/reports/2026-28.json)
 

--- a/docs/reports/2026-28/index.html
+++ b/docs/reports/2026-28/index.html
@@ -72,6 +72,25 @@
       .wip-banner a { transition: none; }
     }
   </style>
+<script type="application/ld+json" data-injector="gaia-json-ld">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Gaia Weekly Report — 2026-28",
+  "url": "https://gaiaskilltree.com/reports/2026-28/",
+  "publisher": {
+    "@type": "Organization",
+    "name": "Gaia Skill Tree",
+    "url": "https://gaiaskilltree.com/"
+  }
+}
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Gaia Weekly Report — 2026-28",
+  "url": "https://gaiaskilltree.com/reports/2026-28/"
+}
+</script>
 </head>
 <body>
   <nav id="site-nav"></nav>

--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "6.0.1";</script>
+  <script>window.GAIA_VERSION = "6.1.0";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -20,8 +20,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;500;600;700&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
-  <link rel="stylesheet" href="../css/tokens.css?v=6.0.1">
-  <link rel="stylesheet" href="../css/styles.css?v=6.0.1">
+  <link rel="stylesheet" href="../css/tokens.css?v=6.1.0">
+  <link rel="stylesheet" href="../css/styles.css?v=6.1.0">
   <link rel="alternate" type="application/json" href="/api/v1/reports/index.json">
 
   <script>
@@ -305,8 +305,8 @@
 </head>
 <body>
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.0.1"></script>
-  <script src="../js/site-nav.js?v=6.0.1"></script>
+  <script src="../js/mounts.js?v=6.1.0"></script>
+  <script src="../js/site-nav.js?v=6.1.0"></script>
 
   <main class="reports-shell">
 
@@ -346,6 +346,6 @@
   </main>
 
   <div id="site-footer-mount"></div>
-  <script src="../js/site-footer.js?v=6.0.1"></script>
+  <script src="../js/site-footer.js?v=6.1.0"></script>
 </body>
 </html>

--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "6.1.0";</script>
+  <script>window.GAIA_VERSION = "6.1.1";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -20,8 +20,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;500;600;700&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
-  <link rel="stylesheet" href="../css/tokens.css?v=6.1.0">
-  <link rel="stylesheet" href="../css/styles.css?v=6.1.0">
+  <link rel="stylesheet" href="../css/tokens.css?v=6.1.1">
+  <link rel="stylesheet" href="../css/styles.css?v=6.1.1">
   <link rel="alternate" type="application/json" href="/api/v1/reports/index.json">
 
   <script>
@@ -305,8 +305,8 @@
 </head>
 <body>
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.1.0"></script>
-  <script src="../js/site-nav.js?v=6.1.0"></script>
+  <script src="../js/mounts.js?v=6.1.1"></script>
+  <script src="../js/site-nav.js?v=6.1.1"></script>
 
   <main class="reports-shell">
 
@@ -346,6 +346,6 @@
   </main>
 
   <div id="site-footer-mount"></div>
-  <script src="../js/site-footer.js?v=6.1.0"></script>
+  <script src="../js/site-footer.js?v=6.1.1"></script>
 </body>
 </html>

--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -1,57 +1,351 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "6.1.1";</script>
+  <script>window.GAIA_VERSION = "6.0.1";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="generator" content="gaia-content-engine">
-  <title>Weekly Reports — Gaia</title>
-  <meta name="description" content="Archive of Gaia weekly reports — a permanent record of what moved in the skill registry each ISO week.">
+  <title>Weekly Reports | Gaia Registry</title>
+  <meta name="description" content="Archive of Gaia weekly reports. One report per ISO week. Trending, ascended, contested. Mechanically compiled from the trending API.">
   <link rel="canonical" href="https://gaiaskilltree.com/reports/">
   <meta property="og:type" content="website">
-  <meta property="og:title" content="Weekly Reports — Gaia">
+  <meta property="og:title" content="Weekly Reports | Gaia Registry">
   <meta property="og:description" content="Every Monday: what changed in the Gaia skill registry, mechanically compiled from the trending API.">
   <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
-  <link rel="stylesheet" href="../css/tokens.css?v=6.1.1">
-  <link rel="stylesheet" href="../css/styles.css?v=6.1.1">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;500;600;700&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+
+  <link rel="stylesheet" href="../css/tokens.css?v=6.0.1">
+  <link rel="stylesheet" href="../css/styles.css?v=6.0.1">
   <link rel="alternate" type="application/json" href="/api/v1/reports/index.json">
+
+  <script>
+    window.gaiaIconBase = function () { return '../assets/icons.svg'; };
+  </script>
+
+  <style>
+    /* ─────────────────────────────────────────────────────────────
+       WEEKLY REPORTS ARCHIVE — ledger surface, not blog index.
+       Matches the benchmarks landing register (bench-shell): one
+       display hero, one contract line, a list where the list IS the
+       experience. EB Garamond for display, Bricolage for body,
+       Departure/JetBrains Mono reserved for ISO identifiers and
+       provenance labels. Body copy sits on --text (#e2e8f0) against
+       --bg (#030712) for 4.5:1+ contrast.
+       ───────────────────────────────────────────────────────────── */
+
+    .reports-shell {
+      max-width: 62rem;
+      margin: 0 auto;
+      padding: 5rem 1.5rem 6rem;
+      color: var(--text);
+      font-family: var(--font-body);
+    }
+    @media (min-width: 768px) {
+      .reports-shell { padding: 8rem 2rem 7rem; }
+    }
+
+    /* ── Hero: thesis, not tagline ─────────────────────────── */
+    .reports-hero {
+      max-width: 44rem;
+      margin: 0 0 5rem;
+    }
+    .reports-hero h1 {
+      font-family: var(--font-display);
+      font-weight: 500;
+      font-size: clamp(2.4rem, 6.5vw, 4.25rem);
+      line-height: 1.02;
+      letter-spacing: -0.02em;
+      margin: 0 0 1.75rem;
+      color: var(--text);
+      text-wrap: balance;
+    }
+    .reports-hero h1 em {
+      font-style: italic;
+      color: var(--apex-gold);
+      font-weight: 400;
+    }
+    .reports-hero p {
+      font-size: 1.15rem;
+      line-height: 1.55;
+      color: var(--text);
+      opacity: 0.82;
+      margin: 0 0 1rem;
+      max-width: 38rem;
+      text-wrap: pretty;
+    }
+    @media (min-width: 768px) {
+      .reports-hero p { font-size: 1.25rem; }
+    }
+    .reports-hero .contract {
+      margin-top: 1.5rem;
+      font-family: var(--font-mono);
+      font-size: 0.82rem;
+      line-height: 1.7;
+      color: var(--text);
+      opacity: 0.72;
+      max-width: 40rem;
+    }
+    .reports-hero .contract code {
+      font-family: var(--font-mono);
+      color: var(--apex-gold);
+      background: none;
+      padding: 0;
+    }
+
+    /* ── Archive block ─────────────────────────────────────── */
+    .reports-block { margin-bottom: 5rem; }
+    .reports-block-head {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 1.5rem;
+      padding-bottom: 1.25rem;
+      margin-bottom: 0;
+      border-bottom: 1px solid var(--border);
+      flex-wrap: wrap;
+    }
+    .reports-block-head h2 {
+      font-family: var(--font-display);
+      font-weight: 500;
+      font-size: clamp(1.5rem, 3vw, 2rem);
+      line-height: 1.15;
+      letter-spacing: -0.01em;
+      margin: 0;
+      color: var(--text);
+    }
+    .reports-block-head .count {
+      font-family: var(--font-mono);
+      font-size: 0.82rem;
+      color: var(--muted);
+      letter-spacing: 0.02em;
+    }
+
+    /* ── The list is the experience ────────────────────────── */
+    .reports-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+    .reports-row {
+      display: grid;
+      grid-template-columns: minmax(9rem, auto) 1fr auto;
+      align-items: baseline;
+      gap: 1rem 1.5rem;
+      padding: 1.5rem 0;
+      border-bottom: 1px solid var(--border);
+    }
+    @media (max-width: 640px) {
+      .reports-row {
+        grid-template-columns: 1fr;
+        gap: 0.5rem;
+      }
+    }
+    .reports-row:last-child { border-bottom: none; }
+
+    .reports-row a.rr-title {
+      font-family: var(--font-display);
+      font-size: clamp(1.4rem, 2.4vw, 1.75rem);
+      font-weight: 500;
+      letter-spacing: -0.01em;
+      line-height: 1.1;
+      color: var(--text);
+      text-decoration: none;
+      display: inline-flex;
+      align-items: baseline;
+      gap: 0.5rem;
+      transition: color 160ms ease-out;
+    }
+    .reports-row a.rr-title:hover,
+    .reports-row a.rr-title:focus-visible {
+      color: var(--apex-gold);
+      outline: none;
+    }
+    .reports-row a.rr-title .rr-tail {
+      color: var(--muted);
+      font-family: var(--font-mono);
+      font-size: 0.7em;
+      transition: color 160ms ease-out, transform 160ms ease-out;
+    }
+    .reports-row a.rr-title:hover .rr-tail,
+    .reports-row a.rr-title:focus-visible .rr-tail {
+      color: var(--apex-gold);
+      transform: translateX(2px);
+    }
+
+    .reports-row .rr-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem 1.25rem;
+      align-items: baseline;
+      font-family: var(--font-mono);
+      font-size: 0.78rem;
+      color: var(--muted);
+      letter-spacing: 0.02em;
+    }
+    .reports-row .rr-meta .rr-layer {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4em;
+    }
+    .reports-row .rr-meta .rr-layer code {
+      font-family: var(--font-mono);
+      color: var(--evidence-gold);
+      background: rgba(var(--evidence-gold-rgb), 0.08);
+      border: 1px solid rgba(var(--evidence-gold-rgb), 0.28);
+      padding: 0.05em 0.4em;
+      border-radius: 3px;
+      font-size: 0.85em;
+    }
+
+    .reports-row a.rr-json {
+      font-family: var(--font-mono);
+      font-size: 0.78rem;
+      color: var(--muted);
+      text-decoration: none;
+      letter-spacing: 0.02em;
+      padding: 0.25rem 0;
+      border-bottom: 1px solid transparent;
+      transition: color 160ms ease-out, border-color 160ms ease-out;
+      justify-self: end;
+    }
+    .reports-row a.rr-json:hover,
+    .reports-row a.rr-json:focus-visible {
+      color: var(--text);
+      border-bottom-color: var(--border);
+      outline: none;
+    }
+    @media (max-width: 640px) {
+      .reports-row a.rr-json { justify-self: start; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .reports-row a.rr-title,
+      .reports-row a.rr-title .rr-tail,
+      .reports-row a.rr-json { transition: none; }
+      .reports-row a.rr-title:hover .rr-tail,
+      .reports-row a.rr-title:focus-visible .rr-tail { transform: none; }
+    }
+
+    /* ── Empty state ───────────────────────────────────────── */
+    .reports-empty {
+      padding: 4rem 0;
+      text-align: center;
+      color: var(--text);
+    }
+    .reports-empty .glyph {
+      font-family: var(--font-display);
+      font-size: 3rem;
+      color: var(--muted);
+      margin-bottom: 1rem;
+      line-height: 1;
+    }
+    .reports-empty h3 {
+      font-family: var(--font-display);
+      font-weight: 500;
+      font-size: 1.5rem;
+      margin: 0 0 0.75rem;
+      color: var(--text);
+    }
+    .reports-empty p {
+      color: var(--text);
+      opacity: 0.72;
+      max-width: 32rem;
+      margin: 0 auto;
+      line-height: 1.55;
+    }
+    .reports-empty .cadence {
+      display: inline-block;
+      margin-top: 1.5rem;
+      font-family: var(--font-mono);
+      font-size: 0.78rem;
+      color: var(--muted);
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+
+    /* ── Footer caption ────────────────────────────────────── */
+    .reports-caption {
+      margin-top: 4rem;
+      padding-top: 2rem;
+      border-top: 1px solid var(--border);
+      font-family: var(--font-mono);
+      font-size: 0.78rem;
+      line-height: 1.7;
+      color: var(--muted);
+      letter-spacing: 0.02em;
+    }
+    .reports-caption a {
+      color: var(--muted);
+      text-decoration: none;
+      border-bottom: 1px solid transparent;
+      transition: color 160ms ease-out, border-color 160ms ease-out;
+    }
+    .reports-caption a:hover,
+    .reports-caption a:focus-visible {
+      color: var(--text);
+      border-bottom-color: var(--border);
+      outline: none;
+    }
+  </style>
+
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
-  "@type": "WebPage",
-  "name": "Index",
+  "@type": "CollectionPage",
+  "name": "Weekly Reports",
   "url": "https://gaiaskilltree.com/reports/"
 }
 </script>
 </head>
 <body>
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.1.1"></script>
-  <script src="../js/site-nav.js?v=6.1.1"></script>
+  <script src="../js/mounts.js?v=6.0.1"></script>
+  <script src="../js/site-nav.js?v=6.0.1"></script>
 
-  <main class="reports-archive" style="max-width: 72rem; margin: 2rem auto; padding: 0 1.25rem; color: var(--text); font-family: 'EB Garamond', Georgia, serif; line-height: 1.6;">
-    <header style="border-bottom: 1px solid var(--border); padding-bottom: 1rem; margin-bottom: 1.5rem;">
-      <div style="font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: .75rem; color: var(--muted); letter-spacing: .12em; text-transform: uppercase;">Gaia · Weekly Reports</div>
-      <h1 style="margin: .25rem 0 0; font-family: 'Bricolage Grotesque', 'EB Garamond', sans-serif; font-weight: 600;">What moved this week</h1>
-      <p style="color: var(--muted); font-size: .95rem; margin-top: .5rem;">One report per ISO week. Trending, ascended, contested — mechanically compiled from the <a href="/api/v1/trending/" style="color: var(--evidence-gold);">trending API</a>.</p>
+  <main class="reports-shell">
+
+    <header class="reports-hero">
+      <h1>The ledger, <em>week by week</em>.</h1>
+      <p>Every Monday, Gaia publishes what moved in the skill registry over the prior ISO week. Trending skills, recent rank-ups, contested contribution spaces. Mechanically compiled from the trending API, not editorial commentary.</p>
+      <p class="contract">
+        One report per ISO week at <code>/reports/YYYY-WW/</code>. Canonical JSON at <code>/api/v1/reports/YYYY-WW.json</code>. Archive index at <code>/api/v1/reports/index.json</code>. Cadence: Monday 08:00 UTC via cron.
+      </p>
     </header>
 
-      <ul style="list-style: none; padding: 0; margin: 0;">
-        <li style="padding: 1rem 0; border-bottom: 1px solid var(--border);">
-          <a href="/reports/2026-28/" style="color: var(--text); font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 1.1rem; text-decoration: none;">
-            2026-28
-          </a>
-          <span style="color: var(--muted); font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: .75rem; margin-left: 1rem;">ISO 2026-W28</span>
-<span style="color: var(--muted); font-size: .75rem; margin-left: 1rem;">Layer <code>L3</code></span>          <span style="color: var(--muted); font-size: .75rem; margin-left: 1rem;"><a href="/api/v1/reports/2026-28.json" style="color: var(--muted);">JSON</a></span>
-        </li>
-      </ul>
+    <section class="reports-block" aria-labelledby="archiveHeading">
+      <div class="reports-block-head">
+        <h2 id="archiveHeading">Archive</h2>
+        <span class="count">1 report</span>
+      </div>
 
-    <footer style="margin-top: 2rem; color: var(--muted); font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: .75rem;">
-      Archive rebuilt on every publish. Machine-readable index: <a href="/api/v1/reports/index.json" style="color: var(--muted);">/api/v1/reports/index.json</a>.
+        <ol class="reports-list">
+          <li class="reports-row">
+            <a class="rr-title" href="/reports/2026-28/">
+              <span>2026-28</span>
+              <span class="rr-tail" aria-hidden="true">→</span>
+            </a>
+            <div class="rr-meta">
+              <span>ISO 2026-W28</span>
+              <span class="rr-layer">Layer <code>L3</code></span>
+            </div>
+            <a class="rr-json" href="/api/v1/reports/2026-28.json" aria-label="Canonical JSON for report 2026-28">JSON</a>
+          </li>
+        </ol>
+    </section>
+
+    <footer class="reports-caption">
+      Archive rebuilt on every publish. Machine-readable index at <a href="/api/v1/reports/index.json">/api/v1/reports/index.json</a>. Compiled from the <a href="/api/v1/trending/">trending API</a>.
     </footer>
+
   </main>
+
+  <div id="site-footer-mount"></div>
+  <script src="../js/site-footer.js?v=6.0.1"></script>
 </body>
 </html>

--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -297,8 +297,8 @@
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
-  "@type": "CollectionPage",
-  "name": "Weekly Reports",
+  "@type": "WebPage",
+  "name": "Index",
   "url": "https://gaiaskilltree.com/reports/"
 }
 </script>

--- a/docs/trending/trending.css
+++ b/docs/trending/trending.css
@@ -7,7 +7,12 @@
 .trending-main {
   max-width: 860px;
   margin: 0 auto;
-  padding: 0 1.5rem 4rem;
+  /* Clear the fixed nav (~58px). Matches the 5rem/6rem top-clearance
+     pattern used by .bench-shell, .reports-shell, and .wip-banner. */
+  padding: 5rem 1.5rem 4rem;
+}
+@media (min-width: 768px) {
+  .trending-main { padding-top: 6rem; }
 }
 
 /* ── Hero tweaks ─────────────────────────────────────────────── */

--- a/docs/trust/leaderboard/leaderboard.js
+++ b/docs/trust/leaderboard/leaderboard.js
@@ -196,8 +196,12 @@
     return Math.ceil(rotated + labelLines * fontPx * 1.4 + 24);
   }
 
-  // Resolve target container width — viewport-aware, capped at design max.
+  // Resolve target container width — uses the actual panel element width when
+  // available so embedded contexts (e.g. homepage #trust-preview with a
+  // max-width:1180px wrapper) don't produce an SVG wider than the container.
   function chartContainerW() {
+    var panel = document.querySelector('.lb-chart-panel');
+    if (panel && panel.offsetWidth > 0) return panel.offsetWidth;
     var vw = (typeof window !== 'undefined' && window.innerWidth) || 1024;
     return Math.min(vw - 40, 1280);
   }

--- a/founder/handovers/design-v6.1.1-ascension-overdrive-commissions.md
+++ b/founder/handovers/design-v6.1.1-ascension-overdrive-commissions.md
@@ -1,0 +1,252 @@
+# Commission asset brief — Ascension Cycle Overdrive (v6.1.x)
+
+> Vendor-facing shopping list for the illustration/motion assets required by `founder/handovers/design-v6.1.1-ascension-overdrive-shape.md`. This document is safe to share externally with commissioned illustrators / motion designers.
+>
+> Tracking issue: **TBD** (filed alongside this brief). Ship target: PR follows once assets land.
+
+---
+
+## Project context (for the illustrator)
+
+Gaia is an evidence-backed skill registry for AI agents, presented as a public ledger with the ceremonial gravity of a guild admissions register. The homepage's Ascension Cycle section teaches how ranks (0★ Basic through 6★ Apex) actually work, plus a parallel prestige class called **Unique** that non-suite skills earn at 4★+.
+
+**Reference anchors (mood board):**
+- 19th-century natural history atlas plates — Ernst Haeckel's *Kunstformen der Natur*; Charles Darwin's *Origin* first-edition plates; Alexander von Humboldt's *Cosmos*
+- Museum specimen annotation — brass identification tags, plate cartouche labels, hairline plate rulings
+- Ceremonial admissions register — leather-bound ledger books; hand-ruled pages; ink-and-lamp-oil lighting
+- Solo Leveling guild-registry gravity, without any anime UI
+
+**Anti-references (do not deliver):**
+- No hand-sketchy woodcut clip art
+- No AI-generated illustration
+- No Fiverr / vector-stock generic "atlas" imagery
+- No fantasy-game gates or portals
+- No sci-fi space-scene renderings
+- No decorative "aged parchment" textures with fake weathering
+
+---
+
+## Asset A — Apex Gate arch (Tier 1, priority signature)
+
+**Purpose:** the visual backdrop of the Apex Gate predicate panel. Six-columned or six-arched atlas plate rendering that anchors the six named predicates displayed in front of it.
+
+**Deliverables:**
+- One primary illustration, ~1200×800px display size
+- Formats: transparent PNG (retina 2400×1600 source), plus SVG source (Illustrator .ai or Figma export acceptable)
+- Style: single-plate natural-history-atlas rendering, hairline linework, restrained cross-hatching. Six architectural elements (columns, arches, gates, or steles) arranged in a plate composition. The plate should read as *"the six conditions of admission"* metaphorically, not as a fantasy portal.
+- Colour: **monochrome greyscale linework only** — CSS filter will tint the delivered asset with `--apex-gold` (#d4af37) at 6–10% opacity. Do not deliver pre-tinted or coloured. Fine linework must survive at 10% opacity over a near-black background.
+- Composition weight: content clusters in the horizontal middle band; leave top and bottom quarters clean so the panel eyebrow and caption sit against negative space.
+
+**Failure conditions:**
+- Reads as a fantasy game portal
+- Any element feels illustrated recently (2020s vector aesthetic)
+- Linework too heavy to remain visible at 10% opacity
+- Symmetrical composition that looks generic rather than plate-specific
+
+**Estimated budget:** $600–1400 depending on illustrator tier.
+**Turnaround:** 2–3 weeks including one revision round.
+
+---
+
+## Asset B — Ledger paper base texture (Tier 1, atmospheric foundation)
+
+**Purpose:** the section-wide background texture blended `multiply` at 8–12% opacity over `--bg` (#030712), giving the whole plate a ledger-paper substrate.
+
+**Deliverables:**
+- One high-resolution image, ~2000×3000px
+- Formats: WebP (primary, ≤80KB after optimization) + JPEG fallback (≤120KB)
+- Source: preferably a genuine period ledger page scan from a public-domain archive (British Library, MET Open Access, Internet Archive, National Archives). Alternatively, a hand-photographed scan of aged paper with hairline rulings.
+- Colour: warm-cool neutral, low saturation (chroma near 0.02 in OKLCH — i.e. *desaturated near-neutral*, not warm beige). At 8–12% opacity over near-black `--bg`, the texture reads as substrate, not stain.
+
+**Failure conditions:**
+- Any AI-generated paper texture
+- Overtly "aged" or "distressed" — the ledger should read as *kept*, not *ruined*
+- Warm beige at high saturation (this lands on PRODUCT.md's saturated-warm-neutral anti-reference)
+
+**Estimated budget:** $0 if sourced from public-domain scans; $50–150 for licensed period paper stock; $200–400 for a commissioned scan.
+**Turnaround:** days if public-domain-sourced; 1 week if commissioned scan.
+
+---
+
+## Asset C — Six rank-glyph atlas stamps (Tier 2, elevates the whole section)
+
+**Purpose:** one small hand-drawn atlas-plate stamp above each rank card, matching Asset A's linework style so all elements read as one plate family.
+
+**Deliverables:**
+- Six illustrations delivered as **one coherent series**, ~200×200px each display size (retina 400×400 source)
+- Formats: transparent PNG per stamp, plus one combined SVG sprite (Illustrator source)
+- Style: single-mark atlas plate stamps in the same linework language as Asset A. Each is one clear iconic subject, hairline execution.
+- Colour: monochrome greyscale linework — CSS will tint each to its rank token (`--rank-N`) at display time
+
+**Six subjects (fixed, not for reinterpretation):**
+
+| Rank | Subject | Metaphor |
+|---|---|---|
+| 1★ Awakened | A candle or single ember | *verified as real, not yet named* |
+| 2★ Named | A signet stamp or wax seal impression | *RPG title assigned* |
+| 3★ Evolved | A brass compass with visible verified point | *blob link verified* |
+| 4★ Hardened | An anvil, or a stylised shield | *security-reviewed* |
+| 5★ Transcendent | A laurel wreath, half-open | *enterprise-ready* |
+| 6★ Apex | *Reserved* — this rank uses the Apex Gate arch (Asset A) instead of an individual stamp |
+
+Note: only five stamps are actually commissioned. The 6★ slot is rendered by Asset A.
+
+**Failure conditions:**
+- Any two stamps read as siblings but not as *the same illustrator's hand*
+- Any stamp reads more literal than iconic (e.g. a photo-realistic anvil rather than an illustrated plate stamp)
+- Style drift from Asset A's linework
+
+**Estimated budget:** $600–1500 for five stamps as a coherent series from the same illustrator as Asset A.
+**Turnaround:** 2–3 weeks; commission alongside Asset A for style consistency.
+
+---
+
+## Asset D — Three Unique class glyphs (Tier 2, signature)
+
+**Purpose:** the three Unique cards on the parallel branch, each with its own colour treatment representing the class's evolution across 4★ → 5★ → 6★. This is the section's most distinctive visual argument.
+
+**Deliverables:**
+- Three illustrations delivered as **one coherent evolution series**, ~240×240px each display size (retina 480×480 source)
+- Formats: transparent PNG per glyph, plus one combined SVG source. Assets D2 and D3 optionally also delivered as looping WebM+MP4 pair (see Asset E for motion spec).
+
+**Three subjects (color pegs operator-ratified):**
+
+### D1 — Unique 4★ (violet, *structural*)
+- Subject: a struck coin or medallion in the atlas-plate stamp style, bearing the `◉` glyph in the centre
+- Colour: monochrome linework, CSS-tinted to `--tier-unique` (#7c3aed) at display
+- Metaphor: *the structural off-ramp — a Basic/Extra skill that stayed non-suite*
+
+### D2 — Unique 5★ (**black hole + gold**, *gravitational*)
+- Subject: a gravitational singularity rendered in the atlas-plate style — a deep near-black core with a hairline gold accretion ring at ~85% of the outer radius. The `◉` glyph sits at the centre, low-luminance gold.
+- Style: still readable as atlas-plate illustration (hairline linework at the ring's edge and gold cross-hatching or engraved detail on the accretion band), but composition is gravitational, not flat.
+- Colour: deep near-black centre (`#050202`), `--apex-gold` (#d4af37) ring at low luminance. Do NOT deliver full-saturation gold — the ring must read as *ember gold on void*, not decorative bling.
+- Metaphor: *depth so severe it curves gravitationally — the specimen has mass now*
+
+### D3 — Unique 6★ (**white + black hole**, *impossible*)
+- Subject: the same near-black gravitational field as D2, but the centre carries a small white singularity — a bright core (~8px radial spike) that fades outward through faint gold to void. The `◉` glyph is inverted: pure white on the void.
+- Style: hairline atlas-plate linework at the edges, but the core is a genuine bright singular point (rendered, not stylised). The illustration must read as *"this shouldn't be possible."*
+- Colour: near-black field (`#050202`), white core (`#ffffff` at full luminance), faint gold intermediate glow. High contrast between core and field.
+- Metaphor: *Apex without fusion. A non-suite skill that reached Grade S. The impossible object.*
+
+**Failure conditions:**
+- The three glyphs read as three separate visual languages rather than the same class deepening
+- D2's accretion ring reads as decorative bling rather than gravitational depth
+- D3's white core reads as sci-fi optical bloom rather than as *the impossible point*
+- Any of the three lose the `◉` glyph reference — that mark is the class's identity anchor
+
+**Estimated budget:** $700–1800 for the three-piece coherent series. If the same illustrator delivers Asset A and Asset C, they can typically hold the linework family across D as well; commission as one contract.
+**Turnaround:** 3 weeks; commission alongside A and C.
+
+---
+
+## Asset E — Optional motion loops for Unique 5★ and 6★ (Tier 3, polish)
+
+**Purpose:** subtle looping motion on Assets D2 and D3 to sell the "gravitational" reading. The static illustrations work; motion elevates them from *illustrated depth* to *felt depth*.
+
+**Deliverables (optional; commission only if D2 and D3 already delivered and read cleanly):**
+
+### E1 — Unique 5★ accretion ring rotation loop
+- Subject: D2's gold accretion ring rotates once every 8–12 seconds, one full revolution. Rotation is uniform; no easing.
+- Format: WebM (VP9) + MP4 (H.264) pair, 640×640, ≤300KB combined, seamless loop
+- Alpha channel: WebM with alpha; MP4 with matte fallback
+- Frame rate: 30fps (24fps acceptable for size reduction)
+
+### E2 — Unique 6★ white core breathe loop
+- Subject: D3's white singularity core "breathes" — subtle luminance modulation between full white and 85% white over ~4-second cycle, ease-in-out sine
+- Format: WebM (VP9) + MP4 (H.264) pair, 640×640, ≤250KB combined, seamless loop
+- Alpha channel: as E1
+- Frame rate: 30fps
+
+**Playback discipline (implementation-side, not vendor):**
+- Both loops autoplay muted, `loop`, `playsinline`
+- Both wrapped in `@media (prefers-reduced-motion: no-preference)` guard; reduced-motion falls back to the static PNGs from Asset D
+- Both pause when off-screen via IntersectionObserver; resume when in-viewport
+
+**Failure conditions:**
+- Loop seam visible (any frame-to-frame discontinuity at the join)
+- Motion reads as busy rather than gravitational
+- File size exceeds spec — this is a signature section, not a video wall
+
+**Estimated budget:** $400–1000 for both loops delivered by a motion designer with credentials in editorial + scientific-illustration adjacent motion. Motion Society, Cartoon Brew–adjacent illustrator/motion-designer collaboratives; not stock motion-graphics vendors.
+**Turnaround:** 2 weeks after Asset D delivery.
+
+---
+
+## Summary table
+
+| Asset | Purpose | Priority | Budget | Turnaround |
+|---|---|---|---|---|
+| A — Apex Gate arch | Signature backdrop | **Tier 1 (must)** | $600–1400 | 2–3 wk |
+| B — Ledger paper texture | Section base | **Tier 1 (must)** | $0–400 | days–1 wk |
+| C — Five rank stamps | Per-rank atlas marks | Tier 2 (recommended) | $600–1500 | 2–3 wk |
+| D — Three Unique glyphs (violet / gold-hole / white-hole) | Signature evolution | **Tier 2 (recommended — highest ROI)** | $700–1800 | 3 wk |
+| E — Unique motion loops (5★ / 6★) | Optional polish | Tier 3 (if D reads clean) | $400–1000 | 2 wk after D |
+
+**Recommended commission bundle for full signature ship:** A + B + D. That's ~$1300–3600 depending on illustrator tier, and it lands the two most distinctive visual arguments (the Apex Gate arch + the Unique evolution) plus the ledger substrate that makes everything else feel plate-consistent. Asset C is a nice-to-have that elevates the middle-rank stages from "chip on a card" to "specimen in a plate"; skip if budget is tight.
+
+**Recommended commission bundle for maximum impact:** A + B + C + D + E. ~$1700–4600. This is the full atlas-plate treatment with motion polish. Would justify the "extravagant" instruction from the operator.
+
+---
+
+## Illustrator vendor guidance
+
+Prefer illustrators with **editorial + scientific-illustration** credentials. Portfolios that include:
+
+- Scientific / natural-history plate illustration (botanical, zoological, geological)
+- Editorial illustration for magazines like *Nautilus*, *Scientific American*, *Aeon*, *The New York Review of Books*
+- Book cover work for university presses or small independent literary publishers
+- Any published scientific plate work post-2010 that reads as *contemporary hand* interpreting a period language
+
+Avoid illustrators whose portfolios are primarily:
+- Character illustration / concept art / game art
+- Vector-stock or Fiverr-tier commercial work
+- AI-composited or hybrid AI-assisted styles
+- Fantasy game art or portal/gate imagery specifically
+
+Named illustrators as style pegs (not necessarily commission-available, but examples of the register):
+- Kate Baylay
+- Emily Carroll
+- Nate Kitch (editorial abstract)
+- Klaas Verplancke (editorial plate style)
+- Elenia Beretta (natural history editorial)
+- Marta Monteiro (linework-driven editorial)
+
+For **motion (Asset E)**, prefer motion designers who have worked on:
+- Editorial explainer motion for *The Pudding*, *The New York Times*, *Bloomberg*
+- Scientific-illustration adjacent motion (data visualisation with restraint)
+- Not: motion-graphics agencies whose reel is dominated by SaaS explainer video work
+
+---
+
+## Handover format
+
+When commissioning, send illustrators:
+
+1. This document
+2. `founder/handovers/design-v6.1.1-ascension-overdrive-shape.md`
+3. Access to Gaia's `PRODUCT.md` and `DESIGN.md` (public — link to the GitHub repo)
+4. The public site at `gaiaskilltree.com/` so they can see the tonal context
+
+Do NOT send:
+- Screenshots of AI-generated versions "for reference"
+- Fantasy-game gate references
+- Sci-fi space visualisation references
+
+If the illustrator asks for tighter mood-board input, the natural-history atlas anchors listed at the top of this document are the answer.
+
+---
+
+## Delivery + ratification checklist
+
+Upon delivery of each asset, verify:
+
+- [ ] Format spec met (dimensions, file size, transparency, format list)
+- [ ] Displays cleanly at 10% opacity over `--bg` (Asset A) or blended `multiply` at 12% (Asset B)
+- [ ] Renders correctly with CSS filter tinting (Assets A, C, D1)
+- [ ] Assets D2 and D3 hold their gravitational reading at final display size
+- [ ] Motion loops (E1, E2) are seamless — no visible loop seam
+- [ ] All asset filenames follow the pattern `ascension-overdrive-<asset-id>-<version>.<format>` (e.g. `ascension-overdrive-apex-arch-v1.svg`)
+- [ ] Sources delivered alongside rendered outputs (Illustrator, Figma, or comparable)
+- [ ] Licensing terms captured in `evidence/asset-licenses/ascension-overdrive.md` on delivery
+
+**Storage location on delivery:** `docs/assets/ascension-overdrive/` for shipped optimised outputs; `founder/handovers/design-v6.1.1-assets/` for source files.

--- a/founder/handovers/design-v6.1.1-ascension-overdrive-shape.md
+++ b/founder/handovers/design-v6.1.1-ascension-overdrive-shape.md
@@ -1,0 +1,309 @@
+# design-v6.1.1 — Ascension Cycle Overdrive Shape
+
+> `/impeccable overdrive` — the Ascension Cycle section (`#ascension` on `docs/index.html` L743–790) becomes the homepage's educational centerpiece: a single-page visual refresher on how ranks actually work, treated with the ceremonial gravity of the mechanic itself. No CTA burden — the section teaches, the earlier hero handles conversion.
+
+## Framing correction from Direction B
+
+The earlier Direction B shape treated the section as decorative ceremony with an "Apex Threshold" beat. That was too thin. Research surfaced three concrete mechanics that must all be legible in the section:
+
+1. **Rank ladder** — six stages, ascending (existing intent)
+2. **Star Bar** (per `META.md §2.4`) — the threshold ladder each rank must **actually clear**. Not a progress bar. Concrete gates: evidence grade floor, installability requirement, security review, enterprise-ready, Apex 6-predicate gate.
+3. **Apex Gate** — the six named predicates that hard-gate 5★ → 6★ Apex promotion. Currently only documented on `docs/codex/trust-methodology.html §5`; on the homepage the 5★→6★ transition is a bare `→` arrow, which is dishonest to the mechanic.
+4. **Unique class off-ramp** — per #935 ratification: Basic/Extra skills that reach 4★ without becoming a Suite earn `◉ Unique` as a parallel prestige class. This must appear in the section or the "here's how ranks work" refresher is incomplete.
+
+Overdrive scope is therefore the coordinated visual assertion of **four mechanics simultaneously**, on one section, without collapsing into a spec dump. The ceremonial voice (guild ledger kept with obsessive care) is the tonal glue.
+
+---
+
+## The scene sentence
+
+An initiate stands at the base of a six-step atlas plate. Each step is a threshold with the specific conditions carved into its riser. A gated arch spans the top step; six brass-tag predicates dangle from the gate's crossbar. To the right of the fourth step, a side door leads to a parallel plate marked `UNIQUE · ◉`. The whole plate is lit as if by lamp-oil, catching hairline gold on the riser edges and the gate's arch.
+
+**Category-reflex check.** Guessing "evidence-backed registry → clean rank ladder with progress bars" is the first reflex. Guessing "editorial-typographic ledger" is the second. Neither predicts the mechanic-forward, brass-tag Apex Gate treatment — that's the composition's identity move. The ceremonial gate + brass-tag predicate motif is not visible in AI landing-page training data for skill registries; it's borrowed from admissions-hall and museum-annotation visual language, adjacent to Gaia's stated 19th-century natural-history-atlas anchor but distinct from anything on the site today.
+
+---
+
+## The composition, plane by plane
+
+The section renders as **one full-viewport plate** (min-height `100vh` clamped, or `88vh` on ≤900px) with the following layered composition. Layer count ceiling: five planes total (parallax discipline permits three atmospheric; we're adding two content planes that are load-bearing).
+
+### Plane −2 · Ledger paper base (atmospheric, static)
+
+A commissioned or hand-composed **ledger-paper texture** covering the section background at 8–12% opacity, blended `multiply` over `--bg`. Warm-cool balance: faint umber warmth, not literal parchment beige (that lands on PRODUCT.md anti-references as "warm-neutral AI default"). This is the plate the whole composition sits on.
+
+**Asset ask:** one high-res texture, ~1600×2400px, WebP + JPEG fallback, ≤80 KB. See § Asset commission menu below.
+
+### Plane −1 · Ascending risers (atmospheric, parallax 0.10×)
+
+Six horizontal riser strokes, each aligned under one rank, ascending in unequal heights so the composition physically climbs left-to-right. Riser under Apex is +80–120px above the riser under Awakened.
+
+**Hairline colour ladder:** each riser inherits its rank's own `--rank-N` token at 20% alpha as a subtle chromatic hint (Awakened blue → Named teal → Evolved violet → Hardened pink → Transcendent gold-pink → Apex gold). Adjacent risers pass through connecting hairlines in `--border`. The gradient is signal, not decoration — it reads as the palette climbing.
+
+Parallax drift: `translate3d(0, y * 0.10, 0)` on scroll. On section entry (IntersectionObserver, `unobserve` after fire): each riser draws in via `stroke-dashoffset` animation, staggered 80ms apart, ease-out-quart 900ms. Reduced-motion: all risers pre-drawn at rest position.
+
+### Plane 0 · The six rank stages (load-bearing content)
+
+Each stage is a **stepped card** riding its riser, containing top-to-bottom:
+
+- **Rank name** — EB Garamond, `clamp(1.2rem, 1.8vw, 1.5rem)`, medium weight
+- **`.rank-badge` chip** — existing component, unchanged (preserves screen-reader semantics)
+- **Star Bar tag** — the concrete threshold this rank must clear, expressed as a compact mono line in an inline `<code>`-styled tag. Rendered as one or two short strings per rank. Examples:
+
+  | Rank | Star Bar tag(s) |
+  |---|---|
+  | 1★ Awakened | `verified as real skill` |
+  | 2★ Named | `RPG title assigned` · `Grade C+ evidence` |
+  | 3★ Evolved | `Grade B+` · `verified blob link` |
+  | 4★ Hardened | `Grade B+ rank-floor` · `security-reviewed` |
+  | 5★ Transcendent | `Grade B+ rank-floor` · `enterprise-ready` |
+  | 6★ Apex | `Grade S` · `6-predicate Apex Gate` *(links to Plane +2 panel below)* |
+
+- **Optional per-rank micro-glyph** — a hand-drawn atlas-plate stamp specific to the rank's semantic (compass rose for Named, anvil for Hardened, laurel for Transcendent). If commissioned; see asset menu. Without commission: rank-appropriate Unicode glyph in muted mono is acceptable but weaker.
+
+### Plane 0b · The Unique parallel branch (three cards, color evolves)
+
+At the 4★ stage on the main line, a **branch exits to the right** and runs parallel to the main ascension from 4★ through 6★. **Three Unique cards** sit on the branch, one mirroring each of the three highest main-line stages (Hardened / Transcendent / Apex). Per #935 ratification: a Basic or Extra skill that is NOT a suite earns Unique class at 4★+; the class persists as the skill advances, so the branch runs the full length of the top half of the plate.
+
+**The Unique branch's colour language evolves rank by rank** — this is the section's most distinctive visual argument. Unique's terminal form is gravitational; the palette climbs from *structural* (violet) through *gravitational* (black hole gold) to *impossible* (white/black hole):
+
+| Card | Star Bar tag | Colour treatment |
+|---|---|---|
+| **4★ Unique ◉** | `Basic or Extra` · `not a Suite` · `4★+` | `--tier-unique` violet (`#7c3aed`). Standard token palette. Card border-hairline in `--tier-unique` at 40% alpha, `--tier-unique-bg` fill at 12%. The *structural* off-ramp. |
+| **5★ Unique ◉** | `Transcendent Unique` · `enterprise-ready` · `non-Suite` | **Black hole + gold.** Card fill is a deep near-black radial gradient sinking toward `#050202` at centre, ringed by a hairline `--apex-gold` accretion ring at ~85% radius. The `◉` glyph sits in the centre in `--apex-gold` at low luminance. Optional: subtle rotation loop on the accretion ring (see asset menu). Reads as *the specimen has gravity now.* |
+| **6★ Unique ◉** | `Apex Unique` · `Grade S` · `never fused` | **White + black hole.** Card fill is the same deep near-black but with a small white singularity at centre, rendered as a `--text`-white radial spike (~8px) that fades outward through faint gold to void. The `◉` glyph is inverted — white on the void. This is the *impossible object*: a non-suite skill that reached Apex-grade trust without ever fusing. Optional: subtle white-core breathe loop. |
+
+Between the three Unique cards, the branch line remains a hairline `--tier-unique` violet at 40% alpha, terminating at each card boundary — the branch stays chromatically stable while the cards themselves *transform through the gates*. That colour contrast (stable violet branch vs. evolving card treatments) is deliberate: it argues that the **class is one thing** but its *state* deepens as it advances.
+
+Each Unique card carries a one-line caption below it in `--muted` italic:
+
+- 4★ Unique: *"A parallel prestige class. Not a rank step."*
+- 5★ Unique: *"The Unique passes through Transcendent. Depth becomes gravity."*
+- 6★ Unique: *"Apex without fusion. The rarest form."*
+
+The visitor's eye follows both tracks: main-line ascension climbing through the Apex Gate, and the parallel Unique branch climbing through its own transformation. At Apex, the two tracks are visually siblings but chromatically opposite — gold arch/gate versus white/black hole. Two ways to be rare.
+
+**Content plane, no parallax on these cards.** They are the load-bearing story.
+
+### Plane +1 · The Apex Gate panel (load-bearing content, the crescendo)
+
+Between the 5★ Transcendent stage and the 6★ Apex stage, spanning ~40–50% of section width, sits **THE APEX GATE** — the compositional crescendo the whole plate ascends toward.
+
+Structure:
+
+- Section eyebrow: `THE APEX GATE · 6 PREDICATES` in `--font-mono`, `--apex-gold`, uppercase, 0.72rem, letter-spacing 0.12em
+- Beneath: a 2×3 grid (2×3 on desktop, 1×6 on ≤700px) of **brass-tag predicates**, each rendered as:
+  - Predicate ID in `--font-mono` at 0.78rem, `--tier-extra` colour (matching the existing `docs/codex/trust-methodology.html §5` styling of `.tm-predicate-list .pred-id`)
+  - One-line human-readable summary in body font, `--muted`
+  - A left border-hairline in `--apex-gold` at 60% alpha (echoes the `border-left: 3px solid var(--tier-extra)` on `.pred-pass` but in gold to signal "all six must pass")
+- Below the grid: a subtle mono caption `All six predicates must evaluate true. Partial satisfaction is logged, not promoted.`
+- The whole panel sits behind a **commissioned or hand-composed gate/arch atlas plate illustration** at 6–10% opacity, tinted `--apex-gold`. Not a stock woodcut, not clip art — a genuine plate-style rendering. This is the signature move.
+
+The six predicates rendered:
+
+1. `aGradedOriginsGte5` — At least 5 fusion-origin components each hold Grade A or higher.
+2. `directNestedSuiteGte1` — At least 1 directly-nested suite exists among the origins.
+3. `depth2OnlyReachableGte1` — At least 1 origin is reachable only at depth-2.
+4. `overallGradeS` — Trust Magnitude ≥ 250 with diversity gate satisfied.
+5. `sourceTenureDaysGte180AorS` — At least 1 A/S evidence row has ≥ 180 days public tenure.
+6. `apexPromotionPrSigned` — Maintainer-signed promotion PR.
+
+### Plane +2 · The gold thread + brass-tag reveal (motion crescendo)
+
+One continuous `--apex-gold` thread at 1px weight, `stroke-linecap: round`, drawn along the ascension geometry from Awakened's baseline through each stage's riser edge, up and around the Apex Gate panel's top arch, and terminating at the 6★ Apex chip. This is the visual argument that **the ascension is one line, drawn once, terminating only at Apex through the six-predicate gate**.
+
+On section entry (staged after Plane −1 risers complete):
+
+1. **T=0ms** — Risers begin draw-in cascade (Plane −1, 900ms total)
+2. **T=1100ms** — Gold thread begins `stroke-dashoffset` animation, 1400ms ease-out-quart, following the ascending geometry
+3. **T=1600ms** — As the thread crosses the Apex Gate panel's arch, the six brass-tag predicates illuminate one-by-one, 120ms stagger, each fading its left-border from `--muted` to `--apex-gold` and its predicate ID from `--tier-extra` to `--apex-gold` briefly (240ms) then settling back to `--tier-extra` — the transient gold flash reads as *"this condition just verified true."*
+4. **T=2400ms** — Thread completes its stroke at the Apex chip. The chip's existing `.is-apex` state gets a one-shot `box-shadow` pulse: `0 0 0 rgba(var(--apex-gold-rgb), 0.6)` expanding to `0 0 60px rgba(var(--apex-gold-rgb), 0)` over 600ms, ease-out-expo. The Apex is *earned* at the end of the animation, not merely displayed.
+
+Total choreographed motion length: ~3.0 seconds. Fires once per session (IntersectionObserver → `unobserve` on first fire, stored in `sessionStorage` to prevent re-fire on same-tab navigation).
+
+**Reduced-motion collapse:** all planes render in composed final state. Risers full-drawn. Thread full-drawn. All brass-tag predicates gold-lit. Apex chip carries the standard `.is-apex` treatment without the pulse. The composition still reads as ceremonial and earned — the motion is the delivery, the composed state is the message.
+
+---
+
+## Signature moves (four, each with a specific role)
+
+1. **The ascending riser palette** — riser hairlines carry each rank's own `--rank-N` colour at 20% alpha. The palette IS the ascension; you can identify what rank a strip belongs to from the colour alone. This is unique to Gaia's rank tokenization and readable at a glance.
+
+2. **The Unique branch's evolving colour language** — violet (structural) at 4★, black hole + gold (gravitational) at 5★, white + black hole (impossible) at 6★. The class stays the same; its *state* deepens. This is the single most distinctive visual argument in the whole section and the strongest lure to commission real illustration or subtle motion loops (see asset menu C and E). The colour peg is operator-ratified.
+
+3. **The main-line vs. Unique-branch chromatic opposition at Apex** — at the top of the plate, the two tracks are visually siblings but chromatically opposite: the main line terminates in the gold Apex Gate arch, the Unique branch terminates in the white/black hole. Two ways to be rare, presented side-by-side. A visitor's eye must be able to read this diptych in one glance.
+
+4. **Brass-tag predicates with the transient gold flash** — the six Apex Gate conditions read as brass identification tags on a museum specimen, each verifying with a moment of gold. Solo-Leveling guild-ceremony energy borrowed from PRODUCT.md's anchor, delivered through 19th-century-atlas language, without any anime UI.
+
+---
+
+## Interaction contract
+
+The section is **display + educational**, not transactional. What visitors must still be able to do:
+
+- Read every rank name and star count at 3s glance
+- Read every Star Bar tag (contrast-verified `--text` on `--bg`, no `--muted` on primary content)
+- Read every Apex Gate predicate name and description
+- Locate the Unique branch as a genuinely-visible off-ramp
+- Follow a keyboard tab order that visits: each rank card in order (1★→6★), then the Unique card, then each of the six predicates. All are `role="listitem"` inside a labelled `role="list"`; no interactive controls beyond focus.
+- One optional link on the Apex Gate eyebrow → `docs/codex/trust-methodology.html#apex-gate` for the full spec. This is the only navigation the section carries.
+
+No hover-pop, no click-to-expand, no accordion. The whole section is legible without interaction. Motion enhances; motion is not required for comprehension.
+
+---
+
+## Reduced-motion fallback (the composed static state)
+
+`@media (prefers-reduced-motion: reduce)` collapses:
+
+- Plane −1 risers: pre-drawn full at rest position, no draw-in cascade
+- Plane +2 gold thread: fully drawn at rest along the ascension path
+- Brass-tag predicates: all six left-borders in `--apex-gold` at 60% alpha, all predicate IDs in `--tier-extra`
+- Apex chip: `.is-apex` standard state, no pulse
+- Parallax `translate3d` layers: transform removed, layers at their rest offset
+
+The section is fully composed, fully readable, ceremonial in tone. A visitor with `prefers-reduced-motion` never sees the motion delivery but receives the whole message. This is the passing bar per `SKILL.md` Motion rules and `animate.md` reduced-motion policy.
+
+---
+
+## Failure test (what would let a reviewer say "wrong")
+
+Any of these on landing:
+
+1. A visitor reads the section for 15 seconds and cannot answer "what makes something Apex?" That means the Apex Gate panel didn't land.
+2. A visitor reads the section for 15 seconds and doesn't notice the Unique branch exists. That means the branch geometry was too subtle or the caption was buried.
+3. A visitor sees the three Unique cards but cannot articulate that they are the *same class deepening* rather than three separate classes. That means the branch's chromatic stability (violet hairline connecting all three) got out-shouted by the individual card treatments; rebalance.
+4. A visitor says "row of six chips" instead of "a staircase to a gate." That means the ascending geometry didn't win.
+5. The section reads as decorative rather than educational. If someone asks "why is this here on the landing page?", the answer *must* be "this is how ranks actually work"; if the answer is "atmosphere," we've built decoration.
+6. The gold thread reads as decoration rather than as the section's spine. Cut it if it's not the argument.
+7. The 6★ Unique white/black hole reads as sci-fi decoration rather than as *the impossible object*. If it doesn't carry the argument that a non-suite skill reaching Apex is genuinely rare, the treatment is wrong.
+8. Motion fires more than once per session on reload. Nauseating.
+
+## Fixed-nav clearance & positioning
+
+The section is not the first below the nav (hero + hall-of-heroes + trust-preview precede it), so the 5rem/8rem clearance ladder does not apply to its own container. Standard `.reveal` section boundary + `.section-divider` above and below. Section minimum height 88vh at ≥900px viewports (composed as one full plate on desktop) and `auto` below with cards stacking vertically.
+
+---
+
+## Cross-section discipline
+
+**Palette (permitted).**
+- Section-wide: `--bg`, `--text`, `--muted`, `--border`, `--font-display`, `--font-body`, `--font-mono`
+- Riser hairlines: each `--rank-N` at 20% alpha (canonical rank colours in their canonical roles — signal, not decoration)
+- Star Bar tags: `--muted` background at 8% alpha, `--text` foreground
+- Main-line rank cards: standard token palette, no cascade
+- Unique branch hairline (connecting the three cards): `--tier-unique` violet at 40% alpha, stable through all three cards
+- Unique 4★ card: `--tier-unique` palette, standard treatment
+- Unique 5★ card: **black hole + gold** — near-black radial fill sinking to `#050202` at centre, `--apex-gold` hairline accretion ring at ~85% radius; the ◉ glyph in `--apex-gold` at low luminance
+- Unique 6★ card: **white + black hole** — same near-black base, small white singularity core (`--text` at full luminance, ~8px radial spike fading through faint gold to void); the ◉ glyph inverted white
+- Apex Gate: `--apex-gold` for eyebrow + brass-tag left-borders + thread + pulse; `--tier-extra` for predicate IDs (matching existing methodology page); `--muted` for descriptions
+
+**Palette (refused everywhere in this section).**
+- `--honor-red` — contributor identity token, never scenery
+- Gradient text — banned per `SKILL.md` Absolute bans
+- Glass / backdrop-blur — no glassmorphism as decoration
+- Tier tokens (`--tier-basic`, `--tier-extra`, `--tier-ultimate`) outside their semantic roles above
+
+**Typography.**
+- Display: EB Garamond medium for rank names + Apex Gate title
+- Body: Bricolage Grotesque for descriptions
+- Mono: Departure Mono / JetBrains Mono for predicate IDs, Star Bar tags, section eyebrows
+
+**Motion budget.**
+- One choreographed sequence per section entry, ~3.0s total, fires once per session
+- Parallax on scroll: two atmospheric planes at 0.10× / 0× drift
+- Reduced-motion: full composed rest state
+
+**Content invariance.**
+- Rank names come from `META.md §1.1` — do not paraphrase
+- Star Bar tags come from `META.md §1.1` and `META.md §2.4` — quote verbatim
+- Apex predicates come from `founder/handovers/G7_TRUST_TAXONOMY_RFC.md §11.12` (active set post-2026-06-17 delta) — quote verbatim
+- Unique class rule comes from #935 comment `IC_kwDOSNHq388AAAABIxE1PQ` — quote verbatim
+
+---
+
+## Asset commission menu
+
+Operator budget confirmed available. Priority ordering by ROI-per-dollar:
+
+### Tier 1 — Signature (highest impact, commission if only one)
+
+**Apex Gate arch illustration.** One piece, ~1200×800px, transparent PNG + SVG source. Style: 19th-century natural-history atlas plate — think Ernst Haeckel's Kunstformen or Charles Darwin's Origin plates, adapted to a metaphorical gate/arch motif. Six columns or six arches (one per predicate). Etched hairline linework, restrained cross-hatching. Tintable via `filter` for `--apex-gold` overlay. Sits behind the Apex Gate predicate grid at 6–10% opacity.
+
+Vendor guidance: illustrator with editorial + scientific-illustration credentials; not Fiverr, not generic vector-stock. Reference: Kate Baylay, Emily Carroll, or a scientific illustrator with plate-style credentials.
+
+**Estimated cost:** $400–1200 depending on illustrator tier. Turnaround 1–3 weeks.
+
+### Tier 2 — Foundation (elevates the whole section)
+
+**Ledger paper base texture.** One high-res image, ~2000×3000px, WebP primary + JPEG fallback, target ≤80KB after optimization. NOT stock parchment texture, NOT AI-generated paper — a genuine scanned ledger page from a period source (British Library digital collection, MET Open Access, National Archives) or a hand-photographed piece of aged paper with hairline rulings. Warm-neutral but low-saturation (chroma near 0.02 in OKLCH). Blended `multiply` over `--bg` at 8–12% opacity.
+
+**Estimated cost:** $0 if sourced from public-domain scans; $50–150 for licensed stock at appropriate quality; $200–400 for a commissioned scan of a period ledger.
+
+### Tier 3 — Elaboration (ships nicely if budget permits)
+
+**Six rank-glyph atlas stamps.** One coherent series of six small illustrations (~200×200px each), matching the Apex arch's linework style. One per rank:
+- 1★ Awakened — a candle or ember (verified as real, not yet named)
+- 2★ Named — a signet stamp or seal (RPG title assigned)
+- 3★ Evolved — a verified compass (blob link verified)
+- 4★ Hardened — an anvil or shield (security-reviewed)
+- 5★ Transcendent — a laurel (enterprise-ready)
+- 6★ Apex — reserved / rendered by the Apex Gate arch itself
+
+Sits above each rank card at ~64×64px display size, tintable to `--rank-N`.
+
+**Estimated cost:** $600–1500 for a six-piece coherent series.
+
+**Ratification of series style:** if commissioned, all six must ship together from the same illustrator on the same brief so they read as siblings.
+
+### Tier 4 — Distinctive but skippable
+
+**Unique class glyph illustration.** Custom rendering of `◉` as a full illustration — a struck coin or medallion in the same atlas-plate style. Sits above the Unique branch card at ~80×80px.
+
+**Estimated cost:** $150–300 for one piece if the same illustrator has already delivered Tier 1 or Tier 3.
+
+### Total budget guidance
+
+- **Signature-only ship** (Tier 1 + Tier 2 public-domain texture): ~$400–1350
+- **Elevated ship** (Tier 1 + Tier 2 + Tier 3): ~$1000–3050
+- **Full ship** (all tiers): ~$1150–3350
+
+I recommend **Tier 1 + Tier 2 (public-domain sourced)** as the minimum for the overdrive treatment to land. Tier 3 elevates the section from "excellent" to "signature," but the composition works cleanly without it. Tier 4 is polish; skip unless the Unique branch is materially deprioritized as a marketing surface.
+
+---
+
+## Rollout
+
+This is `/impeccable overdrive shape` output. Follow-on is `/impeccable overdrive craft` — a dedicated implementation delegation that:
+
+1. Rewrites the `#ascension` section in `docs/index.html` per this brief
+2. Adds a scoped CSS block (either inline `<style>` per the pattern used by `.bench-shell` / `.reports-shell`, or a new `docs/css/ascension-overdrive.css` if the block exceeds ~250 lines — call from the shape approval)
+3. Writes the choreographed IntersectionObserver + `stroke-dashoffset` + brass-tag reveal sequence in JS (~120 lines target; module-scoped, tree-shakeable if we later migrate)
+4. Integrates commissioned assets when they arrive from the operator (skeleton composition works with placeholder assets; live assets swap in without markup changes)
+5. Validates against all six failure tests before shipping
+
+**Delegation target:** `sonnet-worker` or `opus-worker` depending on final scope after craft handoff. Motion choreography favours opus for the polish pass.
+
+**Estimated craft effort:** 6–10 hours of focused work if assets ship in parallel. 4 hours if we defer assets and ship the atlas-plate composition with tokens-only atmospheric planes as a stepping stone.
+
+**Ship in same PR (#972) or separate:** *recommend separate.* This is a section-scale rewrite that deserves its own review surface, its own before/after screenshots, and its own commit history. PR #972 stays scoped to entrypoint polish + WIP-banner + Trending CTA + nav clearance codification.
+
+---
+
+## Confirmation gate
+
+Operator confirms four things before craft:
+
+1. **Composition acceptance.** The one-plate, five-plane composition with Unique branch, Apex Gate panel, and choreographed gold-thread crescendo is the direction — or override with specific corrections.
+
+2. **Content invariance.** The Star Bar tags at each rank quoted from `META.md §1.1` + `§2.4` and the six Apex predicates quoted from the G7 RFC §11.12 are correct as summarized above — or supply corrections. (Verbatim strings will be pulled at craft time; this brief captures the semantic set.)
+
+3. **Unique class positioning.** The Unique branch off 4★ per #935 ratification comment is the correct treatment — parallel prestige class visualized as a side path, not a rank step. Confirm or override the phrasing of the branch caption *"A parallel prestige class. Not a rank step."*
+
+4. **Asset commission scope.** Which tier to commission:
+   - Tier 1 only (Apex Gate arch): ~$400–1200
+   - Tier 1 + Tier 2 (arch + ledger paper): ~$400–1350 (Tier 2 free if public-domain sourced)
+   - Tier 1 + Tier 2 + Tier 3 (arch + paper + six rank stamps): ~$1000–3050
+   - All tiers: ~$1150–3350
+   - Or: ship tokens-only first, commission assets in a follow-up polish PR
+
+On confirmation, hand this brief to `/impeccable overdrive craft` with `docs/index.html`, `docs/css/styles.css` (or a new `ascension-overdrive.css`), and the commissioned asset paths as the working files.

--- a/scripts/contentEngine/templates/archive.html.j2
+++ b/scripts/contentEngine/templates/archive.html.j2
@@ -1,55 +1,366 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../assets/icons.svg">
 <head>
+  <script>window.GAIA_VERSION = "{{ version }}";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="generator" content="gaia-content-engine">
-  <title>Weekly Reports — Gaia</title>
-  <meta name="description" content="Archive of Gaia weekly reports — a permanent record of what moved in the skill registry each ISO week.">
+  <title>Weekly Reports | Gaia Registry</title>
+  <meta name="description" content="Archive of Gaia weekly reports. One report per ISO week. Trending, ascended, contested. Mechanically compiled from the trending API.">
   <link rel="canonical" href="https://gaiaskilltree.com/reports/">
   <meta property="og:type" content="website">
-  <meta property="og:title" content="Weekly Reports — Gaia">
+  <meta property="og:title" content="Weekly Reports | Gaia Registry">
   <meta property="og:description" content="Every Monday: what changed in the Gaia skill registry, mechanically compiled from the trending API.">
   <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;500;600;700&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+
   <link rel="stylesheet" href="../css/tokens.css?v={{ version }}">
   <link rel="stylesheet" href="../css/styles.css?v={{ version }}">
   <link rel="alternate" type="application/json" href="/api/v1/reports/index.json">
+
+  <script>
+    window.gaiaIconBase = function () { return '../assets/icons.svg'; };
+  </script>
+
+  <style>
+    /* ─────────────────────────────────────────────────────────────
+       WEEKLY REPORTS ARCHIVE — ledger surface, not blog index.
+       Matches the benchmarks landing register (bench-shell): one
+       display hero, one contract line, a list where the list IS the
+       experience. EB Garamond for display, Bricolage for body,
+       Departure/JetBrains Mono reserved for ISO identifiers and
+       provenance labels. Body copy sits on --text (#e2e8f0) against
+       --bg (#030712) for 4.5:1+ contrast.
+       ───────────────────────────────────────────────────────────── */
+
+    .reports-shell {
+      max-width: 62rem;
+      margin: 0 auto;
+      padding: 5rem 1.5rem 6rem;
+      color: var(--text);
+      font-family: var(--font-body);
+    }
+    @media (min-width: 768px) {
+      .reports-shell { padding: 8rem 2rem 7rem; }
+    }
+
+    /* ── Hero: thesis, not tagline ─────────────────────────── */
+    .reports-hero {
+      max-width: 44rem;
+      margin: 0 0 5rem;
+    }
+    .reports-hero h1 {
+      font-family: var(--font-display);
+      font-weight: 500;
+      font-size: clamp(2.4rem, 6.5vw, 4.25rem);
+      line-height: 1.02;
+      letter-spacing: -0.02em;
+      margin: 0 0 1.75rem;
+      color: var(--text);
+      text-wrap: balance;
+    }
+    .reports-hero h1 em {
+      font-style: italic;
+      color: var(--apex-gold);
+      font-weight: 400;
+    }
+    .reports-hero p {
+      font-size: 1.15rem;
+      line-height: 1.55;
+      color: var(--text);
+      opacity: 0.82;
+      margin: 0 0 1rem;
+      max-width: 38rem;
+      text-wrap: pretty;
+    }
+    @media (min-width: 768px) {
+      .reports-hero p { font-size: 1.25rem; }
+    }
+    .reports-hero .contract {
+      margin-top: 1.5rem;
+      font-family: var(--font-mono);
+      font-size: 0.82rem;
+      line-height: 1.7;
+      color: var(--text);
+      opacity: 0.72;
+      max-width: 40rem;
+    }
+    .reports-hero .contract code {
+      font-family: var(--font-mono);
+      color: var(--apex-gold);
+      background: none;
+      padding: 0;
+    }
+
+    /* ── Archive block ─────────────────────────────────────── */
+    .reports-block { margin-bottom: 5rem; }
+    .reports-block-head {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 1.5rem;
+      padding-bottom: 1.25rem;
+      margin-bottom: 0;
+      border-bottom: 1px solid var(--border);
+      flex-wrap: wrap;
+    }
+    .reports-block-head h2 {
+      font-family: var(--font-display);
+      font-weight: 500;
+      font-size: clamp(1.5rem, 3vw, 2rem);
+      line-height: 1.15;
+      letter-spacing: -0.01em;
+      margin: 0;
+      color: var(--text);
+    }
+    .reports-block-head .count {
+      font-family: var(--font-mono);
+      font-size: 0.82rem;
+      color: var(--muted);
+      letter-spacing: 0.02em;
+    }
+
+    /* ── The list is the experience ────────────────────────── */
+    .reports-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+    .reports-row {
+      display: grid;
+      grid-template-columns: minmax(9rem, auto) 1fr auto;
+      align-items: baseline;
+      gap: 1rem 1.5rem;
+      padding: 1.5rem 0;
+      border-bottom: 1px solid var(--border);
+    }
+    @media (max-width: 640px) {
+      .reports-row {
+        grid-template-columns: 1fr;
+        gap: 0.5rem;
+      }
+    }
+    .reports-row:last-child { border-bottom: none; }
+
+    .reports-row a.rr-title {
+      font-family: var(--font-display);
+      font-size: clamp(1.4rem, 2.4vw, 1.75rem);
+      font-weight: 500;
+      letter-spacing: -0.01em;
+      line-height: 1.1;
+      color: var(--text);
+      text-decoration: none;
+      display: inline-flex;
+      align-items: baseline;
+      gap: 0.5rem;
+      transition: color 160ms ease-out;
+    }
+    .reports-row a.rr-title:hover,
+    .reports-row a.rr-title:focus-visible {
+      color: var(--apex-gold);
+      outline: none;
+    }
+    .reports-row a.rr-title .rr-tail {
+      color: var(--muted);
+      font-family: var(--font-mono);
+      font-size: 0.7em;
+      transition: color 160ms ease-out, transform 160ms ease-out;
+    }
+    .reports-row a.rr-title:hover .rr-tail,
+    .reports-row a.rr-title:focus-visible .rr-tail {
+      color: var(--apex-gold);
+      transform: translateX(2px);
+    }
+
+    .reports-row .rr-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem 1.25rem;
+      align-items: baseline;
+      font-family: var(--font-mono);
+      font-size: 0.78rem;
+      color: var(--muted);
+      letter-spacing: 0.02em;
+    }
+    .reports-row .rr-meta .rr-layer {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4em;
+    }
+    .reports-row .rr-meta .rr-layer code {
+      font-family: var(--font-mono);
+      color: var(--evidence-gold);
+      background: rgba(var(--evidence-gold-rgb), 0.08);
+      border: 1px solid rgba(var(--evidence-gold-rgb), 0.28);
+      padding: 0.05em 0.4em;
+      border-radius: 3px;
+      font-size: 0.85em;
+    }
+
+    .reports-row a.rr-json {
+      font-family: var(--font-mono);
+      font-size: 0.78rem;
+      color: var(--muted);
+      text-decoration: none;
+      letter-spacing: 0.02em;
+      padding: 0.25rem 0;
+      border-bottom: 1px solid transparent;
+      transition: color 160ms ease-out, border-color 160ms ease-out;
+      justify-self: end;
+    }
+    .reports-row a.rr-json:hover,
+    .reports-row a.rr-json:focus-visible {
+      color: var(--text);
+      border-bottom-color: var(--border);
+      outline: none;
+    }
+    @media (max-width: 640px) {
+      .reports-row a.rr-json { justify-self: start; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .reports-row a.rr-title,
+      .reports-row a.rr-title .rr-tail,
+      .reports-row a.rr-json { transition: none; }
+      .reports-row a.rr-title:hover .rr-tail,
+      .reports-row a.rr-title:focus-visible .rr-tail { transform: none; }
+    }
+
+    /* ── Empty state ───────────────────────────────────────── */
+    .reports-empty {
+      padding: 4rem 0;
+      text-align: center;
+      color: var(--text);
+    }
+    .reports-empty .glyph {
+      font-family: var(--font-display);
+      font-size: 3rem;
+      color: var(--muted);
+      margin-bottom: 1rem;
+      line-height: 1;
+    }
+    .reports-empty h3 {
+      font-family: var(--font-display);
+      font-weight: 500;
+      font-size: 1.5rem;
+      margin: 0 0 0.75rem;
+      color: var(--text);
+    }
+    .reports-empty p {
+      color: var(--text);
+      opacity: 0.72;
+      max-width: 32rem;
+      margin: 0 auto;
+      line-height: 1.55;
+    }
+    .reports-empty .cadence {
+      display: inline-block;
+      margin-top: 1.5rem;
+      font-family: var(--font-mono);
+      font-size: 0.78rem;
+      color: var(--muted);
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+
+    /* ── Footer caption ────────────────────────────────────── */
+    .reports-caption {
+      margin-top: 4rem;
+      padding-top: 2rem;
+      border-top: 1px solid var(--border);
+      font-family: var(--font-mono);
+      font-size: 0.78rem;
+      line-height: 1.7;
+      color: var(--muted);
+      letter-spacing: 0.02em;
+    }
+    .reports-caption a {
+      color: var(--muted);
+      text-decoration: none;
+      border-bottom: 1px solid transparent;
+      transition: color 160ms ease-out, border-color 160ms ease-out;
+    }
+    .reports-caption a:hover,
+    .reports-caption a:focus-visible {
+      color: var(--text);
+      border-bottom-color: var(--border);
+      outline: none;
+    }
+  </style>
+
+<script type="application/ld+json" data-injector="gaia-json-ld">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "name": "Weekly Reports",
+  "url": "https://gaiaskilltree.com/reports/"
+}
+</script>
 </head>
 <body>
   <nav id="site-nav"></nav>
   <script src="../js/mounts.js?v={{ version }}"></script>
   <script src="../js/site-nav.js?v={{ version }}"></script>
 
-  <main class="reports-archive" style="max-width: 72rem; margin: 2rem auto; padding: 0 1.25rem; color: var(--text); font-family: 'EB Garamond', Georgia, serif; line-height: 1.6;">
-    <header style="border-bottom: 1px solid var(--border); padding-bottom: 1rem; margin-bottom: 1.5rem;">
-      <div style="font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: .75rem; color: var(--muted); letter-spacing: .12em; text-transform: uppercase;">Gaia · Weekly Reports</div>
-      <h1 style="margin: .25rem 0 0; font-family: 'Bricolage Grotesque', 'EB Garamond', sans-serif; font-weight: 600;">What moved this week</h1>
-      <p style="color: var(--muted); font-size: .95rem; margin-top: .5rem;">One report per ISO week. Trending, ascended, contested — mechanically compiled from the <a href="/api/v1/trending/" style="color: var(--evidence-gold);">trending API</a>.</p>
+  <main class="reports-shell">
+
+    <header class="reports-hero">
+      <h1>The ledger, <em>week by week</em>.</h1>
+      <p>Every Monday, Gaia publishes what moved in the skill registry over the prior ISO week. Trending skills, recent rank-ups, contested contribution spaces. Mechanically compiled from the trending API, not editorial commentary.</p>
+      <p class="contract">
+        One report per ISO week at <code>/reports/YYYY-WW/</code>. Canonical JSON at <code>/api/v1/reports/YYYY-WW.json</code>. Archive index at <code>/api/v1/reports/index.json</code>. Cadence: Monday 08:00 UTC via cron.
+      </p>
     </header>
 
-    {% if not reports %}
-      <p style="color: var(--muted);">No reports published yet — the first one lands Monday 08:00 UTC.</p>
-    {% else %}
-      <ul style="list-style: none; padding: 0; margin: 0;">
-        {% for r in reports %}
-        <li style="padding: 1rem 0; border-bottom: 1px solid var(--border);">
-          <a href="/reports/{{ r.reportId }}/" style="color: var(--text); font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 1.1rem; text-decoration: none;">
-            {{ r.reportId }}
-          </a>
-          <span style="color: var(--muted); font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: .75rem; margin-left: 1rem;">ISO {{ r.isoYear }}-W{{ '%02d' | format(r.isoWeek) }}</span>
-          {% if r.salvageLayer %}<span style="color: var(--muted); font-size: .75rem; margin-left: 1rem;">Layer <code>{{ r.salvageLayer }}</code></span>{% endif %}
-          <span style="color: var(--muted); font-size: .75rem; margin-left: 1rem;"><a href="/api/v1/reports/{{ r.reportId }}.json" style="color: var(--muted);">JSON</a></span>
-        </li>
-        {% endfor %}
-      </ul>
-    {% endif %}
+    <section class="reports-block" aria-labelledby="archiveHeading">
+      <div class="reports-block-head">
+        <h2 id="archiveHeading">Archive</h2>
+        {% if reports %}
+        <span class="count">{{ reports | length }} report{{ '' if reports | length == 1 else 's' }}</span>
+        {% endif %}
+      </div>
 
-    <footer style="margin-top: 2rem; color: var(--muted); font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: .75rem;">
-      Archive rebuilt on every publish. Machine-readable index: <a href="/api/v1/reports/index.json" style="color: var(--muted);">/api/v1/reports/index.json</a>.
+      {% if not reports %}
+        <div class="reports-empty" role="status">
+          <div class="glyph" aria-hidden="true">◇</div>
+          <h3>No reports published yet.</h3>
+          <p>The first weekly report lands on the next Monday cadence. Until then, the archive is empty by design, not by omission.</p>
+          <span class="cadence">Monday 08:00 UTC</span>
+        </div>
+      {% else %}
+        <ol class="reports-list">
+          {% for r in reports %}
+          <li class="reports-row">
+            <a class="rr-title" href="/reports/{{ r.reportId }}/">
+              <span>{{ r.reportId }}</span>
+              <span class="rr-tail" aria-hidden="true">→</span>
+            </a>
+            <div class="rr-meta">
+              <span>ISO {{ r.isoYear }}-W{{ '%02d' | format(r.isoWeek) }}</span>
+              {% if r.salvageLayer %}
+              <span class="rr-layer">Layer <code>{{ r.salvageLayer }}</code></span>
+              {% endif %}
+            </div>
+            <a class="rr-json" href="/api/v1/reports/{{ r.reportId }}.json" aria-label="Canonical JSON for report {{ r.reportId }}">JSON</a>
+          </li>
+          {% endfor %}
+        </ol>
+      {% endif %}
+    </section>
+
+    <footer class="reports-caption">
+      Archive rebuilt on every publish. Machine-readable index at <a href="/api/v1/reports/index.json">/api/v1/reports/index.json</a>. Compiled from the <a href="/api/v1/trending/">trending API</a>.
     </footer>
+
   </main>
+
+  <div id="site-footer-mount"></div>
+  <script src="../js/site-footer.js?v={{ version }}"></script>
 </body>
 </html>

--- a/scripts/contentEngine/templates/report.html.j2
+++ b/scripts/contentEngine/templates/report.html.j2
@@ -20,11 +20,68 @@
   <link rel="stylesheet" href="../../css/tokens.css?v={{ report.generatorVersion }}">
   <link rel="stylesheet" href="../../css/styles.css?v={{ report.generatorVersion }}">
   <link rel="alternate" type="application/json" href="{{ report.urls.json }}">
+
+  <style>
+    /* ── Deferred-surface WIP banner ──────────────────────────────────────
+       Discloses that this surface renders in its L3-mechanical bridge
+       state pending the Sprint F rendering-layer rewrite (issue #973).
+       Follows the deferred-surface convention in CLAUDE.md §Deferred
+       surface convention. Removed by the port. */
+    .wip-banner {
+      max-width: 62rem;
+      /* Clear the fixed nav (~58px). Matches the 5rem/6rem top-clearance
+         pattern used by .bench-shell and .reports-shell. */
+      margin: 5rem auto 0;
+      padding: 0.75rem 1.5rem;
+      display: flex;
+      align-items: baseline;
+      flex-wrap: wrap;
+      gap: 0.5rem 0.9rem;
+      font-family: var(--font-mono);
+      font-size: 0.78rem;
+      line-height: 1.55;
+      color: var(--text);
+      background: rgba(var(--evidence-gold-rgb), 0.06);
+      border: 1px solid rgba(var(--evidence-gold-rgb), 0.28);
+      border-radius: 6px;
+      letter-spacing: 0.02em;
+    }
+    @media (min-width: 768px) {
+      .wip-banner { margin-top: 6rem; }
+    }
+    .wip-banner .wip-tag {
+      color: var(--evidence-gold);
+      font-weight: 500;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      font-size: 0.72rem;
+    }
+    .wip-banner .wip-body { color: var(--text); opacity: 0.86; }
+    .wip-banner a {
+      color: var(--evidence-gold);
+      text-decoration: none;
+      border-bottom: 1px solid rgba(var(--evidence-gold-rgb), 0.45);
+      transition: border-color 160ms ease-out;
+    }
+    .wip-banner a:hover,
+    .wip-banner a:focus-visible {
+      border-bottom-color: var(--evidence-gold);
+      outline: none;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .wip-banner a { transition: none; }
+    }
+  </style>
 </head>
 <body>
   <nav id="site-nav"></nav>
   <script src="../../js/mounts.js?v={{ report.generatorVersion }}"></script>
   <script src="../../js/site-nav.js?v={{ report.generatorVersion }}"></script>
+
+  <aside class="wip-banner" role="note" aria-label="Interim rendering notice">
+    <span class="wip-tag">◇ Interim rendering</span>
+    <span class="wip-body">Tables render as source markdown in this bridge state. Leaderboard view lands in Sprint F (<a href="https://github.com/gaia-research/gaia-skill-tree/issues/973">#973</a>). The <a href="{{ report.urls.json }}">canonical JSON</a> is frozen and permanent.</span>
+  </aside>
 
   <main class="report-body" style="max-width: 72rem; margin: 2rem auto; padding: 0 1.25rem; color: var(--text); font-family: 'EB Garamond', Georgia, serif; line-height: 1.6;">
     <div style="font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: .75rem; color: var(--muted); letter-spacing: .12em; text-transform: uppercase; margin-bottom: .5rem;">


### PR DESCRIPTION
> **Rebased onto v6.1.0 (SHA `ad7d4deed`) 2026-07-06** after auto-release bumped main past v6.0.1 on merge of #970. On merge, auto-release will bump to **v6.1.1**.

Closes #969.

Impeccable-guided v6.1.1 entrypoint polish for `/benchmarks/` + `/reports/`. Four items from the issue, plus both stretch fixes, plus a full rework of the `/reports/` archive landing (which turned out to be the actual weak link — inline-styled single-row placeholder, not landing-page craft).

Originally scoped as v6.0.1 fast-follow on the pre-merge sweep.

## Items shipped

### Item 1 — Surface Benchmarks + Weekly Reports nearer the fold

Two entrypoints, additive to the canonical `#evidence-cycle` section (preserved, not moved, per issue).

- **New `.hero-ledger-flash` strip** between `#hero` and `#hall-of-heroes`. Two ledger-typography links (`◇ Latest weekly report →` / `▲ Benchmarks leaderboard →`) with a mono separator. Sits in the first two viewports. Mono type + subdued separator match the in-hero `.ledger-strip` register; not a chip row.
- **Weekly Reports CTA added to `#evidence-cycle`** alongside Evidence Library / Trust Methodology / Benchmarks (all four evidence entrypoints in their canonical home).

Explicitly rejected during shape: adding chips to `.hero-pills`. That was a v1 attempt that got cut — Trust Ledger is the one earned identity pill; diluting it with three more chips broke the brand voice.

### Item 2 — Footer Hall of Heroes dedupe

Discover column no longer links Hall of Heroes. Evidence column owns the `/heroes/` destination. Homepage anchor still reachable via the on-page section itself.

### Item 3 — Skill Index in mobile drawer

Added `<li>Skill Index → skills/</li>` after Benchmarks in the mobile drawer. Achieves desktop More-menu parity.

### Item 4 — Copy prune + Registry column rename

Em-dashes at `docs/index.html` L667/724/794 rewritten with commas / parens / colons per impeccable copy rules. `grep '—' docs/index.html` returns zero U+2014 hits in targeted prose lines.

Footer Registry column `Meta Reports` → `Meta Changelog` to disambiguate from Evidence column `Weekly Reports`. Page title / h1 of `meta.html` unchanged.

### Stretch S1 — `.review-sim-wrapper` ghost-card

`box-shadow` tightened from `0 4px 24px rgba(0,0,0,0.2)` (blur 24, impeccable ghost-card slop) → `0 2px 8px rgba(0,0,0,0.24)` (blur 8, defined elevation). Pairs with the 1px border to read as a framed terminal panel, not diffuse glow.

### Stretch S2 — `#evidence-cycle` section-sub opacity

Dropped inline `opacity:0.85`. `.section-sub` already applies `color: var(--muted)` (#64748b); the opacity was double-muting on top of the token, reducing contrast below the 4.5:1 baseline.

## Weekly Reports archive rework (not surgical)

`scripts/contentEngine/templates/archive.html.j2` + regenerated `docs/reports/index.html`.

**Previous state:** every element inline-styled, single `<ul>` list with `<span>` metadata sprayed across one line, no class hierarchy, no empty state, no responsive treatment. Failed the impeccable production bar for a page promoted from the homepage.

**New state:** matches the `docs/benchmarks/index.html` landing register.

- `.reports-shell` — 62rem max, editorial 5rem/8rem padding
- `.reports-hero` — EB Garamond display h1 with `clamp(2.4rem, 6.5vw, 4.25rem)`, italic gold accent word, thesis paragraph on `--text`, mono contract line naming the URL / JSON / cadence contract
- `.reports-block-head` — Archive heading + report count on a bordered baseline
- `.reports-row` — 3-column grid (title / meta / JSON), EB Garamond title with mono tail glyph and hover translate, ISO week + salvage-layer pill, right-aligned JSON link, single-column stack ≤640px
- `.reports-empty` — designed empty state (glyph + heading + cadence stamp), not a muted `<p>` tag
- `.reports-caption` — mono footer treated as ledger caption
- Contrast pass: body copy on `--text` (not `--muted`), semantic muted only for genuine metadata
- Reduced-motion honored (transitions gated behind `@media (prefers-reduced-motion: reduce)`)
- All type via `--font-display` / `--font-body` / `--font-mono`; no hardcoded family strings

Copy: half-merged voice per PRODUCT.md. Hero: *"The ledger, week by week."* No em-dashes, no aphoristic rebuttals, no marketing buzzwords.

## Entrypoints (per CLAUDE.md §Design Entrypoints)

| Surface | Status |
|---|---|
| Main nav (`site-nav.js`) | **Touched** — mobile drawer Skill Index parity (item #3) |
| Footer (`site-footer.js`) | **Touched** — Discover dedupe + Registry rename (items #2, #4) |
| Homepage (`docs/index.html`) | **Touched** — `.hero-ledger-flash` + `#evidence-cycle` Weekly Reports CTA (item #1) |
| `mounts.js` | Unchanged — no new sections; `reports`, `benchmarks`, `heroes`, `skills` already registered |
| Cross-page | New inbound: hero → `/reports/`, hero → `/benchmarks/`. Evidence Grade → `/reports/` |
| Cache-busting | Already registered — `scripts/build_docs.py` L461 covers `reports/index.html` |

## Verification

Local server (`python -m http.server 8765` from `docs/`) verified:
- Home page: hero-ledger-flash renders with correct typography, HoH section unchanged, Evidence Grade section shows all four CTAs
- `/reports/`: new landing renders with hero, one archived row (`2026-28`, ISO 2026-W28, Layer L3), JSON link, footer caption
- `/benchmarks/`: untouched, still craft-quality
- Footer Discover column shows Named Skills / Named Contributors / GitHub Badges (no dup Hall of Heroes)
- Mobile drawer includes Skill Index
- `grep '—' docs/index.html` → 0 U+2014 hits in targeted prose lines

## Non-goals (deliberately unshipped)

- No new report data generated — `2026-28` remains the sole entry, correctly reflected in the archive
- `docs/benchmarks/index.html` untouched — already craft-quality per prior review

## Release

Ships as **v6.1.1** (auto-release will bump from v6.1.0 on merge, since commits use `design(...)` prefix → patch bump).

/cc @mbtiongson1

---

## Deferred surfaces (per new CLAUDE.md §Deferred-surface convention)

| Surface | Bridge state | Tracking issue | Sprint |
|---|---|---|---|
| `/reports/YYYY-WW/` (per-report page) | Renders `{{ markdownBody }}` as `<pre>` dump; tables display as raw pipe-syntax | #973 | Sprint F (rendering-layer rewrite) |

The per-report page carries a `.wip-banner` between `<nav>` and `<main>` disclosing the interim state, naming what's frozen (canonical JSON), and linking to #973. Removed by the Sprint F port. See `CLAUDE.md` §Deferred-surface convention for the full policy and `DESIGN.md` §Key UI Patterns → Deferred-surface WIP banner for the visual spec.

**Why this pattern:** the per-report page satisfies its ratified Sprint D kill criterion (KC3: *"returns a permanent, indexed, tweetable URL"*) — the URL exists, the JSON contract is frozen, the cron produces output. What's below the design bar is the rendering layer, and roadmap L228–250 explicitly assigns that work to Sprint F. Silently shipping the bridge state confused v6.0.1 review; disclosing it via banner + tracking issue is the codified fix.
