### PR TITLE
docs: evidence-class wording + org migration sweep + skill-fuse note (#917, #874, #1004)

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,14 @@ To help AI agents and automated clients discover and crawl the registry programm
 
 ---
 
+## Ecosystem
+
+Companion tools that build on Gaia but run independently:
+
+- **[skill-fuse](https://github.com/mbtiongson1/skill-fuse)** — a standalone skill that combines two AI agent skills into one fused skill. Powered by Gaia, works without it. Registered in the registry as [`gaia-research/skill-fuse`](https://gaiaskilltree.com/named/).
+
+---
+
 ## Repository Structure
 
 <!-- gaia:layout-start -->

--- a/docs/about.html
+++ b/docs/about.html
@@ -983,7 +983,7 @@
             <dd class="ab-tally-num">220</dd>
           </div>
         </dl>
-        <p class="ab-tally-note">Live from <a href="https://github.com/mbtiongson1/gaia-skill-tree/blob/main/registry/gaia.json" target="_blank" rel="noopener">registry/gaia.json</a> v4.1.2. Counts grow with the record.</p>
+        <p class="ab-tally-note">Live from <a href="https://github.com/gaia-research/gaia-skill-tree/blob/main/registry/gaia.json" target="_blank" rel="noopener">registry/gaia.json</a> v4.1.2. Counts grow with the record.</p>
 
         <div class="ab-record-prose">
           <p>Gaia is a registry, not a marketplace. A marketplace asks <em>what you can use</em>. A registry asks <em>what's on the record</em>: who demonstrated a capability first, and the evidence that proves it.</p>
@@ -1110,7 +1110,7 @@
                 <svg class="ico" width="14" height="14" aria-hidden="true"><use href="assets/icons.svg#claim-arrow"/></svg>
                 Register your repo
               </a>
-              <a class="ab-cta ab-cta-ghost" href="https://github.com/mbtiongson1/gaia-skill-tree" target="_blank" rel="noopener">
+              <a class="ab-cta ab-cta-ghost" href="https://github.com/gaia-research/gaia-skill-tree" target="_blank" rel="noopener">
                 <svg class="ico" width="14" height="14" aria-hidden="true"><use href="assets/icons.svg#github"/></svg>
                 View on GitHub
               </a>

--- a/docs/codex.html
+++ b/docs/codex.html
@@ -466,7 +466,7 @@
     </p>
     <div class="process-actions">
       <a class="btn btn-primary" href="index.html#paths">Push a skill</a>
-      <a class="btn btn-ghost" href="https://github.com/mbtiongson1/gaia-skill-tree/issues" target="_blank">Open Issues</a>
+      <a class="btn btn-ghost" href="https://github.com/gaia-research/gaia-skill-tree/issues" target="_blank">Open Issues</a>
     </div>
   </section>
 
@@ -1072,7 +1072,7 @@
     <p class="branch-bypass-note">
       To bypass CI scope enforcement in an emergency, add label <code>skip-scope-check</code> to the PR.
     </p>
-    <a class="btn btn-ghost branch-contributing-btn" href="https://github.com/mbtiongson1/gaia-skill-tree/blob/main/CONTRIBUTING.md" target="_blank">Read Contributing</a>
+    <a class="btn btn-ghost branch-contributing-btn" href="https://github.com/gaia-research/gaia-skill-tree/blob/main/CONTRIBUTING.md" target="_blank">Read Contributing</a>
   </section>
 </main>
 

--- a/docs/codex/trust-methodology.html
+++ b/docs/codex/trust-methodology.html
@@ -339,7 +339,7 @@
       </p>
       <div class="process-actions">
         <a class="btn btn-ghost" href="../evidence/index.html">Evidence Explorer</a>
-        <a class="btn btn-ghost" href="https://github.com/mbtiongson1/gaia-skill-tree/issues/715" target="_blank" rel="noopener">RFC G7 · Issue #715</a>
+        <a class="btn btn-ghost" href="https://github.com/gaia-research/gaia-skill-tree/issues/715" target="_blank" rel="noopener">RFC G7 · Issue #715</a>
       </div>
     </section>
 
@@ -1311,12 +1311,12 @@
           <h3>References &amp; Canonical Docs</h3>
           <ul>
             <li>
-              <a href="https://github.com/mbtiongson1/gaia-skill-tree/issues/715" target="_blank" rel="noopener" style="color: var(--tier-basic); text-decoration: none;">
+              <a href="https://github.com/gaia-research/gaia-skill-tree/issues/715" target="_blank" rel="noopener" style="color: var(--tier-basic); text-decoration: none;">
                 RFC G7 — Trust Taxonomy Consensus (Issue #715)
               </a>
             </li>
             <li>
-              <a href="https://github.com/mbtiongson1/gaia-skill-tree" target="_blank" rel="noopener" style="color: var(--tier-basic); text-decoration: none;">
+              <a href="https://github.com/gaia-research/gaia-skill-tree" target="_blank" rel="noopener" style="color: var(--tier-basic); text-decoration: none;">
                 GitHub — gaia-skill-tree
               </a>
             </li>

--- a/docs/en/RESOURCES.md
+++ b/docs/en/RESOURCES.md
@@ -13,5 +13,5 @@
 
 ## Wisdom (Communities)
 
-- [GitHub Issues & PRs](https://github.com/mbtiongson1/gaia-skill-tree)
+- [GitHub Issues & PRs](https://github.com/gaia-research/gaia-skill-tree)
   The primary community workspace for submitting skills, participating in reviews, and seeing examples of successful skill intakes.

--- a/docs/en/cli-reference.html
+++ b/docs/en/cli-reference.html
@@ -2299,7 +2299,7 @@
     <div class="docs-footer-right">
       <a href="index.html" style="color:var(--muted,#64748b);">Docs</a>
       <a href="../index.html" style="color:var(--muted,#64748b);">Atlas</a>
-      <a href="https://github.com/mbtiongson1/gaia-skill-tree" target="_blank" rel="noopener"
+      <a href="https://github.com/gaia-research/gaia-skill-tree" target="_blank" rel="noopener"
         style="color:var(--muted,#64748b);">GitHub</a>
     </div>
   </footer>

--- a/docs/en/contributing.html
+++ b/docs/en/contributing.html
@@ -803,7 +803,7 @@ gaia dev validate --intake   <span class="c"># validate intake batch too</span><
 
         <h3>Monthly Meta Sweep</h3>
         <div class="section-body">
-          <p>On the first Monday of each month, a designated maintainer runs <code>/gaia-meta-sweep</code> to audit the entire registry against <a href="https://github.com/mbtiongson1/gaia-skill-tree/blob/main/META.md">META.md</a>. The sweep produces an HTML report at <code>docs/meta/reports/YYYY-MM-DD-meta-audit.html</code> plus machine-readable JSON.</p>
+          <p>On the first Monday of each month, a designated maintainer runs <code>/gaia-meta-sweep</code> to audit the entire registry against <a href="https://github.com/gaia-research/gaia-skill-tree/blob/main/META.md">META.md</a>. The sweep produces an HTML report at <code>docs/meta/reports/YYYY-MM-DD-meta-audit.html</code> plus machine-readable JSON.</p>
         </div>
       </section>
 
@@ -818,7 +818,7 @@ gaia dev validate --intake   <span class="c"># validate intake batch too</span><
 
         <h3>Where does long-form guidance go?</h3>
         <div class="section-body">
-          <p>Review standards, curation heuristics, edge cases, and troubleshooting live in the <a href="https://github.com/mbtiongson1/gaia-skill-tree/wiki">GitHub Wiki</a>. Keep PRs and code comments focused on the specific change.</p>
+          <p>Review standards, curation heuristics, edge cases, and troubleshooting live in the <a href="https://github.com/gaia-research/gaia-skill-tree/wiki">GitHub Wiki</a>. Keep PRs and code comments focused on the specific change.</p>
         </div>
 
         <h3>Can I edit <code>registry/nodes/*.json</code> directly?</h3>
@@ -833,7 +833,7 @@ gaia dev validate --intake   <span class="c"># validate intake batch too</span><
       </section>
 
       <footer class="page-footer">
-        <span>Gaia v6.1.8 — <a href="https://github.com/mbtiongson1/gaia-skill-tree">mbtiongson1/gaia-skill-tree</a></span>
+        <span>Gaia v6.1.8 — <a href="https://github.com/gaia-research/gaia-skill-tree">gaia-research/gaia-skill-tree</a></span>
         <a href="index.html">← Back to Docs</a>
       </footer>
     </main>

--- a/docs/en/evidence-classes.html
+++ b/docs/en/evidence-classes.html
@@ -701,7 +701,7 @@
     <div class="docs-footer-links">
       <a href="index.html">← Docs Home</a>
       <a href="contributing.html">Contributing →</a>
-      <a href="https://github.com/mbtiongson1/gaia-skill-tree" target="_blank" rel="noopener">GitHub ↗</a>
+      <a href="https://github.com/gaia-research/gaia-skill-tree" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </footer>
 

--- a/docs/en/faq.html
+++ b/docs/en/faq.html
@@ -728,7 +728,7 @@
             <div class="faq-answer-inner">
               <p>
                 Only <code>gaia_propose</code> requires <code>GITHUB_TOKEN</code>. It opens a
-                pull request on <code>mbtiongson1/gaia-skill-tree</code> to claim a fusion or
+                pull request on <code>gaia-research/gaia-skill-tree</code> to claim a fusion or
                 propose a new skill. All read-only tools work without a token.
               </p>
               <p>
@@ -898,7 +898,7 @@
             <li><a href="fusion.html">Skill Fusion</a></li>
             <li><a href="mcp-server.html">MCP Server</a></li>
             <li><a href="faq.html" style="color:var(--tier-basic,#38bdf8);">FAQ</a></li>
-            <li><a href="https://github.com/mbtiongson1/gaia-skill-tree" target="_blank" rel="noopener">GitHub</a></li>
+            <li><a href="https://github.com/gaia-research/gaia-skill-tree" target="_blank" rel="noopener">GitHub</a></li>
           </ul>
         </div>
       </nav>

--- a/docs/en/fusion.html
+++ b/docs/en/fusion.html
@@ -1024,7 +1024,7 @@
             <li><a href="named-skills.html">Named Skills</a></li>
             <li><a href="evidence-classes.html">Evidence Classes</a></li>
             <li><a href="fusion.html" style="color:var(--tier-basic,#38bdf8);">Skill Fusion</a></li>
-            <li><a href="https://github.com/mbtiongson1/gaia-skill-tree" target="_blank" rel="noopener" class="footer-ext">GitHub</a></li>
+            <li><a href="https://github.com/gaia-research/gaia-skill-tree" target="_blank" rel="noopener" class="footer-ext">GitHub</a></li>
           </ul>
         </div>
       </nav>

--- a/docs/en/getting-started.html
+++ b/docs/en/getting-started.html
@@ -624,7 +624,7 @@
 
         <div class="code-fence">
           <div class="code-fence-header"><span class="code-fence-label">shell</span></div>
-          <pre><span class="cmd">git clone https://github.com/mbtiongson1/gaia-skill-tree.git</span>
+          <pre><span class="cmd">git clone https://github.com/gaia-research/gaia-skill-tree.git</span>
 <span class="cmd">cd gaia-skill-tree</span>
 <span class="cmd">python -m venv .venv &amp;&amp; source .venv/bin/activate</span>
 <span class="cmd">pip install -e ".[dev,embeddings]"</span></pre>

--- a/docs/en/index.html
+++ b/docs/en/index.html
@@ -596,8 +596,8 @@
           <span class="footer-col-heading">Contribute</span>
           <ul>
             <li><a href="../index.html#paths">Push a skill</a></li>
-            <li><a href="https://github.com/mbtiongson1/gaia-skill-tree" target="_blank" rel="noopener" class="footer-ext">GitHub</a></li>
-            <li><a href="https://github.com/mbtiongson1/gaia-skill-tree/issues" target="_blank" rel="noopener" class="footer-ext">Open Issues</a></li>
+            <li><a href="https://github.com/gaia-research/gaia-skill-tree" target="_blank" rel="noopener" class="footer-ext">GitHub</a></li>
+            <li><a href="https://github.com/gaia-research/gaia-skill-tree/issues" target="_blank" rel="noopener" class="footer-ext">Open Issues</a></li>
             <li><a href="../about.html">About Gaia</a></li>
           </ul>
         </div>

--- a/docs/en/mcp-server.html
+++ b/docs/en/mcp-server.html
@@ -1154,7 +1154,7 @@
             <li><a href="fusion.html">Skill Fusion</a></li>
             <li><a href="mcp-server.html" style="color:var(--tier-basic,#38bdf8);">MCP Server</a></li>
             <li><a href="faq.html">FAQ</a></li>
-            <li><a href="https://github.com/mbtiongson1/gaia-skill-tree" target="_blank" rel="noopener">GitHub</a></li>
+            <li><a href="https://github.com/gaia-research/gaia-skill-tree" target="_blank" rel="noopener">GitHub</a></li>
           </ul>
         </div>
       </nav>

--- a/docs/en/named-skills.html
+++ b/docs/en/named-skills.html
@@ -720,7 +720,7 @@
         </div>
 
         <div class="callout info">
-          <strong>CLI command (when implemented):</strong> <code>gaia lookup web-scrape</code> lists all bucket entries with role labels. See <a href="https://github.com/mbtiongson1/gaia-skill-tree/issues/71">issue #71</a> for the full spec.
+          <strong>CLI command (when implemented):</strong> <code>gaia lookup web-scrape</code> lists all bucket entries with role labels. See <a href="https://github.com/gaia-research/gaia-skill-tree/issues/71">issue #71</a> for the full spec.
         </div>
 
         <h3>Frontmatter fields</h3>
@@ -1015,7 +1015,7 @@ links:
       </section>
 
       <footer class="page-footer">
-        <span>Gaia v6.1.8 — <a href="https://github.com/mbtiongson1/gaia-skill-tree">mbtiongson1/gaia-skill-tree</a></span>
+        <span>Gaia v6.1.8 — <a href="https://github.com/gaia-research/gaia-skill-tree">gaia-research/gaia-skill-tree</a></span>
         <a href="index.html">← Back to Docs</a>
       </footer>
     </main>

--- a/docs/en/share-bundles.html
+++ b/docs/en/share-bundles.html
@@ -626,7 +626,7 @@ Summary:
   <span class="key">"bundleVersion"</span>: <span class="val">"1"</span>,
   <span class="key">"generatedAt"</span>:   <span class="val">"2026-06-12T13:00:00Z"</span>,
   <span class="key">"sharer"</span>:        <span class="val">"marco"</span>,
-  <span class="key">"sourceRepo"</span>:    <span class="val">"https://github.com/mbtiongson1/gaia-skill-tree"</span>,
+  <span class="key">"sourceRepo"</span>:    <span class="val">"https://github.com/gaia-research/gaia-skill-tree"</span>,
   <span class="key">"tree"</span>: { … },          <span class="c">// Part 1 — tree snapshot</span>
   <span class="key">"skillMeta"</span>: { … },    <span class="c">// Part 3 — pre-resolved metadata</span>
   <span class="key">"install"</span>: [ … ]       <span class="c">// Part 2 — install manifest</span>
@@ -678,7 +678,7 @@ Summary:
         <h2>Known Issues</h2>
 
         <h3>No static copy-link page (Issue #128)</h3>
-        <p>The planned <code>docs/share/</code> page — a static web UI where you paste a bundle URL and get a shareable copy-link — is a deferred fast-follow tracked in <a href="https://github.com/mbtiongson1/gaia-skill-tree/issues/128" target="_blank" rel="noopener">Issue #128</a>. Until it ships, share bundles must be distributed as raw files or URLs pointing to raw JSON.</p>
+        <p>The planned <code>docs/share/</code> page — a static web UI where you paste a bundle URL and get a shareable copy-link — is a deferred fast-follow tracked in <a href="https://github.com/gaia-research/gaia-skill-tree/issues/128" target="_blank" rel="noopener">Issue #128</a>. Until it ships, share bundles must be distributed as raw files or URLs pointing to raw JSON.</p>
 
         <h3>Private-repo skills resolve as unresolved</h3>
         <p>If a Named Skill's source repository is private, the direct-URL path fails and the skill lands in the <em>unresolved</em> count. The producer still includes the skill in <code>skillMeta</code> for preview rendering, but the manifest entry is omitted because there is no public source to fetch from.</p>
@@ -698,7 +698,7 @@ Summary:
           Gaia Docs · <span id="footerVersion">v6.1.8</span>
         </div>
         <div class="page-footer-right">
-          <a href="https://github.com/mbtiongson1/gaia-skill-tree" target="_blank" rel="noopener">Registry →</a>
+          <a href="https://github.com/gaia-research/gaia-skill-tree" target="_blank" rel="noopener">Registry →</a>
         </div>
       </footer>
 

--- a/docs/en/skill-hierarchy.html
+++ b/docs/en/skill-hierarchy.html
@@ -877,7 +877,7 @@
         <div class="section-body">
           <p>
             A Named Skill is a canonical skill that has been claimed by a real contributor
-            with Class C evidence or better. At the moment of naming, the skill reaches 2★
+            with Bronze (Grade C) evidence or better. At the moment of naming, the skill reaches 2★
             Named rank. The contributor's name attaches permanently as the
             <strong>Origin Contributor</strong> and renders in honor red across the registry.
           </p>
@@ -1030,7 +1030,7 @@
     <div class="docs-footer-right">
       <a href="index.html" style="color:var(--muted,#64748b);">Docs</a>
       <a href="../index.html" style="color:var(--muted,#64748b);">Atlas</a>
-      <a href="https://github.com/mbtiongson1/gaia-skill-tree" target="_blank" rel="noopener" style="color:var(--muted,#64748b);">GitHub</a>
+      <a href="https://github.com/gaia-research/gaia-skill-tree" target="_blank" rel="noopener" style="color:var(--muted,#64748b);">GitHub</a>
     </div>
   </footer>
 

--- a/docs/en/timeline-audit.html
+++ b/docs/en/timeline-audit.html
@@ -1018,7 +1018,7 @@ git log --oneline --all | grep -iE "demot|star-bar|calibrat|reclassif"</pre>
             <li><a href="mcp-server.html">MCP Server</a></li>
             <li><a href="timeline-audit.html" style="color:var(--tier-basic,#38bdf8);">Timeline Audit</a></li>
             <li><a href="faq.html">FAQ</a></li>
-            <li><a href="https://github.com/mbtiongson1/gaia-skill-tree" target="_blank" rel="noopener">GitHub</a></li>
+            <li><a href="https://github.com/gaia-research/gaia-skill-tree" target="_blank" rel="noopener">GitHub</a></li>
           </ul>
         </div>
       </nav>

--- a/docs/index.html
+++ b/docs/index.html
@@ -663,7 +663,7 @@
             </div>
             <div class="rite-term">
               <pre><span class="cmd">claude mcp add</span> <span class="str">gaia</span> -- <span class="cmd">npx</span> <span class="str">@gaia-registry/mcp-server</span></pre>
-              <div class="qs-tip mt-sm"><span class="qs-tip-icon">💡</span><span>Any MCP-compatible agent: use <code>npx @gaia-registry/mcp-server</code>. See <a href="https://github.com/mbtiongson1/gaia-skill-tree/tree/main/packages/mcp" target="_blank" class="text-tier-basic">packages/mcp</a> for config-file examples.</span></div>
+              <div class="qs-tip mt-sm"><span class="qs-tip-icon">💡</span><span>Any MCP-compatible agent: use <code>npx @gaia-registry/mcp-server</code>. See <a href="https://github.com/gaia-research/gaia-skill-tree/tree/main/packages/mcp" target="_blank" class="text-tier-basic">packages/mcp</a> for config-file examples.</span></div>
             </div>
           </li>
           <li class="rite-step">
@@ -701,7 +701,7 @@
           <div class="ult-loading">Loading ultimates…</div>
         </div>
         <div class="path-cta" style="display:flex;gap:.75rem;flex-wrap:wrap;align-items:center;">
-          <a href="https://github.com/mbtiongson1/gaia-skill-tree/issues" target="_blank" rel="noopener" class="btn btn-ghost propose-cta text-sm">
+          <a href="https://github.com/gaia-research/gaia-skill-tree/issues" target="_blank" rel="noopener" class="btn btn-ghost propose-cta text-sm">
             <svg class="ico propose-gh" width="14" height="14" aria-hidden="true"><use href="assets/icons.svg#github"/></svg>
             Propose a new Ultimate →
           </a>

--- a/docs/js/site-footer.js
+++ b/docs/js/site-footer.js
@@ -82,8 +82,8 @@
             <span class="footer-col-heading">Contribute</span>
             <ul>
               <li><a href="${r}index.html#paths">Push a skill</a></li>
-              <li><a href="https://github.com/mbtiongson1/gaia-skill-tree" target="_blank" rel="noopener" class="footer-ext">GitHub</a></li>
-              <li><a href="https://github.com/mbtiongson1/gaia-skill-tree/issues" target="_blank" rel="noopener" class="footer-ext">Open Issues</a></li>
+              <li><a href="https://github.com/gaia-research/gaia-skill-tree" target="_blank" rel="noopener" class="footer-ext">GitHub</a></li>
+              <li><a href="https://github.com/gaia-research/gaia-skill-tree/issues" target="_blank" rel="noopener" class="footer-ext">Open Issues</a></li>
             </ul>
           </div>
 
@@ -111,7 +111,7 @@
         <span class="footer-bottom-sep">—</span>
         <span>Gaia Registry</span>
         <span class="footer-bottom-sep">·</span>
-        <a href="https://github.com/mbtiongson1/gaia-skill-tree" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://github.com/gaia-research/gaia-skill-tree" target="_blank" rel="noopener">GitHub</a>
         <span class="footer-bottom-sep">·</span>
         <a href="${r}privacy.html">Privacy</a>
       </div>

--- a/docs/js/skill-explorer.js
+++ b/docs/js/skill-explorer.js
@@ -19,7 +19,7 @@
   var REPO_SLUG = (function(){
     var m = location.hostname.match(/^(.+)\.github\.io$/);
     if (m) return m[1] + '/gaia-skill-tree';
-    return 'mbtiongson1/gaia-skill-tree';
+    return 'gaia-research/gaia-skill-tree';
   })();
 
   function esc(v) {
@@ -1197,7 +1197,7 @@
           '</a>' +
           ((!redacted && ns.contributor && ns.contributor !== 'generic')
             ? '<a id="seSubmitEvidenceInline" href="' +
-                'https://github.com/mbtiongson1/gaia-skill-tree/issues/new' +
+                'https://github.com/gaia-research/gaia-skill-tree/issues/new' +
                 '?labels=evidence' +
                 '&title=' + encodeURIComponent('Evidence for ' + (ns.id||'')) +
                 '&body=' + encodeURIComponent(

--- a/docs/samples/index.html
+++ b/docs/samples/index.html
@@ -632,11 +632,11 @@
     </div>
     <div class="si-footer-group">
       <div class="si-footer-label">Glossary</div>
-      <a href="https://github.com/mbtiongson1/gaia-skill-tree/blob/main/CONTEXT.md" target="_blank" rel="noopener">CONTEXT.md — domain language &amp; banned synonyms</a>
+      <a href="https://github.com/gaia-research/gaia-skill-tree/blob/main/CONTEXT.md" target="_blank" rel="noopener">CONTEXT.md — domain language &amp; banned synonyms</a>
     </div>
     <div class="si-footer-group">
       <div class="si-footer-label">Visual language</div>
-      <a href="https://github.com/mbtiongson1/gaia-skill-tree/blob/main/DESIGN.md" target="_blank" rel="noopener">DESIGN.md — visual system &amp; design decisions</a>
+      <a href="https://github.com/gaia-research/gaia-skill-tree/blob/main/DESIGN.md" target="_blank" rel="noopener">DESIGN.md — visual system &amp; design decisions</a>
     </div>
   </div>
 

--- a/docs/trust/leaderboard/index.html
+++ b/docs/trust/leaderboard/index.html
@@ -191,7 +191,7 @@
       <h3 class="lb-cta-title">Is your AI skill missing?</h3>
       <p class="lb-cta-body">Push it to the registry. Evidence gets you on the board.</p>
       <pre class="lb-cta-code"><code><span class="cmd">gaia</span> push</code></pre>
-      <a class="lb-cta-link" href="https://github.com/mbtiongson1/gaia-skill-tree/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">Contributing Guide →</a>
+      <a class="lb-cta-link" href="https://github.com/gaia-research/gaia-skill-tree/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">Contributing Guide →</a>
     </section>
   </main>
   </div>

--- a/docs/trust/ledger/index.html
+++ b/docs/trust/ledger/index.html
@@ -102,7 +102,7 @@
       </div>
       <div class="lb-ledger__row">
         <span class="lb-ledger__key">May / June</span>
-        <span class="lb-ledger__val"><strong>May</strong> = stars on the eve of the G7 cutover (2026-06-18), under the pre-G7 meta. <strong>June</strong> = current stars under G7 (<a href="https://github.com/mbtiongson1/gaia-skill-tree/issues/715" target="_blank" rel="noopener">RFC §10.10</a>). Differences reflect grade-driven re-anchoring at ratification.</span>
+        <span class="lb-ledger__val"><strong>May</strong> = stars on the eve of the G7 cutover (2026-06-18), under the pre-G7 meta. <strong>June</strong> = current stars under G7 (<a href="https://github.com/gaia-research/gaia-skill-tree/issues/715" target="_blank" rel="noopener">RFC §10.10</a>). Differences reflect grade-driven re-anchoring at ratification.</span>
       </div>
       <div class="lb-ledger__row">
         <span class="lb-ledger__key">Rank #</span>

--- a/docs/wiki.md
+++ b/docs/wiki.md
@@ -2,7 +2,7 @@
 
 The long-form contributing guide is maintained in the GitHub Wiki repository:
 
-- Wiki home: https://github.com/mbtiongson1/gaia-skill-tree/wiki
-- Wiki git repo: https://github.com/mbtiongson1/gaia-skill-tree.wiki.git
+- Wiki home: https://github.com/gaia-research/gaia-skill-tree/wiki
+- Wiki git repo: https://github.com/gaia-research/gaia-skill-tree.wiki.git
 
 Use `CONTRIBUTING.md` for quickstart content in this repo. Keep extended reviewer policy, playbooks, and deep troubleshooting in the wiki repo.

--- a/src/gaia_cli/CLAUDE.md
+++ b/src/gaia_cli/CLAUDE.md
@@ -177,7 +177,7 @@ symlinked `.claude/skills → .agents/skills` from producing duplicate results.
 Warning: Using bundled registry snapshot from <DATE>. Run `gaia pull` for the latest.
 ```
 
-**`gaia pull` / `gaia fetch`:** Downloads `gaia-artifacts.tar.gz` from the latest GitHub Release (`https://api.github.com/repos/mbtiongson1/gaia-skill-tree/releases/latest`), verifies the SHA256 checksum if present, and unpacks into `.gaia/registry/`. This path takes priority over the bundled snapshot in subsequent invocations (resolution step 3 via `.gaia/config.toml`, or step 4 if CWD is the checkout).
+**`gaia pull` / `gaia fetch`:** Downloads `gaia-artifacts.tar.gz` from the latest GitHub Release (`https://api.github.com/repos/gaia-research/gaia-skill-tree/releases/latest`), verifies the SHA256 checksum if present, and unpacks into `.gaia/registry/`. This path takes priority over the bundled snapshot in subsequent invocations (resolution step 3 via `.gaia/config.toml`, or step 4 if CWD is the checkout).
 
 ---
 


### PR DESCRIPTION
Wave-1 docs batch for the 2026-07 triage sprint. Targets `dev/triage-sprint-2026-07`.

## #917 — drop last deprecated Evidence-Class reference
`docs/en/skill-hierarchy.html:880` "with Class C evidence or better" → "with Bronze (Grade C) evidence or better". Per the triage comment, the `#evidence` section, sidebar link, and all `--class A/B/C` CLI examples were already removed; this was the sole residual.

## #874 — org migration sweep (scoped: live source + hand-authored HTML)
Replaced the exact old-repo string `mbtiongson1/gaia-skill-tree` → `gaia-research/gaia-skill-tree` across:
- Hand-authored HTML under `docs/**` (about, codex, trust, en/*, index, samples)
- Live site JS: `docs/js/site-footer.js`, `docs/js/skill-explorer.js` (incl. the `getRootPath` fallback return + issue-submit URL) — both pass `node --check`
- `src/gaia_cli/CLAUDE.md:180` `gaia pull` release-fetch API URL doc

**Deliberately preserved:** bare contributor-handle links (`github.com/mbtiongson1`, no `/gaia-skill-tree`) — that's the human handle, not the org.
**Deliberately excluded** (own scoped branches / generated): Class S artifacts (`docs/api`, `docs/graph`, `docs/badges`, `docs/u`), `scripts/` files (infra scope), `founder/`, `.impeccable/drafts/`, historical `docs/meta/reports`. The `mbtiongson1/skill-fuse` repo URL is left as-is — that repo has not been transferred to the org yet (issue #1004).

## #1004 — skill-fuse ecosystem mention (README only, here)
Added an **Ecosystem** section to README linking [skill-fuse](https://github.com/mbtiongson1/skill-fuse). The CLAUDE.md `/fuse` entry + the actual skill import land on the infra branch (`.claude/skills/` scope), per the operator's follow-up to add it into the repo.

## Entrypoints
No new pages/sections added — text edits to existing surfaces only. README gains a top-level Ecosystem heading (peer of Agent Discovery).

Refs #917, #874, #1004 (partial — remaining #1004 items on infra branch + a curation follow-up).