### PR TITLE
infra: upstream-watcher labels + issue template (PR 1/7)

### DIFF
--- a/.github/ISSUE_TEMPLATE/upstream_release.yml
+++ b/.github/ISSUE_TEMPLATE/upstream_release.yml
@@ -1,0 +1,207 @@
+name: "Upstream Release — Suite Watcher"
+description: "Propose a version bump and component delta sync for a curated Gaia suite whose upstream repo has released a new version. Normally auto-populated by the upstream watcher crawler; can also be filed by hand."
+title: "[upstream] <owner/repo> → <new-version>   e.g. mattpocock/skills → v1.1.0"
+labels: ["upstream:release", "needs-triage"]
+assignees: []
+body:
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Upstream Release Tracker
+
+        This issue tracks a detected new release in an upstream source repository
+        for a curated Gaia suite skill.
+
+        **When auto-filed by the watcher crawler**, the machine-readable payload
+        and human-readable sections below are fully populated. A maintainer reviews
+        and applies one of the labels from the **Label vocabulary** table to act.
+
+        **When filed by hand**, fill in as much of the payload and summary sections
+        as you can. The crawler will not retroactively populate missing fields, but
+        a maintainer can manually trigger the sync workflow after review.
+
+        > **Note:** This issue only tracks the *version bump* and *component delta*
+        > for an existing curated suite. To propose a brand-new skill, use the
+        > **Skill Intake — Batch Proposal** template instead.
+
+  - type: textarea
+    id: machine_payload
+    attributes:
+      label: "Machine-readable payload (crawler-populated — do not edit by hand)"
+      description: |
+        JSON payload consumed by the upstream-approve workflow. Populated
+        automatically by the watcher crawler. If filing by hand, leave this blank
+        or fill in what you know — the workflow will validate on apply.
+      value: |
+        <!-- gaia-upstream-payload
+        {
+          "skillId": "",
+          "previousVersion": "",
+          "newVersion": "",
+          "releasedAt": "",
+          "sourceUrl": "",
+          "componentAdds": [],
+          "componentRemoves": [],
+          "linkLiveness": {}
+        }
+        -->
+      render: shell
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+
+        ## Version
+
+        *(Crawler fills this in. Hand-filers: paste the release comparison here.)*
+
+        | Field | Value |
+        |---|---|
+        | Skill ID | *(e.g. `mattpocock-skills`)* |
+        | Upstream repo | *(e.g. `mattpocock/skills`)* |
+        | Previous version | *(e.g. `v1.0.3`)* |
+        | New version | *(e.g. `v1.1.0`)* |
+        | Released at | *(ISO 8601 UTC)* |
+        | Release URL | *(GitHub releases tag URL)* |
+
+  - type: textarea
+    id: version_summary
+    attributes:
+      label: "Version summary"
+      description: "Human-readable 'was X → is Y; released on date' summary. Auto-filled by crawler."
+      placeholder: |
+        **was** v1.0.3 → **is** v1.1.0
+        Released: 2026-07-05 (5 days ago)
+        Release notes: https://github.com/mattpocock/skills/releases/tag/v1.1.0
+    validations:
+      required: false
+
+  - type: textarea
+    id: component_delta
+    attributes:
+      label: "Component delta"
+      description: |
+        Checklist of added and removed components. Populated by the crawler.
+        - `+` new components will have a linked child intake issue.
+        - `-` removed components will be proposed for freeze (installable: false).
+      placeholder: |
+        ### Added
+        - [ ] + `new-component-a` — child intake: #123
+        - [ ] + `new-component-b` — child intake: #124
+
+        ### Removed (proposed freeze)
+        - [ ] - `old-component-x` — freeze via `gaia dev freeze`; umbrella approval covers this
+        - [ ] - `old-component-y` — freeze via `gaia dev freeze`
+
+        ### Unchanged
+        All other components remain in the suite with no changes detected.
+
+        ---
+        Child intakes: #123, #124
+    validations:
+      required: false
+
+  - type: textarea
+    id: link_liveness
+    attributes:
+      label: "Link liveness report"
+      description: |
+        HEAD-check results for each component's `links.github` URL.
+        200 = healthy. 4xx/5xx = broken. Empty = not checked (version-only mode).
+      placeholder: |
+        | Component | URL | Status |
+        |---|---|---|
+        | `component-a` | https://github.com/owner/repo/blob/main/skills/a/SKILL.md | ✅ 200 |
+        | `component-b` | https://github.com/owner/repo/blob/main/skills/b/SKILL.md | ❌ 404 |
+
+        **Action needed:** `component-b` link is broken — upstream file may have been renamed.
+        Use `gaia dev relink component-b --new-url <url>` if the correct path is known,
+        or flag as `upstream:needs-info` if unclear.
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+
+        ## Label vocabulary
+
+        Every label that can be applied to this issue and its effect on automation:
+
+        | Label | Applied by | When | Effect |
+        |---|---|---|---|
+        | `intake` | crawler / human | new-skill intake issue creation | categorization for skill batch proposals |
+        | `upstream:release` | crawler | umbrella creation | categorizes this as a release-delta umbrella |
+        | `upstream:child` | crawler | child intake creation | links child to umbrella; auto-closes on umbrella rejection |
+        | `upstream:bootstrap` | crawler | first-poll baselining | fires bootstrap confirmation flow (one-time per suite) |
+        | `needs-triage` | crawler | any issue creation | standard triage queue; remove when reviewed |
+        | `upstream:approved` | maintainer | after review | fires `upstream-approve.yml` workflow (gated on child resolution unless `skip-child-gate` also applied) |
+        | `upstream:rejected` | maintainer | after review | closes issue with sync-skipped comment; auto-closes open child intakes |
+        | `upstream:needs-info` | maintainer | after review | puts issue on hold; no automation fires |
+        | `skip-child-gate` | maintainer (rare) | alongside `upstream:approved` | bypasses the child-intake resolution gate; auditable via label history |
+
+        > **Child gate rule:** when you apply `upstream:approved`, the sync workflow
+        > checks that all child intake issues are closed (accepted or rejected) before
+        > opening the draft PR. If any are still open, the workflow posts a comment
+        > and waits. To bypass (e.g. when a child intake is irrelevant or handled
+        > separately), apply `skip-child-gate` *before* or *alongside* `upstream:approved`.
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: "Reviewer notes (optional)"
+      description: "Any context, concerns, or curation decisions that should be recorded alongside this issue."
+      placeholder: |
+        e.g. The v1.1.0 release renames `typescript-expert` → `ts-expert`; the component
+        ID in our registry doesn't need to change since our naming is independent.
+        Freezing `old-component-x` is straightforward — it was removed from suite root
+        in the upstream changelog and had no active users per our install telemetry.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: reviewer_checklist
+    attributes:
+      label: Reviewer checklist (maintainer)
+      options:
+        - label: "Verified that the machine-readable payload `skillId` matches the registry node"
+          required: false
+        - label: "Verified the upstream release URL is authentic (not a draft or pre-release)"
+          required: false
+        - label: "Reviewed all component additions — each has a child intake issue or is explicitly deferred"
+          required: false
+        - label: "Reviewed all component removals — freeze action is appropriate (no 3★+ Star Bar conflicts)"
+          required: false
+        - label: "Reviewed link liveness — any 4xx/5xx flagged is understood and actioned"
+          required: false
+        - label: "All child intake issues are closed (or `skip-child-gate` is justified above)"
+          required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+
+        ### Reviewer actions (maintainer only)
+
+        Apply exactly **one** of these labels to trigger the corresponding automation:
+
+        | Action label | Shorthand | Effect |
+        |---|---|---|
+        | `upstream:approved` | ✅ Approve | Fires `upstream-approve.yml` → opens draft `review/meta/upstream-<skill>-<version>` PR after child gate passes |
+        | `upstream:rejected` | ❌ Reject | Closes this umbrella with a sync-skipped comment; auto-closes open child intakes |
+        | `upstream:needs-info` | ⏸ Hold | No automation; issue stays open until info arrives and label is swapped |
+        | `skip-child-gate` + `upstream:approved` | ⚡ Force-approve | Bypasses child resolution check; use only when child intakes are irrelevant/deferred |
+
+        **After approval:** a draft PR is opened automatically on branch
+        `review/meta/upstream-<skill>-<version>`. That PR runs `gaia dev sync-upstream`
+        and `gaia dev freeze` for removed components, then `gaia dev docs` to regen
+        Class S artifacts. Merge that PR as normal — the umbrella issue auto-closes
+        on merge via the `Fixes #<N>` reference in the PR body.
+
+        **Design reference:** `docs/agents/upstream-watcher.md` §5 (Issue shape), §6 (Labels), §7 (Approval mechanics).

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,334 @@
+# .github/labels.yml
+# Authoritative label definitions for the gaia-skill-tree repo.
+# Managed by crazy-max/ghaction-github-labeler via .github/workflows/labels-sync.yml.
+# Sync runs automatically on push to main when this file changes.
+#
+# Color conventions:
+#   Source / classifier labels:   purple  #5319E7
+#   skip-* bypass labels:         orange-red  #e04e25
+#   upstream:* state labels:      teal family
+#   Workflow/status:              varies (see per-group comments)
+#   Generic/neutral tags:         light grey  #ededed
+
+# ── Pre-existing labels (preserve verbatim) ────────────────────────────────
+
+- name: bug
+  color: "d73a4a"
+  description: "Something isn't working"
+
+- name: documentation
+  color: "0075ca"
+  description: "Improvements or additions to documentation"
+
+- name: duplicate
+  color: "cfd3d7"
+  description: "This issue or pull request already exists"
+
+- name: enhancement
+  color: "a2eeef"
+  description: "New feature or request"
+
+- name: "good first issue"
+  color: "7057ff"
+  description: "Good for newcomers"
+
+- name: "help wanted"
+  color: "008672"
+  description: "Extra attention is needed"
+
+- name: invalid
+  color: "e4e669"
+  description: "This doesn't seem right"
+
+- name: question
+  color: "d876e3"
+  description: "Further information is requested"
+
+- name: wontfix
+  color: "ffffff"
+  description: "This will not be worked on"
+
+- name: codex
+  color: "ededed"
+  description: ""
+
+- name: human-proposal
+  color: "1d76db"
+  description: ""
+
+- name: needs-review
+  color: "0e8a16"
+  description: ""
+
+- name: draft-skills
+  color: "5319e7"
+  description: ""
+
+- name: CLI
+  color: "0075ca"
+  description: "CLI tooling"
+
+- name: RFC
+  color: "d93f0b"
+  description: "Request for comments — design discussion"
+
+- name: codex-automation
+  color: "ededed"
+  description: ""
+
+- name: bot-proposal
+  color: "0E8A16"
+  description: "Automated crawler proposal"
+
+- name: "source:vscode"
+  color: "5319E7"
+  description: "Proposal from VS Code Marketplace crawler"
+
+- name: "source:huggingface"
+  color: "5319E7"
+  description: "Proposal from HuggingFace crawler"
+
+- name: "source:github"
+  color: "5319E7"
+  description: "Proposal from GitHub crawler"
+
+- name: skip-scope-check
+  color: "e04e25"
+  description: ""
+
+- name: ultimate-review
+  color: "aa9235"
+  description: "review for 5 star promotions and demotions"
+
+- name: mcp
+  color: "d5c9eb"
+  description: ""
+
+- name: Jules
+  color: "5319e7"
+  description: "Daily / Weekly Jules updates"
+
+- name: deprecation
+  color: "ededed"
+  description: ""
+
+- name: schema
+  color: "ededed"
+  description: ""
+
+- name: tech-debt
+  color: "ededed"
+  description: ""
+
+- name: auto-merge
+  color: "ededed"
+  description: ""
+
+- name: claude-bot
+  color: "ededed"
+  description: ""
+
+- name: docs
+  color: "ededed"
+  description: ""
+
+- name: dependencies
+  color: "0366d6"
+  description: "Pull requests that update a dependency file"
+
+- name: "python:uv"
+  color: "2b67c6"
+  description: "Pull requests that update python:uv code"
+
+- name: javascript
+  color: "168700"
+  description: "Pull requests that update javascript code"
+
+- name: security
+  color: "1f4984"
+  description: ""
+
+- name: exploration
+  color: "ededed"
+  description: "Issues found during feature exploration"
+
+- name: needs-triage
+  color: "ededed"
+  description: "New issues waiting for triage"
+
+- name: taxonomy
+  color: "ededed"
+  description: ""
+
+- name: backend
+  color: "0052cc"
+  description: "Server-side logic and infrastructure"
+
+- name: infrastructure
+  color: "d93f0b"
+  description: "Foundational systems and architecture"
+
+- name: planning
+  color: "cfd3d7"
+  description: "Research and design phases"
+
+- name: frontend
+  color: "006b75"
+  description: "User interface and presentation"
+
+- name: transparency
+  color: "f9d0c4"
+  description: "Focus on explainability and open data"
+
+- name: v2-roadmap
+  color: "0E8A16"
+  description: "Part of the GAIA V2 Strategic Roadmap"
+
+- name: v2-unrelated
+  color: "D1D5DA"
+  description: "Not part of the V2 roadmap deliverables"
+
+- name: phase-1
+  color: "0E8A16"
+  description: "Phase 1 — Trust Infrastructure scope"
+
+- name: phase-2
+  color: "1D76DB"
+  description: "Phase 2 — Product Moat scope"
+
+- name: phase-1.5
+  color: "BFDBFE"
+  description: "Phase 1.5 — G7 Implementation"
+
+- name: apex-promotion
+  color: "FBBF24"
+  description: "PR promotes a skill to 6★ — requires 2 verifier sign-offs and apex gate audit"
+
+- name: verifier-signoff
+  color: "A78BFA"
+  description: "Cosign on an apex-promotion PR by a 4★+ Verifier"
+
+- name: evidence
+  color: "2cf4d3"
+  description: ""
+
+- name: gemini-bot
+  color: "ededed"
+  description: ""
+
+- name: epic
+  color: "ededed"
+  description: ""
+
+- name: technical-debt
+  color: "ededed"
+  description: ""
+
+- name: ci-cd
+  color: "ededed"
+  description: ""
+
+- name: sub-issue
+  color: "ededed"
+  description: ""
+
+- name: monorepo
+  color: "ededed"
+  description: ""
+
+- name: quality-gates
+  color: "ededed"
+  description: ""
+
+- name: refactoring
+  color: "ededed"
+  description: ""
+
+- name: skills
+  color: "ededed"
+  description: ""
+
+- name: versioning
+  color: "ededed"
+  description: ""
+
+- name: sprint-b
+  color: "0052CC"
+  description: "Sprint B — API + Trending + Hall of Heroes"
+
+- name: sprint-d
+  color: "5319E7"
+  description: "Sprint D — Content Engine + Benchmark MVP"
+
+- name: content-engine
+  color: "0E8A16"
+  description: "Weekly auto-report content pipeline"
+
+- name: auto-merge-eligible
+  color: "C2E0C6"
+  description: "Satisfice PRs <100 LoC + CI green — auto-merge"
+
+- name: migration-notes-missing
+  color: "E99695"
+  description: "PR lacks required Migration Notes block"
+
+- name: sprint-f
+  color: "8B5CF6"
+  description: "Sprint F — Migration + Monorepo Move (React/Node port)"
+
+- name: awaiting-assets
+  color: "FBCA04"
+  description: "Blocked on commissioned illustration / motion asset delivery"
+
+- name: capability-gap
+  color: "0e8a16"
+  description: "A missing generic node the registry should have"
+
+# ── New labels: intake (latent bug fix) ────────────────────────────────────
+# NOTE: `intake` was missing from the repo despite being referenced in
+# .github/ISSUE_TEMPLATE/new_skill_intake.yml — applying it as a latent bug fix.
+
+- name: intake
+  color: "5319E7"
+  description: "New skill intake — batch proposal awaiting triage"
+
+# ── New labels: upstream-watcher family ────────────────────────────────────
+# Colors:
+#   upstream:release / upstream:child / upstream:bootstrap  →  teal #0D9B8A
+#     (categorisation labels — identify the issue type at a glance)
+#   upstream:approved                                        →  green #0E8A16
+#     (positive action; same green as bot-proposal/needs-review family)
+#   upstream:rejected                                        →  red #d73a4a
+#     (negative resolution; same red as bug)
+#   upstream:needs-info                                      →  yellow #FBCA04
+#     (hold/blocked; matches awaiting-assets amber)
+#   skip-child-gate                                          →  orange-red #e04e25
+#     (bypass label; matches skip-scope-check convention)
+
+- name: "upstream:release"
+  color: "0D9B8A"
+  description: "Upstream watcher — release-delta umbrella issue"
+
+- name: "upstream:child"
+  color: "0D9B8A"
+  description: "Upstream watcher — child intake issue linked to an umbrella"
+
+- name: "upstream:bootstrap"
+  color: "0D9B8A"
+  description: "Upstream watcher — first-run baselining issue (one-time per suite)"
+
+- name: "upstream:approved"
+  color: "0E8A16"
+  description: "Upstream watcher — maintainer approved; fires sync workflow"
+
+- name: "upstream:rejected"
+  color: "d73a4a"
+  description: "Upstream watcher — maintainer rejected; closes with sync-skipped comment"
+
+- name: "upstream:needs-info"
+  color: "FBCA04"
+  description: "Upstream watcher — on hold; no automation fires until resolved"
+
+- name: skip-child-gate
+  color: "e04e25"
+  description: "Bypass the child-intake resolution gate on an upstream:approved umbrella"

