### PR TITLE
fix(ci): make trending drift warn-only in gaia dev docs --check (#1108)

### DIFF
--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -1527,6 +1527,21 @@ def main(argv: list[str] | None = None) -> int:
             "not structural schema change).",
             file=sys.stderr,
         )
+    # Trending drift is warn-only. docs/api/v1/trending/{7d,30d}.json + feed.xml
+    # are *rolling time-window* artifacts: the 7d/30d windows and RSS timestamps
+    # recompute to different bytes the moment the UTC day advances past the last
+    # release regen, so an unrelated PR that merely triggers validate.yml (e.g.
+    # touches tests/** or scripts/**) trips `Schema + DAG + Integrity Checks` on
+    # drift it did not cause. This mirrors the ISO-week rollover skip already in
+    # build_content_engine and the okf/badges warn-only precedent above. The cron
+    # still regenerates the real windows in production; the drift stays visible in
+    # the diff output for inspection. See issue #1108.
+    if trending_changed and args.check:
+        print(
+            "::warning::docs/api/v1/trending/ is stale (warn-only — rolling "
+            "time-window artifact, recomputes on UTC-day rollover; see #1108).",
+            file=sys.stderr,
+        )
 
     changed = (
         assembly_changed
@@ -1542,7 +1557,7 @@ def main(argv: list[str] | None = None) -> int:
         or trust_ledger_changed
         or api_changed
         or benchmark_proj_changed
-        or trending_changed
+        # trending_changed: intentionally omitted — see warn-only block above (#1108).
         or content_engine_changed
         or profiles_changed
         # badges_changed: intentionally omitted — see warn-only block above.


### PR DESCRIPTION
## Problem

\`docs/api/v1/trending/{7d,30d}.json\` + \`feed.xml\` are **rolling time-window** artifacts. Their bytes recompute the moment the UTC day advances past the last release regen — independent of any PR's content. Because \`trending_changed\` fed the \`gaia dev docs --check\` exit code, every PR that merely triggers \`validate.yml\` (touches \`tests/**\`, \`scripts/**\`, etc.) failed **Schema + DAG + Integrity Checks** on trending drift it did not cause, once run on a later UTC day than the last regen.

### Evidence
- PR #1107 (\`cli/\` branch, 6 files, zero docs artifacts) failed on \`7d.json\` + \`feed.xml\` on 2026-07-10; its committed trending files were byte-identical to base.
- PR #1105 (same shape) passed the identical check on 2026-07-09 — the UTC day the trending files were baked at v6.3.15.
- Only variable between pass and fail: the wall clock.

## Fix

Option 1 from #1108 (warn-only, the low-risk choice matching existing precedent):

- Remove \`trending_changed\` from the \`changed\` aggregation that feeds the \`--check\` exit code.
- Emit a \`::warning::\` instead, mirroring the okf/badges warn-only blocks directly above it and the ISO-week rollover skip in \`build_content_engine\`.

The production cron still regenerates the real windows; the drift stays visible in \`--check\` diff output for inspection. No change to the trending engine's output or to \`validate.yml\` trigger paths.

## Testing

- \`python -c "import ast; ast.parse(...)"\` — syntax OK.
- Full suite run; remaining failures (\`test_scanner\`, \`test_push\`, \`test_workspace_mode\`, \`test_timelines\`, etc.) reproduce identically on clean \`main\` — pre-existing Windows-environment failures (\`ValueError: I/O operation on closed file\`, path-casing), not regressions. This change only removes a boolean from a CI-gate aggregation.

## Entrypoints
N/A — no new user-facing page or section; CI-gating change only.

Closes #1108.