### PR TITLE
docs: tighten homepage registry copy (#872)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -9,14 +9,14 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Gaia Skill Tree - The Evidence-Backed AI Agent Capability Registry</title>
-  <meta name="description" content="An evidence-backed atlas of agent capabilities. Bring your repo, claim your name.">
+  <meta name="description" content="An evidence-backed registry of agent capabilities, catalogued with public provenance. Bring your repo, claim your name.">
   <meta name="keywords" content="AI agent skills, skill registry, LLM operations, agent framework, AI capabilities, skill graph, agent skills, capability registry">
   <link rel="canonical" href="https://gaiaskilltree.com/" />
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website" />
   <meta property="og:title" content="Gaia Skill Tree - The Evidence-Backed AI Agent Capability Registry" />
-  <meta property="og:description" content="A public attribution engine for agent capabilities. Discover, verify, and catalogue AI agent skills with evidence-backed provenance." />
+  <meta property="og:description" content="A public attribution engine for the Gaia Registry. Discover evidence-backed agent skills catalogued with public provenance." />
   <meta property="og:url" content="https://gaiaskilltree.com/" />
   <meta property="og:image" content="https://gaiaskilltree.com/assets/og-image.png" />
   <meta property="og:site_name" content="Gaia Skill Tree" />
@@ -232,7 +232,7 @@
         Names are <em>earned</em>.<br>
         Apex is <span>rare</span>.
       </h1>
-      <p class="hero-sub">An evidence-backed atlas of agent capabilities. Bring your repo, claim your name.</p>
+      <p class="hero-sub">An evidence-backed Registry of agent capabilities, catalogued with public provenance. Bring your repo, claim your name.</p>
       <div class="two-doors">
         <a href="#paths" class="door door-a door--primary">
           <span class="door-icon">◆</span>
@@ -444,7 +444,7 @@
       <div class="path-a">
         <div class="path-plate-num">Path A — Initiate's Rite</div>
         <h2>Register Your Repo</h2>
-        <p class="section-sub mt-sm">Four steps from zero to a named entry in the canonical registry.</p>
+        <p class="section-sub mt-sm">Four evidence-backed steps from a public repo to a catalogued entry in the canonical Registry.</p>
         <ol class="rite-steps">
           <li class="rite-step">
             <div class="rite-meta">


### PR DESCRIPTION
Closes #872.

Adopts the copy improvements originally proposed in PR #974 (@lovewave02), re-authored under verified maintainer identity per the belt-tightening decision on unknown-fork PR acceptance. See #977 for the policy work.

## Changes

Four homepage copy tweaks in `docs/index.html`:
- `<meta name="description">` — 'atlas of agent capabilities' → 'registry of agent capabilities, catalogued with public provenance'
- `<meta property="og:description">` — reframed around 'the Gaia Registry' with 'evidence-backed' + 'catalogued with public provenance'
- `<p class="hero-sub">` — same reframe applied to the visible hero subtitle
- Path A section-sub — 'Four steps from zero to a named entry in the canonical registry' → 'Four evidence-backed steps from a public repo to a catalogued entry in the canonical Registry'

## Provenance

Copy content is byte-identical to PR #974's proposed diff. Adopted here under verified authorship because PR #974's underlying commit carried an unverified author identity (`author_login: null`, author name `openClaw` with a `.local` hostname email). This is a policy adoption, not a rejection of the copy — the improvements land under a signable audit trail as belt-tightening on unknown-fork acceptance.

## Entrypoints

- Main nav: unchanged
- Footer: unchanged
- Homepage: copy-only edit to four existing strings; no structural changes
- `mounts.js`: unchanged
- Cross-page: no new refs
- Cache-busting: no new pages

## References

- Original proposal: #974 (closed)
- Original issue: #872
- Belt-tightening policy: #977