### PR TITLE
cli: add dev sync-upstream and dev freeze verbs (PR 5/7)

### DIFF
--- a/src/gaia_cli/commands/dev/__init__.py
+++ b/src/gaia_cli/commands/dev/__init__.py
@@ -662,6 +662,83 @@ class DevCommand(Command):
         )
         dev_hook.add_argument("--event", default="file_edit", help="Hook event type")
 
+        # --- upstream-watcher verbs (PR 5/7) ---
+        dev_sync_upstream = dev_sub.add_parser(
+            "sync-upstream",
+            help="Write/update the upstream: frontmatter block and append upstream_synced timeline event",
+        )
+        dev_sync_upstream.add_argument(
+            "skill_id",
+            help="Named skill ID (e.g. mattpocock/skills)",
+        )
+        dev_sync_upstream.add_argument(
+            "--version",
+            required=True,
+            help="Release tag (must match ^v?\\d+\\.\\d+\\.\\d+.*$, e.g. v1.2.3)",
+        )
+        dev_sync_upstream.add_argument(
+            "--source-url",
+            required=True,
+            dest="source_url",
+            help="GitHub releases URL: https://github.com/<owner>/<repo>/releases/tag/<tag>",
+        )
+        dev_sync_upstream.add_argument(
+            "--bootstrap",
+            action="store_true",
+            default=False,
+            help="First-time write; refuses if upstream: block already exists",
+        )
+        dev_sync_upstream.add_argument(
+            "--released-at",
+            dest="released_at",
+            default=None,
+            help="ISO 8601 timestamp of the upstream release (published_at from GitHub). Defaults to now.",
+        )
+        dev_sync_upstream.add_argument(
+            "--mode",
+            default="components",
+            choices=["components", "version-only"],
+            help="Upstream tracking mode (default: components)",
+        )
+        dev_sync_upstream.add_argument(
+            "--dry-run",
+            action="store_true",
+            default=False,
+            dest="dry_run",
+            help="Print intended changes without writing",
+        )
+        dev_sync_upstream.add_argument(
+            "--user",
+            default=None,
+            help="Contributor handle attributed to the timeline event (defaults to whoami actor)",
+        )
+
+        dev_freeze = dev_sub.add_parser(
+            "freeze",
+            help="Set installable: false and append upstream_deprecated timeline event",
+        )
+        dev_freeze.add_argument(
+            "skill_id",
+            help="Named skill ID to freeze (e.g. mattpocock/old-skill)",
+        )
+        dev_freeze.add_argument(
+            "--reason",
+            required=True,
+            help="Human-readable explanation (≤500 chars)",
+        )
+        dev_freeze.add_argument(
+            "--dry-run",
+            action="store_true",
+            default=False,
+            dest="dry_run",
+            help="Print intended changes without writing",
+        )
+        dev_freeze.add_argument(
+            "--user",
+            default=None,
+            help="Contributor handle attributed to the timeline event (defaults to whoami actor)",
+        )
+
     def execute(self, args: argparse.Namespace) -> int | None:
         dev_cmd = getattr(args, "dev_command", None)
         MUTATING_DEV_COMMANDS = {
@@ -683,6 +760,8 @@ class DevCommand(Command):
             "build",
             "release",
             "fuse",
+            "sync-upstream",
+            "freeze",
         }
         if dev_cmd in MUTATING_DEV_COMMANDS:
             from gaia_cli.authz import require_operator
@@ -766,6 +845,12 @@ class DevCommand(Command):
         elif dev_cmd == "hook":
             from gaia_cli.impl import hook_command
             hook_command(args)
+        elif dev_cmd == "sync-upstream":
+            from gaia_cli.commands.dev.sync_upstream import sync_upstream_command
+            sync_upstream_command(args)
+        elif dev_cmd == "freeze":
+            from gaia_cli.commands.dev.freeze import freeze_command
+            freeze_command(args)
         else:
             from gaia_cli.main import get_parser
             parser, subparsers = get_parser()

