### PR TITLE
fix(ci): fix 100%-failing Release workflow (regenerate Class P index before validators)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,20 @@ jobs:
           python-version: '3.12'
 
       - name: Install dependencies
-        run: python -m pip install jsonschema==4.26.0 PyYAML==6.0.1
+        run: python -m pip install -e ".[dev]"
+
+      # registry/named-skills.json (+ the docs/graph mirror) is a gitignored
+      # Class P artifact — absent on a fresh checkout. The validators below read
+      # it as their source of truth, so it MUST be regenerated first, exactly as
+      # validate.yml does on every PR. Without this step validate_redaction.py
+      # dies with "cannot find registry/named-skills.json" and the release job
+      # (needs: validate-graph) never runs — the 100%-failure root cause.
+      - name: Build intermediate registry artifacts
+        run: |
+          python scripts/assemble_gaia.py
+          python scripts/generateNamedIndex.py
+          mkdir -p docs/graph/named
+          cp registry/named-skills.json docs/graph/named/index.json
 
       - name: Validate schema + DAG + evidence
         run: python scripts/validate.py


### PR DESCRIPTION
## Problem — Release workflow has a 100% failure rate

\`release.yml\` (fires on \`v*\` tag push) gates the GitHub Release on a \`validate-graph\` job. That job installed only \`jsonschema\`+\`PyYAML\` and ran the validators **directly**:

\`\`\`
- name: Install dependencies
  run: python -m pip install jsonschema==4.26.0 PyYAML==6.0.1
- name: Validate redaction invariant …
  run: python scripts/validate_redaction.py
\`\`\`

But \`validate_redaction.py\` reads **\`registry/named-skills.json\`** as its source of truth — a **gitignored Class P artifact** that does not exist on a fresh CI checkout. So the step dies every time:

\`\`\`
redaction: cannot find …/registry/named-skills.json
##[error]Process completed with exit code 1.
\`\`\`

The \`release\` job (\`needs: [test-python, test-mcp, validate-graph]\`) then never runs. Confirmed failing on **v6.0.0, v5.1.0, v4.4.0, v4.2.1** (Python Tests ✓, MCP Tests ✓, Validate Graph ✗ every time). Every GitHub Release since has been produced by \`sync-artifacts.yml\`'s fallback \`gh release create\` path — which is why tags accumulated as canary pre-releases and Latest is still stuck at v6.0.0.

## Fix (yml-only)

Mirror what \`validate.yml\` already does correctly on every PR — install the package and regenerate the intermediate registry artifacts before validating:

- \`pip install -e ".[dev]"\` (so \`gaia_cli\` is importable by the generators)
- new **Build intermediate registry artifacts** step: \`assemble_gaia.py\` + \`generateNamedIndex.py\` + mirror to \`docs/graph/named/index.json\`

**No change to how Class P/S artifacts are stored.** The index stays gitignored and is regenerated in-CI, byte-identical to \`validate.yml\`'s approach.

## Verification

Reproduced the failure and the fix locally (Windows checkout):
- Index **absent** → \`validate_redaction.py\` **exit 1** (the CI failure).
- Run \`assemble_gaia.py\` + \`generateNamedIndex.py\`, index **present** → \`validate.py\`, \`validate_redaction.py\` **exit 0**.
- YAML syntax validated with \`yaml.safe_load\`.

## Entrypoints
N/A — CI workflow fix only, no user-facing surface.