--- a/.github/workflows/labels-sync.yml
+++ b/.github/workflows/labels-sync.yml
@@ -1,0 +1,32 @@
+name: Sync GitHub Labels
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/labels.yml'
+
+# Only run on pushes to main — not on PRs — so label state is only reconciled
+# from the authoritative merged definition, never from a speculative branch.
+jobs:
+  labels:
+    name: Reconcile labels from .github/labels.yml
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Sync labels
+        uses: crazy-max/ghaction-github-labeler@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          yaml-file: .github/labels.yml
+          # skip-delete: leave labels not listed in labels.yml intact rather
+          # than deleting them. Set to false only when you intend a full purge.
+          skip-delete: false
+          dry-run: false
+          verbose: true


### PR DESCRIPTION
## Summary

Implements PR 1 of the upstream-watcher V1 rollout (see §14 of the design spec). No behavior change — labels metadata and issue template only.

---

## Design ref

- **Upstream design PR:** #1022 (draft)
- **Spec file:** `docs/agents/upstream-watcher.md` on `origin/docs/upstream-watcher-design`
- **Sections implemented:**
  - **§6 — Labels:** `.github/labels.yml` adds all 8 new upstream-watcher labels plus fixes the latent `intake` label gap
  - **§5 — Issue shape:** `.github/ISSUE_TEMPLATE/upstream_release.yml` mirrors the structural pattern of `new_skill_intake.yml` (markdown intro → payload textarea → human summary → label vocab → reviewer actions)

