### PR TITLE
fix(cli): graph palette drift (#332) + pushable highlight (#139) + promotion box cutoff (#118)

### DIFF
--- a/docs/graph/gaia.svg
+++ b/docs/graph/gaia.svg
@@ -13,407 +13,407 @@
 <circle cx="640.0" cy="440.0" r="54"/>
 </g>
 <g class="edges" fill="none">
-<line x1="383.265" y1="316.257" x2="649.288" y2="609.746" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="542.068" y1="578.958" x2="649.288" y2="609.746" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="648.66" y1="270.221" x2="641.078" y2="270.003" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="478.186" y1="387.882" x2="641.078" y2="270.003" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="850.292" y1="632.359" x2="641.078" y2="270.003" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="478.484" y1="205.186" x2="515.9" y2="323.814" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="494.286" y1="684.933" x2="515.9" y2="323.814" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="497.18" y1="193.368" x2="648.66" y2="270.221" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="708.121" y1="716.739" x2="648.66" y2="270.221" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="587.169" y1="720.06" x2="522.197" y2="317.434" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="478.484" y1="205.186" x2="522.197" y2="317.434" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="390.555" y1="577.848" x2="522.197" y2="317.434" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="419.183" y1="620.18" x2="658.024" y2="270.958" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="550.892" y1="584.775" x2="658.024" y2="270.958" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="588.153" y1="601.901" x2="542.014" y2="301.08" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="658.024" y1="270.958" x2="542.014" y2="301.08" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="358.238" y1="397.161" x2="542.014" y2="301.08" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="418.988" y1="260.059" x2="542.014" y2="301.08" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="428.745" y1="248.698" x2="542.014" y2="301.08" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="699.704" y1="599.171" x2="665.161" y2="271.872" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="869.9" y1="608.437" x2="665.161" y2="271.872" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="836.909" y1="233.961" x2="674.044" y2="273.444" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="369.314" y1="529.187" x2="674.044" y2="273.444" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="555.61" y1="167.781" x2="674.044" y2="273.444" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="361.23" y1="499.264" x2="638.61" y2="609.994" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="782.979" y1="193.46" x2="638.61" y2="609.994" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="881.464" y1="288.606" x2="638.61" y2="609.994" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="744.329" y1="305.778" x2="683.306" y2="275.608" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="923.692" y1="467.276" x2="683.306" y2="275.608" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="779.063" y1="537.783" x2="683.306" y2="275.608" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="467.39" y1="213.217" x2="488.019" y2="516.169" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="782.979" y1="193.46" x2="488.019" y2="516.169" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="881.464" y1="288.606" x2="488.019" y2="516.169" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="788.062" y1="356.468" x2="629.903" y2="609.7" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="799.917" y1="382.323" x2="629.903" y2="609.7" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="779.063" y1="537.783" x2="629.903" y2="609.7" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="500.345" y1="536.936" x2="629.903" y2="609.7" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="453.881" y1="655.835" x2="629.903" y2="609.7" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="799.173" y1="676.409" x2="483.263" y2="505.828" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="525.927" y1="178.825" x2="483.263" y2="505.828" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="453.881" y1="655.835" x2="698.311" y2="280.313" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="810.921" y1="211.941" x2="698.311" y2="280.313" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="629.903" y1="609.7" x2="623.48" y2="609.195" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="587.169" y1="720.06" x2="623.48" y2="609.195" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="478.484" y1="205.186" x2="623.48" y2="609.195" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="919.118" y1="382.396" x2="708.082" y2="284.228" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="924.87" y1="448.591" x2="708.082" y2="284.228" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="625.891" y1="724.651" x2="708.082" y2="284.228" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="640.139" y1="155.0" x2="614.369" y2="608.057" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="494.286" y1="684.933" x2="614.369" y2="608.057" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="467.39" y1="213.217" x2="480.57" y2="499.009" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="849.003" y1="246.24" x2="480.57" y2="499.009" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="497.18" y1="193.368" x2="480.57" y2="499.009" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="640.139" y1="155.0" x2="715.118" y2="287.497" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="836.909" y1="233.961" x2="715.118" y2="287.497" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="688.939" y1="159.233" x2="722.37" y2="291.288" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="915.332" y1="366.398" x2="722.37" y2="291.288" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="921.935" y1="481.683" x2="722.37" y2="291.288" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="836.398" y1="646.526" x2="722.37" y2="291.288" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="825.679" y1="656.214" x2="722.37" y2="291.288" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="757.4" y1="180.304" x2="728.734" y2="294.996" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="676.083" y1="722.707" x2="728.734" y2="294.996" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="889.06" y1="301.457" x2="728.734" y2="294.996" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="525.927" y1="178.825" x2="737.293" y2="300.594" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="550.892" y1="584.775" x2="737.293" y2="300.594" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="756.394" y1="700.149" x2="737.293" y2="300.594" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="905.049" y1="335.243" x2="744.329" y2="305.778" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="836.909" y1="233.961" x2="744.329" y2="305.778" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="587.169" y1="720.06" x2="744.329" y2="305.778" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="699.704" y1="599.171" x2="477.688" y2="490.544" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="782.979" y1="193.46" x2="477.688" y2="490.544" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="467.39" y1="213.217" x2="607.189" y2="606.804" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="467.47" y1="666.844" x2="607.189" y2="606.804" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="497.18" y1="193.368" x2="475.427" y2="482.609" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="869.9" y1="608.437" x2="475.427" y2="482.609" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="698.311" y1="280.313" x2="473.44" y2="474.024" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="903.846" y1="547.751" x2="473.44" y2="474.024" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="497.18" y1="193.368" x2="471.769" y2="464.461" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="881.464" y1="288.606" x2="471.769" y2="464.461" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="869.9" y1="608.437" x2="470.928" y2="457.739" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="910.906" y1="528.517" x2="470.928" y2="457.739" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="383.265" y1="316.257" x2="480.645" y2="380.789" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="441.136" y1="235.847" x2="480.645" y2="380.789" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="910.906" y1="528.517" x2="596.539" y2="604.351" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="872.123" y1="274.64" x2="596.539" y2="604.351" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="428.745" y1="248.698" x2="588.153" y2="601.901" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="550.892" y1="584.775" x2="588.153" y2="601.901" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="889.06" y1="301.457" x2="750.521" y2="310.829" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="369.314" y1="529.187" x2="750.521" y2="310.829" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="919.438" y1="496.029" x2="750.521" y2="310.829" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="896.887" y1="563.427" x2="750.521" y2="310.829" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="889.875" y1="577.068" x2="750.521" y2="310.829" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="587.169" y1="720.06" x2="750.521" y2="310.829" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="355.07" y1="446.302" x2="549.911" y2="295.834" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="356.271" y1="466.887" x2="549.911" y2="295.834" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="355.156" y1="430.585" x2="549.911" y2="295.834" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="698.311" y1="280.313" x2="470.175" y2="447.703" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="638.61" y1="609.994" x2="470.175" y2="447.703" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="497.18" y1="193.368" x2="756.963" y2="316.632" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="897.523" y1="317.905" x2="756.963" y2="316.632" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="590.903" y1="159.261" x2="756.963" y2="316.632" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="488.019" y1="516.169" x2="621.859" y2="270.971" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="538.251" y1="173.782" x2="621.859" y2="270.971" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="606.987" y1="273.236" x2="621.859" y2="270.971" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="483.267" y1="374.161" x2="621.859" y2="270.971" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="512.132" y1="185.295" x2="621.859" y2="270.971" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="505.916" y1="335.494" x2="621.859" y2="270.971" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="796.917" y1="202.088" x2="621.859" y2="270.971" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="475.756" y1="396.136" x2="621.859" y2="270.971" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="492.017" y1="523.671" x2="621.859" y2="270.971" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="515.9" y1="323.814" x2="621.859" y2="270.971" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="613.93" y1="272.011" x2="470.0" y2="440.289" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="494.286" y1="684.933" x2="470.0" y2="440.289" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="836.909" y1="233.961" x2="763.729" y2="323.419" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="497.18" y1="193.368" x2="763.729" y2="323.419" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="625.891" y1="724.651" x2="763.729" y2="323.419" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="744.329" y1="305.778" x2="768.848" y2="329.103" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="905.049" y1="335.243" x2="768.848" y2="329.103" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="625.891" y1="724.651" x2="768.848" y2="329.103" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="480.57" y1="499.009" x2="470.239" y2="430.983" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="849.003" y1="246.24" x2="470.239" y2="430.983" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="525.927" y1="178.825" x2="646.334" y2="386.373" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="497.18" y1="193.368" x2="646.334" y2="386.373" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="480.57" y1="499.009" x2="646.334" y2="386.373" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="624.529" y1="155.42" x2="646.334" y2="386.373" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="606.987" y1="273.236" x2="646.334" y2="386.373" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="473.44" y1="474.024" x2="646.334" y2="386.373" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="475.427" y1="482.609" x2="646.334" y2="386.373" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="467.39" y1="213.217" x2="646.334" y2="386.373" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="495.739" y1="350.062" x2="646.334" y2="386.373" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="470.175" y1="447.703" x2="646.334" y2="386.373" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="470.239" y1="430.983" x2="646.334" y2="386.373" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="477.688" y1="490.544" x2="646.334" y2="386.373" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="471.769" y1="464.461" x2="646.334" y2="386.373" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="478.484" y1="205.186" x2="646.334" y2="386.373" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="698.311" y1="280.313" x2="646.334" y2="386.373" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="487.97" y1="363.929" x2="646.334" y2="386.373" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="455.164" y1="223.065" x2="646.334" y2="386.373" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="500.345" y1="536.936" x2="646.334" y2="386.373" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="491.599" y1="357.072" x2="646.334" y2="386.373" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="555.61" y1="167.781" x2="646.334" y2="386.373" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="542.068" y1="578.958" x2="646.334" y2="386.373" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="510.682" y1="550.349" x2="646.334" y2="386.373" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="638.61" y1="609.994" x2="646.334" y2="386.373" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="356.267" y1="413.155" x2="646.334" y2="386.373" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="550.892" y1="584.775" x2="646.334" y2="386.373" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="478.186" y1="387.882" x2="646.334" y2="386.373" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="557.175" y1="588.459" x2="646.334" y2="386.373" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="369.314" y1="529.187" x2="646.334" y2="386.373" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="496.299" y1="530.829" x2="646.334" y2="386.373" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="535.446" y1="574.047" x2="646.334" y2="386.373" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="573.008" y1="283.756" x2="646.334" y2="386.373" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="480.57" y1="499.009" x2="774.664" y2="336.242" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="638.61" y1="609.994" x2="774.664" y2="336.242" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="538.251" y1="173.782" x2="774.664" y2="336.242" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="606.095" y1="722.976" x2="780.216" y2="343.878" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="640.139" y1="155.0" x2="780.216" y2="343.878" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="508.367" y1="692.78" x2="780.216" y2="343.878" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="640.139" y1="155.0" x2="784.427" y2="350.329" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="836.909" y1="233.961" x2="784.427" y2="350.329" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="779.063" y1="537.783" x2="788.062" y2="356.468" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="555.61" y1="167.781" x2="788.062" y2="356.468" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="656.821" y1="155.497" x2="788.062" y2="356.468" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="480.57" y1="499.009" x2="472.09" y2="413.425" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="361.522" y1="379.379" x2="472.09" y2="413.425" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="477.688" y1="490.544" x2="472.09" y2="413.425" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="535.446" y1="574.047" x2="472.09" y2="413.425" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="699.704" y1="599.171" x2="472.09" y2="413.425" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="483.263" y1="505.828" x2="690.592" y2="421.12" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="613.93" y1="272.011" x2="690.592" y2="421.12" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="588.833" y1="277.883" x2="690.592" y2="421.12" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="511.928" y1="328.207" x2="690.592" y2="421.12" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="470.239" y1="430.983" x2="690.592" y2="421.12" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="512.132" y1="185.295" x2="564.7" y2="592.414" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="558.477" y1="290.822" x2="564.7" y2="592.414" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="475.427" y1="482.609" x2="473.461" y2="405.87" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="689.897" y1="720.598" x2="473.461" y2="405.87" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="473.461" y1="405.87" x2="475.756" y2="396.136" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="505.916" y1="335.494" x2="475.756" y2="396.136" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="478.484" y1="205.186" x2="475.756" y2="396.136" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="782.907" y1="686.582" x2="793.073" y2="366.051" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="737.688" y1="172.265" x2="793.073" y2="366.051" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="497.18" y1="193.368" x2="793.073" y2="366.051" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="497.18" y1="193.368" x2="478.186" y2="387.882" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="757.4" y1="180.304" x2="478.186" y2="387.882" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="606.095" y1="722.976" x2="478.186" y2="387.882" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="478.484" y1="205.186" x2="796.75" y2="374.202" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="656.821" y1="155.497" x2="796.75" y2="374.202" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="369.314" y1="529.187" x2="796.75" y2="374.202" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="889.06" y1="301.457" x2="558.477" y2="290.822" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="924.87" y1="448.591" x2="558.477" y2="290.822" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="500.345" y1="536.936" x2="799.917" y2="382.323" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="889.06" y1="301.457" x2="799.917" y2="382.323" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="872.123" y1="274.64" x2="799.917" y2="382.323" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="640.139" y1="155.0" x2="557.175" y2="588.459" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="782.907" y1="686.582" x2="557.175" y2="588.459" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="737.688" y1="172.265" x2="801.835" y2="387.948" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="924.901" y1="432.506" x2="801.835" y2="387.948" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="779.063" y1="537.783" x2="801.835" y2="387.948" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="587.169" y1="720.06" x2="801.835" y2="387.948" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="782.979" y1="193.46" x2="809.723" y2="430.295" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="836.909" y1="233.961" x2="809.723" y2="430.295" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="356.267" y1="413.155" x2="804.754" y2="398.094" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="538.251" y1="173.782" x2="804.754" y2="398.094" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="356.267" y1="413.155" x2="806.591" y2="406.124" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="500.481" y1="342.868" x2="806.591" y2="406.124" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="640.139" y1="155.0" x2="806.591" y2="406.124" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="390.555" y1="577.848" x2="550.892" y2="584.775" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="782.907" y1="686.582" x2="550.892" y2="584.775" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="640.139" y1="155.0" x2="808.227" y2="415.512" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="757.4" y1="180.304" x2="808.227" y2="415.512" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="744.329" y1="305.778" x2="809.232" y2="423.859" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="638.61" y1="609.994" x2="809.232" y2="423.859" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="467.39" y1="213.217" x2="809.232" y2="423.859" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="689.897" y1="720.598" x2="542.068" y2="578.958" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="497.18" y1="193.368" x2="542.068" y2="578.958" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="709.197" y1="163.528" x2="542.068" y2="578.958" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="807.945" y1="466.354" x2="810.0" y2="440.31" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="756.394" y1="700.149" x2="810.0" y2="440.31" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="508.367" y1="692.78" x2="810.0" y2="440.31" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="810.0" y1="440.31" x2="470.887" y2="422.658" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="614.369" y1="608.057" x2="470.887" y2="422.658" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="596.539" y1="604.351" x2="470.887" y2="422.658" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="470.887" y1="422.658" x2="676.907" y2="479.419" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="542.014" y1="301.08" x2="676.907" y2="479.419" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="472.09" y1="413.425" x2="676.907" y2="479.419" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="580.571" y1="280.726" x2="676.907" y2="479.419" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="566.312" y1="286.8" x2="676.907" y2="479.419" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="549.911" y1="295.834" x2="676.907" y2="479.419" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="921.774" y1="397.238" x2="809.725" y2="449.666" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="525.927" y1="178.825" x2="809.725" y2="449.666" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="924.87" y1="448.591" x2="809.725" y2="449.666" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="889.06" y1="301.457" x2="808.974" y2="458.647" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="558.477" y1="290.822" x2="808.974" y2="458.647" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="741.017" y1="706.497" x2="808.974" y2="458.647" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="478.484" y1="205.186" x2="530.151" y2="310.257" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="535.924" y1="305.582" x2="530.151" y2="310.257" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="782.907" y1="686.582" x2="535.924" y2="305.582" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="390.555" y1="577.848" x2="535.924" y2="305.582" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="756.394" y1="700.149" x2="807.945" y2="466.354" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="869.9" y1="608.437" x2="807.945" y2="466.354" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="508.367" y1="692.78" x2="807.945" y2="466.354" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="399.229" y1="592.493" x2="566.312" y2="286.8" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="381.858" y1="560.78" x2="566.312" y2="286.8" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="389.447" y1="304.176" x2="566.312" y2="286.8" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="590.903" y1="159.261" x2="566.312" y2="286.8" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="649.288" y1="609.746" x2="566.312" y2="286.8" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="555.61" y1="167.781" x2="483.267" y2="374.161" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="869.9" y1="608.437" x2="483.267" y2="374.161" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="744.329" y1="305.778" x2="806.641" y2="473.627" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="453.881" y1="655.835" x2="806.641" y2="473.627" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="625.891" y1="724.651" x2="806.641" y2="473.627" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="522.197" y1="317.434" x2="632.204" y2="270.179" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="390.555" y1="577.848" x2="632.204" y2="270.179" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="473.461" y1="405.87" x2="632.204" y2="270.179" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="500.481" y1="342.868" x2="632.204" y2="270.179" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="640.139" y1="155.0" x2="535.446" y2="574.047" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="512.132" y1="185.295" x2="535.446" y2="574.047" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="497.18" y1="193.368" x2="573.008" y2="283.756" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="909.919" y1="348.518" x2="573.008" y2="283.756" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="467.39" y1="213.217" x2="492.017" y2="523.671" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="782.979" y1="193.46" x2="492.017" y2="523.671" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="782.907" y1="686.582" x2="804.91" y2="481.288" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="720.689" y1="166.661" x2="804.91" y2="481.288" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="872.123" y1="274.64" x2="804.91" y2="481.288" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="708.121" y1="716.739" x2="804.91" y2="481.288" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="522.859" y1="699.813" x2="804.91" y2="481.288" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="814.956" y1="664.979" x2="804.91" y2="481.288" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="869.9" y1="608.437" x2="801.771" y2="492.25" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="494.286" y1="684.933" x2="801.771" y2="492.25" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="714.504" y1="592.804" x2="799.539" y2="498.714" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="550.892" y1="584.775" x2="799.539" y2="498.714" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="807.945" y1="466.354" x2="799.539" y2="498.714" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="419.183" y1="620.18" x2="580.571" y2="280.726" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="658.024" y1="270.958" x2="580.571" y2="280.726" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="522.516" y1="562.872" x2="529.723" y2="569.379" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="511.928" y1="328.207" x2="529.723" y2="569.379" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="488.019" y1="516.169" x2="795.857" y2="507.886" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="497.18" y1="193.368" x2="795.857" y2="507.886" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="807.945" y1="466.354" x2="795.857" y2="507.886" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="779.063" y1="537.783" x2="792.909" y2="514.29" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="467.39" y1="213.217" x2="792.909" y2="514.29" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="782.979" y1="193.46" x2="792.909" y2="514.29" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="782.907" y1="686.582" x2="580.475" y2="599.238" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="737.688" y1="172.265" x2="580.475" y2="599.238" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="497.18" y1="193.368" x2="580.475" y2="599.238" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="580.475" y1="599.238" x2="571.707" y2="595.679" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="792.909" y1="514.29" x2="571.707" y2="595.679" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="471.769" y1="464.461" x2="571.707" y2="595.679" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="889.06" y1="301.457" x2="788.631" y2="522.516" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="558.477" y1="290.822" x2="788.631" y2="522.516" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="487.97" y1="363.929" x2="788.631" y2="522.516" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="699.704" y1="599.171" x2="784.978" y2="528.778" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="782.979" y1="193.46" x2="784.978" y2="528.778" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="909.919" y1="348.518" x2="784.978" y2="528.778" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="480.57" y1="499.009" x2="522.516" y2="562.872" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="470.928" y1="457.739" x2="522.516" y2="562.872" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="453.881" y1="655.835" x2="779.063" y2="537.783" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="587.169" y1="720.06" x2="779.063" y2="537.783" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="737.688" y1="172.265" x2="779.063" y2="537.783" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="722.37" y1="291.288" x2="689.946" y2="277.503" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="919.118" y1="382.396" x2="689.946" y2="277.503" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="923.692" y1="467.276" x2="689.946" y2="277.503" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="779.063" y1="537.783" x2="689.946" y2="277.503" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="555.61" y1="167.781" x2="773.808" y2="544.858" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="737.688" y1="172.265" x2="773.808" y2="544.858" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="720.541" y1="713.383" x2="773.808" y2="544.858" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="903.846" y1="547.751" x2="681.549" y2="604.844" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="896.887" y1="563.427" x2="681.549" y2="604.844" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="480.57" y1="499.009" x2="487.97" y2="363.929" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="497.18" y1="193.368" x2="487.97" y2="363.929" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="909.919" y1="348.518" x2="491.599" y2="357.072" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="606.095" y1="722.976" x2="491.599" y2="357.072" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="467.39" y1="213.217" x2="491.599" y2="357.072" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="792.909" y1="514.29" x2="517.438" y2="557.807" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="491.599" y1="357.072" x2="517.438" y2="557.807" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="621.859" y1="270.971" x2="590.318" y2="418.842" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="632.204" y1="270.179" x2="590.318" y2="418.842" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="530.151" y1="310.257" x2="590.318" y2="418.842" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="500.481" y1="342.868" x2="590.318" y2="418.842" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="505.916" y1="335.494" x2="590.318" y2="418.842" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="648.66" y1="270.221" x2="510.682" y2="550.349" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="376.679" y1="330.971" x2="510.682" y2="550.349" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="625.891" y1="724.651" x2="510.682" y2="550.349" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="487.97" y1="363.929" x2="769.872" y2="549.696" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="850.292" y1="632.359" x2="769.872" y2="549.696" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="376.679" y1="330.971" x2="769.872" y2="549.696" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="698.311" y1="280.313" x2="763.112" y2="557.233" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="810.921" y1="211.941" x2="763.112" y2="557.233" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="470.0" y1="440.289" x2="588.833" y2="277.883" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="470.928" y1="457.739" x2="588.833" y2="277.883" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="480.57" y1="499.009" x2="588.833" y2="277.883" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="483.263" y1="505.828" x2="610.287" y2="485.09" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="470.928" y1="457.739" x2="610.287" y2="485.09" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="470.0" y1="440.289" x2="610.287" y2="485.09" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="470.239" y1="430.983" x2="610.287" y2="485.09" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="529.723" y1="569.379" x2="610.287" y2="485.09" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="522.516" y1="562.872" x2="610.287" y2="485.09" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="588.833" y1="277.883" x2="610.287" y2="485.09" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="495.739" y1="350.062" x2="610.287" y2="485.09" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="598.577" y1="275.124" x2="610.287" y2="485.09" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="511.928" y1="328.207" x2="610.287" y2="485.09" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="613.93" y1="272.011" x2="610.287" y2="485.09" stroke="#fbbf24" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="744.329" y1="305.778" x2="757.637" y2="562.725" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="471.769" y1="464.461" x2="757.637" y2="562.725" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="625.891" y1="724.651" x2="757.637" y2="562.725" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="919.118" y1="382.396" x2="495.739" y2="350.062" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="881.464" y1="288.606" x2="495.739" y2="350.062" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="905.049" y1="335.243" x2="751.385" y2="568.427" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="896.887" y1="563.427" x2="751.385" y2="568.427" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="369.314" y1="529.187" x2="751.385" y2="568.427" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="375.396" y1="545.876" x2="743.813" y2="574.621" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="558.477" y1="290.822" x2="743.813" y2="574.621" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="487.97" y1="363.929" x2="743.813" y2="574.621" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="494.286" y1="684.933" x2="737.578" y2="579.207" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="508.367" y1="692.78" x2="737.578" y2="579.207" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="467.39" y1="213.217" x2="500.481" y2="342.868" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="494.286" y1="684.933" x2="500.481" y2="342.868" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="479.178" y1="675.29" x2="729.069" y2="584.799" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="676.083" y1="722.707" x2="729.069" y2="584.799" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="656.821" y1="155.497" x2="729.069" y2="584.799" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="709.197" y1="163.528" x2="723.036" y2="588.341" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="869.9" y1="608.437" x2="723.036" y2="588.341" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="889.06" y1="301.457" x2="505.916" y2="335.494" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="799.173" y1="676.409" x2="505.916" y2="335.494" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="782.979" y1="193.46" x2="598.577" y2="275.124" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="494.286" y1="684.933" x2="598.577" y2="275.124" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="782.979" y1="193.46" x2="511.928" y2="328.207" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="689.897" y1="720.598" x2="511.928" y2="328.207" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="869.9" y1="608.437" x2="606.987" y2="273.236" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="756.394" y1="700.149" x2="606.987" y2="273.236" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="809.725" y1="449.666" x2="505.299" y2="543.71" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="639.641" y1="725.0" x2="505.299" y2="543.71" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="639.641" y1="725.0" x2="714.504" y2="592.804" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="525.927" y1="178.825" x2="714.504" y2="592.804" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="557.033" y1="712.656" x2="714.504" y2="592.804" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="455.164" y1="223.065" x2="674.797" y2="606.401" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="624.529" y1="155.42" x2="674.797" y2="606.401" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="480.57" y1="499.009" x2="665.813" y2="608.029" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="590.903" y1="159.261" x2="665.813" y2="608.029" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="571.707" y1="595.679" x2="656.662" y2="609.182" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="590.903" y1="159.261" x2="656.662" y2="609.182" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="681.549" y1="604.844" x2="656.662" y2="609.182" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="674.797" y1="606.401" x2="656.662" y2="609.182" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="665.813" y1="608.029" x2="656.662" y2="609.182" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="453.881" y1="655.835" x2="500.345" y2="536.936" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="903.846" y1="547.751" x2="500.345" y2="536.936" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="889.06" y1="301.457" x2="500.345" y2="536.936" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="782.907" y1="686.582" x2="706.63" y2="596.398" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="872.123" y1="274.64" x2="706.63" y2="596.398" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="587.169" y1="720.06" x2="706.63" y2="596.398" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="869.9" y1="608.437" x2="699.704" y2="599.171" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="494.286" y1="684.933" x2="699.704" y2="599.171" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="640.139" y1="155.0" x2="699.704" y2="599.171" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="640.139" y1="155.0" x2="496.299" y2="530.829" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="478.484" y1="205.186" x2="496.299" y2="530.829" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="869.9" y1="608.437" x2="613.93" y2="272.011" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="799.173" y1="676.409" x2="613.93" y2="272.011" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="698.311" y1="280.313" x2="691.441" y2="602.03" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="500.345" y1="536.936" x2="691.441" y2="602.03" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
-<line x1="699.704" y1="599.171" x2="691.441" y2="602.03" stroke="#a78bfa" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="383.265" y1="316.257" x2="649.288" y2="609.746" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="542.068" y1="578.958" x2="649.288" y2="609.746" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="648.66" y1="270.221" x2="641.078" y2="270.003" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="478.186" y1="387.882" x2="641.078" y2="270.003" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="850.292" y1="632.359" x2="641.078" y2="270.003" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="478.484" y1="205.186" x2="515.9" y2="323.814" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="494.286" y1="684.933" x2="515.9" y2="323.814" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="497.18" y1="193.368" x2="648.66" y2="270.221" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="708.121" y1="716.739" x2="648.66" y2="270.221" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="587.169" y1="720.06" x2="522.197" y2="317.434" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="478.484" y1="205.186" x2="522.197" y2="317.434" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="390.555" y1="577.848" x2="522.197" y2="317.434" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="419.183" y1="620.18" x2="658.024" y2="270.958" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="550.892" y1="584.775" x2="658.024" y2="270.958" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="588.153" y1="601.901" x2="542.014" y2="301.08" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="658.024" y1="270.958" x2="542.014" y2="301.08" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="358.238" y1="397.161" x2="542.014" y2="301.08" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="418.988" y1="260.059" x2="542.014" y2="301.08" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="428.745" y1="248.698" x2="542.014" y2="301.08" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="699.704" y1="599.171" x2="665.161" y2="271.872" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="869.9" y1="608.437" x2="665.161" y2="271.872" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="836.909" y1="233.961" x2="674.044" y2="273.444" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="369.314" y1="529.187" x2="674.044" y2="273.444" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="555.61" y1="167.781" x2="674.044" y2="273.444" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="361.23" y1="499.264" x2="638.61" y2="609.994" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="782.979" y1="193.46" x2="638.61" y2="609.994" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="881.464" y1="288.606" x2="638.61" y2="609.994" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="744.329" y1="305.778" x2="683.306" y2="275.608" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="923.692" y1="467.276" x2="683.306" y2="275.608" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="779.063" y1="537.783" x2="683.306" y2="275.608" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="467.39" y1="213.217" x2="488.019" y2="516.169" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="782.979" y1="193.46" x2="488.019" y2="516.169" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="881.464" y1="288.606" x2="488.019" y2="516.169" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="788.062" y1="356.468" x2="629.903" y2="609.7" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="799.917" y1="382.323" x2="629.903" y2="609.7" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="779.063" y1="537.783" x2="629.903" y2="609.7" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="500.345" y1="536.936" x2="629.903" y2="609.7" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="453.881" y1="655.835" x2="629.903" y2="609.7" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="799.173" y1="676.409" x2="483.263" y2="505.828" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="525.927" y1="178.825" x2="483.263" y2="505.828" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="453.881" y1="655.835" x2="698.311" y2="280.313" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="810.921" y1="211.941" x2="698.311" y2="280.313" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="629.903" y1="609.7" x2="623.48" y2="609.195" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="587.169" y1="720.06" x2="623.48" y2="609.195" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="478.484" y1="205.186" x2="623.48" y2="609.195" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="919.118" y1="382.396" x2="708.082" y2="284.228" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="924.87" y1="448.591" x2="708.082" y2="284.228" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="625.891" y1="724.651" x2="708.082" y2="284.228" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="640.139" y1="155.0" x2="614.369" y2="608.057" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="494.286" y1="684.933" x2="614.369" y2="608.057" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="467.39" y1="213.217" x2="480.57" y2="499.009" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="849.003" y1="246.24" x2="480.57" y2="499.009" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="497.18" y1="193.368" x2="480.57" y2="499.009" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="640.139" y1="155.0" x2="715.118" y2="287.497" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="836.909" y1="233.961" x2="715.118" y2="287.497" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="688.939" y1="159.233" x2="722.37" y2="291.288" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="915.332" y1="366.398" x2="722.37" y2="291.288" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="921.935" y1="481.683" x2="722.37" y2="291.288" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="836.398" y1="646.526" x2="722.37" y2="291.288" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="825.679" y1="656.214" x2="722.37" y2="291.288" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="757.4" y1="180.304" x2="728.734" y2="294.996" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="676.083" y1="722.707" x2="728.734" y2="294.996" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="889.06" y1="301.457" x2="728.734" y2="294.996" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="525.927" y1="178.825" x2="737.293" y2="300.594" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="550.892" y1="584.775" x2="737.293" y2="300.594" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="756.394" y1="700.149" x2="737.293" y2="300.594" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="905.049" y1="335.243" x2="744.329" y2="305.778" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="836.909" y1="233.961" x2="744.329" y2="305.778" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="587.169" y1="720.06" x2="744.329" y2="305.778" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="699.704" y1="599.171" x2="477.688" y2="490.544" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="782.979" y1="193.46" x2="477.688" y2="490.544" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="467.39" y1="213.217" x2="607.189" y2="606.804" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="467.47" y1="666.844" x2="607.189" y2="606.804" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="497.18" y1="193.368" x2="475.427" y2="482.609" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="869.9" y1="608.437" x2="475.427" y2="482.609" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="698.311" y1="280.313" x2="473.44" y2="474.024" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="903.846" y1="547.751" x2="473.44" y2="474.024" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="497.18" y1="193.368" x2="471.769" y2="464.461" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="881.464" y1="288.606" x2="471.769" y2="464.461" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="869.9" y1="608.437" x2="470.928" y2="457.739" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="910.906" y1="528.517" x2="470.928" y2="457.739" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="383.265" y1="316.257" x2="480.645" y2="380.789" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="441.136" y1="235.847" x2="480.645" y2="380.789" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="910.906" y1="528.517" x2="596.539" y2="604.351" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="872.123" y1="274.64" x2="596.539" y2="604.351" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="428.745" y1="248.698" x2="588.153" y2="601.901" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="550.892" y1="584.775" x2="588.153" y2="601.901" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="889.06" y1="301.457" x2="750.521" y2="310.829" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="369.314" y1="529.187" x2="750.521" y2="310.829" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="919.438" y1="496.029" x2="750.521" y2="310.829" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="896.887" y1="563.427" x2="750.521" y2="310.829" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="889.875" y1="577.068" x2="750.521" y2="310.829" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="587.169" y1="720.06" x2="750.521" y2="310.829" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="355.07" y1="446.302" x2="549.911" y2="295.834" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="356.271" y1="466.887" x2="549.911" y2="295.834" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="355.156" y1="430.585" x2="549.911" y2="295.834" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="698.311" y1="280.313" x2="470.175" y2="447.703" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="638.61" y1="609.994" x2="470.175" y2="447.703" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="497.18" y1="193.368" x2="756.963" y2="316.632" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="897.523" y1="317.905" x2="756.963" y2="316.632" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="590.903" y1="159.261" x2="756.963" y2="316.632" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="488.019" y1="516.169" x2="621.859" y2="270.971" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="538.251" y1="173.782" x2="621.859" y2="270.971" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="606.987" y1="273.236" x2="621.859" y2="270.971" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="483.267" y1="374.161" x2="621.859" y2="270.971" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="512.132" y1="185.295" x2="621.859" y2="270.971" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="505.916" y1="335.494" x2="621.859" y2="270.971" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="796.917" y1="202.088" x2="621.859" y2="270.971" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="475.756" y1="396.136" x2="621.859" y2="270.971" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="492.017" y1="523.671" x2="621.859" y2="270.971" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="515.9" y1="323.814" x2="621.859" y2="270.971" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="613.93" y1="272.011" x2="470.0" y2="440.289" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="494.286" y1="684.933" x2="470.0" y2="440.289" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="836.909" y1="233.961" x2="763.729" y2="323.419" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="497.18" y1="193.368" x2="763.729" y2="323.419" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="625.891" y1="724.651" x2="763.729" y2="323.419" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="744.329" y1="305.778" x2="768.848" y2="329.103" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="905.049" y1="335.243" x2="768.848" y2="329.103" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="625.891" y1="724.651" x2="768.848" y2="329.103" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="480.57" y1="499.009" x2="470.239" y2="430.983" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="849.003" y1="246.24" x2="470.239" y2="430.983" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="525.927" y1="178.825" x2="646.334" y2="386.373" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="497.18" y1="193.368" x2="646.334" y2="386.373" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="480.57" y1="499.009" x2="646.334" y2="386.373" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="624.529" y1="155.42" x2="646.334" y2="386.373" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="606.987" y1="273.236" x2="646.334" y2="386.373" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="473.44" y1="474.024" x2="646.334" y2="386.373" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="475.427" y1="482.609" x2="646.334" y2="386.373" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="467.39" y1="213.217" x2="646.334" y2="386.373" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="495.739" y1="350.062" x2="646.334" y2="386.373" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="470.175" y1="447.703" x2="646.334" y2="386.373" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="470.239" y1="430.983" x2="646.334" y2="386.373" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="477.688" y1="490.544" x2="646.334" y2="386.373" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="471.769" y1="464.461" x2="646.334" y2="386.373" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="478.484" y1="205.186" x2="646.334" y2="386.373" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="698.311" y1="280.313" x2="646.334" y2="386.373" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="487.97" y1="363.929" x2="646.334" y2="386.373" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="455.164" y1="223.065" x2="646.334" y2="386.373" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="500.345" y1="536.936" x2="646.334" y2="386.373" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="491.599" y1="357.072" x2="646.334" y2="386.373" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="555.61" y1="167.781" x2="646.334" y2="386.373" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="542.068" y1="578.958" x2="646.334" y2="386.373" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="510.682" y1="550.349" x2="646.334" y2="386.373" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="638.61" y1="609.994" x2="646.334" y2="386.373" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="356.267" y1="413.155" x2="646.334" y2="386.373" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="550.892" y1="584.775" x2="646.334" y2="386.373" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="478.186" y1="387.882" x2="646.334" y2="386.373" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="557.175" y1="588.459" x2="646.334" y2="386.373" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="369.314" y1="529.187" x2="646.334" y2="386.373" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="496.299" y1="530.829" x2="646.334" y2="386.373" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="535.446" y1="574.047" x2="646.334" y2="386.373" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="573.008" y1="283.756" x2="646.334" y2="386.373" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="480.57" y1="499.009" x2="774.664" y2="336.242" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="638.61" y1="609.994" x2="774.664" y2="336.242" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="538.251" y1="173.782" x2="774.664" y2="336.242" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="606.095" y1="722.976" x2="780.216" y2="343.878" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="640.139" y1="155.0" x2="780.216" y2="343.878" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="508.367" y1="692.78" x2="780.216" y2="343.878" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="640.139" y1="155.0" x2="784.427" y2="350.329" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="836.909" y1="233.961" x2="784.427" y2="350.329" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="779.063" y1="537.783" x2="788.062" y2="356.468" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="555.61" y1="167.781" x2="788.062" y2="356.468" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="656.821" y1="155.497" x2="788.062" y2="356.468" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="480.57" y1="499.009" x2="472.09" y2="413.425" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="361.522" y1="379.379" x2="472.09" y2="413.425" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="477.688" y1="490.544" x2="472.09" y2="413.425" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="535.446" y1="574.047" x2="472.09" y2="413.425" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="699.704" y1="599.171" x2="472.09" y2="413.425" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="483.263" y1="505.828" x2="690.592" y2="421.12" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="613.93" y1="272.011" x2="690.592" y2="421.12" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="588.833" y1="277.883" x2="690.592" y2="421.12" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="511.928" y1="328.207" x2="690.592" y2="421.12" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="470.239" y1="430.983" x2="690.592" y2="421.12" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="512.132" y1="185.295" x2="564.7" y2="592.414" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="558.477" y1="290.822" x2="564.7" y2="592.414" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="475.427" y1="482.609" x2="473.461" y2="405.87" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="689.897" y1="720.598" x2="473.461" y2="405.87" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="473.461" y1="405.87" x2="475.756" y2="396.136" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="505.916" y1="335.494" x2="475.756" y2="396.136" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="478.484" y1="205.186" x2="475.756" y2="396.136" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="782.907" y1="686.582" x2="793.073" y2="366.051" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="737.688" y1="172.265" x2="793.073" y2="366.051" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="497.18" y1="193.368" x2="793.073" y2="366.051" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="497.18" y1="193.368" x2="478.186" y2="387.882" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="757.4" y1="180.304" x2="478.186" y2="387.882" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="606.095" y1="722.976" x2="478.186" y2="387.882" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="478.484" y1="205.186" x2="796.75" y2="374.202" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="656.821" y1="155.497" x2="796.75" y2="374.202" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="369.314" y1="529.187" x2="796.75" y2="374.202" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="889.06" y1="301.457" x2="558.477" y2="290.822" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="924.87" y1="448.591" x2="558.477" y2="290.822" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="500.345" y1="536.936" x2="799.917" y2="382.323" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="889.06" y1="301.457" x2="799.917" y2="382.323" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="872.123" y1="274.64" x2="799.917" y2="382.323" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="640.139" y1="155.0" x2="557.175" y2="588.459" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="782.907" y1="686.582" x2="557.175" y2="588.459" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="737.688" y1="172.265" x2="801.835" y2="387.948" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="924.901" y1="432.506" x2="801.835" y2="387.948" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="779.063" y1="537.783" x2="801.835" y2="387.948" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="587.169" y1="720.06" x2="801.835" y2="387.948" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="782.979" y1="193.46" x2="809.723" y2="430.295" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="836.909" y1="233.961" x2="809.723" y2="430.295" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="356.267" y1="413.155" x2="804.754" y2="398.094" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="538.251" y1="173.782" x2="804.754" y2="398.094" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="356.267" y1="413.155" x2="806.591" y2="406.124" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="500.481" y1="342.868" x2="806.591" y2="406.124" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="640.139" y1="155.0" x2="806.591" y2="406.124" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="390.555" y1="577.848" x2="550.892" y2="584.775" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="782.907" y1="686.582" x2="550.892" y2="584.775" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="640.139" y1="155.0" x2="808.227" y2="415.512" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="757.4" y1="180.304" x2="808.227" y2="415.512" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="744.329" y1="305.778" x2="809.232" y2="423.859" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="638.61" y1="609.994" x2="809.232" y2="423.859" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="467.39" y1="213.217" x2="809.232" y2="423.859" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="689.897" y1="720.598" x2="542.068" y2="578.958" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="497.18" y1="193.368" x2="542.068" y2="578.958" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="709.197" y1="163.528" x2="542.068" y2="578.958" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="807.945" y1="466.354" x2="810.0" y2="440.31" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="756.394" y1="700.149" x2="810.0" y2="440.31" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="508.367" y1="692.78" x2="810.0" y2="440.31" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="810.0" y1="440.31" x2="470.887" y2="422.658" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="614.369" y1="608.057" x2="470.887" y2="422.658" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="596.539" y1="604.351" x2="470.887" y2="422.658" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="470.887" y1="422.658" x2="676.907" y2="479.419" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="542.014" y1="301.08" x2="676.907" y2="479.419" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="472.09" y1="413.425" x2="676.907" y2="479.419" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="580.571" y1="280.726" x2="676.907" y2="479.419" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="566.312" y1="286.8" x2="676.907" y2="479.419" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="549.911" y1="295.834" x2="676.907" y2="479.419" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="921.774" y1="397.238" x2="809.725" y2="449.666" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="525.927" y1="178.825" x2="809.725" y2="449.666" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="924.87" y1="448.591" x2="809.725" y2="449.666" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="889.06" y1="301.457" x2="808.974" y2="458.647" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="558.477" y1="290.822" x2="808.974" y2="458.647" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="741.017" y1="706.497" x2="808.974" y2="458.647" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="478.484" y1="205.186" x2="530.151" y2="310.257" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="535.924" y1="305.582" x2="530.151" y2="310.257" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="782.907" y1="686.582" x2="535.924" y2="305.582" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="390.555" y1="577.848" x2="535.924" y2="305.582" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="756.394" y1="700.149" x2="807.945" y2="466.354" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="869.9" y1="608.437" x2="807.945" y2="466.354" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="508.367" y1="692.78" x2="807.945" y2="466.354" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="399.229" y1="592.493" x2="566.312" y2="286.8" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="381.858" y1="560.78" x2="566.312" y2="286.8" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="389.447" y1="304.176" x2="566.312" y2="286.8" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="590.903" y1="159.261" x2="566.312" y2="286.8" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="649.288" y1="609.746" x2="566.312" y2="286.8" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="555.61" y1="167.781" x2="483.267" y2="374.161" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="869.9" y1="608.437" x2="483.267" y2="374.161" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="744.329" y1="305.778" x2="806.641" y2="473.627" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="453.881" y1="655.835" x2="806.641" y2="473.627" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="625.891" y1="724.651" x2="806.641" y2="473.627" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="522.197" y1="317.434" x2="632.204" y2="270.179" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="390.555" y1="577.848" x2="632.204" y2="270.179" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="473.461" y1="405.87" x2="632.204" y2="270.179" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="500.481" y1="342.868" x2="632.204" y2="270.179" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="640.139" y1="155.0" x2="535.446" y2="574.047" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="512.132" y1="185.295" x2="535.446" y2="574.047" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="497.18" y1="193.368" x2="573.008" y2="283.756" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="909.919" y1="348.518" x2="573.008" y2="283.756" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="467.39" y1="213.217" x2="492.017" y2="523.671" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="782.979" y1="193.46" x2="492.017" y2="523.671" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="782.907" y1="686.582" x2="804.91" y2="481.288" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="720.689" y1="166.661" x2="804.91" y2="481.288" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="872.123" y1="274.64" x2="804.91" y2="481.288" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="708.121" y1="716.739" x2="804.91" y2="481.288" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="522.859" y1="699.813" x2="804.91" y2="481.288" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="814.956" y1="664.979" x2="804.91" y2="481.288" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="869.9" y1="608.437" x2="801.771" y2="492.25" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="494.286" y1="684.933" x2="801.771" y2="492.25" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="714.504" y1="592.804" x2="799.539" y2="498.714" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="550.892" y1="584.775" x2="799.539" y2="498.714" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="807.945" y1="466.354" x2="799.539" y2="498.714" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="419.183" y1="620.18" x2="580.571" y2="280.726" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="658.024" y1="270.958" x2="580.571" y2="280.726" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="522.516" y1="562.872" x2="529.723" y2="569.379" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="511.928" y1="328.207" x2="529.723" y2="569.379" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="488.019" y1="516.169" x2="795.857" y2="507.886" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="497.18" y1="193.368" x2="795.857" y2="507.886" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="807.945" y1="466.354" x2="795.857" y2="507.886" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="779.063" y1="537.783" x2="792.909" y2="514.29" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="467.39" y1="213.217" x2="792.909" y2="514.29" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="782.979" y1="193.46" x2="792.909" y2="514.29" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="782.907" y1="686.582" x2="580.475" y2="599.238" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="737.688" y1="172.265" x2="580.475" y2="599.238" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="497.18" y1="193.368" x2="580.475" y2="599.238" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="580.475" y1="599.238" x2="571.707" y2="595.679" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="792.909" y1="514.29" x2="571.707" y2="595.679" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="471.769" y1="464.461" x2="571.707" y2="595.679" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="889.06" y1="301.457" x2="788.631" y2="522.516" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="558.477" y1="290.822" x2="788.631" y2="522.516" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="487.97" y1="363.929" x2="788.631" y2="522.516" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="699.704" y1="599.171" x2="784.978" y2="528.778" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="782.979" y1="193.46" x2="784.978" y2="528.778" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="909.919" y1="348.518" x2="784.978" y2="528.778" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="480.57" y1="499.009" x2="522.516" y2="562.872" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="470.928" y1="457.739" x2="522.516" y2="562.872" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="453.881" y1="655.835" x2="779.063" y2="537.783" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="587.169" y1="720.06" x2="779.063" y2="537.783" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="737.688" y1="172.265" x2="779.063" y2="537.783" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="722.37" y1="291.288" x2="689.946" y2="277.503" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="919.118" y1="382.396" x2="689.946" y2="277.503" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="923.692" y1="467.276" x2="689.946" y2="277.503" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="779.063" y1="537.783" x2="689.946" y2="277.503" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="555.61" y1="167.781" x2="773.808" y2="544.858" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="737.688" y1="172.265" x2="773.808" y2="544.858" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="720.541" y1="713.383" x2="773.808" y2="544.858" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="903.846" y1="547.751" x2="681.549" y2="604.844" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="896.887" y1="563.427" x2="681.549" y2="604.844" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="480.57" y1="499.009" x2="487.97" y2="363.929" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="497.18" y1="193.368" x2="487.97" y2="363.929" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="909.919" y1="348.518" x2="491.599" y2="357.072" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="606.095" y1="722.976" x2="491.599" y2="357.072" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="467.39" y1="213.217" x2="491.599" y2="357.072" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="792.909" y1="514.29" x2="517.438" y2="557.807" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="491.599" y1="357.072" x2="517.438" y2="557.807" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="621.859" y1="270.971" x2="590.318" y2="418.842" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="632.204" y1="270.179" x2="590.318" y2="418.842" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="530.151" y1="310.257" x2="590.318" y2="418.842" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="500.481" y1="342.868" x2="590.318" y2="418.842" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="505.916" y1="335.494" x2="590.318" y2="418.842" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="648.66" y1="270.221" x2="510.682" y2="550.349" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="376.679" y1="330.971" x2="510.682" y2="550.349" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="625.891" y1="724.651" x2="510.682" y2="550.349" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="487.97" y1="363.929" x2="769.872" y2="549.696" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="850.292" y1="632.359" x2="769.872" y2="549.696" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="376.679" y1="330.971" x2="769.872" y2="549.696" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="698.311" y1="280.313" x2="763.112" y2="557.233" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="810.921" y1="211.941" x2="763.112" y2="557.233" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="470.0" y1="440.289" x2="588.833" y2="277.883" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="470.928" y1="457.739" x2="588.833" y2="277.883" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="480.57" y1="499.009" x2="588.833" y2="277.883" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="483.263" y1="505.828" x2="610.287" y2="485.09" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="470.928" y1="457.739" x2="610.287" y2="485.09" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="470.0" y1="440.289" x2="610.287" y2="485.09" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="470.239" y1="430.983" x2="610.287" y2="485.09" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="529.723" y1="569.379" x2="610.287" y2="485.09" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="522.516" y1="562.872" x2="610.287" y2="485.09" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="588.833" y1="277.883" x2="610.287" y2="485.09" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="495.739" y1="350.062" x2="610.287" y2="485.09" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="598.577" y1="275.124" x2="610.287" y2="485.09" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="511.928" y1="328.207" x2="610.287" y2="485.09" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="613.93" y1="272.011" x2="610.287" y2="485.09" stroke="#f59e0b" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="744.329" y1="305.778" x2="757.637" y2="562.725" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="471.769" y1="464.461" x2="757.637" y2="562.725" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="625.891" y1="724.651" x2="757.637" y2="562.725" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="919.118" y1="382.396" x2="495.739" y2="350.062" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="881.464" y1="288.606" x2="495.739" y2="350.062" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="905.049" y1="335.243" x2="751.385" y2="568.427" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="896.887" y1="563.427" x2="751.385" y2="568.427" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="369.314" y1="529.187" x2="751.385" y2="568.427" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="375.396" y1="545.876" x2="743.813" y2="574.621" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="558.477" y1="290.822" x2="743.813" y2="574.621" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="487.97" y1="363.929" x2="743.813" y2="574.621" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="494.286" y1="684.933" x2="737.578" y2="579.207" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="508.367" y1="692.78" x2="737.578" y2="579.207" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="467.39" y1="213.217" x2="500.481" y2="342.868" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="494.286" y1="684.933" x2="500.481" y2="342.868" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="479.178" y1="675.29" x2="729.069" y2="584.799" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="676.083" y1="722.707" x2="729.069" y2="584.799" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="656.821" y1="155.497" x2="729.069" y2="584.799" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="709.197" y1="163.528" x2="723.036" y2="588.341" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="869.9" y1="608.437" x2="723.036" y2="588.341" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="889.06" y1="301.457" x2="505.916" y2="335.494" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="799.173" y1="676.409" x2="505.916" y2="335.494" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="782.979" y1="193.46" x2="598.577" y2="275.124" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="494.286" y1="684.933" x2="598.577" y2="275.124" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="782.979" y1="193.46" x2="511.928" y2="328.207" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="689.897" y1="720.598" x2="511.928" y2="328.207" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="869.9" y1="608.437" x2="606.987" y2="273.236" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="756.394" y1="700.149" x2="606.987" y2="273.236" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="809.725" y1="449.666" x2="505.299" y2="543.71" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="639.641" y1="725.0" x2="505.299" y2="543.71" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="639.641" y1="725.0" x2="714.504" y2="592.804" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="525.927" y1="178.825" x2="714.504" y2="592.804" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="557.033" y1="712.656" x2="714.504" y2="592.804" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="455.164" y1="223.065" x2="674.797" y2="606.401" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="624.529" y1="155.42" x2="674.797" y2="606.401" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="480.57" y1="499.009" x2="665.813" y2="608.029" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="590.903" y1="159.261" x2="665.813" y2="608.029" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="571.707" y1="595.679" x2="656.662" y2="609.182" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="590.903" y1="159.261" x2="656.662" y2="609.182" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="681.549" y1="604.844" x2="656.662" y2="609.182" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="674.797" y1="606.401" x2="656.662" y2="609.182" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="665.813" y1="608.029" x2="656.662" y2="609.182" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="453.881" y1="655.835" x2="500.345" y2="536.936" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="903.846" y1="547.751" x2="500.345" y2="536.936" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="889.06" y1="301.457" x2="500.345" y2="536.936" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="782.907" y1="686.582" x2="706.63" y2="596.398" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="872.123" y1="274.64" x2="706.63" y2="596.398" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="587.169" y1="720.06" x2="706.63" y2="596.398" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="869.9" y1="608.437" x2="699.704" y2="599.171" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="494.286" y1="684.933" x2="699.704" y2="599.171" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="640.139" y1="155.0" x2="699.704" y2="599.171" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="640.139" y1="155.0" x2="496.299" y2="530.829" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="478.484" y1="205.186" x2="496.299" y2="530.829" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="869.9" y1="608.437" x2="613.93" y2="272.011" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="799.173" y1="676.409" x2="613.93" y2="272.011" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="698.311" y1="280.313" x2="691.441" y2="602.03" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="500.345" y1="536.936" x2="691.441" y2="602.03" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
+<line x1="699.704" y1="599.171" x2="691.441" y2="602.03" stroke="#c084fc" stroke-opacity="0.32" stroke-width="1.15"/>
 </g>
 <g class="nodes" filter="url(#glow)">
 <circle cx="640.139" cy="155.0" r="6" fill="#38bdf8" stroke="#7dd3fc" stroke-width="1.6"><title>API Call</title></circle>
@@ -522,135 +522,135 @@
 <circle cx="555.61" cy="167.781" r="6" fill="#38bdf8" stroke="#7dd3fc" stroke-width="1.6"><title>Write Report</title></circle>
 <circle cx="442.701" cy="645.665" r="6" fill="#38bdf8" stroke="#7dd3fc" stroke-width="1.6"><title>evidence-attestation</title></circle>
 <circle cx="429.655" cy="632.302" r="6" fill="#38bdf8" stroke="#7dd3fc" stroke-width="1.6"><title>implement-with-discernment</title></circle>
-<circle cx="649.288" cy="609.746" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Advanced Swarm Coordination</title></circle>
-<circle cx="641.078" cy="270.003" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Adversarial Robustness Testing</title></circle>
-<circle cx="648.66" cy="270.221" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Agent Evaluation</title></circle>
-<circle cx="658.024" cy="270.958" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Agent Memory Learning</title></circle>
-<circle cx="542.014" cy="301.08" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Agent Memory Platform</title></circle>
-<circle cx="665.161" cy="271.872" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Agentic Workflow Design</title></circle>
-<circle cx="674.044" cy="273.444" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Architecture Diagram</title></circle>
-<circle cx="638.61" cy="609.994" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Automated Testing</title></circle>
-<circle cx="683.306" cy="275.608" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Autonomous Data Scientist</title></circle>
-<circle cx="488.019" cy="516.169" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Autonomous Debug</title></circle>
-<circle cx="689.946" cy="277.503" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Autonomous Scientific Discovery</title></circle>
-<circle cx="629.903" cy="609.7" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Autonomous Web Research</title></circle>
-<circle cx="483.263" cy="505.828" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Brainstorming</title></circle>
-<circle cx="698.311" cy="280.313" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Browser Automation</title></circle>
-<circle cx="623.48" cy="609.195" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Career Operations</title></circle>
-<circle cx="708.082" cy="284.228" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Causal Inference</title></circle>
-<circle cx="614.369" cy="608.057" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Cloud Platform Management</title></circle>
-<circle cx="480.57" cy="499.009" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Code Review Pipeline</title></circle>
-<circle cx="715.118" cy="287.497" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Collaborative Diagramming</title></circle>
-<circle cx="722.37" cy="291.288" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Computational Biology Workflows</title></circle>
-<circle cx="728.734" cy="294.996" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Content Moderation</title></circle>
-<circle cx="737.293" cy="300.594" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Conversational Agent</title></circle>
-<circle cx="744.329" cy="305.778" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Data Analysis</title></circle>
-<circle cx="477.688" cy="490.544" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Deployment Automation</title></circle>
-<circle cx="607.189" cy="606.804" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Design Generation</title></circle>
-<circle cx="475.427" cy="482.609" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Design Review</title></circle>
-<circle cx="473.44" cy="474.024" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Design System Extraction</title></circle>
-<circle cx="471.769" cy="464.461" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Detect Anomaly</title></circle>
-<circle cx="470.928" cy="457.739" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Dispatching Parallel Agents</title></circle>
-<circle cx="596.539" cy="604.351" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Distributed Neural Training</title></circle>
-<circle cx="588.153" cy="601.901" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Distributed Vector Memory</title></circle>
-<circle cx="750.521" cy="310.829" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Document Analyst</title></circle>
-<circle cx="549.911" cy="295.834" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Dual Mode</title></circle>
-<circle cx="756.963" cy="316.632" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Edge Optimization</title></circle>
-<circle cx="470.175" cy="447.703" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>End-to-End Testing</title></circle>
-<circle cx="470.0" cy="440.289" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Executing Plans</title></circle>
-<circle cx="763.729" cy="323.419" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Explainability Audit</title></circle>
-<circle cx="768.848" cy="329.103" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Financial Modeling</title></circle>
-<circle cx="470.239" cy="430.983" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Finishing a Development Branch</title></circle>
-<circle cx="470.887" cy="422.658" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Flow Nexus Orchestration</title></circle>
-<circle cx="774.664" cy="336.242" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Full-Stack Developer</title></circle>
-<circle cx="780.216" cy="343.878" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Function Calling</title></circle>
-<circle cx="580.475" cy="599.238" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Gaia Audit</title></circle>
-<circle cx="571.707" cy="595.679" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Gaia Meta Audit</title></circle>
-<circle cx="784.427" cy="350.329" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Generative Media</title></circle>
-<circle cx="788.062" cy="356.468" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Ghostwrite</title></circle>
-<circle cx="472.09" cy="413.425" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>GitHub Platform Mastery</title></circle>
-<circle cx="564.7" cy="592.414" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Graph-Driven Issue Triage</title></circle>
-<circle cx="473.461" cy="405.87" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Grill Me</title></circle>
-<circle cx="475.756" cy="396.136" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Grill With Docs</title></circle>
-<circle cx="793.073" cy="366.051" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Grounding</title></circle>
-<circle cx="478.186" cy="387.882" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Guardrails</title></circle>
-<circle cx="480.645" cy="380.789" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Hive Mind Coordination</title></circle>
-<circle cx="796.75" cy="374.202" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Humanize Prose</title></circle>
-<circle cx="558.477" cy="290.822" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Knowledge Graph Construction</title></circle>
-<circle cx="799.917" cy="382.323" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Knowledge Harvest</title></circle>
-<circle cx="557.175" cy="588.459" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Knowledge Management</title></circle>
-<circle cx="801.835" cy="387.948" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Literature Review</title></circle>
-<circle cx="804.754" cy="398.094" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>MCP Debugger Control</title></circle>
-<circle cx="806.591" cy="406.124" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>MCP Server Creation</title></circle>
-<circle cx="808.227" cy="415.512" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>ML Artifact Management</title></circle>
-<circle cx="809.232" cy="423.859" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>ML Pipeline</title></circle>
-<circle cx="809.723" cy="430.295" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Mathematical Animation</title></circle>
-<circle cx="550.892" cy="584.775" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Memory Manage</title></circle>
-<circle cx="542.068" cy="578.958" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Multi-Agent Debate</title></circle>
-<circle cx="810.0" cy="440.31" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Multi-Agent Orchestration</title></circle>
-<circle cx="809.725" cy="449.666" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Multimodal Reasoning</title></circle>
-<circle cx="808.974" cy="458.647" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Ontology Alignment</title></circle>
-<circle cx="483.267" cy="374.161" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>PRD Generation</title></circle>
-<circle cx="807.945" cy="466.354" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Plan and Execute</title></circle>
-<circle cx="566.312" cy="286.8" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Platform Modernization Sprint</title></circle>
-<circle cx="806.641" cy="473.627" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Prediction Market Analysis</title></circle>
-<circle cx="535.446" cy="574.047" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Project Management</title></circle>
-<circle cx="573.008" cy="283.756" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Prompt Optimization</title></circle>
-<circle cx="804.91" cy="481.288" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>RAG Pipeline</title></circle>
-<circle cx="801.771" cy="492.25" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>ReAct Reasoning</title></circle>
-<circle cx="799.539" cy="498.714" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Real-Time Voice Assistant</title></circle>
-<circle cx="580.571" cy="280.726" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Reasoning Pattern Bank</title></circle>
-<circle cx="529.723" cy="569.379" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Receiving Code Review</title></circle>
-<circle cx="795.857" cy="507.886" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Recursive Self-Improvement</title></circle>
-<circle cx="792.909" cy="514.29" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Registry Curation</title></circle>
-<circle cx="788.631" cy="522.516" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Regulatory Compliance Mapping</title></circle>
-<circle cx="784.978" cy="528.778" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Release Automation</title></circle>
-<circle cx="522.516" cy="562.872" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Requesting Code Review</title></circle>
-<circle cx="779.063" cy="537.783" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Research</title></circle>
-<circle cx="773.808" cy="544.858" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Scientific Writing</title></circle>
-<circle cx="487.97" cy="363.929" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Security Audit</title></circle>
-<circle cx="491.599" cy="357.072" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Skill Authoring</title></circle>
-<circle cx="517.438" cy="557.807" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Skill Fusion</title></circle>
-<circle cx="510.682" cy="550.349" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Skill Performance Benchmarking</title></circle>
-<circle cx="769.872" cy="549.696" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Skill Security Analysis</title></circle>
-<circle cx="763.112" cy="557.233" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Stealth Browser Interaction</title></circle>
-<circle cx="588.833" cy="277.883" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Subagent-Driven Development</title></circle>
-<circle cx="757.637" cy="562.725" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Supply Chain Optimization</title></circle>
-<circle cx="495.739" cy="350.062" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Systematic Debugging</title></circle>
-<circle cx="751.385" cy="568.427" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Text-to-SQL Pipeline</title></circle>
-<circle cx="743.813" cy="574.621" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Threat Intelligence Synthesis</title></circle>
-<circle cx="737.578" cy="579.207" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Tool Chaining</title></circle>
-<circle cx="500.481" cy="342.868" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Tool Creation</title></circle>
-<circle cx="729.069" cy="584.799" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Translation Pipeline</title></circle>
-<circle cx="723.036" cy="588.341" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Tree of Thought</title></circle>
-<circle cx="505.916" cy="335.494" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Ubiquitous Language</title></circle>
-<circle cx="598.577" cy="275.124" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Using Git Worktrees</title></circle>
-<circle cx="511.928" cy="328.207" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Verification Before Completion</title></circle>
-<circle cx="606.987" cy="273.236" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Vertical Slice Planning</title></circle>
-<circle cx="505.299" cy="543.71" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Video Intelligence</title></circle>
-<circle cx="714.504" cy="592.804" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Voice Agent</title></circle>
-<circle cx="500.345" cy="536.936" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Web Scrape</title></circle>
-<circle cx="706.63" cy="596.398" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Wiki Search</title></circle>
-<circle cx="699.704" cy="599.171" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Workflow Automation</title></circle>
-<circle cx="496.299" cy="530.829" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Workspace Automation</title></circle>
-<circle cx="613.93" cy="272.011" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>Writing Plans</title></circle>
-<circle cx="691.441" cy="602.03" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>X/Twitter Automation</title></circle>
-<circle cx="515.9" cy="323.814" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>agent-environment-setup</title></circle>
-<circle cx="522.197" cy="317.434" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>agent-handoff</title></circle>
-<circle cx="621.859" cy="270.971" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>mattpocock-engineering</title></circle>
-<circle cx="530.151" cy="310.257" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>mattpocock-personal</title></circle>
-<circle cx="632.204" cy="270.179" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>mattpocock-productivity</title></circle>
-<circle cx="535.924" cy="305.582" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>personal-knowledge-management</title></circle>
-<circle cx="492.017" cy="523.671" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>prototype</title></circle>
-<circle cx="681.549" cy="604.844" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>search-engine-optimization</title></circle>
-<circle cx="674.797" cy="606.401" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>web-accessibility</title></circle>
-<circle cx="665.813" cy="608.029" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>web-best-practices</title></circle>
-<circle cx="656.662" cy="609.182" r="10" fill="#a78bfa" stroke="#c4b5fd" stroke-width="1.6"><title>web-quality-audit</title></circle>
-<circle cx="646.334" cy="386.373" r="15" fill="#fbbf24" stroke="#fde68a" stroke-width="1.6"><title>Founder Mode</title></circle>
-<circle cx="690.592" cy="421.12" r="15" fill="#fbbf24" stroke="#fde68a" stroke-width="1.6"><title>Git Ship Done Pipeline</title></circle>
-<circle cx="676.907" cy="479.419" r="15" fill="#fbbf24" stroke="#fde68a" stroke-width="1.6"><title>Ruflo</title></circle>
-<circle cx="610.287" cy="485.09" r="15" fill="#fbbf24" stroke="#fde68a" stroke-width="1.6"><title>Superpowers</title></circle>
-<circle cx="590.318" cy="418.842" r="15" fill="#fbbf24" stroke="#fde68a" stroke-width="1.6"><title>mattpocock-skills</title></circle>
+<circle cx="649.288" cy="609.746" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Advanced Swarm Coordination</title></circle>
+<circle cx="641.078" cy="270.003" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Adversarial Robustness Testing</title></circle>
+<circle cx="648.66" cy="270.221" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Agent Evaluation</title></circle>
+<circle cx="658.024" cy="270.958" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Agent Memory Learning</title></circle>
+<circle cx="542.014" cy="301.08" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Agent Memory Platform</title></circle>
+<circle cx="665.161" cy="271.872" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Agentic Workflow Design</title></circle>
+<circle cx="674.044" cy="273.444" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Architecture Diagram</title></circle>
+<circle cx="638.61" cy="609.994" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Automated Testing</title></circle>
+<circle cx="683.306" cy="275.608" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Autonomous Data Scientist</title></circle>
+<circle cx="488.019" cy="516.169" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Autonomous Debug</title></circle>
+<circle cx="689.946" cy="277.503" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Autonomous Scientific Discovery</title></circle>
+<circle cx="629.903" cy="609.7" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Autonomous Web Research</title></circle>
+<circle cx="483.263" cy="505.828" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Brainstorming</title></circle>
+<circle cx="698.311" cy="280.313" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Browser Automation</title></circle>
+<circle cx="623.48" cy="609.195" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Career Operations</title></circle>
+<circle cx="708.082" cy="284.228" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Causal Inference</title></circle>
+<circle cx="614.369" cy="608.057" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Cloud Platform Management</title></circle>
+<circle cx="480.57" cy="499.009" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Code Review Pipeline</title></circle>
+<circle cx="715.118" cy="287.497" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Collaborative Diagramming</title></circle>
+<circle cx="722.37" cy="291.288" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Computational Biology Workflows</title></circle>
+<circle cx="728.734" cy="294.996" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Content Moderation</title></circle>
+<circle cx="737.293" cy="300.594" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Conversational Agent</title></circle>
+<circle cx="744.329" cy="305.778" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Data Analysis</title></circle>
+<circle cx="477.688" cy="490.544" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Deployment Automation</title></circle>
+<circle cx="607.189" cy="606.804" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Design Generation</title></circle>
+<circle cx="475.427" cy="482.609" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Design Review</title></circle>
+<circle cx="473.44" cy="474.024" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Design System Extraction</title></circle>
+<circle cx="471.769" cy="464.461" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Detect Anomaly</title></circle>
+<circle cx="470.928" cy="457.739" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Dispatching Parallel Agents</title></circle>
+<circle cx="596.539" cy="604.351" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Distributed Neural Training</title></circle>
+<circle cx="588.153" cy="601.901" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Distributed Vector Memory</title></circle>
+<circle cx="750.521" cy="310.829" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Document Analyst</title></circle>
+<circle cx="549.911" cy="295.834" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Dual Mode</title></circle>
+<circle cx="756.963" cy="316.632" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Edge Optimization</title></circle>
+<circle cx="470.175" cy="447.703" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>End-to-End Testing</title></circle>
+<circle cx="470.0" cy="440.289" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Executing Plans</title></circle>
+<circle cx="763.729" cy="323.419" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Explainability Audit</title></circle>
+<circle cx="768.848" cy="329.103" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Financial Modeling</title></circle>
+<circle cx="470.239" cy="430.983" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Finishing a Development Branch</title></circle>
+<circle cx="470.887" cy="422.658" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Flow Nexus Orchestration</title></circle>
+<circle cx="774.664" cy="336.242" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Full-Stack Developer</title></circle>
+<circle cx="780.216" cy="343.878" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Function Calling</title></circle>
+<circle cx="580.475" cy="599.238" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Gaia Audit</title></circle>
+<circle cx="571.707" cy="595.679" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Gaia Meta Audit</title></circle>
+<circle cx="784.427" cy="350.329" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Generative Media</title></circle>
+<circle cx="788.062" cy="356.468" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Ghostwrite</title></circle>
+<circle cx="472.09" cy="413.425" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>GitHub Platform Mastery</title></circle>
+<circle cx="564.7" cy="592.414" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Graph-Driven Issue Triage</title></circle>
+<circle cx="473.461" cy="405.87" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Grill Me</title></circle>
+<circle cx="475.756" cy="396.136" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Grill With Docs</title></circle>
+<circle cx="793.073" cy="366.051" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Grounding</title></circle>
+<circle cx="478.186" cy="387.882" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Guardrails</title></circle>
+<circle cx="480.645" cy="380.789" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Hive Mind Coordination</title></circle>
+<circle cx="796.75" cy="374.202" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Humanize Prose</title></circle>
+<circle cx="558.477" cy="290.822" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Knowledge Graph Construction</title></circle>
+<circle cx="799.917" cy="382.323" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Knowledge Harvest</title></circle>
+<circle cx="557.175" cy="588.459" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Knowledge Management</title></circle>
+<circle cx="801.835" cy="387.948" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Literature Review</title></circle>
+<circle cx="804.754" cy="398.094" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>MCP Debugger Control</title></circle>
+<circle cx="806.591" cy="406.124" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>MCP Server Creation</title></circle>
+<circle cx="808.227" cy="415.512" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>ML Artifact Management</title></circle>
+<circle cx="809.232" cy="423.859" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>ML Pipeline</title></circle>
+<circle cx="809.723" cy="430.295" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Mathematical Animation</title></circle>
+<circle cx="550.892" cy="584.775" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Memory Manage</title></circle>
+<circle cx="542.068" cy="578.958" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Multi-Agent Debate</title></circle>
+<circle cx="810.0" cy="440.31" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Multi-Agent Orchestration</title></circle>
+<circle cx="809.725" cy="449.666" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Multimodal Reasoning</title></circle>
+<circle cx="808.974" cy="458.647" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Ontology Alignment</title></circle>
+<circle cx="483.267" cy="374.161" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>PRD Generation</title></circle>
+<circle cx="807.945" cy="466.354" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Plan and Execute</title></circle>
+<circle cx="566.312" cy="286.8" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Platform Modernization Sprint</title></circle>
+<circle cx="806.641" cy="473.627" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Prediction Market Analysis</title></circle>
+<circle cx="535.446" cy="574.047" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Project Management</title></circle>
+<circle cx="573.008" cy="283.756" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Prompt Optimization</title></circle>
+<circle cx="804.91" cy="481.288" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>RAG Pipeline</title></circle>
+<circle cx="801.771" cy="492.25" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>ReAct Reasoning</title></circle>
+<circle cx="799.539" cy="498.714" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Real-Time Voice Assistant</title></circle>
+<circle cx="580.571" cy="280.726" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Reasoning Pattern Bank</title></circle>
+<circle cx="529.723" cy="569.379" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Receiving Code Review</title></circle>
+<circle cx="795.857" cy="507.886" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Recursive Self-Improvement</title></circle>
+<circle cx="792.909" cy="514.29" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Registry Curation</title></circle>
+<circle cx="788.631" cy="522.516" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Regulatory Compliance Mapping</title></circle>
+<circle cx="784.978" cy="528.778" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Release Automation</title></circle>
+<circle cx="522.516" cy="562.872" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Requesting Code Review</title></circle>
+<circle cx="779.063" cy="537.783" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Research</title></circle>
+<circle cx="773.808" cy="544.858" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Scientific Writing</title></circle>
+<circle cx="487.97" cy="363.929" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Security Audit</title></circle>
+<circle cx="491.599" cy="357.072" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Skill Authoring</title></circle>
+<circle cx="517.438" cy="557.807" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Skill Fusion</title></circle>
+<circle cx="510.682" cy="550.349" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Skill Performance Benchmarking</title></circle>
+<circle cx="769.872" cy="549.696" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Skill Security Analysis</title></circle>
+<circle cx="763.112" cy="557.233" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Stealth Browser Interaction</title></circle>
+<circle cx="588.833" cy="277.883" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Subagent-Driven Development</title></circle>
+<circle cx="757.637" cy="562.725" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Supply Chain Optimization</title></circle>
+<circle cx="495.739" cy="350.062" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Systematic Debugging</title></circle>
+<circle cx="751.385" cy="568.427" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Text-to-SQL Pipeline</title></circle>
+<circle cx="743.813" cy="574.621" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Threat Intelligence Synthesis</title></circle>
+<circle cx="737.578" cy="579.207" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Tool Chaining</title></circle>
+<circle cx="500.481" cy="342.868" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Tool Creation</title></circle>
+<circle cx="729.069" cy="584.799" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Translation Pipeline</title></circle>
+<circle cx="723.036" cy="588.341" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Tree of Thought</title></circle>
+<circle cx="505.916" cy="335.494" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Ubiquitous Language</title></circle>
+<circle cx="598.577" cy="275.124" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Using Git Worktrees</title></circle>
+<circle cx="511.928" cy="328.207" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Verification Before Completion</title></circle>
+<circle cx="606.987" cy="273.236" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Vertical Slice Planning</title></circle>
+<circle cx="505.299" cy="543.71" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Video Intelligence</title></circle>
+<circle cx="714.504" cy="592.804" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Voice Agent</title></circle>
+<circle cx="500.345" cy="536.936" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Web Scrape</title></circle>
+<circle cx="706.63" cy="596.398" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Wiki Search</title></circle>
+<circle cx="699.704" cy="599.171" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Workflow Automation</title></circle>
+<circle cx="496.299" cy="530.829" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Workspace Automation</title></circle>
+<circle cx="613.93" cy="272.011" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>Writing Plans</title></circle>
+<circle cx="691.441" cy="602.03" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>X/Twitter Automation</title></circle>
+<circle cx="515.9" cy="323.814" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>agent-environment-setup</title></circle>
+<circle cx="522.197" cy="317.434" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>agent-handoff</title></circle>
+<circle cx="621.859" cy="270.971" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>mattpocock-engineering</title></circle>
+<circle cx="530.151" cy="310.257" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>mattpocock-personal</title></circle>
+<circle cx="632.204" cy="270.179" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>mattpocock-productivity</title></circle>
+<circle cx="535.924" cy="305.582" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>personal-knowledge-management</title></circle>
+<circle cx="492.017" cy="523.671" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>prototype</title></circle>
+<circle cx="681.549" cy="604.844" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>search-engine-optimization</title></circle>
+<circle cx="674.797" cy="606.401" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>web-accessibility</title></circle>
+<circle cx="665.813" cy="608.029" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>web-best-practices</title></circle>
+<circle cx="656.662" cy="609.182" r="10" fill="#c084fc" stroke="#c4b5fd" stroke-width="1.6"><title>web-quality-audit</title></circle>
+<circle cx="646.334" cy="386.373" r="15" fill="#f59e0b" stroke="#fde68a" stroke-width="1.6"><title>Founder Mode</title></circle>
+<circle cx="690.592" cy="421.12" r="15" fill="#f59e0b" stroke="#fde68a" stroke-width="1.6"><title>Git Ship Done Pipeline</title></circle>
+<circle cx="676.907" cy="479.419" r="15" fill="#f59e0b" stroke="#fde68a" stroke-width="1.6"><title>Ruflo</title></circle>
+<circle cx="610.287" cy="485.09" r="15" fill="#f59e0b" stroke="#fde68a" stroke-width="1.6"><title>Superpowers</title></circle>
+<circle cx="590.318" cy="418.842" r="15" fill="#f59e0b" stroke="#fde68a" stroke-width="1.6"><title>mattpocock-skills</title></circle>
 </g>
 <g class="labels" font-family="Inter, ui-sans-serif, system-ui, sans-serif" text-anchor="middle">
 <text x="656.821" y="142.5" fill="#38bdf8" font-size="10" font-weight="600" opacity="0.92">Audience Model</text>
@@ -680,145 +680,145 @@
 <text x="494.286" y="671.9" fill="#38bdf8" font-size="10" font-weight="600" opacity="0.92">Tool Use</text>
 <text x="555.61" y="154.8" fill="#38bdf8" font-size="10" font-weight="600" opacity="0.92">Write Report</text>
 <text x="442.701" y="632.7" fill="#38bdf8" font-size="10" font-weight="600" opacity="0.92">evidence-attestation</text>
-<text x="649.288" y="592.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Advanced Swarm Coordination</text>
-<text x="641.078" y="253.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Adversarial Robustness Testing</text>
-<text x="648.66" y="253.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Agent Evaluation</text>
-<text x="658.024" y="254.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Agent Memory Learning</text>
-<text x="542.014" y="284.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Agent Memory Platform</text>
-<text x="665.161" y="254.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Agentic Workflow Design</text>
-<text x="674.044" y="256.4" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Architecture Diagram</text>
-<text x="638.61" y="593.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Automated Testing</text>
-<text x="683.306" y="258.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Autonomous Data Scientist</text>
-<text x="488.019" y="499.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Autonomous Debug</text>
-<text x="689.946" y="260.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Autonomous Scientific Discovery</text>
-<text x="629.903" y="592.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Autonomous Web Research</text>
-<text x="483.263" y="488.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Brainstorming</text>
-<text x="698.311" y="263.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Browser Automation</text>
-<text x="623.48" y="592.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Career Operations</text>
-<text x="708.082" y="267.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Causal Inference</text>
-<text x="614.369" y="591.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Cloud Platform Management</text>
-<text x="480.57" y="482.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Code Review Pipeline</text>
-<text x="715.118" y="270.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Collaborative Diagramming</text>
-<text x="722.37" y="274.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Computational Biology Workflows</text>
-<text x="728.734" y="278.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Content Moderation</text>
-<text x="737.293" y="283.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Conversational Agent</text>
-<text x="744.329" y="288.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Data Analysis</text>
-<text x="477.688" y="473.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Deployment Automation</text>
-<text x="607.189" y="589.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Design Generation</text>
-<text x="475.427" y="465.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Design Review</text>
-<text x="473.44" y="457.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Design System Extraction</text>
-<text x="471.769" y="447.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Detect Anomaly</text>
-<text x="470.928" y="440.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Dispatching Parallel Agents</text>
-<text x="596.539" y="587.4" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Distributed Neural Training</text>
-<text x="588.153" y="584.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Distributed Vector Memory</text>
-<text x="750.521" y="293.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Document Analyst</text>
-<text x="549.911" y="278.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Dual Mode</text>
-<text x="756.963" y="299.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Edge Optimization</text>
-<text x="470.175" y="430.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">End-to-End Testing</text>
-<text x="470.0" y="423.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Executing Plans</text>
-<text x="763.729" y="306.4" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Explainability Audit</text>
-<text x="768.848" y="312.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Financial Modeling</text>
-<text x="470.239" y="414.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Finishing a Development Branch</text>
-<text x="470.887" y="405.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Flow Nexus Orchestration</text>
-<text x="774.664" y="319.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Full-Stack Developer</text>
-<text x="780.216" y="326.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Function Calling</text>
-<text x="580.475" y="582.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Gaia Audit</text>
-<text x="571.707" y="578.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Gaia Meta Audit</text>
-<text x="784.427" y="333.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Generative Media</text>
-<text x="788.062" y="339.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Ghostwrite</text>
-<text x="472.09" y="396.4" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">GitHub Platform Mastery</text>
-<text x="564.7" y="575.4" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Graph-Driven Issue Triage</text>
-<text x="473.461" y="388.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Grill Me</text>
-<text x="475.756" y="379.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Grill With Docs</text>
-<text x="793.073" y="349.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Grounding</text>
-<text x="478.186" y="370.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Guardrails</text>
-<text x="480.645" y="363.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Hive Mind Coordination</text>
-<text x="796.75" y="357.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Humanize Prose</text>
-<text x="558.477" y="273.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Knowledge Graph Construction</text>
-<text x="799.917" y="365.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Knowledge Harvest</text>
-<text x="557.175" y="571.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Knowledge Management</text>
-<text x="801.835" y="370.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Literature Review</text>
-<text x="804.754" y="381.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">MCP Debugger Control</text>
-<text x="806.591" y="389.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">MCP Server Creation</text>
-<text x="808.227" y="398.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">ML Artifact Management</text>
-<text x="809.232" y="406.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">ML Pipeline</text>
-<text x="809.723" y="413.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Mathematical Animation</text>
-<text x="550.892" y="567.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Memory Manage</text>
-<text x="542.068" y="562.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Multi-Agent Debate</text>
-<text x="810.0" y="423.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Multi-Agent Orchestration</text>
-<text x="809.725" y="432.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Multimodal Reasoning</text>
-<text x="808.974" y="441.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Ontology Alignment</text>
-<text x="483.267" y="357.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">PRD Generation</text>
-<text x="807.945" y="449.4" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Plan and Execute</text>
-<text x="566.312" y="269.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Platform Modernization Sprint</text>
-<text x="806.641" y="456.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Prediction Market Analysis</text>
-<text x="535.446" y="557.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Project Management</text>
-<text x="573.008" y="266.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Prompt Optimization</text>
-<text x="804.91" y="464.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">RAG Pipeline</text>
-<text x="801.771" y="475.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">ReAct Reasoning</text>
-<text x="799.539" y="481.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Real-Time Voice Assistant</text>
-<text x="580.571" y="263.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Reasoning Pattern Bank</text>
-<text x="529.723" y="552.4" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Receiving Code Review</text>
-<text x="795.857" y="490.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Recursive Self-Improvement</text>
-<text x="792.909" y="497.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Registry Curation</text>
-<text x="788.631" y="505.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Regulatory Compliance Mapping</text>
-<text x="784.978" y="511.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Release Automation</text>
-<text x="522.516" y="545.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Requesting Code Review</text>
-<text x="779.063" y="520.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Research</text>
-<text x="773.808" y="527.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Scientific Writing</text>
-<text x="487.97" y="346.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Security Audit</text>
-<text x="491.599" y="340.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Skill Authoring</text>
-<text x="517.438" y="540.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Skill Fusion</text>
-<text x="510.682" y="533.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Skill Performance Benchmarking</text>
-<text x="769.872" y="532.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Skill Security Analysis</text>
-<text x="763.112" y="540.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Stealth Browser Interaction</text>
-<text x="588.833" y="260.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Subagent-Driven Development</text>
-<text x="757.637" y="545.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Supply Chain Optimization</text>
-<text x="495.739" y="333.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Systematic Debugging</text>
-<text x="751.385" y="551.4" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Text-to-SQL Pipeline</text>
-<text x="743.813" y="557.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Threat Intelligence Synthesis</text>
-<text x="737.578" y="562.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Tool Chaining</text>
-<text x="500.481" y="325.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Tool Creation</text>
-<text x="729.069" y="567.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Translation Pipeline</text>
-<text x="723.036" y="571.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Tree of Thought</text>
-<text x="505.916" y="318.5" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Ubiquitous Language</text>
-<text x="598.577" y="258.1" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Using Git Worktrees</text>
-<text x="511.928" y="311.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Verification Before Completion</text>
-<text x="606.987" y="256.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Vertical Slice Planning</text>
-<text x="505.299" y="526.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Video Intelligence</text>
-<text x="714.504" y="575.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Voice Agent</text>
-<text x="500.345" y="519.9" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Web Scrape</text>
-<text x="706.63" y="579.4" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Wiki Search</text>
-<text x="699.704" y="582.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Workflow Automation</text>
-<text x="496.299" y="513.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Workspace Automation</text>
-<text x="613.93" y="255.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">Writing Plans</text>
-<text x="691.441" y="585.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">X/Twitter Automation</text>
-<text x="515.9" y="306.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">agent-environment-setup</text>
-<text x="522.197" y="300.4" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">agent-handoff</text>
-<text x="621.859" y="254.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">mattpocock-engineering</text>
-<text x="530.151" y="293.3" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">mattpocock-personal</text>
-<text x="632.204" y="253.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">mattpocock-productivity</text>
-<text x="535.924" y="288.6" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">personal-knowledge-management</text>
-<text x="492.017" y="506.7" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">prototype</text>
-<text x="681.549" y="587.8" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">search-engine-optimization</text>
-<text x="674.797" y="589.4" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">web-accessibility</text>
-<text x="665.813" y="591.0" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">web-best-practices</text>
-<text x="656.662" y="592.2" fill="#a78bfa" font-size="12" font-weight="600" opacity="0.92">web-quality-audit</text>
-<text x="646.334" y="364.4" fill="#fbbf24" font-size="16" font-weight="800" opacity="0.92">Founder Mode</text>
-<text x="690.592" y="399.1" fill="#fbbf24" font-size="16" font-weight="800" opacity="0.92">Git Ship Done Pipeline</text>
-<text x="676.907" y="457.4" fill="#fbbf24" font-size="16" font-weight="800" opacity="0.92">Ruflo</text>
-<text x="610.287" y="463.1" fill="#fbbf24" font-size="16" font-weight="800" opacity="0.92">Superpowers</text>
-<text x="590.318" y="396.8" fill="#fbbf24" font-size="16" font-weight="800" opacity="0.92">mattpocock-skills</text>
+<text x="649.288" y="592.7" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Advanced Swarm Coordination</text>
+<text x="641.078" y="253.0" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Adversarial Robustness Testing</text>
+<text x="648.66" y="253.2" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Agent Evaluation</text>
+<text x="658.024" y="254.0" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Agent Memory Learning</text>
+<text x="542.014" y="284.1" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Agent Memory Platform</text>
+<text x="665.161" y="254.9" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Agentic Workflow Design</text>
+<text x="674.044" y="256.4" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Architecture Diagram</text>
+<text x="638.61" y="593.0" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Automated Testing</text>
+<text x="683.306" y="258.6" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Autonomous Data Scientist</text>
+<text x="488.019" y="499.2" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Autonomous Debug</text>
+<text x="689.946" y="260.5" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Autonomous Scientific Discovery</text>
+<text x="629.903" y="592.7" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Autonomous Web Research</text>
+<text x="483.263" y="488.8" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Brainstorming</text>
+<text x="698.311" y="263.3" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Browser Automation</text>
+<text x="623.48" y="592.2" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Career Operations</text>
+<text x="708.082" y="267.2" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Causal Inference</text>
+<text x="614.369" y="591.1" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Cloud Platform Management</text>
+<text x="480.57" y="482.0" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Code Review Pipeline</text>
+<text x="715.118" y="270.5" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Collaborative Diagramming</text>
+<text x="722.37" y="274.3" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Computational Biology Workflows</text>
+<text x="728.734" y="278.0" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Content Moderation</text>
+<text x="737.293" y="283.6" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Conversational Agent</text>
+<text x="744.329" y="288.8" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Data Analysis</text>
+<text x="477.688" y="473.5" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Deployment Automation</text>
+<text x="607.189" y="589.8" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Design Generation</text>
+<text x="475.427" y="465.6" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Design Review</text>
+<text x="473.44" y="457.0" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Design System Extraction</text>
+<text x="471.769" y="447.5" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Detect Anomaly</text>
+<text x="470.928" y="440.7" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Dispatching Parallel Agents</text>
+<text x="596.539" y="587.4" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Distributed Neural Training</text>
+<text x="588.153" y="584.9" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Distributed Vector Memory</text>
+<text x="750.521" y="293.8" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Document Analyst</text>
+<text x="549.911" y="278.8" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Dual Mode</text>
+<text x="756.963" y="299.6" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Edge Optimization</text>
+<text x="470.175" y="430.7" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">End-to-End Testing</text>
+<text x="470.0" y="423.3" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Executing Plans</text>
+<text x="763.729" y="306.4" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Explainability Audit</text>
+<text x="768.848" y="312.1" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Financial Modeling</text>
+<text x="470.239" y="414.0" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Finishing a Development Branch</text>
+<text x="470.887" y="405.7" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Flow Nexus Orchestration</text>
+<text x="774.664" y="319.2" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Full-Stack Developer</text>
+<text x="780.216" y="326.9" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Function Calling</text>
+<text x="580.475" y="582.2" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Gaia Audit</text>
+<text x="571.707" y="578.7" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Gaia Meta Audit</text>
+<text x="784.427" y="333.3" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Generative Media</text>
+<text x="788.062" y="339.5" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Ghostwrite</text>
+<text x="472.09" y="396.4" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">GitHub Platform Mastery</text>
+<text x="564.7" y="575.4" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Graph-Driven Issue Triage</text>
+<text x="473.461" y="388.9" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Grill Me</text>
+<text x="475.756" y="379.1" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Grill With Docs</text>
+<text x="793.073" y="349.1" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Grounding</text>
+<text x="478.186" y="370.9" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Guardrails</text>
+<text x="480.645" y="363.8" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Hive Mind Coordination</text>
+<text x="796.75" y="357.2" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Humanize Prose</text>
+<text x="558.477" y="273.8" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Knowledge Graph Construction</text>
+<text x="799.917" y="365.3" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Knowledge Harvest</text>
+<text x="557.175" y="571.5" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Knowledge Management</text>
+<text x="801.835" y="370.9" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Literature Review</text>
+<text x="804.754" y="381.1" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">MCP Debugger Control</text>
+<text x="806.591" y="389.1" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">MCP Server Creation</text>
+<text x="808.227" y="398.5" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">ML Artifact Management</text>
+<text x="809.232" y="406.9" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">ML Pipeline</text>
+<text x="809.723" y="413.3" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Mathematical Animation</text>
+<text x="550.892" y="567.8" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Memory Manage</text>
+<text x="542.068" y="562.0" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Multi-Agent Debate</text>
+<text x="810.0" y="423.3" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Multi-Agent Orchestration</text>
+<text x="809.725" y="432.7" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Multimodal Reasoning</text>
+<text x="808.974" y="441.6" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Ontology Alignment</text>
+<text x="483.267" y="357.2" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">PRD Generation</text>
+<text x="807.945" y="449.4" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Plan and Execute</text>
+<text x="566.312" y="269.8" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Platform Modernization Sprint</text>
+<text x="806.641" y="456.6" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Prediction Market Analysis</text>
+<text x="535.446" y="557.0" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Project Management</text>
+<text x="573.008" y="266.8" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Prompt Optimization</text>
+<text x="804.91" y="464.3" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">RAG Pipeline</text>
+<text x="801.771" y="475.2" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">ReAct Reasoning</text>
+<text x="799.539" y="481.7" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Real-Time Voice Assistant</text>
+<text x="580.571" y="263.7" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Reasoning Pattern Bank</text>
+<text x="529.723" y="552.4" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Receiving Code Review</text>
+<text x="795.857" y="490.9" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Recursive Self-Improvement</text>
+<text x="792.909" y="497.3" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Registry Curation</text>
+<text x="788.631" y="505.5" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Regulatory Compliance Mapping</text>
+<text x="784.978" y="511.8" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Release Automation</text>
+<text x="522.516" y="545.9" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Requesting Code Review</text>
+<text x="779.063" y="520.8" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Research</text>
+<text x="773.808" y="527.9" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Scientific Writing</text>
+<text x="487.97" y="346.9" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Security Audit</text>
+<text x="491.599" y="340.1" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Skill Authoring</text>
+<text x="517.438" y="540.8" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Skill Fusion</text>
+<text x="510.682" y="533.3" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Skill Performance Benchmarking</text>
+<text x="769.872" y="532.7" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Skill Security Analysis</text>
+<text x="763.112" y="540.2" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Stealth Browser Interaction</text>
+<text x="588.833" y="260.9" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Subagent-Driven Development</text>
+<text x="757.637" y="545.7" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Supply Chain Optimization</text>
+<text x="495.739" y="333.1" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Systematic Debugging</text>
+<text x="751.385" y="551.4" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Text-to-SQL Pipeline</text>
+<text x="743.813" y="557.6" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Threat Intelligence Synthesis</text>
+<text x="737.578" y="562.2" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Tool Chaining</text>
+<text x="500.481" y="325.9" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Tool Creation</text>
+<text x="729.069" y="567.8" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Translation Pipeline</text>
+<text x="723.036" y="571.3" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Tree of Thought</text>
+<text x="505.916" y="318.5" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Ubiquitous Language</text>
+<text x="598.577" y="258.1" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Using Git Worktrees</text>
+<text x="511.928" y="311.2" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Verification Before Completion</text>
+<text x="606.987" y="256.2" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Vertical Slice Planning</text>
+<text x="505.299" y="526.7" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Video Intelligence</text>
+<text x="714.504" y="575.8" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Voice Agent</text>
+<text x="500.345" y="519.9" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Web Scrape</text>
+<text x="706.63" y="579.4" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Wiki Search</text>
+<text x="699.704" y="582.2" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Workflow Automation</text>
+<text x="496.299" y="513.8" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Workspace Automation</text>
+<text x="613.93" y="255.0" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">Writing Plans</text>
+<text x="691.441" y="585.0" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">X/Twitter Automation</text>
+<text x="515.9" y="306.8" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">agent-environment-setup</text>
+<text x="522.197" y="300.4" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">agent-handoff</text>
+<text x="621.859" y="254.0" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">mattpocock-engineering</text>
+<text x="530.151" y="293.3" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">mattpocock-personal</text>
+<text x="632.204" y="253.2" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">mattpocock-productivity</text>
+<text x="535.924" y="288.6" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">personal-knowledge-management</text>
+<text x="492.017" y="506.7" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">prototype</text>
+<text x="681.549" y="587.8" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">search-engine-optimization</text>
+<text x="674.797" y="589.4" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">web-accessibility</text>
+<text x="665.813" y="591.0" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">web-best-practices</text>
+<text x="656.662" y="592.2" fill="#c084fc" font-size="12" font-weight="600" opacity="0.92">web-quality-audit</text>
+<text x="646.334" y="364.4" fill="#f59e0b" font-size="16" font-weight="800" opacity="0.92">Founder Mode</text>
+<text x="690.592" y="399.1" fill="#f59e0b" font-size="16" font-weight="800" opacity="0.92">Git Ship Done Pipeline</text>
+<text x="676.907" y="457.4" fill="#f59e0b" font-size="16" font-weight="800" opacity="0.92">Ruflo</text>
+<text x="610.287" y="463.1" fill="#f59e0b" font-size="16" font-weight="800" opacity="0.92">Superpowers</text>
+<text x="590.318" y="396.8" fill="#f59e0b" font-size="16" font-weight="800" opacity="0.92">mattpocock-skills</text>
 </g>
 <g font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#cbd5e1">
 <text x="44" y="748" font-size="20" font-weight="800" fill="#e2e8f0">Gaia Skill Graph</text>
 <circle cx="52" cy="765" r="6" fill="#38bdf8"/>
 <text x="68" y="770">Basic: 106</text>
-<circle cx="52" cy="793" r="6" fill="#a78bfa"/>
+<circle cx="52" cy="793" r="6" fill="#c084fc"/>
 <text x="68" y="798">Extra: 124</text>
 <circle cx="52" cy="821" r="6" fill="#7c3aed"/>
 <text x="68" y="826">Unique: 0</text>
-<circle cx="52" cy="849" r="6" fill="#fbbf24"/>
+<circle cx="52" cy="849" r="6" fill="#f59e0b"/>
 <text x="68" y="854">Ultimate: 5</text>
 </g>
 </svg>

--- a/src/gaia_cli/cardRenderer.py
+++ b/src/gaia_cli/cardRenderer.py
@@ -797,16 +797,34 @@ def render_promotion_prompt(
     else:
         display_colored = f"{tc}{b}{display}{r}"
 
-    lines.extend(
-        [
-            f"  {gc}┌─ Promotion Available ─────────────────────────────────┐{r}",
-            f"  {gc}│{r}  {display_colored} can rank up to {b}Level {proposed_level}{r} ({level_name})",
-            f"  {gc}│{r}  Run: {b}gaia promote {skill_id}{r}",
-            f'  {gc}│{r}  Rename? {b}gaia promote {skill_id} --name "{display.lstrip("/")}"{r}',
-            f"  {gc}└───────────────────────────────────────────────────────┘{r}",
-            "",
-        ]
-    )
+    # Build each content row as a (plain, colored) pair. The plain twin drives
+    # the box width so the fixed-dash borders can no longer clip the longest
+    # line (issue #118: the Rename? hint overran the old hardcoded 55-dash box).
+    rename_name = display.lstrip("/")
+    rows = [
+        (
+            f"  {display} can rank up to Level {proposed_level} ({level_name})",
+            f"  {display_colored} can rank up to {b}Level {proposed_level}{r} ({level_name})",
+        ),
+        (
+            f"  Run: gaia promote {skill_id}",
+            f"  Run: {b}gaia promote {skill_id}{r}",
+        ),
+        (
+            f'  Rename? gaia promote {skill_id} --name "{rename_name}"',
+            f'  Rename? {b}gaia promote {skill_id} --name "{rename_name}"{r}',
+        ),
+    ]
+    title_seg = "─ Promotion Available "
+    # Inner width spans the space between the ┌ ┐ corners. Size to the widest
+    # content row (plus a trailing pad) but never narrower than the title.
+    inner = max(*(len(plain) for plain, _ in rows), len(title_seg)) + 1
+
+    lines.append(f"  {gc}┌{title_seg}{'─' * (inner - len(title_seg))}┐{r}")
+    for plain, colored in rows:
+        lines.append(f"  {gc}│{r}{colored}{' ' * (inner - len(plain))}{gc}│{r}")
+    lines.append(f"  {gc}└{'─' * inner}┘{r}")
+    lines.append("")
     return "\n".join(lines)
 
 

--- a/src/gaia_cli/formatting.py
+++ b/src/gaia_cli/formatting.py
@@ -299,6 +299,12 @@ def rank_hex(rank: str) -> str:
     return f"#{r:02x}{g:02x}{b:02x}"
 
 
+def tier_hex(skill_type: str) -> str:
+    """Return '#rrggbb' for a skill type, sourced from TIER_COLORS (registry meta.typeColors)."""
+    r, g, b = TIER_COLORS.get(skill_type, TIER_COLORS.get("basic", (56, 189, 248)))
+    return f"#{r:02x}{g:02x}{b:02x}"
+
+
 def fusion_equation(prereqs: list[str], result: str, result_glyph: str = "◇") -> str:
     """Plain text fusion equation: /a + /b -> /result glyph"""
     parts = " + ".join(f"/{p}" for p in prereqs)

--- a/src/gaia_cli/graph.py
+++ b/src/gaia_cli/graph.py
@@ -19,15 +19,32 @@ from html import escape
 from pathlib import Path
 from typing import Any
 
+from gaia_cli.formatting import COLOR_LOCAL_USER, tier_hex
 from gaia_cli.leveling import level_summary
 from gaia_cli.registry import named_skills_index_path, registry_graph_path, registry_nodes_dir
 
-PALETTE = {
-    "basic": {"fill": "#38bdf8", "stroke": "#7dd3fc", "label": "Basic"},
-    "extra": {"fill": "#a78bfa", "stroke": "#c4b5fd", "label": "Extra"},
-    "unique": {"fill": "#7c3aed", "stroke": "#a78bfa", "label": "Unique"},
-    "ultimate": {"fill": "#fbbf24", "stroke": "#fde68a", "label": "Ultimate"},
+# Node fills are sourced from the registry palette (meta.typeColors) via tier_hex so
+# the SVG never drifts from the canonical tokens. Stroke tints are lighter accents
+# with no registry equivalent, so they stay local (issue #332).
+_STROKE_TINTS = {
+    "basic": "#7dd3fc",
+    "extra": "#c4b5fd",
+    "unique": "#a78bfa",
+    "ultimate": "#fde68a",
 }
+_TYPE_LABELS = {
+    "basic": "Basic",
+    "extra": "Extra",
+    "unique": "Unique",
+    "ultimate": "Ultimate",
+}
+PALETTE = {
+    t: {"fill": tier_hex(t), "stroke": _STROKE_TINTS[t], "label": _TYPE_LABELS[t]}
+    for t in _TYPE_LABELS
+}
+# Green highlight for pushable local skills (issue #139), sourced from the shared
+# COLOR_LOCAL_USER token rather than a raw hex literal.
+PUSH_GREEN = "#%02x%02x%02x" % COLOR_LOCAL_USER
 TYPE_ORDER = {"basic": 0, "extra": 1, "unique": 2, "ultimate": 3}
 RADIUS_BY_TYPE = {"basic": 285, "extra": 170, "unique": 112, "ultimate": 54}
 NODE_RADIUS = {"basic": 6, "extra": 10, "unique": 13, "ultimate": 15}
@@ -78,8 +95,10 @@ def _named_max_levels(named_buckets: dict[str, Any]) -> dict[str, str]:
 def build_render_graph(
     graph: dict[str, Any], width: int = 1280, height: int = 880,
     named_buckets: dict[str, Any] | None = None,
+    pushable: set[str] | None = None,
 ) -> dict[str, Any]:
     skills = graph.get("skills", [])
+    pushable = pushable or set()
     named_max = _named_max_levels(named_buckets or {})
     groups: dict[str, list[dict[str, Any]]] = {
         "basic": [],
@@ -123,6 +142,7 @@ def build_render_graph(
                     "x": round(x, 3),
                     "y": round(y, 3),
                     "radius": NODE_RADIUS.get(skill_type, 7),
+                    "pushable": sid in pushable,
                 }
             )
 
@@ -327,8 +347,14 @@ def render_svg(render_graph: dict[str, Any], is_workspace_mode: bool = False) ->
     lines.append('<g class="nodes" filter="url(#glow)">')
     for node in nodes:
         color = PALETTE.get(str(node.get("type")), PALETTE["basic"])
+        # Pushable local skills (issue #139) are highlighted green so the operator
+        # can see at a glance what `gaia push` would propose.
+        if node.get("pushable"):
+            fill = stroke = PUSH_GREEN
+        else:
+            fill, stroke = color["fill"], color["stroke"]
         lines.append(
-            f'<circle cx="{node["x"]}" cy="{node["y"]}" r="{node["radius"]}" fill="{color["fill"]}" stroke="{color["stroke"]}" stroke-width="1.6"><title>{escape(str(node.get("label", "")))}</title></circle>'
+            f'<circle cx="{node["x"]}" cy="{node["y"]}" r="{node["radius"]}" fill="{fill}" stroke="{stroke}" stroke-width="1.6"><title>{escape(str(node.get("label", "")))}</title></circle>'
         )
     lines.append("</g>")
 
@@ -368,6 +394,17 @@ def render_svg(render_graph: dict[str, Any], is_workspace_mode: bool = False) ->
         )
         lines.append(
             f'<text x="{legend_x + 24}" y="{y}">{color["label"]}: {count}</text>'
+        )
+    # Pushable highlight legend (issue #139) — only shown when the local graph has
+    # skills that `gaia push` would propose.
+    pushable_count = sum(1 for node in nodes if node.get("pushable"))
+    if pushable_count:
+        y = legend_y + 4 * 28
+        lines.append(
+            f'<circle cx="{legend_x + 8}" cy="{y - 5}" r="6" fill="{PUSH_GREEN}"/>'
+        )
+        lines.append(
+            f'<text x="{legend_x + 24}" y="{y}">Pushable: {pushable_count}</text>'
         )
     lines.append("</g>")
     if is_workspace_mode:
@@ -615,7 +652,19 @@ def write_graph_artifact(
 
         graph["skills"] = [sk for sk in canon_skills.values() if sk["id"] in display_ids]
         graph["version"] = "local-custom"
-    render_graph = build_render_graph(graph, named_buckets=named_buckets)
+
+    # Highlight the skills that `gaia push` would propose (issue #139). Only the
+    # local/custom graph carries this — the canonical registry graph has no
+    # per-user push state.
+    pushable_ids: set[str] = set()
+    if custom:
+        try:
+            from gaia_cli import scanner
+            from gaia_cli.push import pushable_skill_ids
+            pushable_ids = pushable_skill_ids(scanner.load_config(), str(root))
+        except Exception:
+            pushable_ids = set()
+    render_graph = build_render_graph(graph, named_buckets=named_buckets, pushable=pushable_ids)
     fmt = fmt.lower()
     if output is None:
         if custom:

--- a/src/gaia_cli/push.py
+++ b/src/gaia_cli/push.py
@@ -252,6 +252,34 @@ def write_skill_batch(batch, registry_root):
     return batch_path
 
 
+def pushable_skill_ids(config, registry_root):
+    """Return the set of graph node ids that `gaia push` would propose.
+
+    Reuses build_skill_batch so the local-graph highlight (issue #139) can never
+    drift from what actually gets pushed. Ids are bare (no leading slash) to match
+    build_render_graph node ids. Combines starless known skills (canonical id),
+    proposed custom skills, and fusion targets.
+    """
+    try:
+        batch = build_skill_batch([], config, registry_root)
+    except Exception:
+        return set()
+    ids: set[str] = set()
+    for entry in batch.get("knownSkills", []):
+        sid = (entry.get("skillId") or "").lstrip("/")
+        if sid:
+            ids.add(sid)
+    for entry in batch.get("proposedSkills", []):
+        sid = (entry.get("id") or "").lstrip("/")
+        if sid:
+            ids.add(sid)
+    for combo in batch.get("proposedCombinations", []):
+        sid = (combo.get("candidateResult") or "").lstrip("/")
+        if sid:
+            ids.add(sid)
+    return ids
+
+
 _SKILL_MD_CANDIDATES = ("skill.md", "SKILL.md", "README.md", "readme.md")
 
 

--- a/tests/test_card_renderer.py
+++ b/tests/test_card_renderer.py
@@ -382,6 +382,35 @@ class TestRenderPromotionPrompt:
         )
         assert "──▶" in prompt
 
+    def test_box_closes_and_no_cutoff(self):
+        """Regression for #118: the promotion box must size to its content so the
+        Rename? hint is never clipped, and every content row must close with the
+        right border aligned to the top/bottom rules."""
+        import re
+
+        # A long skill id makes the Rename? line the widest row — the old fixed
+        # 55-dash border cut it off.
+        prompt = render_promotion_prompt(
+            {"id": "autonomous-research-and-synthesis-agent", "type": "extra", "prerequisites": []},
+            "4★",
+        )
+        ansi = re.compile(r"\x1b\[[0-9;]*m")
+        box_lines = [
+            ansi.sub("", ln)
+            for ln in prompt.split("\n")
+            if "│" in ln or "┌" in ln or "└" in ln
+        ]
+        # The full rename command must appear intact (not truncated with an ellipsis).
+        assert 'gaia promote autonomous-research-and-synthesis-agent --name' in prompt
+        assert "…" not in "".join(box_lines)
+        # Top, content, and bottom rows all share one right-edge column.
+        edge_cols = {ln.rstrip().index("┐") if "┐" in ln
+                     else ln.rstrip().index("┘") if "┘" in ln
+                     else ln.rstrip().rindex("│")
+                     for ln in box_lines}
+        assert len(edge_cols) == 1, f"ragged right edge: {edge_cols}"
+
+
 
 # ---------------------------------------------------------------------------
 # load_and_render tests

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -367,3 +367,60 @@ class TestScrutiny_CustomGraphSchema:
 
         # Version should carry through
         assert render_graph["version"] == "local-custom"
+
+
+class TestPaletteFromRegistry:
+    """#332 — PALETTE fills must track the registry tokens, not a drifted copy."""
+
+    def test_palette_fills_match_tier_hex(self):
+        from gaia_cli.formatting import tier_hex
+
+        for skill_type in ("basic", "extra", "unique", "ultimate"):
+            assert graph_mod.PALETTE[skill_type]["fill"] == tier_hex(skill_type)
+
+    def test_extra_and_ultimate_no_longer_drifted(self):
+        # The old hardcoded values were extra=#a78bfa and ultimate=#fbbf24.
+        # After sourcing from the registry they must be the canonical tokens.
+        assert graph_mod.PALETTE["extra"]["fill"] == "#c084fc"
+        assert graph_mod.PALETTE["ultimate"]["fill"] == "#f59e0b"
+
+    def test_no_raw_push_green_hex(self):
+        from gaia_cli.formatting import COLOR_LOCAL_USER
+
+        assert graph_mod.PUSH_GREEN == "#%02x%02x%02x" % COLOR_LOCAL_USER
+
+
+class TestPushableHighlight:
+    """#139 — pushable local skills render green with a legend entry."""
+
+    def _graph(self):
+        return {
+            "version": "local-custom",
+            "skills": [
+                {"id": "alpha", "name": "Alpha", "type": "basic",
+                 "level": "0★", "prerequisites": []},
+                {"id": "beta", "name": "Beta", "type": "basic",
+                 "level": "0★", "prerequisites": []},
+            ],
+        }
+
+    def test_pushable_flag_set_on_nodes(self):
+        render_graph = graph_mod.build_render_graph(self._graph(), pushable={"alpha"})
+        by_id = {n["id"]: n for n in render_graph["nodes"]}
+        assert by_id["alpha"]["pushable"] is True
+        assert by_id["beta"]["pushable"] is False
+
+    def test_pushable_defaults_false(self):
+        render_graph = graph_mod.build_render_graph(self._graph())
+        assert all(n["pushable"] is False for n in render_graph["nodes"])
+
+    def test_svg_renders_pushable_green_and_legend(self):
+        render_graph = graph_mod.build_render_graph(self._graph(), pushable={"alpha"})
+        svg = graph_mod.render_svg(render_graph)
+        assert graph_mod.PUSH_GREEN in svg
+        assert "Pushable: 1" in svg
+
+    def test_svg_no_pushable_legend_when_none(self):
+        render_graph = graph_mod.build_render_graph(self._graph())
+        svg = graph_mod.render_svg(render_graph)
+        assert "Pushable:" not in svg


### PR DESCRIPTION
## Wave 2 — CLI bundle → `dev/triage-sprint-2026-07`

Part of the triage sprint. Staged into the integration branch, **not** main.

### #332 — Graph palette drift
`src/gaia_cli/graph.py::PALETTE` had drifted from the canonical registry tokens:
| type | old (drifted) | canonical (registry meta.typeColors) |
|---|---|---|
| `extra` | `#a78bfa` | `#c084fc` |
| `ultimate` | `#fbbf24` | `#f59e0b` |

**Fix:** added `formatting.tier_hex(skill_type)` (mirrors `rank_hex`) and now source PALETTE fills dynamically from `TIER_COLORS`. Stroke tints are lighter accents with no registry equivalent, so they stay local (commented). Regenerated `docs/graph/gaia.svg` (Class S — Guard E). The SVG diff is a **pure color-token change** — 0 drifted colors remain, no version stamp added (per #807 decorative-asset rule).

### #139 — Pushable-skill highlight in the local graph
The local/custom graph gave no visual cue for which skills `gaia push` would propose.

**Fix:** `push.pushable_skill_ids(config, root)` reuses `build_skill_batch` so the highlight can never drift from the real push set (known/starless + proposed + fusion targets). `build_render_graph` gains a `pushable` param; `render_svg` paints those nodes `PUSH_GREEN` (derived from the shared `COLOR_LOCAL_USER` token, **not** a raw hex literal) and adds a "Pushable: N" legend row shown only when local pushables exist.

### #118 — Promotion card box cutoff
`render_promotion_prompt()` used hardcoded 55-dash borders that clipped the longest `Rename?` hint for long skill ids.

**Fix:** the box now sizes to ANSI-stripped content width, so the full rename command is never clipped. (The "rename shows slash form not Title" sub-concern was already fixed; the "redundant research levels" sub-concern is registry-data, out of scope here.)

## Tests
- `tests/test_graph.py`: +8 — palette-fills-match-tier_hex, drift-corrected, PUSH_GREEN-from-token, pushable flag/default/svg-green/legend-absent.
- `tests/test_card_renderer.py`: +1 — box closes and no cutoff for long ids.
- 126 passed across `test_graph` / `test_card_renderer` / `test_formatting`. Pre-existing Windows-only interactive/packaging/timeline failures confirmed identical on the base branch (not regressions).

## Scope note
This is a `cli/` branch that also touches `docs/graph/gaia.svg` (Class S), required by Guard E because the palette change alters the site-served SVG. Needs the **`skip-scope-check`** label (the SVG regen is the mandated cohesion artifact, not out-of-scope work).

## Entrypoints
N/A — no new user-facing page or nav surface; SVG is an existing served asset regenerated in place.