### PR TITLE
docs: tighten homepage registry copy

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -9,14 +9,14 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Gaia Skill Tree - The Evidence-Backed AI Agent Capability Registry</title>
-  <meta name="description" content="An evidence-backed atlas of agent capabilities. Bring your repo, claim your name.">
+  <meta name="description" content="An evidence-backed registry of agent capabilities, catalogued with public provenance. Bring your repo, claim your name.">
   <meta name="keywords" content="AI agent skills, skill registry, LLM operations, agent framework, AI capabilities, skill graph, agent skills, capability registry">
   <link rel="canonical" href="https://gaiaskilltree.com/" />
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website" />
   <meta property="og:title" content="Gaia Skill Tree - The Evidence-Backed AI Agent Capability Registry" />
-  <meta property="og:description" content="A public attribution engine for agent capabilities. Discover, verify, and catalogue AI agent skills with evidence-backed provenance." />
+  <meta property="og:description" content="A public attribution engine for the Gaia Registry. Discover evidence-backed agent skills catalogued with public provenance." />
   <meta property="og:url" content="https://gaiaskilltree.com/" />
   <meta property="og:image" content="https://gaiaskilltree.com/assets/og-image.png" />
   <meta property="og:site_name" content="Gaia Skill Tree" />
@@ -232,7 +232,7 @@
         Names are <em>earned</em>.<br>
         Apex is <span>rare</span>.
       </h1>
-      <p class="hero-sub">An evidence-backed atlas of agent capabilities. Bring your repo, claim your name.</p>
+      <p class="hero-sub">An evidence-backed Registry of agent capabilities, catalogued with public provenance. Bring your repo, claim your name.</p>
       <div class="two-doors">
         <a href="#paths" class="door door-a door--primary">
           <span class="door-icon">◆</span>
@@ -444,7 +444,7 @@
       <div class="path-a">
         <div class="path-plate-num">Path A — Initiate's Rite</div>
         <h2>Register Your Repo</h2>
-        <p class="section-sub mt-sm">Four steps from zero to a named entry in the canonical registry.</p>
+        <p class="section-sub mt-sm">Four evidence-backed steps from a public repo to a catalogued entry in the canonical Registry.</p>
         <ol class="rite-steps">
           <li class="rite-step">
             <div class="rite-meta">


### PR DESCRIPTION
# PR Draft: gaia-research/gaia-skill-tree#872

## Title

docs: tighten homepage registry copy

## Body

Closes #872.

## Summary

- Updates homepage meta and Open Graph descriptions to emphasize the Gaia Registry and evidence-backed provenance.
- Tightens the hero subtitle while retaining the requested terms around `registry`, `evidence-backed`, and `catalogued`.
- Rewrites the Path A intro sentence so it clearly describes the route from public repo to canonical Registry entry.

## Verification

- `git diff --check HEAD~1..HEAD`
- HTML parser smoke check for `docs/index.html`
- Required copy term check for `evidence-backed Registry`, `catalogued with public provenance`, and `canonical Registry`
- `python3 -m py_compile scripts/injectJsonLd.py scripts/build_docs.py scripts/generateProfilePages.py`

## Notes

This is intentionally limited to search-facing/homepage copy in `docs/index.html`.