---

## Files created

| File | What |
|---|---|
| `.github/labels.yml` | Authoritative label definitions in `github-labeler`-compatible format. Includes all 67 pre-existing labels (preserved verbatim) + 8 new labels. |
| `.github/workflows/labels-sync.yml` | Reconciliation workflow using `crazy-max/ghaction-github-labeler@v5`. Triggers only on push to main on path `.github/labels.yml`. Guarded by `if: github.ref == 'refs/heads/main'`. |
| `.github/ISSUE_TEMPLATE/upstream_release.yml` | Skeleton issue template for upstream release tracking. Structural mirror of `new_skill_intake.yml`. Includes full label vocab table inline (§5 design decision). |

---

## New labels

| Label | Color | Rationale |
|---|---|---|
| `intake` | `#5319E7` (purple) | Latent bug fix — referenced by `new_skill_intake.yml` but missing from repo |
| `upstream:release` | `#0D9B8A` (teal) | Categorization — umbrella issue type |
| `upstream:child` | `#0D9B8A` (teal) | Categorization — child intake linked to umbrella |
| `upstream:bootstrap` | `#0D9B8A` (teal) | Categorization — first-run baselining (one-time per suite) |
| `upstream:approved` | `#0E8A16` (green) | Positive action; matches `bot-proposal`/`needs-review` green family |
| `upstream:rejected` | `#d73a4a` (red) | Negative resolution; matches `bug` red |
| `upstream:needs-info` | `#FBCA04` (amber) | Hold state; matches `awaiting-assets` amber |
| `skip-child-gate` | `#e04e25` (orange-red) | Bypass label; matches `skip-scope-check` convention |

---

## Entrypoints

Per CLAUDE.md Design Entrypoints rule — enumerated explicitly, most N/A for admin infra:

1. **Main nav (`docs/js/site-nav.js`)** — N/A. No new user-facing page added.
2. **Footer (`docs/js/site-footer.js`)** — N/A. No new section added.
3. **Homepage (`docs/index.html`)** — N/A. Label and template infra is not user-facing.
4. **`docs/js/mounts.js`** — N/A. No new `docs/<section>/` directory added.
5. **Cross-page references** — N/A. No new discoverable surfaces added.
6. **Cache-busting** — N/A. No new HTML pages added.

---

## Scope compliance

Branch prefix: `infra/` ✅
Files touched: `.github/` only ✅
No registry, src, docs/graph, or schema changes ✅

---

## CI

Labels-sync workflow is guarded by `if: github.ref == 'refs/heads/main'` — it will NOT run on this PR, only on merge to main. Branch-scope check should pass since all changed files are under `.github/`.

---

## Token spend

*To be posted as PR comment at end of session.*