### PR TITLE
docs: codify sprint completeness rule (no follow-ups) + close #611

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,15 @@ Guidance for AI coding agents working in this repository.
 - Read key files BEFORE running exploratory bash commands.
 - When asked to monitor/loop CI checks, monitor — do not switch to debugging failures unless instructed.
 
+## Sprint Completeness — no follow-ups
+
+**Every sprint is expected to ship COMPLETE. A sprint does NOT generate follow-up issues.** If a sprint would leave loose ends, those loose ends are scoped during staging as their own extra PR within the sprint — not deferred as a "follow-up" to be picked up later.
+
+- Do **not** close out a sprint by filing `follow-up`/`tech-debt` issues that carry the sprint's own unfinished work. That work belongs in the sprint.
+- When staging a sprint, enumerate everything the sprint touches and pre-scope any spillover as an additional PR in the same sprint. Land it before declaring the sprint done.
+- A sprint is "done" only when there is nothing left that a reasonable reviewer would call a direct consequence of the sprint's changes. Rolling-window CI false positives, doc drift, deferred surface states, and CLI gaps introduced by the sprint all count as in-scope and must be resolved inside the sprint.
+- This does not forbid filing genuinely new, out-of-scope work discovered during a sprint — that's normal backlog hygiene. It forbids treating the sprint's own remainder as "future work."
+
 ## Graphify
 
 Graphify is an approved tool for codebase analysis and is used on an as-needed basis (deep architecture audits, dependency mapping, cross-cutting impact assessments). Running it costs real token spend — only invoke it when the task warrants a structural code graph. The valuable outputs (`graph.json`, `graph.html`, `manifest.json`, `GRAPH_REPORT.md`, `cost.json`) are tracked in git; the regenerable cache (`graphify-out/cache/`) is gitignored.


### PR DESCRIPTION
## What

Two things, both closing out the 2026-07 triage sprint so it leaves **zero** follow-ups:

1. **`CLAUDE.md` — new "Sprint Completeness — no follow-ups" section.** Codifies the operator directive: every sprint ships complete; spillover is scoped during staging as an extra PR *within* the sprint, never deferred as a follow-up issue. Genuinely new out-of-scope discoveries are still normal backlog hygiene — what's forbidden is treating a sprint's own remainder as "future work."

2. **Closes #611** (`gaia push --update` incremental pushes). The feature shipped in PR #1107 (merged to main via #1109): \`skill_identity_key\` + \`skill_fingerprint\` identity model, \`classify_against_pending\` NEW/CHANGED/UNCHANGED classifier, and the issue-body identity-block round-trip. Covered by 23 passing tests in \`tests/test_push_incremental.py\`.

## Why in this sprint

Per the new rule this PR adds: the trending CI false positive (#1108, fixed in the sibling PR) and this #611 closure are both direct consequences of the triage sprint's own work, so they're resolved *inside* the sprint rather than deferred.

## Entrypoints
N/A — docs/policy change only, no new user-facing page or section.