### PR TITLE
infra: upstream-approve workflow — no-op abort + parse_error.txt sandbox + --tag rename (hotfix 2)

### DIFF
--- a/.github/workflows/upstream-approve.yml
+++ b/.github/workflows/upstream-approve.yml
@@ -146,10 +146,10 @@ jobs:
           except json.JSONDecodeError as e:
               print(f'JSON parse error: {e}', file=sys.stderr)
               sys.exit(1)
-          " 2>parse_error.txt || true)
+          " 2>"$RUNNER_TEMP/parse_error.txt" || true)
 
           if [ -z "$PAYLOAD_JSON" ] || [ "$PAYLOAD_JSON" = "{}" ]; then
-            ERROR=$(cat parse_error.txt 2>/dev/null || echo "unknown parse error")
+            ERROR=$(cat "$RUNNER_TEMP/parse_error.txt" 2>/dev/null || echo "unknown parse error")
             gh issue comment "$ISSUE_NUMBER" \
               --body "⚠️ **Payload parse failure.** Could not extract the machine-readable payload from this issue body. Error: \`$ERROR\`. Cannot proceed with sync."
             exit 1
@@ -233,7 +233,7 @@ jobs:
           git checkout -b "$BRANCH"
           echo "branch=$BRANCH" >> $GITHUB_OUTPUT
 
-      # ── Bug 1 fix: bootstrap mode uses --bootstrap flag, not --mode bootstrap
+      # ── Hotfix 2: bootstrap mode uses --bootstrap flag; --version renamed to --tag
       - name: Run gaia dev sync-upstream
         env:
           GAIA_OPERATOR_OVERRIDE: "1"
@@ -246,14 +246,14 @@ jobs:
           set -euo pipefail
           if [ "$MODE" = "bootstrap" ]; then
             python -m gaia_cli dev sync-upstream "$SKILL_ID" \
-              --version "$NEW_VERSION" \
+              --tag "$NEW_VERSION" \
               --source-url "$SOURCE_URL" \
               --released-at "$RELEASED_AT" \
               --bootstrap \
               --user "github-actions[bot]"
           else
             python -m gaia_cli dev sync-upstream "$SKILL_ID" \
-              --version "$NEW_VERSION" \
+              --tag "$NEW_VERSION" \
               --source-url "$SOURCE_URL" \
               --released-at "$RELEASED_AT" \
               --mode "$MODE" \
@@ -285,14 +285,37 @@ jobs:
         run: |
           python -m gaia_cli dev docs || true
 
+      # ── Hotfix 2: abort if sync produced no real registry changes ──────────
+      - name: Verify sync produced real changes
+        id: change_check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
+        run: |
+          set -euo pipefail
+          # Sync-upstream + freeze should have modified files under registry/named/
+          # If the ONLY changes are docs regen noise, this was a no-op and we abort.
+          REGISTRY_CHANGES=$(git status --porcelain registry/named/ | wc -l)
+          if [ "$REGISTRY_CHANGES" -eq 0 ]; then
+            echo "no_changes=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::sync-upstream produced no changes to registry/named/. Aborting PR creation."
+            gh issue comment "$ISSUE_NUMBER" \
+              --body "⚠️ **Sync aborted: no registry changes.** The \`gaia dev sync-upstream\` step ran but did not modify any file under \`registry/named/\`. This usually means the sync silently no-op'd (see PR #1043 for the known argparse clash regression). No PR was opened. Please re-run once diagnostics are complete."
+            exit 0
+          fi
+          echo "no_changes=false" >> "$GITHUB_OUTPUT"
+
       - name: Commit and push
+        if: steps.change_check.outputs.no_changes != 'true'
         env:
           BRANCH: ${{ steps.branch.outputs.branch }}
           NEW_VERSION: ${{ steps.payload.outputs.new_version }}
           SKILL_ID: ${{ steps.payload.outputs.skill_id }}
         run: |
           set -euo pipefail
-          git add -A
+          # Stage only the paths we intend to commit — defence-in-depth against
+          # stray files (e.g. parse_error.txt) leaking into the commit.
+          git add registry/named/ registry/gaia.json registry/named-skills.json docs/graph/ || true
           if git diff --cached --quiet; then
             echo "No changes to commit."
             exit 0
