### PR TITLE
infra(scope-guard): allow scripts/contentEngine/templates/*.j2 on design/ branches

### DIFF
--- a/.github/workflows/branch-scope.yml
+++ b/.github/workflows/branch-scope.yml
@@ -134,8 +134,8 @@ jobs:
                 ;;
               design)
                 case "$file" in
-                  docs/*|*.md) ;; # allowed
-                  *) VIOLATIONS="$VIOLATIONS\n  ❌ $file (design/ branches may only touch docs/ or *.md files)" ;;
+                  docs/*|*.md|scripts/contentEngine/templates/*.j2) ;; # allowed
+                  *) VIOLATIONS="$VIOLATIONS\n  ❌ $file (design/ branches may only touch docs/, scripts/contentEngine/templates/*.j2, or *.md files)" ;;
                 esac
                 ;;
               review-push)


### PR DESCRIPTION
One-line amendment to `.github/workflows/branch-scope.yml` — add `scripts/contentEngine/templates/*.j2` to the design/ branch allowlist.

## Why

The Jinja templates under `scripts/contentEngine/templates/` define what the generated `/reports/` pages look like. Conceptually they are design surfaces (their sole purpose is visual output), but they live under `scripts/` so the build pipeline can consume them.

Design PRs that redesign the archive landing or the per-report page inevitably need to edit these templates alongside the regenerated `docs/reports/` output. The current design/ allowlist only permits `docs/*` and `*.md`, which forces template edits onto `infra/` branches — but infra/ can't touch the corresponding `docs/reports/*` output either, creating a chicken-and-egg where neither branch prefix can hold a coherent template-plus-generated-output change.

## Discovered on

PR #972 (v6.1.1 entrypoint polish + Weekly Reports archive redesign + per-report WIP banner). Both template edits are load-bearing to the redesign; extracting them to a separate branch would ship rendered HTML that doesn't match its Jinja source on the same commit.

## Non-goals

- Does NOT reclassify other paths under `scripts/` as design surfaces
- Does NOT expand infra/ allowlist
- Does NOT change any other branch-prefix rules

Only the two visual-output template files under `scripts/contentEngine/templates/*.j2` are added; everything else in `scripts/` remains `infra/`-scoped.