### PR TITLE
fix(design): flowchart popover flicker (#346) + --rank-N-rgb tokens (#868)

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -10326,13 +10326,34 @@ button.nav-graph-trigger:hover {
   z-index: 30;
 }
 
-/* The popover card is itself a .plaque, so the global .plaque:hover
-   lift (translateY(-2px)) competes with the translateX(-50%) centering
-   when the cursor crosses onto the card — the card shifts sideways, the
-   cursor leaves it, and the hover state thrashes. Pin the transform for
-   the card while it is open. */
+/* Root cause 2 — the rank rows (.ns-dag-rank / .se-flowchart-row /
+   .git-rank-row) each establish a stacking context at z-index: 2 (see the
+   rank-row rule below). A hovered node lifted to z-index: 30 is still trapped
+   *inside* its own row's context, so its downward popover was painted over by
+   the NEXT row's nodes. Lift the row that actually contains the hovered node
+   above its sibling rows. */
+.ns-dag-rank:has(.git-node:hover),
+.se-flowchart-row:has(.git-node:hover),
+.git-rank-row:has(.git-node:hover) {
+  z-index: 30;
+}
+
+/* Root cause 1 — the popover card is positioned with transform:
+   translateX(-50%). When the cursor crosses onto the card, the card's own
+   :hover transform fires and overrides the centering:
+     • .plaque--mini:hover { transform: none !important }  (mini/DAG cards)
+     • .flow-node:hover    { transform: translateY(-3px) } (upgrade-path cards)
+   Either one shifts the card sideways/up, the cursor leaves it, and the hover
+   state thrashes → flicker. Pin the centering transform for every popover card
+   type while it is open. !important + the descendant chain beat the
+   .plaque--mini:hover !important rule; the .git-node:hover scope leaves
+   standalone flow-nodes (skill-explorer upgrade path) with their lift intact. */
+.git-node:hover .ns-dag-card:hover,
+.git-node:hover .flow-node:hover,
+.git-node:hover .git-card:hover,
+.git-node:hover .se-stack-deck:hover,
 .git-node > .plaque:hover {
-  transform: translateX(-50%);
+  transform: translateX(-50%) !important;
 }
 
 .git-node:hover .ns-dag-card[data-ghost="true"],

--- a/docs/css/tokens.css
+++ b/docs/css/tokens.css
@@ -38,36 +38,43 @@
   /* ── Rank tokens (0★ → 6★) ───────────────────────────────── */
   /* rank: 0★ */
   --rank-0: #94a3b8; /* var(--rank-0, #94a3b8) */
+  --rank-0-rgb: 148, 163, 184;
   --rank-0-bg: rgba(148,163,184,.12);
   --rank-0-border: rgba(148,163,184,.4);
   --rank-0-edge: rgba(148, 163, 184, 0.55);
   /* rank: 1★ */
   --rank-1: #38bdf8; /* var(--rank-1, #38bdf8) */
+  --rank-1-rgb: 56, 189, 248;
   --rank-1-bg: rgba(56,189,248,.12);
   --rank-1-border: rgba(56,189,248,.4);
   --rank-1-edge: rgba(56, 189, 248, 0.55);
   /* rank: 2★ */
   --rank-2: #63cab7; /* var(--rank-2, #63cab7) */
+  --rank-2-rgb: 99, 202, 183;
   --rank-2-bg: rgba(99,202,183,.15);
   --rank-2-border: rgba(99,202,183,.4);
   --rank-2-edge: rgba(99, 202, 183, 0.55);
   /* rank: 3★ */
   --rank-3: #a78bfa; /* var(--rank-3, #a78bfa) */
+  --rank-3-rgb: 167, 139, 250;
   --rank-3-bg: rgba(167,139,250,.15);
   --rank-3-border: rgba(167,139,250,.4);
   --rank-3-edge: rgba(167, 139, 250, 0.55);
   /* rank: 4★ */
   --rank-4: #e879f9; /* var(--rank-4, #e879f9) */
+  --rank-4-rgb: 232, 121, 249;
   --rank-4-bg: rgba(232,121,249,.15);
   --rank-4-border: rgba(232,121,249,.4);
   --rank-4-edge: rgba(232, 121, 249, 0.55);
   /* rank: 5★ */
   --rank-5: #fbbf24; /* var(--rank-5, #fbbf24) */
+  --rank-5-rgb: 251, 191, 36;
   --rank-5-bg: rgba(251,191,36,.15);
   --rank-5-border: rgba(251,191,36,.4);
   --rank-5-edge: rgba(251, 191, 36, 0.55);
   /* rank: 6★ */
   --rank-6: #fbbf24; /* var(--rank-6, #fbbf24) */
+  --rank-6-rgb: 251, 191, 36;
   --rank-6-bg: rgba(251,191,36,.22);
   --rank-6-border: rgba(251,191,36,.55);
   --rank-6-edge: rgba(251, 191, 36, 0.55);

--- a/docs/trust/leaderboard/leaderboard.js
+++ b/docs/trust/leaderboard/leaderboard.js
@@ -125,7 +125,9 @@
     return 'background:oklch(0.55 0.18 ' + handleHue(handle) + ');';
   }
 
