### PR TITLE
schema: add upstream metadata block + timeline actions (PR 4/7)

### DIFF
--- a/registry/schema/namedSkill.schema.json
+++ b/registry/schema/namedSkill.schema.json
@@ -175,6 +175,44 @@
       },
       "description": "Users who have adopted this named skill via gaia install."
     },
+    "upstream": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Upstream release tracking metadata (populated by the upstream watcher on approved sync). See docs/agents/upstream-watcher.md.",
+      "properties": {
+        "repo": {
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]*/[a-zA-Z0-9._-]+$",
+          "description": "owner/repo of the upstream source; stored to catch drift if links.github changes"
+        },
+        "version": {
+          "type": "string",
+          "description": "Last synced release tag (e.g. v1.0.3)"
+        },
+        "releasedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "GitHub release.published_at value"
+        },
+        "syncedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When the sync commit landed on main"
+        },
+        "sourceUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "Full URL to the GitHub release tag page"
+        },
+        "mode": {
+          "type": "string",
+          "enum": ["components", "version-only"],
+          "description": "components = suite with a diffable component list; version-only = general-purpose repo, version tag tracked but no component structure",
+          "default": "components"
+        }
+      },
+      "required": ["repo", "version"]
+    },
     "verification": {
       "type": "object",
       "additionalProperties": false,
@@ -502,7 +540,9 @@
             "verified",
             "disputed",
             "security_scan_passed",
-            "apex_pr_signed"
+            "apex_pr_signed",
+            "upstream_synced",
+            "upstream_deprecated"
           ],
           "description": "The meta-action that occurred."
         },

--- a/src/gaia_cli/data/registry/schema/namedSkill.schema.json
+++ b/src/gaia_cli/data/registry/schema/namedSkill.schema.json
@@ -175,6 +175,44 @@
       },
       "description": "Users who have adopted this named skill via gaia install."
     },
+    "upstream": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Upstream release tracking metadata (populated by the upstream watcher on approved sync). See docs/agents/upstream-watcher.md.",
+      "properties": {
+        "repo": {
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]*/[a-zA-Z0-9._-]+$",
+          "description": "owner/repo of the upstream source; stored to catch drift if links.github changes"
+        },
+        "version": {
+          "type": "string",
+          "description": "Last synced release tag (e.g. v1.0.3)"
+        },
+        "releasedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "GitHub release.published_at value"
+        },
+        "syncedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When the sync commit landed on main"
+        },
+        "sourceUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "Full URL to the GitHub release tag page"
+        },
+        "mode": {
+          "type": "string",
+          "enum": ["components", "version-only"],
+          "description": "components = suite with a diffable component list; version-only = general-purpose repo, version tag tracked but no component structure",
+          "default": "components"
+        }
+      },
+      "required": ["repo", "version"]
+    },
     "verification": {
       "type": "object",
       "additionalProperties": false,
@@ -502,7 +540,9 @@
             "verified",
             "disputed",
             "security_scan_passed",
-            "apex_pr_signed"
+            "apex_pr_signed",
+            "upstream_synced",
+            "upstream_deprecated"
           ],
           "description": "The meta-action that occurred."
         },


### PR DESCRIPTION
## Summary

PR 4 of the upstream-watcher V1 rollout. Schema-only change — no CLI verbs, no tests, no populated `upstream:` blocks on existing named-skill files.

Design spec: `docs/agents/upstream-watcher.md` [§4 Data model](https://github.com/gaia-research/gaia-skill-tree/blob/main/docs/agents/upstream-watcher.md#data-model) and [§14 Phased rollout row 4](https://github.com/gaia-research/gaia-skill-tree/blob/main/docs/agents/upstream-watcher.md#phased-rollout--pr-plan).

## Changes

**Files changed: exactly 2** (both schema dirs move in lockstep per CLAUDE.md schema/ branch rules)

- `registry/schema/namedSkill.schema.json`
- `src/gaia_cli/data/registry/schema/namedSkill.schema.json`

### 1. New optional `upstream` object property

Added to `namedSkill.schema.json` properties (NOT in top-level `required`). Shape:

```yaml
upstream:
  repo: mattpocock/skills          # required; owner/repo pattern
  version: v1.0.3                  # required; last synced release tag
  releasedAt: '2026-06-14T00:00:00Z'   # optional; date-time
  syncedAt: '2026-06-14T08:12:04Z'     # optional; date-time
  sourceUrl: https://github.com/mattpocock/skills/releases/tag/v1.0.3  # optional; uri
  mode: components                 # optional; enum: components | version-only
```

### 2. Extended `timelineEvent.action` enum

Two new values appended at the end (no reordering of existing 19 values):
- `upstream_synced` — a new upstream release was recorded (`previousValue` = old tag, `newValue` = new tag)
- `upstream_deprecated` — a component was frozen because upstream dropped it

## Entrypoints checklist

Schema-only PR — all entrypoints N/A:

- [ ] `docs/js/site-nav.js` — N/A (no new page)
- [ ] `docs/js/site-footer.js` — N/A
- [ ] `docs/index.html` — N/A
- [ ] `docs/js/mounts.js` — N/A
- [ ] Cross-page references — N/A
- [ ] Cache-busting — N/A

## Verification

```
=== 1: diff (must be zero output) ===
$ diff registry/schema/namedSkill.schema.json src/gaia_cli/data/registry/schema/namedSkill.schema.json
(zero output — files are byte-identical)

=== 2: json.tool registry ===
$ python -m json.tool registry/schema/namedSkill.schema.json > /dev/null
EXIT 0 — valid JSON

=== 3: json.tool src ===
$ python -m json.tool src/gaia_cli/data/registry/schema/namedSkill.schema.json > /dev/null
EXIT 0 — valid JSON

=== 4: gaia validate (existing named skills still pass) ===
$ GAIA_OPERATOR_OVERRIDE=1 PYTHONPATH=./src python -m gaia_cli validate

🔍 Validating: registry/nodes
   [1/11] Schema validation...
   [2/11] Unique identifiers...
   [3/11] DAG cycle detection...
   [4/11] Reference integrity...
   [5/11] Prerequisite count...
   [6/11] Named evidence thresholds (warn)...
   [7/11] Ultimate constraints...
   [8/12] Unique skill constraints...
   [9/12] Named skills validation...
   [10/12] Skill suites validation...
   [11/12] Benchmark-result provenance...
   [12/12] Verifier benchmark attestations...

✅ All validation checks passed.
Redaction invariant: 71 pre-named/demoted skill(s) (≤1★), 193 named (2★+), 12 entirely pre-named contributor(s).
✓ All pre-named/demoted handles are redacted; no 2★+ over-redacted.

11 non-blocking named evidence warnings (pre-existing, unrelated to this PR).
```

## Judgment calls

- **Property placement:** `upstream` inserted alphabetically between `updatedAt` and `verification` in the `properties` object. JSON Schema order has no semantic meaning but this keeps the file readable.
- **No `$id` bump:** The schema `$id` is a stable URI (`https://gaia-registry.github.io/schema/namedSkill.schema.json`) — per CLAUDE.md "Decorative assets must NOT carry version metadata", no version stamp is added. Schema evolution is tracked via git history.
- **`mode` default:** Included `"default": "components"` in the `mode` enum property per the spec. JSON Schema `default` is non-normative (validators don't enforce it) but documents intent for CLI consumers.
- **Enum ordering:** New values `upstream_synced` and `upstream_deprecated` appended at the end of the existing 19-value enum without reordering. Preserves stability for any tooling that reads the enum by index.