@@ -301,6 +324,7 @@ jobs:
           git push origin "$BRANCH"
 
       - name: Open draft PR
+        if: steps.change_check.outputs.no_changes != 'true'
         id: pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -324,6 +348,7 @@ jobs:
           echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
 
       - name: Comment PR link on umbrella
+        if: steps.change_check.outputs.no_changes != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ steps.issue.outputs.number }}


### PR DESCRIPTION
## infra: upstream-approve workflow — no-op abort + parse_error.txt sandbox + --tag rename (hotfix 2)

> ⚠️ **Depends on PR #1043 (`cli/upstream-tag-rename`) being merged first.**
> This workflow calls `--tag` (the new flag name) — the CLI must know that flag before this runs.
> If PR #1043 is not yet merged, any approve workflow run will fail with an unrecognised argument error.

### Changes (3 fixes)

#### Fix 1: `parse_error.txt` sandboxed to `$RUNNER_TEMP` (P1)

**Problem:** `2>parse_error.txt` wrote into the repo working tree root. `git add -A` swept it up, and it appeared in PR #1042.

**Fix:** Redirect to `$RUNNER_TEMP/parse_error.txt`. Runner temp is auto-cleaned by Actions and never part of the working tree.

```diff
-          " 2>parse_error.txt || true)
+          " 2>"$RUNNER_TEMP/parse_error.txt" || true)

-            ERROR=$(cat parse_error.txt 2>/dev/null || echo "unknown parse error")
+            ERROR=$(cat "$RUNNER_TEMP/parse_error.txt" 2>/dev/null || echo "unknown parse error")
```

#### Fix 2: No-op detection aborts PR creation (P1)

**Problem:** When sync silently no-op'd (see bug 1, PR #1043), `gaia dev docs` still produced float-noise diffs. `git add -A` committed ONLY those noise diffs and pushed them as if they were a real sync PR.

**Fix:** Add `Verify sync produced real changes` step between artifact regen and commit. Checks `git status --porcelain registry/named/`. If zero changes → soft-abort with umbrella comment, skip Commit/Open PR/Comment steps. Does NOT `exit 1` (soft abort keeps the workflow green so the operator can act — design intent per spec).

Three downstream steps guarded with `if: steps.change_check.outputs.no_changes != 'true'`:
- `Commit and push`
- `Open draft PR`
- `Comment PR link on umbrella`

#### Fix 3: `--version` → `--tag` in sync-upstream invocations (coupling to PR #1043)

Both bootstrap and update paths updated. Also: `git add -A` replaced with explicit path list as defence-in-depth.

**Before:**
```bash
python -m gaia_cli dev sync-upstream "$SKILL_ID" \
  --version "$NEW_VERSION" \
  ...
```

**After:**
```bash
python -m gaia_cli dev sync-upstream "$SKILL_ID" \
  --tag "$NEW_VERSION" \
  ...
```

**Commit step, before:**
```bash
git add -A
```

**After:**
```bash
git add registry/named/ registry/gaia.json registry/named-skills.json docs/graph/ || true
```

---

### Verification audits

**YAML parse:**
```
$ python -c "import yaml; yaml.safe_load(open('.github/workflows/upstream-approve.yml', encoding='utf-8'))"
# exit 0
```

**parse_error.txt grep — all occurrences point to $RUNNER_TEMP:**
```
149:  " 2>"$RUNNER_TEMP/parse_error.txt" || true)
152:    ERROR=$(cat "$RUNNER_TEMP/parse_error.txt" 2>/dev/null || echo "unknown parse error")
317:  # stray files (e.g. parse_error.txt) leaking into the commit.  [comment]
```

**git add grep — no `git add -A` or `git add .`:**
```
318:  git add registry/named/ registry/gaia.json registry/named-skills.json docs/graph/ || true
```

**--version grep in sync-upstream invocations — none:**
```
236:  # ── Hotfix 2: bootstrap mode uses --bootstrap flag; --version renamed to --tag  [comment only]
```

**--tag grep in invocations:**
```
249:    --tag "$NEW_VERSION" \
256:    --tag "$NEW_VERSION" \
```

---

### Files changed

| File | Change |
|---|---|
| `.github/workflows/upstream-approve.yml` | All 3 fixes above |

**Merge order: PR #1043 first, then this PR.**