-  // Fallback for --rank-N-rgb (not all tokens.css emit them)
+  // --rank-N-rgb are emitted by scripts/generateCssTokens.py (issue #868).
+  // The triplet fallbacks stay as a defensive floor for the case where
+  // tokens.css hasn't loaded yet; they mirror the canonical token values.
   function rankRgb(level) {
     var n = parseInt(level) || 0;
     var map = {

--- a/scripts/generateCssTokens.py
+++ b/scripts/generateCssTokens.py
@@ -20,6 +20,7 @@ Tier (one block per tier in ``typeColors``)::
 Rank (one block per ``"N★"`` key in ``levelColors``, where N ∈ 0..6)::
 
     --rank-<N>             /* hex */
+    --rank-<N>-rgb         /* "R, G, B" triplet */
     --rank-<N>-bg          /* rgba(..., .12-.22) */
     --rank-<N>-border      /* rgba(..., .35-.55) */
     --rank-<N>-edge        /* rgba(..., .55) — translucent stroke for arrows */
@@ -118,7 +119,7 @@ def _emit_tier_block(name: str, color: dict, symbol: str | None) -> list[str]:
 
 
 def _emit_rank_block(star: int, color: dict) -> list[str]:
-    """Emit four lines for a single rank star value (hex + bg + border + edge)."""
+    """Emit five lines for a single rank star value (hex + rgb + bg + border + edge)."""
     hex_val = color.get("hex")
     if not hex_val:
         raise ValueError(f"levelColors[{star}★] missing 'hex'")
@@ -129,6 +130,7 @@ def _emit_rank_block(star: int, color: dict) -> list[str]:
     edge = f"rgba({rgb_triplet}, {DEFAULT_EDGE_ALPHA})"
     return [
         f"  --rank-{star}: {hex_val}; /* var(--rank-{star}, {hex_val}) */",
+        f"  --rank-{star}-rgb: {rgb_triplet};",
         f"  --rank-{star}-bg: {bg};",
         f"  --rank-{star}-border: {border};",
         f"  --rank-{star}-edge: {edge};",


### PR DESCRIPTION
## Wave 2 — frontend bundle → `dev/triage-sprint-2026-07`

Part of the triage sprint. Staged into the integration branch, **not** main.

### #346 — Flowchart / DAG popover flicker (long-lived)
Triangulated to **two independent root causes**, both fixed in `docs/css/styles.css`:

**1. Transform-flip.** Popover cards are centered with `transform: translateX(-50%)`. When the cursor crosses onto the card, the card's own `:hover` transform fires and overrides the centering:
- `.plaque--mini:hover { transform: none !important }` (L9886) for mini/DAG cards
- `.flow-node:hover { transform: translateY(-3px) }` (L7402) for upgrade-path cards

Either shifts the card, the cursor falls off, and hover thrashes → flicker. The prior pin `.git-node > .plaque:hover` lacked `!important` (lost to the `!important` mini rule) and didn't cover `.flow-node` at all. **Fix:** pin `transform: translateX(-50%) !important` for every popover card type while open, scoped under `.git-node:hover` so standalone flow-nodes keep their lift.

**2. Stacking-context trap.** The rank rows (`.ns-dag-rank` / `.se-flowchart-row` / `.git-rank-row`) each set `z-index: 2` (L10521), creating a stacking context that caged the hovered node's `z-index: 30` **inside its own row** — so the next rank row's nodes painted over the downward-opening popover. **Fix:** `:has(.git-node:hover) { z-index: 30 }` lifts the row that actually contains the hovered node above its sibling rows. (`:has()` is already an established pattern in this file, L417/420.)

### #868 — `--rank-N-rgb` design tokens
The Trust Leaderboard JS (`docs/trust/leaderboard/leaderboard.js`) read `tok('--rank-N-rgb')` but `tokens.css` never emitted those triplets, so it always fell back to hardcoded RGB values.

**Fix:** added the `--rank-<N>-rgb` line to `_emit_rank_block` in `scripts/generateCssTokens.py` (the tier block already had `--tier-<name>-rgb`; ranks were the gap). Regenerated `docs/css/tokens.css` — pure additions, values match the JS fallbacks exactly. Fallbacks kept as a defensive floor for pre-token-load, comment updated. No version-stamp churn (#807).

### #235 — SVG/graph search by name + slash-name
**Verified already resolved** — closing separately with evidence, no code change here. `docs/js/skill-graph.js::_searchMatches` (L901) already matches `id`, `name`, `description`, `title`, **and** the full `contributor/slug` `namedId`, plus dedicated `/slash` and `@handle` prefix modes (L911-918). Directly satisfies "should work with the name and the slash skill."

## Tests
- `tests/test_tui_tokens.py`: 9 passed (token generator).
- CSS: braces balanced (1726/1726), zero hex literals in the #346 region.
- Guard A (hardcoded-colors) clean on all touched `docs/css` + `docs/js` files.

## Scope note
`design/` scope is `docs/` + `*.md`; this PR also touches `scripts/generateCssTokens.py` (the source of the `tokens.css` regen for #868). Needs **`skip-scope-check`** — the generator change and its emitted `tokens.css` must move together.

## Entrypoints
N/A — no new page or nav surface. #346 fixes an existing interaction on the Named-skills DAG + skill-explorer upgrade path; #868 wires existing leaderboard bars to canonical tokens.