### PR TITLE
infra: extract scripts/lib/ shared primitives (PR 2/7)

### DIFF
--- a/scripts/lib/__init__.py
+++ b/scripts/lib/__init__.py
@@ -1,0 +1,22 @@
+"""
+scripts.lib — shared infrastructure primitives for Gaia registry scripts.
+
+Design contract (upstream-watcher design §9):
+  Primitives belong here only when used by ≥2 scripts.
+  This is not a dumping ground for one-script helpers.
+
+Public sub-modules:
+  frontmatter     — regex-based frontmatter parse/rewrite
+  github_api      — GitHub API client + URL parser
+  named_iterator  — walk registry/named/**/*.md
+
+Import each sub-module directly:
+  from scripts.lib.frontmatter import split_frontmatter
+  from scripts.lib.github_api import parse_owner_repo, fetch_json, head_check
+  from scripts.lib.named_iterator import iter_named_skills
+
+Do NOT import from this package-level __init__ — doing so would trigger all
+sub-module loads regardless of which primitive you actually need.
+"""
+
+__version__ = "0.1.0"

--- a/scripts/lib/frontmatter.py
+++ b/scripts/lib/frontmatter.py
@@ -1,0 +1,313 @@
+"""
+scripts.lib.frontmatter — regex-based YAML frontmatter parse and rewrite.
+
+Ported and generalised from ``scripts/stargazerHeartbeat.py`` so that both
+the heartbeat and the upcoming upstream-watcher share identical parsing logic
+(upstream-watcher design §9, PR 2 of 7).
+
+Public API
+----------
+split_frontmatter(text)
+    Split raw file text into (fence, fm_content, body).
+
+load_yaml_simple(text)
+    Parse a YAML string into a dict (thin pyyaml wrapper).
+
+update_list_item_in_frontmatter(text, list_key, row_index, field_updates)
+    Update specific fields on the Nth item of a list block in the frontmatter.
+    Generalised form of the heartbeat's ``_update_evidence_row_in_text``.
+
+upsert_top_level_block(text, block_key, block_value)
+    Write or merge an entire top-level frontmatter mapping block.
+    Used by the watcher to write/update ``upstream:`` in one shot.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Frontmatter fence regex
+# ---------------------------------------------------------------------------
+
+_FM_RE = re.compile(r"^---\r?\n(.*?)\r?\n---(?:\r?\n|$)", re.DOTALL)
+
+
+# ---------------------------------------------------------------------------
+# Core parse helpers
+# ---------------------------------------------------------------------------
+
+
+def split_frontmatter(text: str) -> tuple[str, str, str]:
+    """Split *text* into ``(pre_fence, fm_content, body)``.
+
+    ``pre_fence`` is always ``'---\\n'`` when frontmatter is present.
+    Returns ``('', '', text)`` when the file has no frontmatter fence.
+
+    Ported verbatim from ``stargazerHeartbeat._split_frontmatter``, renamed
+    to a public API (no leading underscore).
+    """
+    m = _FM_RE.match(text)
+    if not m:
+        return ("", "", text)
+    fm_raw = m.group(1)
+    body = text[m.end():]
+    return ("---\n", fm_raw, body)
+
+
+def load_yaml_simple(text: str) -> dict:
+    """Parse *text* as YAML and return a dict (empty dict on blank/None input).
+
+    Thin wrapper around ``yaml.safe_load`` — pyyaml is always available in
+    this project (listed in ``pyproject.toml`` dependencies).
+
+    Ported from ``stargazerHeartbeat._load_yaml_simple``.
+    """
+    import yaml  # pyyaml — always available in this project
+
+    return yaml.safe_load(text) or {}
+
+
+# ---------------------------------------------------------------------------
+# List-item rewriter
+# ---------------------------------------------------------------------------
+
+
+def update_list_item_in_frontmatter(
+    text: str,
+    list_key: str,
+    row_index: int,
+    field_updates: dict[str, Any],
+) -> str:
+    """Update fields on the *row_index*-th item of the *list_key* block.
+
+    Generalised form of ``stargazerHeartbeat._update_evidence_row_in_text``.
+    The heartbeat use-case (``list_key='evidence'``,
+    ``field_updates={'stars': N, 'updatedAt': 'YYYY-MM-DD'}``) still works
+    unchanged through this API.
+
+    Parameters
+    ----------
+    text:
+        Full raw file text including frontmatter fences.
+    list_key:
+        Name of the top-level list key (e.g. ``'evidence'``, ``'timeline'``).
+    row_index:
+        Zero-based index of the list item to update.
+    field_updates:
+        Mapping of ``{field_name: new_value}`` to apply/insert on the item.
+        Existing non-updated fields are preserved verbatim.  New fields are
+        inserted after the first line of the item block (the ``- …`` line).
+
+    Returns
+    -------
+    str
+        The full file text with the targeted item rewritten.  Returns *text*
+        unchanged if the frontmatter or the requested item cannot be located.
+    """
+    m = _FM_RE.match(text)
+    if not m:
+        return text
+
+    fm_text = m.group(1)
+    body_text = text[m.end():]
+
+    lines = fm_text.split("\n")
+    in_block = False
+    item_idx = -1
+    item_start_line: int | None = None
+    item_end_line: int | None = None
+
+    for i, line in enumerate(lines):
+        if re.match(rf"^{re.escape(list_key)}\s*:", line):
+            in_block = True
+            continue
+        if in_block:
+            # A top-level key (non-indented, non-list-item) ends the block
+            if line and not line[0].isspace() and not line.startswith("-"):
+                in_block = False
+                if item_start_line is not None and item_end_line is None:
+                    item_end_line = i
+                break
+            if re.match(r"^- ", line):
+                item_idx += 1
+                if item_idx == row_index:
+                    item_start_line = i
+                elif item_idx == row_index + 1:
+                    item_end_line = i
+                    break
+
+    if item_start_line is None:
+        return text  # Could not locate the requested item
+
+    if item_end_line is None:
+        item_end_line = len(lines)
+
+    block_lines = lines[item_start_line:item_end_line]
+
+    # Track which fields we've handled (to know which need inserting)
+    handled: set[str] = set()
+    new_block: list[str] = []
+
+    for bl in block_lines:
+        replaced = False
+        for field, value in field_updates.items():
+            if re.match(rf"\s+{re.escape(field)}\s*:", bl):
+                indent_m = re.match(r"(\s+)", bl)
+                prefix = indent_m.group(1) if indent_m else "  "
+                formatted = _format_field_value(value)
+                new_block.append(f"{prefix}{field}: {formatted}")
+                handled.add(field)
+                replaced = True
+                break
+        if not replaced:
+            new_block.append(bl)
+
+    # Insert any fields not found in the existing block (after the '- …' line)
+    insert_pos = 1
+    for field, value in field_updates.items():
+        if field not in handled:
+            formatted = _format_field_value(value)
+            new_block.insert(insert_pos, f"  {field}: {formatted}")
+            insert_pos += 1
+
+    new_lines = lines[:item_start_line] + new_block + lines[item_end_line:]
+    new_fm = "\n".join(new_lines)
+    return f"---\n{new_fm}\n---\n{body_text}"
+
+
+# ---------------------------------------------------------------------------
+# Top-level block upsert
+# ---------------------------------------------------------------------------
+
+
+def upsert_top_level_block(
+    text: str,
+    block_key: str,
+    block_value: dict[str, Any],
+) -> str:
+    """Write or merge a top-level frontmatter mapping block.
+
+    If *block_key* already exists in the frontmatter, its sub-keys are updated
+    with the values from *block_value* (unrelated sub-keys are preserved).  If
+    *block_key* is absent, the entire block is appended before the closing
+    fence.
+
+    Key ordering within the merged/inserted block is deterministic (sorted).
+
+    Intended use: the upstream-watcher writing/updating ``upstream:`` in one
+    shot.
+
+    Parameters
+    ----------
+    text:
+        Full raw file text including frontmatter fences.
+    block_key:
+        Top-level YAML key to create or update (e.g. ``'upstream'``).
+    block_value:
+        Dict of sub-key/value pairs to write under *block_key*.
+
+    Returns
+    -------
+    str
+        Updated full file text.  Returns *text* unchanged if it has no
+        frontmatter.
+    """
+    m = _FM_RE.match(text)
+    if not m:
+        return text
+
+    fm_text = m.group(1)
+    body_text = text[m.end():]
+
+    import yaml  # pyyaml
+
+    existing_fm: dict = yaml.safe_load(fm_text) or {}
+
+    # Merge: preserve existing block, overlay with new values
+    existing_block: dict = existing_fm.get(block_key) or {}
+    merged_block = {**existing_block, **block_value}
+
+    # Rebuild the top-level frontmatter with the block updated
+    # Strategy: parse all keys, replace or append the target block.
+    new_fm_dict = dict(existing_fm)
+    new_fm_dict[block_key] = {k: merged_block[k] for k in sorted(merged_block)}
+
+    # Serialise back.  We want to preserve the *rest* of the frontmatter
+    # exactly as-is.  Safe strategy: locate (or append) the block via
+    # line-level surgery so unrelated keys retain their formatting.
+    new_fm_text = _replace_block_in_fm_text(fm_text, block_key, merged_block)
+    return f"---\n{new_fm_text}\n---\n{body_text}"
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_field_value(value: Any) -> str:
+    """Render a scalar value for inline YAML emission.
+
+    Strings are single-quoted if they look like dates or ISO timestamps;
+    integers/booleans are unquoted; other strings are single-quoted.
+    """
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        return str(value)
+    # Strings: single-quote if they contain a colon, look like a date/datetime,
+    # or are not simple alphanumeric tokens.
+    s = str(value)
+    if re.match(r"^\d{4}-\d{2}-\d{2}", s) or ":" in s or not re.match(r"^[A-Za-z0-9_\-./]+$", s):
+        return f"'{s}'"
+    return s
+
+
+def _replace_block_in_fm_text(
+    fm_text: str,
+    block_key: str,
+    block_value: dict[str, Any],
+) -> str:
+    """Replace or append the *block_key* section in raw frontmatter text.
+
+    Preserves all other lines verbatim.  Deterministic key ordering for the
+    replaced block.
+    """
+    lines = fm_text.split("\n")
+    key_pattern = re.compile(rf"^{re.escape(block_key)}\s*:")
+
+    # Find the range occupied by an existing block (if any)
+    block_start: int | None = None
+    block_end: int | None = None
+
+    for i, line in enumerate(lines):
+        if key_pattern.match(line):
+            block_start = i
+            continue
+        if block_start is not None and block_end is None:
+            # Block ends when we hit a non-empty, non-indented, non-list line
+            if line and not line[0].isspace() and not line.startswith("-"):
+                block_end = i
+                break
+
+    if block_start is not None and block_end is None:
+        block_end = len(lines)
+
+    # Build the replacement block lines
+    new_block_lines = [f"{block_key}:"]
+    for k in sorted(block_value.keys()):
+        v = block_value[k]
+        formatted = _format_field_value(v) if v is not None else "null"
+        new_block_lines.append(f"  {k}: {formatted}")
+
+    if block_start is not None:
+        # Replace existing block
+        new_lines = lines[:block_start] + new_block_lines + lines[block_end:]
+    else:
+        # Append as new block (with blank separator)
+        new_lines = lines + [""] + new_block_lines
+
+    return "\n".join(new_lines)

--- a/scripts/lib/github_api.py
+++ b/scripts/lib/github_api.py
@@ -1,0 +1,181 @@
+"""
+scripts.lib.github_api — GitHub API client and URL parser.
+
+Ported and generalised from ``scripts/stargazerHeartbeat.py`` so that both
+the heartbeat and the upcoming upstream-watcher share identical API call
+semantics (upstream-watcher design §9, PR 2 of 7).
+
+Public API
+----------
+parse_owner_repo(url)
+    Extract (owner, repo) from any GitHub URL.  Returns None on failure.
+
+fetch_json(endpoint, token=None, timeout=10)
+    Fetch a GitHub API endpoint and return the parsed JSON dict.
+    Accepts a full URL or an ``/…`` path (auto-prefixed to api.github.com).
+    Same retry/throttle semantics as the heartbeat's ``fetch_stars``.
+
+head_check(url, timeout=10)
+    Issue an HTTP HEAD to *url* and return the HTTP status code.
+    Returns None on network error.  Safe on ``raw.githubusercontent.com``
+    URLs (design §5 — rendered blob/ URLs can serve HTML on 404; raw URLs
+    are the canonical liveness target).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+# ---------------------------------------------------------------------------
+# GitHub URL parser — ported verbatim from stargazerHeartbeat.parse_owner_repo
+# ---------------------------------------------------------------------------
+
+import re
+
+_GH_RE = re.compile(
+    r"https?://github\.com/([^/]+)/([^/\s#?]+)"
+    r"(?:/(?:blob|tree|stargazers|commits?|releases?)(?:/[^\s#?]*)?)?"
+)
+
+
+def parse_owner_repo(url: str) -> tuple[str, str] | None:
+    """Extract ``(owner, repo)`` from a GitHub URL.
+
+    Handles:
+    - Bare repo URL: ``https://github.com/owner/repo``
+    - ``blob/`` URL: ``https://github.com/owner/repo/blob/main/path``
+    - ``tree/`` URL: ``https://github.com/owner/repo/tree/main/dir``
+    - ``releases/tag/`` URL: ``https://github.com/owner/repo/releases/tag/v1``
+    - ``.git`` suffix stripped automatically.
+
+    Returns ``None`` for non-GitHub URLs or empty input.
+
+    Ported verbatim from ``stargazerHeartbeat.parse_owner_repo``.
+    """
+    if not url:
+        return None
+    m = _GH_RE.match(url.strip())
+    if not m:
+        return None
+    owner = m.group(1)
+    repo = m.group(2).rstrip("/")
+    if repo.endswith(".git"):
+        repo = repo[:-4]
+    return (owner, repo)
+
+
+# ---------------------------------------------------------------------------
+# JSON fetch — generalised from stargazerHeartbeat.fetch_stars
+# ---------------------------------------------------------------------------
+
+_API_BASE = "https://api.github.com"
+_CACHE: dict[str, dict | None] = {}  # URL -> parsed JSON or None on error
+
+
+def fetch_json(
+    endpoint: str,
+    token: str | None = None,
+    timeout: int = 10,
+) -> dict | None:
+    """Fetch *endpoint* and return the parsed JSON dict.
+
+    *endpoint* may be:
+    - A full URL: ``https://api.github.com/repos/owner/repo``
+    - A path:     ``/repos/owner/repo`` (auto-prefixed to ``api.github.com``)
+
+    Auth: *token* overrides; falls back to ``GH_TOKEN`` env var; unauthenticated
+    if neither is set (60 req/hr rate limit).
+
+    Caching: results are cached in-process by full URL.  Re-invoke the script
+    to bypass.
+
+    Throttle: a 100 ms sleep fires in ``finally`` (same as heartbeat) to avoid
+    saturating the rate limit on bulk runs.
+
+    Returns ``None`` on ``HTTPError``, timeout, or any network error; emits a
+    warning to ``stderr``.
+    """
+    # Normalise to a full URL
+    if endpoint.startswith("/"):
+        url = f"{_API_BASE}{endpoint}"
+    elif not endpoint.startswith("http"):
+        url = f"{_API_BASE}/{endpoint}"
+    else:
+        url = endpoint
+
+    if url in _CACHE:
+        return _CACHE[url]
+
+    resolved_token = token or os.environ.get("GH_TOKEN", "")
+
+    req = urllib.request.Request(
+        url,
+        headers={"Accept": "application/vnd.github+json"},
+    )
+    if resolved_token:
+        req.add_header("Authorization", f"token {resolved_token}")
+
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = json.loads(resp.read().decode())
+            _CACHE[url] = data
+            return data
+    except urllib.error.HTTPError as exc:
+        print(
+            f"  [warn] GitHub API HTTP {exc.code} for {url}: {exc.reason}",
+            file=sys.stderr,
+        )
+        _CACHE[url] = None
+        return None
+    except Exception as exc:  # noqa: BLE001
+        print(f"  [warn] GitHub API error for {url}: {exc}", file=sys.stderr)
+        _CACHE[url] = None
+        return None
+    finally:
+        time.sleep(0.1)  # 100 ms throttle — same as heartbeat
+
+
+# ---------------------------------------------------------------------------
+# HEAD check for link liveness (new — used by upstream watcher, design §5)
+# ---------------------------------------------------------------------------
+
+
+def head_check(url: str, timeout: int = 10) -> int | None:
+    """Issue an HTTP HEAD to *url* and return the HTTP status code.
+
+    Returns ``None`` on any network-level error (no HTTP response received).
+
+    Notes
+    -----
+    Design §5 explicitly calls out that rendered GitHub ``blob/`` URLs can
+    serve HTML even for paths that 404 on the raw content endpoint.  Callers
+    should convert ``github.com/.../blob/…`` URLs to
+    ``raw.githubusercontent.com/…`` before passing them here when checking
+    SKILL.md liveness:
+
+    .. code-block:: python
+
+        raw_url = url.replace(
+            "https://github.com/", "https://raw.githubusercontent.com/"
+        ).replace("/blob/", "/")
+
+    This function does NOT do that conversion — the caller decides the
+    canonical liveness target.
+    """
+    req = urllib.request.Request(url, method="HEAD")
+    # Some servers reject bare Python UA; mimic a browser-ish UA
+    req.add_header("User-Agent", "gaia-upstream-watcher/1.0 (link-liveness)")
+
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status
+    except urllib.error.HTTPError as exc:
+        # HTTPError is raised for 4xx/5xx — we still have a status code
+        return exc.code
+    except Exception:  # noqa: BLE001
+        return None