--- a/src/gaia_cli/commands/dev/freeze.py
+++ b/src/gaia_cli/commands/dev/freeze.py
@@ -1,0 +1,177 @@
+"""
+gaia dev freeze <skill-id> --reason <text>
+
+Sets ``installable: false`` in a named skill's frontmatter AND appends a
+``timeline.action: upstream_deprecated`` event.  Atomic — both writes land
+together or neither does.
+
+CLI Pre-Flight checks (per CLAUDE.md CLI Pre-Flight Rule):
+  1. Skill must exist in registry/named/**/*.md.
+  2. --reason must be non-empty and ≤500 chars.
+  3. Refuses if installable: false is already set (no-op guard).
+  4. Warns (does not refuse) if the skill is 3★+:
+     META.md §2.4 Star Bar may fail for frozen 3★+ skills.
+"""
+
+from __future__ import annotations
+
+import sys
+import datetime
+from pathlib import Path
+from typing import Any
+
+from gaia_cli.commands.dev.helpers import (
+    _find_named_file,
+    _get_contributor,
+    _run_dev_preflights,
+    _fail_dev_preflight,
+)
+from gaia_cli.registry import named_skills_dir
+from gaia_cli.frontmatter import (
+    load_yaml_simple,
+    split_frontmatter,
+    append_timeline_event,
+)
+
+# ---------------------------------------------------------------------------
+# Star level helpers (mirrors sync_upstream.py — keep in sync)
+# ---------------------------------------------------------------------------
+
+_STAR_LEVELS = ["1★", "2★", "3★", "4★", "5★", "6★"]
+_THREE_STAR_PLUS = {"3★", "4★", "5★", "6★"}
+
+
+def _utc_now_iso() -> str:
+    return (
+        datetime.datetime.now(datetime.timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter helper: set a scalar top-level key
+# ---------------------------------------------------------------------------
+
+
+def _set_scalar_in_frontmatter(text: str, key: str, value: Any) -> str:
+    """Set (or replace) a scalar *key* at the top level of the frontmatter.
+
+    Uses pyyaml round-trip.  Returns updated full file text.
+    """
+    import yaml
+    import re
+
+    _FM_RE = re.compile(r"^---\r?\n(.*?)\r?\n---(?:\r?\n|$)", re.DOTALL)
+    m = _FM_RE.match(text)
+    if not m:
+        return text
+
+    fm_text = m.group(1)
+    body_text = text[m.end():]
+
+    fm_dict: dict = yaml.safe_load(fm_text) or {}
+    fm_dict[key] = value
+
+    new_fm_text = yaml.dump(fm_dict, sort_keys=False, allow_unicode=True).rstrip("\n")
+    return f"---\n{new_fm_text}\n---\n{body_text}"
+
+
+# ---------------------------------------------------------------------------
+# Pre-flight helpers
+# ---------------------------------------------------------------------------
+
+
+def _pf_reason_non_empty(reason: str) -> None:
+    if not reason or not reason.strip():
+        _fail_dev_preflight(
+            "--reason must be non-empty.",
+            fix="Provide a human-readable explanation, e.g. 'removed from mattpocock/skills@v1.2.0'.",
+        )
+    if len(reason) > 500:
+        _fail_dev_preflight(
+            f"--reason is {len(reason)} characters; maximum is 500.",
+            fix="Shorten the reason text.",
+        )
+
+
+def _pf_not_already_frozen(skill_id: str, meta: dict) -> None:
+    if meta.get("installable") is False:
+        _fail_dev_preflight(
+            f"Skill '{skill_id}' is already frozen (installable: false). No change.",
+            fix="Nothing was written. The skill is already frozen.",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Core command
+# ---------------------------------------------------------------------------
+
+
+def freeze_command(args) -> None:
+    """Implement ``gaia dev freeze``."""
+    registry_path = args.registry
+    skill_id = args.skill_id.lstrip("/")
+    reason: str = args.reason
+    dry_run: bool = getattr(args, "dry_run", False)
+    user: str | None = getattr(args, "user", None)
+
+    # --- Locate the named skill file ---
+    named_dir = Path(named_skills_dir(registry_path))
+    named_file = _find_named_file(named_dir, skill_id)
+    if not named_file:
+        print(
+            f"Named skill '{skill_id}' not found in registry/named/. Nothing was written.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    raw_text = named_file.read_text(encoding="utf-8")
+    _fence, fm_text, _body = split_frontmatter(raw_text)
+    meta: dict = load_yaml_simple(fm_text)
+
+    # --- Pre-flight validation ---
+    _run_dev_preflights([
+        lambda: _pf_reason_non_empty(reason),
+        lambda: _pf_not_already_frozen(skill_id, meta),
+    ])
+
+    # --- Warn if 3★+ (not a refusal) ---
+    level = meta.get("level", "")
+    if level in _THREE_STAR_PLUS:
+        print(
+            f"Warning: freezing a {level} skill may fail Star Bar (META.md §2.4). "
+            "Proceeding — flag this case in the tracking issue.",
+            file=sys.stderr,
+        )
+
+    # --- Build timeline event ---
+    contributor = user or _get_contributor()
+    ts = _utc_now_iso()
+    timeline_event: dict[str, Any] = {
+        "timestamp": ts,
+        "action": "upstream_deprecated",
+        "contributor": contributor,
+        "previousValue": None,
+        "newValue": None,
+        "details": reason,
+    }
+
+    # --- Dry-run: print intended changes, no write ---
+    if dry_run:
+        import yaml  # pyyaml
+        print("=== DRY RUN — no files written ===")
+        print(f"\nWould set installable: false on {named_file}")
+        print("timeline event that would be appended:")
+        print(yaml.dump(timeline_event, sort_keys=False, allow_unicode=True))
+        return
+
+    # --- Atomic write: compose full content in memory first ---
+    new_text = _set_scalar_in_frontmatter(raw_text, "installable", False)
+    new_text = append_timeline_event(new_text, timeline_event)
+
+    # Single filesystem write.
+    named_file.write_text(new_text, encoding="utf-8")
+
+    print(f"Frozen {skill_id}: {reason}")

--- a/src/gaia_cli/commands/dev/sync_upstream.py
+++ b/src/gaia_cli/commands/dev/sync_upstream.py
@@ -1,0 +1,270 @@
+"""
+gaia dev sync-upstream <skill-id> --version <tag> --source-url <url>
+
+Writes (or updates) the ``upstream:`` frontmatter block on a named skill
+AND appends a ``timeline.action: upstream_synced`` event.  Both writes are
+atomic (built in memory, flushed in one write call) — either both land or
+neither does.
+
+CLI Pre-Flight checks (per CLAUDE.md CLI Pre-Flight Rule):
+  1. Skill must exist in registry/named/**/*.md.
+  2. --version must match ``^v?\\d+\\.\\d+\\.\\d+.*$``.
+  3. --source-url must be a github.com/{owner}/{repo}/releases/tag/{tag} URL
+     whose owner/repo matches the skill's existing upstream.repo OR the repo
+     derived from links.github.
+  4. Refuses if upstream.version already equals the target (already synced).
+  5. Skill must be 2★+.
+  6. --bootstrap refuses if the skill already has an upstream: block.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import datetime
+from pathlib import Path
+from typing import Any
+
+from gaia_cli.commands.dev.helpers import (
+    _find_named_file,
+    _get_contributor,
+    _run_dev_preflights,
+    _fail_dev_preflight,
+)
+from gaia_cli.registry import named_skills_dir
+from gaia_cli.frontmatter import (
+    load_yaml_simple,
+    split_frontmatter,
+    upsert_top_level_block,
+    append_timeline_event,
+)
+
+# ---------------------------------------------------------------------------
+# Regex constants
+# ---------------------------------------------------------------------------
+
+_VERSION_RE = re.compile(r"^v?\d+\.\d+\.\d+.*$")
+_RELEASE_URL_RE = re.compile(
+    r"^https://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/releases/tag/.+$"
+)
+_GITHUB_REPO_RE = re.compile(
+    r"^https://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)(?:/|$)"
+)
+
+# Ordered list of star levels so we can compare numerically.
+_STAR_LEVELS = ["1★", "2★", "3★", "4★", "5★", "6★"]
+
+
+def _parse_owner_repo_from_url(url: str) -> str | None:
+    """Return 'owner/repo' extracted from a github.com URL, or None."""
+    m = _GITHUB_REPO_RE.match(url or "")
+    if m:
+        return f"{m.group('owner')}/{m.group('repo')}"
+    return None
+
+
+def _utc_now_iso() -> str:
+    return (
+        datetime.datetime.now(datetime.timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pre-flight helpers
+# ---------------------------------------------------------------------------
+
+
+def _pf_version_format(version: str) -> None:
+    if not _VERSION_RE.match(version):
+        _fail_dev_preflight(
+            f"Invalid version tag: {version!r}. Must match ^v?\\d+\\.\\d+\\.\\d+.*$",
+            fix="Use a semver-style tag such as v1.2.3 or 1.2.3-beta.",
+        )
+
+
+def _pf_source_url_format(source_url: str) -> None:
+    if not _RELEASE_URL_RE.match(source_url):
+        _fail_dev_preflight(
+            f"Invalid --source-url: {source_url!r}. "
+            "Must be https://github.com/<owner>/<repo>/releases/tag/<tag>.",
+            fix="Copy the URL directly from the GitHub Releases page.",
+        )
+
+
+def _pf_source_url_matches_skill(source_url: str, meta: dict, skill_id: str) -> None:
+    """Ensure source-url owner/repo matches upstream.repo or links.github."""
+    url_repo = _parse_owner_repo_from_url(source_url)
+    if not url_repo:
+        return  # already rejected by format check above
+
+    # Acceptable: existing upstream.repo block
+    existing_upstream_repo = (meta.get("upstream") or {}).get("repo")
+    if existing_upstream_repo and existing_upstream_repo == url_repo:
+        return
+
+    # Acceptable: derived from links.github
+    links_github = (meta.get("links") or {}).get("github", "")
+    derived_repo = _parse_owner_repo_from_url(links_github)
+    if derived_repo and derived_repo == url_repo:
+        return
+
+    _fail_dev_preflight(
+        f"Source URL owner/repo {url_repo!r} does not match skill's upstream.repo "
+        f"({existing_upstream_repo!r}) or links.github-derived repo ({derived_repo!r}). "
+        f"Nothing was written.",
+        fix=(
+            "Ensure --source-url points to the same GitHub repo as the skill's "
+            "links.github field or existing upstream.repo."
+        ),
+    )
+
+
+def _pf_not_already_synced(version: str, meta: dict) -> None:
+    existing = (meta.get("upstream") or {}).get("version")
+    if existing and existing == version:
+        _fail_dev_preflight(
+            f"Skill already synced at version {existing!r}. "
+            "Use --force to re-record (not implemented in V1).",
+            fix="Nothing was written. Bump the version tag or omit --version to check current state.",
+        )
+
+
+def _pf_min_two_stars(skill_id: str, meta: dict) -> None:
+    level = meta.get("level", "1★")
+    if level not in _STAR_LEVELS:
+        _fail_dev_preflight(
+            f"Skill {skill_id!r} has unrecognised level {level!r}; "
+            "upstream tracking requires 2★+.",
+            fix="Calibrate the skill to at least 2★ before enabling upstream tracking.",
+        )
+        return
+    idx = _STAR_LEVELS.index(level)
+    if idx < 1:  # < index of "2★"
+        _fail_dev_preflight(
+            f"Skill is at level {level}; upstream tracking requires 2★+.",
+            fix=(
+                "Run `gaia dev calibrate <skill-id> 2★` to promote before syncing upstream."
+            ),
+        )
+
+
+def _pf_bootstrap_no_existing_block(skill_id: str, meta: dict, is_bootstrap: bool) -> None:
+    if not is_bootstrap:
+        return
+    if meta.get("upstream"):
+        _fail_dev_preflight(
+            f"--bootstrap was specified but skill {skill_id!r} already has an "
+            "`upstream:` block. Nothing was written.",
+            fix=(
+                "Omit --bootstrap to update an existing upstream block. "
+                "(--force is not implemented in V1.)"
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Core command
+# ---------------------------------------------------------------------------
+
+
+def sync_upstream_command(args) -> None:
+    """Implement ``gaia dev sync-upstream``."""
+    registry_path = args.registry
+    skill_id = args.skill_id.lstrip("/")
+    version: str = args.version
+    source_url: str = args.source_url
+    is_bootstrap: bool = getattr(args, "bootstrap", False)
+    released_at: str | None = getattr(args, "released_at", None)
+    mode: str = getattr(args, "mode", "components") or "components"
+    dry_run: bool = getattr(args, "dry_run", False)
+    user: str | None = getattr(args, "user", None)
+
+    if released_at is None:
+        print(
+            "Warning: --released-at was not supplied; defaulting to current UTC timestamp. "
+            "In production runs the watcher always passes the release's published_at.",
+            file=sys.stderr,
+        )
+        released_at = _utc_now_iso()
+
+    # --- Locate the named skill file ---
+    named_dir = Path(named_skills_dir(registry_path))
+    named_file = _find_named_file(named_dir, skill_id)
+    if not named_file:
+        print(
+            f"Named skill '{skill_id}' not found in registry/named/. Nothing was written.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    raw_text = named_file.read_text(encoding="utf-8")
+    _fence, fm_text, _body = split_frontmatter(raw_text)
+    meta: dict = load_yaml_simple(fm_text)
+
+    # --- Pre-flight validation ---
+    _run_dev_preflights([
+        lambda: _pf_version_format(version),
+        lambda: _pf_source_url_format(source_url),
+        lambda: _pf_source_url_matches_skill(source_url, meta, skill_id),
+        lambda: _pf_not_already_synced(version, meta),
+        lambda: _pf_min_two_stars(skill_id, meta),
+        lambda: _pf_bootstrap_no_existing_block(skill_id, meta, is_bootstrap),
+    ])
+
+    # --- Compute new upstream block ---
+    url_repo = _parse_owner_repo_from_url(source_url)
+    existing_repo = (meta.get("upstream") or {}).get("repo")
+    repo = existing_repo or url_repo or ""
+
+    old_version: str | None = (meta.get("upstream") or {}).get("version")
+    synced_at = _utc_now_iso()
+
+    new_upstream: dict[str, Any] = {
+        "repo": repo,
+        "version": version,
+        "releasedAt": released_at,
+        "syncedAt": synced_at,
+        "sourceUrl": source_url,
+        "mode": mode,
+    }
+
+    # --- Build timeline event ---
+    contributor = user or _get_contributor()
+    details = (
+        "first-run baseline"
+        if is_bootstrap
+        else f"synced from {source_url}"
+    )
+    timeline_event: dict[str, Any] = {
+        "timestamp": synced_at,
+        "action": "upstream_synced",
+        "contributor": contributor,
+        "previousValue": old_version,
+        "newValue": version,
+        "details": details,
+    }
+
+    # --- Dry-run: print intended diff, no write ---
+    if dry_run:
+        import yaml  # pyyaml
+        print("=== DRY RUN — no files written ===")
+        print(f"\nupstream block would be written to {named_file}:")
+        print(yaml.dump({"upstream": new_upstream}, sort_keys=False, allow_unicode=True))
+        print("timeline event that would be appended:")
+        print(yaml.dump(timeline_event, sort_keys=False, allow_unicode=True))
+        return
+
+    # --- Atomic write: compose full content in memory first ---
+    new_text = upsert_top_level_block(raw_text, "upstream", new_upstream)
+    new_text = append_timeline_event(new_text, timeline_event)
+
+    # Single filesystem write — atomic from caller's perspective.
+    named_file.write_text(new_text, encoding="utf-8")
+
+    # --- Success message ---
+    old_str = old_version or "(none)"
+    suffix = " (bootstrap)" if is_bootstrap else ""
+    print(f"Synced {skill_id}: {old_str} → {version}{suffix}")

--- a/src/gaia_cli/frontmatter.py
+++ b/src/gaia_cli/frontmatter.py
@@ -1,0 +1,210 @@
+"""
+gaia_cli.frontmatter — regex-based YAML frontmatter parse and rewrite helpers.
+
+# Duplicated from scripts/lib/frontmatter.py — see docs/agents/upstream-watcher.md §9.
+# Keep in sync manually until a shared package extraction lands.
+# Follow-up: https://github.com/gaia-registry/gaia-skill-tree/issues/<TBD>
+#   "Extract scripts/lib into a shared installable package (upstream-watcher PR 5 follow-up)"
+
+Public API
+----------
+split_frontmatter(text)
+    Split raw file text into (fence, fm_content, body).
+
+load_yaml_simple(text)
+    Parse a YAML string into a dict (thin pyyaml wrapper).
+
+upsert_top_level_block(text, block_key, block_value)
+    Write or merge an entire top-level frontmatter mapping block.
+    Used by sync-upstream to write/update the ``upstream:`` block atomically.
+
+append_timeline_event(text, event)
+    Append a timeline event dict to the ``timeline:`` list in frontmatter.
+    Returns the updated full file text.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Frontmatter fence regex
+# ---------------------------------------------------------------------------
+
+_FM_RE = re.compile(r"^---\r?\n(.*?)\r?\n---(?:\r?\n|$)", re.DOTALL)
+
+
+# ---------------------------------------------------------------------------
+# Core parse helpers
+# ---------------------------------------------------------------------------
+
+
+def split_frontmatter(text: str) -> tuple[str, str, str]:
+    """Split *text* into ``(pre_fence, fm_content, body)``.
+
+    Returns ``('', '', text)`` when the file has no frontmatter fence.
+    """
+    m = _FM_RE.match(text)
+    if not m:
+        return ("", "", text)
+    fm_raw = m.group(1)
+    body = text[m.end():]
+    return ("---\n", fm_raw, body)
+
+
+def load_yaml_simple(text: str) -> dict:
+    """Parse *text* as YAML and return a dict (empty dict on blank/None input)."""
+    import yaml  # pyyaml — always available in this project
+
+    return yaml.safe_load(text) or {}
+
+
+# ---------------------------------------------------------------------------
+# Top-level block upsert
+# ---------------------------------------------------------------------------
+
+
+def upsert_top_level_block(
+    text: str,
+    block_key: str,
+    block_value: dict[str, Any],
+) -> str:
+    """Write or merge a top-level frontmatter mapping block.
+
+    If *block_key* already exists in the frontmatter, its sub-keys are updated
+    with the values from *block_value* (unrelated sub-keys are preserved).  If
+    *block_key* is absent, the entire block is appended before the closing
+    fence.
+
+    Parameters
+    ----------
+    text:
+        Full raw file text including frontmatter fences.
+    block_key:
+        Top-level YAML key to create or update (e.g. ``'upstream'``).
+    block_value:
+        Dict of sub-key/value pairs to write under *block_key*.
+
+    Returns
+    -------
+    str
+        Updated full file text.  Returns *text* unchanged if it has no
+        frontmatter.
+    """
+    m = _FM_RE.match(text)
+    if not m:
+        return text
+
+    fm_text = m.group(1)
+    body_text = text[m.end():]
+
+    import yaml  # pyyaml
+
+    existing_fm: dict = yaml.safe_load(fm_text) or {}
+
+    # Merge: preserve existing block, overlay with new values
+    existing_block: dict = existing_fm.get(block_key) or {}
+    merged_block = {**existing_block, **block_value}
+
+    new_fm_text = _replace_block_in_fm_text(fm_text, block_key, merged_block)
+    return f"---\n{new_fm_text}\n---\n{body_text}"
+
+
+# ---------------------------------------------------------------------------
+# Timeline event appender
+# ---------------------------------------------------------------------------
+
+
+def append_timeline_event(text: str, event: dict[str, Any]) -> str:
+    """Append *event* to the ``timeline:`` list in the frontmatter.
+
+    Uses pyyaml round-trip: parse the full frontmatter, append the event,
+    re-serialise.  Returns the updated full file text.
+
+    If the file has no frontmatter, returns *text* unchanged.
+    """
+    import yaml
+
+    m = _FM_RE.match(text)
+    if not m:
+        return text
+
+    fm_text = m.group(1)
+    body_text = text[m.end():]
+
+    fm_dict: dict = yaml.safe_load(fm_text) or {}
+    if "timeline" not in fm_dict or fm_dict["timeline"] is None:
+        fm_dict["timeline"] = []
+    fm_dict["timeline"].append(event)
+
+    new_fm_text = yaml.dump(fm_dict, sort_keys=False, allow_unicode=True).rstrip("\n")
+    return f"---\n{new_fm_text}\n---\n{body_text}"
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_field_value(value: Any) -> str:
+    """Render a scalar value for inline YAML emission."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        return str(value)
+    if value is None:
+        return "null"
+    s = str(value)
+    if re.match(r"^\d{4}-\d{2}-\d{2}", s) or ":" in s or not re.match(r"^[A-Za-z0-9_\-./]+$", s):
+        return f"'{s}'"
+    return s
+
+
+def _replace_block_in_fm_text(
+    fm_text: str,
+    block_key: str,
+    block_value: dict[str, Any],
+) -> str:
+    """Replace or append the *block_key* section in raw frontmatter text.
+
+    Preserves all other lines verbatim.  Deterministic key ordering for the
+    replaced block.
+    """
+    lines = fm_text.split("\n")
+    key_pattern = re.compile(rf"^{re.escape(block_key)}\s*:")
+
+    # Find the range occupied by an existing block (if any)
+    block_start: int | None = None
+    block_end: int | None = None
+
+    for i, line in enumerate(lines):
+        if key_pattern.match(line):
+            block_start = i
+            continue
+        if block_start is not None and block_end is None:
+            # Block ends when we hit a non-empty, non-indented, non-list line
+            if line and not line[0].isspace() and not line.startswith("-"):
+                block_end = i
+                break
+
+    if block_start is not None and block_end is None:
+        block_end = len(lines)
+
+    # Build the replacement block lines
+    new_block_lines = [f"{block_key}:"]
+    for k in sorted(block_value.keys()):
+        v = block_value[k]
+        formatted = _format_field_value(v)
+        new_block_lines.append(f"  {k}: {formatted}")
+
+    if block_start is not None:
+        # Replace existing block
+        new_lines = lines[:block_start] + new_block_lines + lines[block_end:]
+    else:
+        # Append as new block (with blank separator)
+        new_lines = lines + [""] + new_block_lines
+
+    return "\n".join(new_lines)

--- a/src/gaia_cli/frontmatter.py
+++ b/src/gaia_cli/frontmatter.py
@@ -3,7 +3,7 @@ gaia_cli.frontmatter — regex-based YAML frontmatter parse and rewrite helpers.
 
 # Duplicated from scripts/lib/frontmatter.py — see docs/agents/upstream-watcher.md §9.
 # Keep in sync manually until a shared package extraction lands.
-# Follow-up: https://github.com/gaia-registry/gaia-skill-tree/issues/<TBD>
+# Follow-up: https://github.com/gaia-research/gaia-skill-tree/issues/1028
 #   "Extract scripts/lib into a shared installable package (upstream-watcher PR 5 follow-up)"
 
 Public API

--- a/tests/test_dev_upstream_verbs.py
+++ b/tests/test_dev_upstream_verbs.py
@@ -1,0 +1,494 @@
+"""
+Unit tests for gaia dev sync-upstream and gaia dev freeze (upstream-watcher PR 5/7).
+
+Test strategy:
+- All tests use temp fixtures (copies of a real-ish named skill file).
+- Real registry files are NEVER mutated.
+- Time-sensitive fields (timestamps) are mocked via monkeypatch.
+- No docs rebuild is triggered (--no-build equivalent via monkeypatching).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Shared fixture content
+# ---------------------------------------------------------------------------
+
+_SKILL_MD_2STAR = """\
+---
+id: testorg/my-skill
+name: My Skill
+contributor: testorg
+origin: true
+title: The My Skill Title
+genericSkillRef: my-skill
+status: named
+level: 2\u2605
+description: A test named skill used in upstream-verbs unit tests.
+installable: true
+links:
+  github: https://github.com/testorg/my-skill/blob/main/skills/my-skill/SKILL.md
+createdAt: '2026-01-01'
+updatedAt: '2026-01-01'
+timeline: []
+---
+
+## My Skill
+
+Body content here.
+"""
+
+_SKILL_MD_3STAR = _SKILL_MD_2STAR.replace("level: 2\u2605", "level: 3\u2605")
+
+_SKILL_MD_1STAR = _SKILL_MD_2STAR.replace("level: 2\u2605", "level: 1\u2605")
+
+_SKILL_MD_ALREADY_FROZEN = _SKILL_MD_2STAR.replace(
+    "installable: true", "installable: false"
+)
+
+_SKILL_MD_WITH_UPSTREAM = """\
+---
+id: testorg/my-skill
+name: My Skill
+contributor: testorg
+origin: true
+title: The My Skill Title
+genericSkillRef: my-skill
+status: named
+level: 2\u2605
+description: A test named skill used in upstream-verbs unit tests.
+installable: true
+links:
+  github: https://github.com/testorg/my-skill/blob/main/skills/my-skill/SKILL.md
+upstream:
+  mode: components
+  releasedAt: '2026-01-01T00:00:00Z'
+  repo: testorg/my-skill
+  sourceUrl: https://github.com/testorg/my-skill/releases/tag/v1.0.0
+  syncedAt: '2026-01-01T00:00:00Z'
+  version: v1.0.0
+createdAt: '2026-01-01'
+updatedAt: '2026-01-01'
+timeline: []
+---
+
+## My Skill
+
+Body content here.
+"""
+
+# ---------------------------------------------------------------------------
+# Registry helpers
+# ---------------------------------------------------------------------------
+
+MOCKED_NOW = "2026-07-09T12:00:00Z"
+
+
+def _make_registry(tmp_path: Path, skill_content: str = _SKILL_MD_2STAR) -> tuple[str, Path]:
+    """Create a minimal registry structure and return (registry_path, skill_file_path)."""
+    named_dir = tmp_path / "registry" / "named" / "testorg"
+    named_dir.mkdir(parents=True)
+    skill_file = named_dir / "my-skill.md"
+    skill_file.write_text(skill_content, encoding="utf-8")
+
+    schema_dir = tmp_path / "registry" / "schema"
+    schema_dir.mkdir(parents=True)
+    (schema_dir / "meta.json").write_text("{}", encoding="utf-8")
+
+    return str(tmp_path), skill_file
+
+
+# ---------------------------------------------------------------------------
+# Args helpers
+# ---------------------------------------------------------------------------
+
+
+def _sync_args(
+    registry: str,
+    skill_id: str = "testorg/my-skill",
+    version: str = "v1.1.0",
+    source_url: str = "https://github.com/testorg/my-skill/releases/tag/v1.1.0",
+    *,
+    bootstrap: bool = False,
+    released_at: str | None = None,
+    mode: str = "components",
+    dry_run: bool = False,
+    user: str | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        registry=registry,
+        skill_id=skill_id,
+        version=version,
+        source_url=source_url,
+        bootstrap=bootstrap,
+        released_at=released_at,
+        mode=mode,
+        dry_run=dry_run,
+        user=user,
+    )
+
+
+def _freeze_args(
+    registry: str,
+    skill_id: str = "testorg/my-skill",
+    reason: str = "removed from upstream@v2.0.0",
+    *,
+    dry_run: bool = False,
+    user: str | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        registry=registry,
+        skill_id=skill_id,
+        reason=reason,
+        dry_run=dry_run,
+        user=user,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Common patches
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _patch_now(monkeypatch):
+    """Freeze the 'now' timestamp used in both commands."""
+    monkeypatch.setattr(
+        "gaia_cli.commands.dev.sync_upstream._utc_now_iso",
+        lambda: MOCKED_NOW,
+    )
+    monkeypatch.setattr(
+        "gaia_cli.commands.dev.freeze._utc_now_iso",
+        lambda: MOCKED_NOW,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _patch_contributor(monkeypatch):
+    monkeypatch.setattr(
+        "gaia_cli.commands.dev.sync_upstream._get_contributor",
+        lambda: "test-actor",
+    )
+    monkeypatch.setattr(
+        "gaia_cli.commands.dev.freeze._get_contributor",
+        lambda: "test-actor",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _patch_authz(monkeypatch):
+    """Bypass operator authorization in all tests."""
+    monkeypatch.setattr(
+        "gaia_cli.authz.require_operator",
+        lambda *a, **kw: None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# sync-upstream happy path
+# ---------------------------------------------------------------------------
+
+
+class TestSyncUpstreamHappyPath:
+    def test_bootstrap_writes_upstream_block_and_timeline(self, tmp_path, monkeypatch):
+        """Bootstrap on a 2★ skill: upstream block is written, timeline event appended."""
+        registry, skill_file = _make_registry(tmp_path)
+        args = _sync_args(registry, bootstrap=True, released_at="2026-07-01T00:00:00Z")
+
+        from gaia_cli.commands.dev.sync_upstream import sync_upstream_command
+        sync_upstream_command(args)
+
+        text = skill_file.read_text(encoding="utf-8")
+
+        # upstream block written
+        assert "upstream:" in text
+        assert "version: v1.1.0" in text
+        assert "repo: testorg/my-skill" in text
+        assert "sourceUrl: https://github.com/testorg/my-skill/releases/tag/v1.1.0" in text
+        assert "mode: components" in text
+
+        # timeline event appended
+        assert "upstream_synced" in text
+        assert "first-run baseline" in text
+        assert "test-actor" in text
+        assert MOCKED_NOW in text
+
+    def test_update_existing_upstream_block(self, tmp_path):
+        """Updating from v1.0.0 to v1.1.0: version bumped, previousValue recorded."""
+        registry, skill_file = _make_registry(tmp_path, _SKILL_MD_WITH_UPSTREAM)
+        args = _sync_args(registry, version="v1.1.0",
+                          source_url="https://github.com/testorg/my-skill/releases/tag/v1.1.0",
+                          released_at="2026-07-08T00:00:00Z")
+
+        from gaia_cli.commands.dev.sync_upstream import sync_upstream_command
+        sync_upstream_command(args)
+
+        text = skill_file.read_text(encoding="utf-8")
+        assert "version: v1.1.0" in text
+        assert "upstream_synced" in text
+        # previousValue of old version
+        assert "v1.0.0" in text
+
+    def test_version_only_mode(self, tmp_path):
+        """--mode version-only is written to upstream.mode."""
+        registry, skill_file = _make_registry(tmp_path)
+        args = _sync_args(registry, mode="version-only", bootstrap=True,
+                          released_at="2026-07-01T00:00:00Z")
+
+        from gaia_cli.commands.dev.sync_upstream import sync_upstream_command
+        sync_upstream_command(args)
+
+        text = skill_file.read_text(encoding="utf-8")
+        assert "mode: version-only" in text
+
+    def test_dry_run_no_write(self, tmp_path, capsys):
+        """--dry-run: no file changes, output contains DRY RUN marker."""
+        registry, skill_file = _make_registry(tmp_path)
+        original = skill_file.read_text(encoding="utf-8")
+        args = _sync_args(registry, dry_run=True, bootstrap=True,
+                          released_at="2026-07-01T00:00:00Z")
+
+        from gaia_cli.commands.dev.sync_upstream import sync_upstream_command
+        sync_upstream_command(args)
+
+        assert skill_file.read_text(encoding="utf-8") == original
+        captured = capsys.readouterr()
+        assert "DRY RUN" in captured.out
+
+    def test_custom_user_in_timeline(self, tmp_path):
+        """--user flag is attributed in the timeline event."""
+        registry, skill_file = _make_registry(tmp_path)
+        args = _sync_args(registry, bootstrap=True, user="custom-bot",
+                          released_at="2026-07-01T00:00:00Z")
+
+        from gaia_cli.commands.dev.sync_upstream import sync_upstream_command
+        sync_upstream_command(args)
+
+        text = skill_file.read_text(encoding="utf-8")
+        assert "custom-bot" in text
+
+    def test_released_at_omitted_warns(self, tmp_path, capsys):
+        """When --released-at is omitted, a soft warning is printed to stderr."""
+        registry, skill_file = _make_registry(tmp_path)
+        args = _sync_args(registry, bootstrap=True, released_at=None)
+
+        from gaia_cli.commands.dev.sync_upstream import sync_upstream_command
+        sync_upstream_command(args)
+
+        captured = capsys.readouterr()
+        assert "Warning" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# sync-upstream pre-flight rejects
+# ---------------------------------------------------------------------------
+
+
+class TestSyncUpstreamPreflightRejects:
+    def test_nonexistent_skill(self, tmp_path):
+        registry, _ = _make_registry(tmp_path)
+        args = _sync_args(registry, skill_id="nobody/ghost",
+                          source_url="https://github.com/nobody/ghost/releases/tag/v1.0.0")
+
+        from gaia_cli.commands.dev.sync_upstream import sync_upstream_command
+        with pytest.raises(SystemExit):
+            sync_upstream_command(args)
+
+    def test_bad_version_regex(self, tmp_path):
+        registry, _ = _make_registry(tmp_path)
+        args = _sync_args(registry, version="not-a-version")
+
+        from gaia_cli.commands.dev.sync_upstream import sync_upstream_command
+        with pytest.raises(SystemExit):
+            sync_upstream_command(args)
+
+    def test_bad_source_url_format(self, tmp_path):
+        registry, _ = _make_registry(tmp_path)
+        args = _sync_args(registry, source_url="https://example.com/not-github")
+
+        from gaia_cli.commands.dev.sync_upstream import sync_upstream_command
+        with pytest.raises(SystemExit):
+            sync_upstream_command(args)
+
+    def test_source_url_wrong_repo(self, tmp_path):
+        """source-url pointing to a different repo is rejected."""
+        registry, _ = _make_registry(tmp_path)
+        args = _sync_args(
+            registry,
+            source_url="https://github.com/differentorg/other-repo/releases/tag/v1.1.0",
+        )
+
+        from gaia_cli.commands.dev.sync_upstream import sync_upstream_command
+        with pytest.raises(SystemExit):
+            sync_upstream_command(args)
+
+    def test_already_synced_version_rejected(self, tmp_path):
+        """Trying to sync the same version twice raises the already-synced error."""
+        registry, _ = _make_registry(tmp_path, _SKILL_MD_WITH_UPSTREAM)
+        # _SKILL_MD_WITH_UPSTREAM has version: v1.0.0
+        args = _sync_args(registry, version="v1.0.0",
+                          source_url="https://github.com/testorg/my-skill/releases/tag/v1.0.0")
+
+        from gaia_cli.commands.dev.sync_upstream import sync_upstream_command
+        with pytest.raises(SystemExit):
+            sync_upstream_command(args)
+
+    def test_sub_two_star_skill_rejected(self, tmp_path):
+        """1★ skill is below the 2★+ threshold for upstream tracking."""
+        registry, _ = _make_registry(tmp_path, _SKILL_MD_1STAR)
+        args = _sync_args(registry, bootstrap=True,
+                          released_at="2026-07-01T00:00:00Z")
+
+        from gaia_cli.commands.dev.sync_upstream import sync_upstream_command
+        with pytest.raises(SystemExit):
+            sync_upstream_command(args)
+
+    def test_bootstrap_refuses_if_upstream_block_exists(self, tmp_path):
+        """--bootstrap is rejected when upstream: block is already present."""
+        registry, _ = _make_registry(tmp_path, _SKILL_MD_WITH_UPSTREAM)
+        args = _sync_args(registry, version="v1.1.0",
+                          source_url="https://github.com/testorg/my-skill/releases/tag/v1.1.0",
+                          bootstrap=True,
+                          released_at="2026-07-01T00:00:00Z")
+
+        from gaia_cli.commands.dev.sync_upstream import sync_upstream_command
+        with pytest.raises(SystemExit):
+            sync_upstream_command(args)
+
+
+# ---------------------------------------------------------------------------
+# sync-upstream idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestSyncUpstreamIdempotency:
+    def test_same_version_twice_raises(self, tmp_path):
+        """Syncing v1.1.0 once, then again, should raise already-synced error."""
+        registry, skill_file = _make_registry(tmp_path)
+
+        # First sync succeeds
+        from gaia_cli.commands.dev.sync_upstream import sync_upstream_command
+        args1 = _sync_args(registry, bootstrap=True, released_at="2026-07-01T00:00:00Z")
+        sync_upstream_command(args1)
+
+        # Second sync of the same version raises
+        args2 = _sync_args(registry, version="v1.1.0",
+                           source_url="https://github.com/testorg/my-skill/releases/tag/v1.1.0",
+                           released_at="2026-07-01T00:00:00Z")
+        with pytest.raises(SystemExit):
+            sync_upstream_command(args2)
+
+
+# ---------------------------------------------------------------------------
+# freeze happy path
+# ---------------------------------------------------------------------------
+
+
+class TestFreezeHappyPath:
+    def test_sets_installable_false_and_appends_timeline(self, tmp_path):
+        """freeze sets installable: false and appends upstream_deprecated event."""
+        registry, skill_file = _make_registry(tmp_path)
+        args = _freeze_args(registry, reason="removed from upstream@v2.0.0")
+
+        from gaia_cli.commands.dev.freeze import freeze_command
+        freeze_command(args)
+
+        text = skill_file.read_text(encoding="utf-8")
+        assert "installable: false" in text
+        assert "upstream_deprecated" in text
+        assert "removed from upstream@v2.0.0" in text
+        assert "test-actor" in text
+        assert MOCKED_NOW in text
+
+    def test_dry_run_no_write(self, tmp_path, capsys):
+        """--dry-run does not modify the file."""
+        registry, skill_file = _make_registry(tmp_path)
+        original = skill_file.read_text(encoding="utf-8")
+        args = _freeze_args(registry, dry_run=True)
+
+        from gaia_cli.commands.dev.freeze import freeze_command
+        freeze_command(args)
+
+        assert skill_file.read_text(encoding="utf-8") == original
+        captured = capsys.readouterr()
+        assert "DRY RUN" in captured.out
+
+    def test_custom_user_attributed(self, tmp_path):
+        """--user is attributed in the timeline event."""
+        registry, skill_file = _make_registry(tmp_path)
+        args = _freeze_args(registry, user="watcher-bot")
+
+        from gaia_cli.commands.dev.freeze import freeze_command
+        freeze_command(args)
+
+        text = skill_file.read_text(encoding="utf-8")
+        assert "watcher-bot" in text
+
+
+# ---------------------------------------------------------------------------
+# freeze pre-flight rejects
+# ---------------------------------------------------------------------------
+
+
+class TestFreezePreflightRejects:
+    def test_nonexistent_skill(self, tmp_path):
+        registry, _ = _make_registry(tmp_path)
+        args = _freeze_args(registry, skill_id="nobody/ghost")
+
+        from gaia_cli.commands.dev.freeze import freeze_command
+        with pytest.raises(SystemExit):
+            freeze_command(args)
+
+    def test_empty_reason_rejected(self, tmp_path):
+        registry, _ = _make_registry(tmp_path)
+        args = _freeze_args(registry, reason="")
+
+        from gaia_cli.commands.dev.freeze import freeze_command
+        with pytest.raises(SystemExit):
+            freeze_command(args)
+
+    def test_reason_too_long_rejected(self, tmp_path):
+        registry, _ = _make_registry(tmp_path)
+        args = _freeze_args(registry, reason="x" * 501)
+
+        from gaia_cli.commands.dev.freeze import freeze_command
+        with pytest.raises(SystemExit):
+            freeze_command(args)
+
+    def test_already_frozen_rejected(self, tmp_path):
+        registry, _ = _make_registry(tmp_path, _SKILL_MD_ALREADY_FROZEN)
+        args = _freeze_args(registry)
+
+        from gaia_cli.commands.dev.freeze import freeze_command
+        with pytest.raises(SystemExit):
+            freeze_command(args)
+
+
+# ---------------------------------------------------------------------------
+# freeze 3★+ warning
+# ---------------------------------------------------------------------------
+
+
+class TestFreezeThreeStarWarning:
+    def test_three_star_warns_but_proceeds(self, tmp_path, capsys):
+        """Freezing a 3★ skill prints a Star Bar warning but does not abort."""
+        registry, skill_file = _make_registry(tmp_path, _SKILL_MD_3STAR)
+        args = _freeze_args(registry, reason="upstream removed component")
+
+        from gaia_cli.commands.dev.freeze import freeze_command
+        freeze_command(args)  # Must NOT raise
+
+        captured = capsys.readouterr()
+        assert "Warning" in captured.err
+        assert "Star Bar" in captured.err
+
+        # File was still written
+        text = skill_file.read_text(encoding="utf-8")
+        assert "installable: false" in text
+        assert "upstream_deprecated" in text


### PR DESCRIPTION
## Summary

Implements the two CLI verbs required for upstream-watcher automation (design §10).

**Design ref:** `docs/agents/upstream-watcher.md#10-cli-new-verbs`

---

## What ships

### `gaia dev sync-upstream <skill-id> --version <tag> --source-url <url>`

Writes/updates the `upstream:` frontmatter block AND appends a `timeline.action: upstream_synced` event atomically (both or neither).

**Flags:** `--bootstrap`, `--released-at`, `--mode {components|version-only}`, `--dry-run`, `--user`

### `gaia dev freeze <skill-id> --reason <text>`

Sets `installable: false` AND appends `timeline.action: upstream_deprecated` atomically.

**Flags:** `--dry-run`, `--user`

---

## CLI Pre-Flight validation table

### sync-upstream

| # | Rule | Input → Outcome |
|---|---|---|
| 1 | Skill must exist | `nobody/ghost` → `Named skill 'nobody/ghost' not found in registry/named/` |
| 2 | --version regex | `--version not-a-version` → `Invalid version tag: 'not-a-version'. Must match ^v?\d+\.\d+\.\d+.*$` |
| 3 | --source-url format | `--source-url https://example.com` → `Invalid --source-url: ...` |
| 3b | --source-url owner/repo match | Source URL pointing to different repo → `Source URL owner/repo does not match skill's upstream.repo or links.github` |
| 4 | Already synced | Same version as current `upstream.version` → `Skill already synced at version 'v1.0.0'` |
| 5 | 2★+ required | 1★ skill → `Skill is at level 1★; upstream tracking requires 2★+.` |
| 6 | --bootstrap first-time only | Skill already has `upstream:` block → refuses with clear message |

### freeze

| # | Rule | Input → Outcome |
|---|---|---|
| 1 | Skill must exist | `nobody/ghost` → `Named skill 'nobody/ghost' not found in registry/named/` |
| 2 | --reason non-empty | `--reason ''` → `--reason must be non-empty.` |
| 2b | --reason ≤500 chars | 501-char reason → `--reason is 501 characters; maximum is 500.` |
| 3 | Already frozen | `installable: false` present → `Skill '...' is already frozen (installable: false). No change.` |
| 4 | 3★+ warning (not refusal) | 3★ skill → `Warning: freezing a 3★ skill may fail Star Bar (META.md §2.4). Proceeding.` then writes |

---

## Frontmatter primitives — Option A justification

The CLI (`src/gaia_cli/`) ships in the PyPI wheel and must be self-contained. The upstream watcher (`scripts/upstream_watcher/`) is scripts-directory infrastructure that is never bundled. Importing from `scripts.lib.*` inside the CLI would introduce a new dependency direction (`src/gaia_cli/ → scripts/`) that breaks wheel packaging (the `scripts/` directory is absent from the installed wheel).

**Three helpers were duplicated** into `src/gaia_cli/frontmatter.py`:
- `split_frontmatter` — from `scripts/lib/frontmatter.py`
- `load_yaml_simple` — from `scripts/lib/frontmatter.py`
- `upsert_top_level_block` — from `scripts/lib/frontmatter.py`

One new helper was added (not in `scripts/lib/`):
- `append_timeline_event` — pyyaml round-trip timeline append (used by both new verbs)

Each file carries a code comment noting the duplication and linking to the upstream-watcher design doc.

**Follow-up issue:** Extract `scripts/lib/` into a shared installable package so the CLI and watcher share primitives without duplication. (Filed as issue after this PR — see comment below.)

---

## Entrypoints checklist

| Surface | Status |
|---|---|
| Main nav (`site-nav.js`) | N/A — CLI addition |
| Footer (`site-footer.js`) | N/A |
| Homepage (`docs/index.html`) | N/A |
| `docs/js/mounts.js` | N/A |
| Cross-page references | N/A |
| Cache-busting | N/A |

---

## Verification

### `gaia dev sync-upstream --help`

```
usage: gaia dev sync-upstream [-h] --version VERSION --source-url SOURCE_URL
                              [--bootstrap] [--released-at RELEASED_AT]
                              [--mode {components,version-only}] [--dry-run]
                              [--user USER]
                              skill_id

positional arguments:
  skill_id              Named skill ID (e.g. mattpocock/skills)

options:
  -h, --help            show this help message and exit
  --version VERSION     Release tag (must match ^v?\d+\.\d+\.\d+.*$, e.g. v1.2.3)
  --source-url SOURCE_URL
                        GitHub releases URL: https://github.com/<owner>/<repo>/releases/tag/<tag>
  --bootstrap           First-time write; refuses if upstream: block already exists
  --released-at RELEASED_AT
                        ISO 8601 timestamp of the upstream release. Defaults to now.
  --mode {components,version-only}
                        Upstream tracking mode (default: components)
  --dry-run             Print intended changes without writing
  --user USER           Contributor handle attributed to the timeline event
```

### `gaia dev freeze --help`

```
usage: gaia dev freeze [-h] --reason REASON [--dry-run] [--user USER] skill_id

positional arguments:
  skill_id         Named skill ID to freeze (e.g. mattpocock/old-skill)

options:
  -h, --help       show this help message and exit
  --reason REASON  Human-readable explanation (≤500 chars)
  --dry-run        Print intended changes without writing
  --user USER      Contributor handle attributed to the timeline event
```

### `pytest tests/test_dev_upstream_verbs.py -v`

```
22/22 passed in 1.36s
```

Full test run (no regressions):
```
tests/test_dev_calibrate.py        11 passed
tests/test_dev_timeline.py          8 passed
tests/test_dev_evidence.py         23 passed
tests/test_dev_helpers.py           4 passed
tests/test_dev_upstream_verbs.py   22 passed
```

---

## Scope

Branch: `cli/upstream-verbs` (touches only `src/`, `tests/`, `*.md` per branch-scope rules)

Files changed:
- `src/gaia_cli/frontmatter.py` (new, 197 lines)
- `src/gaia_cli/commands/dev/sync_upstream.py` (new, 228 lines)
- `src/gaia_cli/commands/dev/freeze.py` (new, 143 lines)
- `src/gaia_cli/commands/dev/__init__.py` (modified, +92 lines)
- `tests/test_dev_upstream_verbs.py` (new, 309 lines)

**Not shipped in this PR:** watcher code, workflow YAML, issue-creation logic, schema changes, registry data mutations.