### PR TITLE
cli(gaia install): fix tree/ URL misrouting and nested suite diagnostic

### DIFF
--- a/src/gaia_cli/install.py
+++ b/src/gaia_cli/install.py
@@ -83,6 +83,7 @@ def _parse_github_url(url: str) -> tuple[str, str, str]:
     Examples:
     - https://github.com/owner/repo -> (https://github.com/owner/repo.git, None, "")
     - https://github.com/owner/repo/blob/main/path/to/skill.md -> (https://github.com/owner/repo.git, main, path/to)
+    - https://github.com/owner/repo/tree/main/path/to/skill -> (https://github.com/owner/repo.git, main, path/to/skill)
     """
     url = url.rstrip("/")
     # Pattern for blob URLs: https://github.com/owner/repo/blob/branch/path
@@ -95,6 +96,17 @@ def _parse_github_url(url: str) -> tuple[str, str, str]:
             subpath = os.path.dirname(path)
         else:
             subpath = path
+        return repo_url, branch, subpath
+
+    # Pattern for tree URLs: https://github.com/owner/repo/tree/branch[/path]
+    # tree/ paths always refer to directories — use the path verbatim (no dirname step).
+    # This is a common curator copy-paste mistake; handle it correctly rather than
+    # silently falling through to the bare-repo pattern and dropping the subpath.
+    tree_match = re.match(r"https://github\.com/([^/]+)/([^/]+)/tree/([^/]+)(.*)", url)
+    if tree_match:
+        owner, repo, branch, path = tree_match.groups()
+        repo_url = f"https://github.com/{owner}/{repo}.git"
+        subpath = path.lstrip("/")  # strip leading slash; empty string = repo root
         return repo_url, branch, subpath
 
     # Pattern for base repo: https://github.com/owner/repo
@@ -312,11 +324,22 @@ def install_suite(suite_id: str, registry_path: str, visited: set[str] | None = 
     print(f"\nInstalling suite: {sid} ({len(components)} components)...")
     success_count = 0
     failed: list[str] = []
+    has_nested_suite_failure = False
     for comp_id in components:
+        # Check if the component is itself a suite so we can annotate failures clearly.
+        _, comp_meta = resolve_named_skill_reference(comp_id, registry_path)
+        comp_is_suite = bool(
+            comp_meta and comp_meta.get("suiteComponents")
+        ) if comp_meta else False
+
         if install_skill(comp_id, registry_path, visited, location=location):
             success_count += 1
         else:
-            failed.append(comp_id)
+            if comp_is_suite:
+                failed.append(f"{comp_id} (nested suite — see above)")
+                has_nested_suite_failure = True
+            else:
+                failed.append(comp_id)
 
     # Install the suite root itself if it has its own github source.
     # Use _install_single directly to bypass suite-component detection and
@@ -338,6 +361,11 @@ def install_suite(suite_id: str, registry_path: str, visited: set[str] | None = 
             f"Failed: {', '.join(failed)}",
             file=sys.stderr,
         )
+        if has_nested_suite_failure:
+            print(
+                "  (nested-suite failures listed their own component summaries above.)",
+                file=sys.stderr,
+            )
         return False
 
     print(f"\n✓ Suite {sid} complete: {achieved}/{total} component(s) installed.")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -75,6 +75,36 @@ class TestInstallInfra:
         assert branch is None
         assert subpath == ""
 
+    def test_parse_github_url_tree_with_subpath(self):
+        """tree/ URL extracts the correct subpath rather than installing the repo root."""
+        url = "https://github.com/garrytan/gstack/tree/main/review"
+        repo, branch, subpath = _parse_github_url(url)
+        assert repo == "https://github.com/garrytan/gstack.git"
+        assert branch == "main"
+        assert subpath == "review"
+
+    def test_parse_github_url_tree_root_only(self):
+        """tree/ URL with no subpath (just /tree/branch) returns subpath=''."""
+        url = "https://github.com/garrytan/gstack/tree/main"
+        repo, branch, subpath = _parse_github_url(url)
+        assert repo == "https://github.com/garrytan/gstack.git"
+        assert branch == "main"
+        assert subpath == ""
+
+    def test_parse_github_url_tree_trailing_slash_stripped(self):
+        """tree/ URL with trailing slash produces same result as without."""
+        with_slash = _parse_github_url("https://github.com/garrytan/gstack/tree/main/review/")
+        without_slash = _parse_github_url("https://github.com/garrytan/gstack/tree/main/review")
+        assert with_slash == without_slash
+
+    def test_parse_github_url_tree_deep_subpath(self):
+        """tree/ URL with a multi-segment path preserves the full path."""
+        url = "https://github.com/owner/repo/tree/main/skills/foo/bar"
+        repo, branch, subpath = _parse_github_url(url)
+        assert repo == "https://github.com/owner/repo.git"
+        assert branch == "main"
+        assert subpath == "skills/foo/bar"
+
     def test_parse_github_url_dir_path_no_md_extension(self):
         """Blob URL pointing to a directory (no .md suffix) → subpath is the full path."""
         url = "https://github.com/garrytan/gstack/blob/main/browse"

--- a/tests/test_suite_install.py
+++ b/tests/test_suite_install.py
@@ -523,6 +523,59 @@ class TestSuiteInstallFlow:
 
         assert result is False
 
+    def test_nested_suite_failure_annotated_in_outer_summary(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """When a nested suite fails, the outer summary labels it '(nested suite -- see above)'.
+
+        The bool propagation was already correct; this tests the diagnostic annotation
+        added for Issue #1015 so operators can trace failures without scanning the full log.
+        """
+        _setup_install_env(tmp_path, monkeypatch)
+        _make_json_registry(
+            tmp_path,
+            [
+                {
+                    "id": "testuser/outer-suite",
+                    "name": "Outer Suite",
+                    "status": "named",
+                    "suiteComponents": ["testuser/inner-suite", "testuser/good-leaf"],
+                },
+                {
+                    "id": "testuser/inner-suite",
+                    "name": "Inner Suite",
+                    "status": "named",
+                    "suiteComponents": ["testuser/broken-leaf"],
+                },
+                {
+                    # No links.github — will fail to install
+                    "id": "testuser/broken-leaf",
+                    "name": "Broken Leaf",
+                    "status": "named",
+                },
+                _component_meta("good-leaf"),
+            ],
+        )
+        monkeypatch.setattr(
+            "gaia_cli.install._run_git",
+            _make_git_mock(tmp_path, {"good-leaf": "Good leaf content"}),
+        )
+
+        result = install_suite("testuser/outer-suite", str(tmp_path))
+
+        assert result is False
+        captured = capsys.readouterr()
+
+        # Inner suite should print its own failure summary
+        assert "inner-suite" in captured.err
+        # Outer summary should annotate the nested suite failure
+        assert "nested suite" in captured.err
+        assert "see above" in captured.err
+        # Good leaf was still installed
+        manifest = load_manifest()
+        installed_ids = {e["id"] for e in manifest["installed"]}
+        assert "testuser/good-leaf" in installed_ids
+
 
 class TestSuiteInstallBugs:
     """Document existing bugs; tests pass by asserting the current buggy behaviour.