--- a/scripts/lib/named_iterator.py
+++ b/scripts/lib/named_iterator.py
@@ -1,0 +1,64 @@
+"""
+scripts.lib.named_iterator — walk registry/named/**/*.md.
+
+Provides a single iterator that yields (path, parsed_frontmatter_dict) for
+every named skill markdown file in the registry.
+
+Public API
+----------
+iter_named_skills(root=None)
+    Walk ``registry/named/**/*.md``, yield ``(Path, dict)`` pairs.
+    Skips files with no frontmatter.  Defaults *root* to the repo's
+    ``registry/named/`` directory, resolved from ``__file__``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterator
+
+from scripts.lib.frontmatter import load_yaml_simple, split_frontmatter
+
+# ---------------------------------------------------------------------------
+# Repo-root resolution (same pattern as heartbeat's REPO_ROOT)
+# ---------------------------------------------------------------------------
+
+_THIS_FILE = Path(__file__).resolve()
+# scripts/lib/named_iterator.py → up two dirs → repo root
+_REPO_ROOT = _THIS_FILE.parent.parent.parent
+_DEFAULT_NAMED_DIR = _REPO_ROOT / "registry" / "named"
+
+
+# ---------------------------------------------------------------------------
+# Iterator
+# ---------------------------------------------------------------------------
+
+
+def iter_named_skills(
+    root: Path | None = None,
+) -> Iterator[tuple[Path, dict]]:
+    """Yield ``(path, frontmatter_dict)`` for every ``registry/named/**/*.md``.
+
+    Parameters
+    ----------
+    root:
+        Override the ``registry/named/`` directory.  Defaults to the
+        canonical location resolved from this file's position in the repo.
+
+    Yields
+    ------
+    tuple[Path, dict]
+        *path* is the absolute ``Path`` to the ``.md`` file.
+        *dict* is the parsed YAML frontmatter (empty dict if no frontmatter).
+
+    Skips files whose frontmatter fence is absent or malformed.
+    """
+    named_dir = root if root is not None else _DEFAULT_NAMED_DIR
+
+    for md_path in sorted(named_dir.rglob("*.md")):
+        text = md_path.read_text(encoding="utf-8")
+        _, fm_raw, _ = split_frontmatter(text)
+        if not fm_raw:
+            continue
+        fm = load_yaml_simple(fm_raw)
+        yield (md_path, fm)

--- a/scripts/lib/tests/__init__.py
+++ b/scripts/lib/tests/__init__.py
@@ -1,0 +1,5 @@
+# scripts/lib/tests/ — unit tests for scripts.lib primitives
+#
+# Test location: under scripts/lib/tests/ (NOT tests/) to stay within
+# the infra/ branch scope allowlist (.github/, scripts/, *.md, etc.).
+# See branch-scope.yml and the PR body for justification.

--- a/scripts/lib/tests/test_lib.py
+++ b/scripts/lib/tests/test_lib.py
@@ -1,0 +1,538 @@
+"""
+tests/test_scripts_lib.py — unit tests for scripts/lib/*.
+
+Test location rationale: tests/ is NOT in the infra/ branch scope allowlist
+(only .github/, scripts/, .claude/skills/, .agents/skills/, *.md, docs/*.html).
+This file lives under scripts/lib/tests/ which IS under scripts/ and therefore
+in-scope for infra/ branches.
+
+Run with:
+    pytest scripts/lib/tests/test_lib.py -v
+or via the normal test suite:
+    pytest
+(pyproject.toml sets testpaths = ["tests"] so this file is also discoverable
+there if we add scripts to sys.path; we do so in conftest below.)
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Ensure scripts/ is on the path so ``scripts.lib`` resolves
+import sys
+import os
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(_REPO_ROOT / "scripts") not in sys.path:
+    # Not strictly needed if pyproject testpaths includes ".", but be explicit
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.lib.frontmatter import (
+    load_yaml_simple,
+    split_frontmatter,
+    update_list_item_in_frontmatter,
+    upsert_top_level_block,
+)
+from scripts.lib.github_api import fetch_json, head_check, parse_owner_repo
+from scripts.lib.named_iterator import iter_named_skills
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SAMPLE_FM = textwrap.dedent("""\
+    ---
+    id: test/skill
+    name: Test Skill
+    evidence:
+    - source: https://github.com/example/repo
+      type: github-stars-own
+      stars: 1000
+      updatedAt: '2026-01-01'
+    - source: https://example.com/post
+      type: social-signal
+      views: 5000
+    ---
+    # Body text
+
+    Some content here.
+    """)
+
+SAMPLE_FM_NO_UPSTREAM = textwrap.dedent("""\
+    ---
+    id: test/skill
+    name: Test Skill
+    status: named
+    level: 2★
+    ---
+    """)
+
+SAMPLE_FM_WITH_UPSTREAM = textwrap.dedent("""\
+    ---
+    id: test/skill
+    name: Test Skill
+    upstream:
+      repo: example/repo
+      version: v1.0.0
+    ---
+    """)
+
+
+# ---------------------------------------------------------------------------
+# split_frontmatter
+# ---------------------------------------------------------------------------
+
+
+class TestSplitFrontmatter:
+    def test_splits_canonical_file(self):
+        pre, fm, body = split_frontmatter(SAMPLE_FM)
+        assert pre == "---\n"
+        assert "id: test/skill" in fm
+        assert "evidence:" in fm
+        assert "# Body text" in body
+
+    def test_round_trip_preserves_content(self):
+        """Round-trip: reassembling the parts must reproduce the original text."""
+        pre, fm, body = split_frontmatter(SAMPLE_FM)
+        reassembled = f"{pre}{fm}\n---\n{body}"
+        assert reassembled == SAMPLE_FM
+
+    def test_returns_empty_tuple_on_no_frontmatter(self):
+        text = "# Just markdown\nNo frontmatter here."
+        pre, fm, body = split_frontmatter(text)
+        assert pre == ""
+        assert fm == ""
+        assert body == text
+
+    def test_real_mattpocock_skills_fixture(self):
+        """Smoke-test against the canonical mattpocock/skills.md."""
+        real_path = _REPO_ROOT / "registry" / "named" / "mattpocock" / "skills.md"
+        if not real_path.exists():
+            pytest.skip("mattpocock/skills.md not present in this checkout")
+        text = real_path.read_text(encoding="utf-8")
+        pre, fm, body = split_frontmatter(text)
+        assert pre == "---\n"
+        assert "id: mattpocock/skills" in fm
+
+    def test_crlf_frontmatter(self):
+        crlf_text = "---\r\nid: foo\r\n---\r\n# body\r\n"
+        pre, fm, body = split_frontmatter(crlf_text)
+        assert pre == "---\n"
+        assert "id: foo" in fm
+
+
+# ---------------------------------------------------------------------------
+# load_yaml_simple
+# ---------------------------------------------------------------------------
+
+
+class TestLoadYamlSimple:
+    def test_parses_basic_dict(self):
+        fm = "id: skill\nname: My Skill\nlevel: 3"
+        result = load_yaml_simple(fm)
+        assert result["id"] == "skill"
+        assert result["name"] == "My Skill"
+
+    def test_returns_empty_dict_on_blank(self):
+        assert load_yaml_simple("") == {}
+        assert load_yaml_simple("   ") == {}
+
+    def test_parses_nested_keys(self):
+        fm = "links:\n  github: https://github.com/owner/repo\n"
+        result = load_yaml_simple(fm)
+        assert result["links"]["github"] == "https://github.com/owner/repo"
+
+
+# ---------------------------------------------------------------------------
+# update_list_item_in_frontmatter
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateListItemInFrontmatter:
+    def test_updates_stars_on_first_evidence_row(self):
+        result = update_list_item_in_frontmatter(
+            SAMPLE_FM,
+            list_key="evidence",
+            row_index=0,
+            field_updates={"stars": 9999},
+        )
+        assert "stars: 9999" in result
+        # Original star count should be gone
+        assert "stars: 1000" not in result
+
+    def test_updates_updatedAt_on_first_evidence_row(self):
+        result = update_list_item_in_frontmatter(
+            SAMPLE_FM,
+            list_key="evidence",
+            row_index=0,
+            field_updates={"updatedAt": "2026-07-09"},
+        )
+        assert "updatedAt: '2026-07-09'" in result
+        assert "updatedAt: '2026-01-01'" not in result
+
+    def test_heartbeat_use_case_both_fields(self):
+        """The heartbeat updates stars + updatedAt simultaneously."""
+        result = update_list_item_in_frontmatter(
+            SAMPLE_FM,
+            list_key="evidence",
+            row_index=0,
+            field_updates={"stars": 55000, "updatedAt": "2026-07-09"},
+        )
+        assert "stars: 55000" in result
+        assert "updatedAt: '2026-07-09'" in result
+
+    def test_preserves_surrounding_rows(self):
+        result = update_list_item_in_frontmatter(
+            SAMPLE_FM,
+            list_key="evidence",
+            row_index=0,
+            field_updates={"stars": 42},
+        )
+        # Second evidence row must be untouched
+        assert "views: 5000" in result
+        assert "type: social-signal" in result
+
+    def test_inserts_new_field_if_absent(self):
+        """A field not present in the item should be inserted."""
+        fm_no_updated_at = SAMPLE_FM.replace("      updatedAt: '2026-01-01'\n", "")
+        result = update_list_item_in_frontmatter(
+            fm_no_updated_at,
+            list_key="evidence",
+            row_index=0,
+            field_updates={"updatedAt": "2026-07-09"},
+        )
+        assert "updatedAt: '2026-07-09'" in result
+
+    def test_returns_text_unchanged_for_out_of_range_index(self):
+        result = update_list_item_in_frontmatter(
+            SAMPLE_FM,
+            list_key="evidence",
+            row_index=99,
+            field_updates={"stars": 1},
+        )
+        assert result == SAMPLE_FM
+
+    def test_returns_text_unchanged_when_no_frontmatter(self):
+        plain = "# No frontmatter\nSome text."
+        result = update_list_item_in_frontmatter(
+            plain, list_key="evidence", row_index=0, field_updates={"stars": 1}
+        )
+        assert result == plain
+
+    def test_preserves_body_text(self):
+        result = update_list_item_in_frontmatter(
+            SAMPLE_FM,
+            list_key="evidence",
+            row_index=0,
+            field_updates={"stars": 1},
+        )
+        assert "# Body text" in result
+        assert "Some content here." in result
+
+
+# ---------------------------------------------------------------------------
+# upsert_top_level_block
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertTopLevelBlock:
+    def test_inserts_new_block_when_absent(self):
+        result = upsert_top_level_block(
+            SAMPLE_FM_NO_UPSTREAM,
+            block_key="upstream",
+            block_value={"repo": "example/repo", "version": "v1.0.0"},
+        )
+        assert "upstream:" in result
+        assert "repo: example/repo" in result
+        assert "version: v1.0.0" in result
+
+    def test_updates_existing_block(self):
+        result = upsert_top_level_block(
+            SAMPLE_FM_WITH_UPSTREAM,
+            block_key="upstream",
+            block_value={"version": "v2.0.0"},
+        )
+        assert "version: v2.0.0" in result
+        # Original unrelated sub-key should be preserved
+        assert "repo: example/repo" in result
+        # Old version gone
+        assert "version: v1.0.0" not in result
+
+    def test_key_ordering_is_deterministic(self):
+        result = upsert_top_level_block(
+            SAMPLE_FM_NO_UPSTREAM,
+            block_key="upstream",
+            block_value={"version": "v1.0.0", "repo": "a/b", "syncedAt": "2026-07-09"},
+        )
+        # Keys should appear in sorted order: repo, syncedAt, version
+        pos_repo = result.index("repo:")
+        pos_synced = result.index("syncedAt:")
+        pos_version = result.index("version:")
+        assert pos_repo < pos_synced < pos_version
+
+    def test_preserves_other_frontmatter_keys(self):
+        result = upsert_top_level_block(
+            SAMPLE_FM_NO_UPSTREAM,
+            block_key="upstream",
+            block_value={"version": "v1.0.0"},
+        )
+        assert "id: test/skill" in result
+        assert "status: named" in result
+
+    def test_returns_unchanged_when_no_frontmatter(self):
+        plain = "# No frontmatter"
+        result = upsert_top_level_block(plain, "upstream", {"version": "v1"})
+        assert result == plain
+
+    def test_upsert_twice_is_idempotent(self):
+        """Applying the same upsert twice should not duplicate the block."""
+        first = upsert_top_level_block(
+            SAMPLE_FM_NO_UPSTREAM,
+            block_key="upstream",
+            block_value={"version": "v1.0.0", "repo": "a/b"},
+        )
+        second = upsert_top_level_block(
+            first,
+            block_key="upstream",
+            block_value={"version": "v1.0.0", "repo": "a/b"},
+        )
+        # 'upstream:' should appear exactly once
+        assert second.count("upstream:") == 1
+
+
+# ---------------------------------------------------------------------------
+# parse_owner_repo
+# ---------------------------------------------------------------------------
+
+
+class TestParseOwnerRepo:
+    def test_bare_repo_url(self):
+        assert parse_owner_repo("https://github.com/owner/repo") == ("owner", "repo")
+
+    def test_blob_url(self):
+        assert parse_owner_repo(
+            "https://github.com/owner/repo/blob/main/skills/foo/SKILL.md"
+        ) == ("owner", "repo")
+
+    def test_tree_url(self):
+        assert parse_owner_repo(
+            "https://github.com/owner/repo/tree/main/src"
+        ) == ("owner", "repo")
+
+    def test_releases_tag_url(self):
+        assert parse_owner_repo(
+            "https://github.com/owner/repo/releases/tag/v1.2.3"
+        ) == ("owner", "repo")
+
+    def test_git_suffix_stripped(self):
+        assert parse_owner_repo("https://github.com/owner/repo.git") == ("owner", "repo")
+
+    def test_non_github_url_returns_none(self):
+        assert parse_owner_repo("https://gitlab.com/owner/repo") is None
+        assert parse_owner_repo("https://example.com/owner/repo") is None
+
+    def test_empty_string_returns_none(self):
+        assert parse_owner_repo("") is None
+
+    def test_none_like_empty(self):
+        assert parse_owner_repo("   ") is None
+
+    def test_stargazers_url(self):
+        assert parse_owner_repo(
+            "https://github.com/mattpocock/skills/stargazers"
+        ) == ("mattpocock", "skills")
+
+
+# ---------------------------------------------------------------------------
+# head_check — mocked (no live network calls in unit tests)
+# ---------------------------------------------------------------------------
+
+
+class TestHeadCheck:
+    def test_returns_200_on_success(self):
+        class FakeResp:
+            status = 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        with patch("urllib.request.urlopen", return_value=FakeResp()):
+            assert head_check("https://example.com/path") == 200
+
+    def test_returns_status_code_on_http_error(self):
+        import urllib.error
+
+        err = urllib.error.HTTPError(
+            "https://example.com/path", 404, "Not Found", {}, None
+        )
+        with patch("urllib.request.urlopen", side_effect=err):
+            assert head_check("https://example.com/path") == 404
+
+    def test_returns_none_on_network_error(self):
+        with patch("urllib.request.urlopen", side_effect=OSError("timeout")):
+            assert head_check("https://example.com/path") is None
+
+    def test_returns_403_on_forbidden(self):
+        import urllib.error
+
+        err = urllib.error.HTTPError(
+            "https://raw.githubusercontent.com/x/y/main/SKILL.md",
+            403,
+            "Forbidden",
+            {},
+            None,
+        )
+        with patch("urllib.request.urlopen", side_effect=err):
+            assert (
+                head_check(
+                    "https://raw.githubusercontent.com/x/y/main/SKILL.md"
+                )
+                == 403
+            )
+
+
+# ---------------------------------------------------------------------------
+# fetch_json — mocked (no live GitHub API calls in unit tests)
+# ---------------------------------------------------------------------------
+
+
+class TestFetchJson:
+    def test_auto_prefixes_path(self):
+        """A bare path like /repos/owner/repo is prefixed to api.github.com."""
+        import json as _json
+
+        captured_url: list[str] = []
+
+        class FakeResp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+            def read(self):
+                return _json.dumps({"stargazers_count": 42}).encode()
+
+        original_urlopen = __import__("urllib.request", fromlist=["urlopen"]).urlopen
+
+        def fake_urlopen(req, timeout=None):
+            captured_url.append(req.full_url)
+            return FakeResp()
+
+        # Clear any cached result first
+        from scripts.lib import github_api
+
+        github_api._CACHE.clear()
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            with patch("time.sleep"):  # suppress 100ms throttle in tests
+                result = fetch_json("/repos/owner/repo")
+
+        assert any("api.github.com" in u for u in captured_url)
+
+    def test_caches_result(self):
+        import json as _json
+
+        call_count = [0]
+
+        class FakeResp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+            def read(self):
+                call_count[0] += 1
+                return _json.dumps({"id": 1}).encode()
+
+        from scripts.lib import github_api
+
+        url = "https://api.github.com/repos/cache-test/repo-xyz"
+        github_api._CACHE.pop(url, None)
+
+        with patch("urllib.request.urlopen", return_value=FakeResp()):
+            with patch("time.sleep"):
+                r1 = fetch_json(url)
+                r2 = fetch_json(url)
+
+        # urlopen called only once — second call served from cache
+        assert call_count[0] == 1
+        assert r1 == r2
+
+    def test_returns_none_on_http_error(self):
+        import urllib.error
+        from scripts.lib import github_api
+
+        url = "https://api.github.com/repos/gone/repo"
+        github_api._CACHE.pop(url, None)
+
+        err = urllib.error.HTTPError(url, 404, "Not Found", {}, None)
+        with patch("urllib.request.urlopen", side_effect=err):
+            with patch("time.sleep"):
+                result = fetch_json(url)
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# iter_named_skills
+# ---------------------------------------------------------------------------
+
+
+class TestIterNamedSkills:
+    def test_yields_tuples_of_path_and_dict(self):
+        named_root = _REPO_ROOT / "registry" / "named"
+        if not named_root.exists():
+            pytest.skip("registry/named/ not present in this checkout")
+
+        count = 0
+        for path, fm in iter_named_skills(root=named_root):
+            assert isinstance(path, Path)
+            assert isinstance(fm, dict)
+            count += 1
+            if count >= 5:
+                break
+
+        assert count > 0, "Expected at least one named skill"
+
+    def test_mattpocock_skills_present(self):
+        named_root = _REPO_ROOT / "registry" / "named"
+        if not named_root.exists():
+            pytest.skip("registry/named/ not present in this checkout")
+
+        ids = [fm.get("id") for _, fm in iter_named_skills(root=named_root)]
+        assert "mattpocock/skills" in ids, "mattpocock/skills must be in the registry"
+
+    def test_garrytan_gstack_present(self):
+        named_root = _REPO_ROOT / "registry" / "named"
+        if not named_root.exists():
+            pytest.skip("registry/named/ not present in this checkout")
+
+        ids = [fm.get("id") for _, fm in iter_named_skills(root=named_root)]
+        assert "garrytan/gstack" in ids, "garrytan/gstack must be in the registry"
+
+    def test_skips_files_without_frontmatter(self, tmp_path):
+        """Files with no frontmatter fence are skipped."""
+        (tmp_path / "no_fm.md").write_text("# Just markdown\nNo fences.", encoding="utf-8")
+        fenced = tmp_path / "has_fm.md"
+        fenced.write_text("---\nid: test/x\nname: X\n---\n# body\n", encoding="utf-8")
+
+        results = list(iter_named_skills(root=tmp_path))
+        assert len(results) == 1
+        assert results[0][1]["id"] == "test/x"
+
+    def test_custom_root_override(self, tmp_path):
+        """Passing an explicit root overrides the default registry/named/ path."""
+        (tmp_path / "custom.md").write_text(
+            "---\nid: custom/skill\nname: Custom\n---\n", encoding="utf-8"
+        )
+        results = list(iter_named_skills(root=tmp_path))
+        assert any(fm.get("id") == "custom/skill" for _, fm in results)

--- a/scripts/lib/tests/test_lib.py
+++ b/scripts/lib/tests/test_lib.py
@@ -435,7 +435,7 @@ class TestFetchJson:
             with patch("time.sleep"):  # suppress 100ms throttle in tests
                 result = fetch_json("/repos/owner/repo")
 
-        assert any("api.github.com" in u for u in captured_url)
+        assert any(u.startswith("https://api.github.com/") for u in captured_url)
 
     def test_caches_result(self):
         import json as _json


### PR DESCRIPTION
## Summary

Introduces `scripts/lib/` — the shared infrastructure primitive package described in upstream-watcher design §9 (Shared plumbing). No behavior changes to any existing script. `stargazerHeartbeat.py` is untouched (zero-byte diff against main).

Design reference: `docs/agents/upstream-watcher.md` [§9 Shared plumbing (`scripts/lib/`)](https://github.com/gaia-research/gaia-skill-tree/blob/main/docs/agents/upstream-watcher.md#shared-plumbing-scriptslib)

Part of the 7-PR rollout table in design §14. Follows PR 1 (labels + template). PR 3 will rewrite `stargazerHeartbeat.py` to import from this package.

---

## Files created

| File | Lines | Description |
|---|---|---|
| `scripts/lib/__init__.py` | 14 | Package marker + `__version__` |
| `scripts/lib/frontmatter.py` | ~295 | `split_frontmatter`, `load_yaml_simple`, `update_list_item_in_frontmatter`, `upsert_top_level_block` |
| `scripts/lib/github_api.py` | ~175 | `parse_owner_repo`, `fetch_json`, `head_check` |
| `scripts/lib/named_iterator.py` | ~60 | `iter_named_skills(root)` |
| `scripts/lib/tests/__init__.py` | 5 | Test package marker |
| `scripts/lib/tests/test_lib.py` | ~500 | 43 unit tests — all passing locally |

---

## What each primitive does

### `scripts/lib/frontmatter.py`

- **`split_frontmatter(text)`** — ported from `stargazerHeartbeat._split_frontmatter`, renamed to public API. Splits raw file text into `(fence, fm_content, body)`.
- **`load_yaml_simple(text)`** — thin pyyaml wrapper. Ported from heartbeat.
- **`update_list_item_in_frontmatter(text, list_key, row_index, field_updates)`** — generalised form of heartbeat's `_update_evidence_row_in_text`. Works for any list key (evidence, timeline, etc.). The heartbeat use-case (`list_key="evidence"`, `field_updates={"stars": N, "updatedAt": ...\}`) passes through unchanged.
- **`upsert_top_level_block(text, block_key, block_value)`** — new helper for writing/merging an entire top-level frontmatter block (e.g. `upstream:`). Deterministic key ordering. Merge-preserves unrelated sub-keys.

### `scripts/lib/github_api.py`

- **`parse_owner_repo(url)`** — verbatim from heartbeat. Handles bare, blob/, tree/, releases/tag/, .git-suffixed URLs.
- **`fetch_json(endpoint, token, timeout)`** — generalised from heartbeat's `fetch_stars`. Accepts full URL or `/path` (auto-prefixed to api.github.com). Same 100ms throttle, in-process cache, GH_TOKEN env fallback, None-on-error semantics.
- **`head_check(url, timeout)`** — new. HTTP HEAD for link liveness. Returns status code (or None on network error). Note in docstring: callers should convert `blob/` → `raw.githubusercontent.com/` for SKILL.md liveness (design §5).

### `scripts/lib/named_iterator.py`

- **`iter_named_skills(root)`** — walks `registry/named/**/*.md`, yields `(Path, dict)`. Skips files with no frontmatter fence. Root defaults to repo's `registry/named/` via `__file__` walk-up (same pattern as heartbeat's `REPO_ROOT`).

---

## Test location rationale

`tests/` is **not** in the `infra/` branch scope allowlist (`.github/`, `scripts/`, `.claude/skills/`, `.agents/skills/`, `*.md`, `docs/*.html`). Tests therefore live at `scripts/lib/tests/test_lib.py` which **is** under `scripts/` and in-scope.

**Known gap:** `pyproject.toml` `testpaths` is `["tests"]` — the new test file is not auto-discovered by `pytest` or `gaia dev test all`. Running `pytest scripts/lib/tests/` finds and passes all 43 tests. Extending `testpaths` requires touching `pyproject.toml` (not in `infra/` scope); that belongs in a follow-up `cli/` branch or can be addressed in PR 3.

---

## Constraints verified

- [x] `stargazerHeartbeat.py` is untouched (0-byte diff against main)
- [x] No new dependencies (stdlib + pyyaml — already in project)
- [x] Branch started from latest main (`git pull --ff-only` confirmed clean)
- [x] All 43 tests pass locally
- [x] Pre-existing CI failure (`test_benchmark_projection.py::TestCheckFlag::test_check_exits_zero_when_committed`) confirmed on main before this branch — not caused by this PR

---

## Entrypoints

This PR is infrastructure, not user-facing.

- [ ] Main nav — N/A (no new page)
- [ ] Footer — N/A
- [ ] Homepage — N/A
- [ ] `docs/js/mounts.js` — N/A
- [ ] Cross-page references — N/A
- [ ] Cache-busting — N/A

---

## Deferred surfaces

None.