### PR DESCRIPTION
## Problem Statement

Two bugs in `src/gaia_cli/install.py`. First: `_parse_github_url()` had no pattern for GitHub `tree/` URLs — a common curator copy-paste mistake. When a `tree/` URL was registered, the bare-repo regex silently matched just `owner/repo`, dropped the subpath entirely, and installed the entire repo root instead of the intended subdirectory with no warning. Second: `install_suite()` had no way to signal to the operator that a failure in the failed list came from a nested suite rather than a leaf — the bool propagation was already correct, but the diagnostic was opaque.

## Related issues
- Closes #1011
- Closes #1015

## Changes
- `_parse_github_url()`: new `tree/` branch inserted before bare-repo fallback; path is used as subpath directly (always a directory, no dirname step needed)
- `install_suite()`: resolves each component's meta to detect nested suites before installing; annotates nested-suite failures as `comp_id (nested suite — see above)` and prints a hint line pointing operators up the log
- 4 new `_parse_github_url` test cases (tree/ subpath, tree/ root, trailing slash, deep path)
- 1 new nested-suite diagnostic test

## Plan

1. `_parse_github_url()` — add `tree/` URL pattern before bare-repo fallback
2. `_parse_github_url()` — handle `tree/` root + trailing-slash variants
3. `tests/test_install.py` — parametrized tree/ URL cases
4. `install_suite()` — annotate nested-suite failures in the `failed` list
5. `install_suite()` — print nested-suite hint line in the failure summary
6. `tests/test_suite_install.py` — nested-suite diagnostic test