### PR TITLE
fix(ci): fold HTML cache-bust rewrite into gaia dev release

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ curl https://gaiaskilltree.com/api/v1/leaderboard.json
 **1. CLI
 
 <!-- gaia:version-start -->
-Current Gaia CLI version: `6.3.20`.
+Current Gaia CLI version: `6.4.0`.
 
 ```bash
 curl -fsSL https://gaiaskilltree.com/install.sh | sh

--- a/docs/about.html
+++ b/docs/about.html
@@ -4,7 +4,7 @@
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <script>window.GAIA_VERSION = "6.3.20";</script>
+  <script>window.GAIA_VERSION = "6.4.0";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>About — Gaia Skill Registry</title>
@@ -17,11 +17,11 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
   <link rel="icon" type="image/svg+xml" href="assets/marks/diamond-seal.svg">
-  <link rel="stylesheet" href="css/styles.css?v=6.3.20">
-  <link rel="stylesheet" href="css/plaque.css?v=6.3.20">
-  <script src="js/icons.js?v=6.3.20"></script>
-  <script src="js/atlas-helpers.js?v=6.3.20"></script>
-  <script src="js/rank-badge.js?v=6.3.20"></script>
+  <link rel="stylesheet" href="css/styles.css?v=6.4.0">
+  <link rel="stylesheet" href="css/plaque.css?v=6.4.0">
+  <script src="js/icons.js?v=6.4.0"></script>
+  <script src="js/atlas-helpers.js?v=6.4.0"></script>
+  <script src="js/rank-badge.js?v=6.4.0"></script>
 
   <style>
     /* ─── about.html — atlas frontispiece layout ───────────────── */
@@ -905,8 +905,8 @@
 
   <!-- ─── NAV ─── -->
   <nav id="site-nav"></nav>
-  <script src="js/mounts.js?v=6.3.20"></script>
-  <script src="js/site-nav.js?v=6.3.20"></script>
+  <script src="js/mounts.js?v=6.4.0"></script>
+  <script src="js/site-nav.js?v=6.4.0"></script>
 
   <!-- ─── BACK ─── -->
   <div class="profile-back-row">
@@ -1241,9 +1241,9 @@
 
   <!-- ─── FOOTER v2 ─── -->
   <div id="site-footer-mount"></div>
-  <script src="js/site-footer.js?v=6.3.20"></script>
+  <script src="js/site-footer.js?v=6.4.0"></script>
 
-  <script src="js/ui.js?v=6.3.20" defer></script>
+  <script src="js/ui.js?v=6.4.0" defer></script>
 
   <!-- Hydrate rank badges from the canonical component (no inline star markup). -->
   <script>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -2,7 +2,7 @@
 <html lang="en" data-icon-base="../assets/icons.svg">
 
 <head>
-  <script>window.GAIA_VERSION = "6.3.20";</script>
+  <script>window.GAIA_VERSION = "6.4.0";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -21,12 +21,12 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
   <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
-  <link rel="stylesheet" href="../css/styles.css?v=6.3.20">
+  <link rel="stylesheet" href="../css/styles.css?v=6.4.0">
   <!-- Scripts -->
-  <script src="../js/icons.js?v=6.3.20"></script>
-  <script src="../js/mounts.js?v=6.3.20"></script>
-  <script src="../js/site-nav.js?v=6.3.20"></script>
-  <script src="../js/site-footer.js?v=6.3.20"></script>
+  <script src="../js/icons.js?v=6.4.0"></script>
+  <script src="../js/mounts.js?v=6.4.0"></script>
+  <script src="../js/site-nav.js?v=6.4.0"></script>
+  <script src="../js/site-footer.js?v=6.4.0"></script>
 
   <style>
     /* ── API Docs Page Styles — tokens only, no hex ── */

--- a/docs/badges/index.html
+++ b/docs/badges/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "6.3.20";</script>
+  <script>window.GAIA_VERSION = "6.4.0";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -17,8 +17,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../css/tokens.css?v=6.3.20">
-  <link rel="stylesheet" href="../css/styles.css?v=6.3.20">
+  <link rel="stylesheet" href="../css/tokens.css?v=6.4.0">
+  <link rel="stylesheet" href="../css/styles.css?v=6.4.0">
   <style>
     a { color: inherit; }
     .bd-live {
@@ -846,7 +846,7 @@
       white-space: nowrap;
     }
   </style>
-  <link rel="stylesheet" href="../css/plaque.css?v=6.3.20">
+  <link rel="stylesheet" href="../css/plaque.css?v=6.4.0">
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -858,8 +858,8 @@
 </head>
 <body class="process-page">
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.3.20"></script>
-  <script src="../js/site-nav.js?v=6.3.20"></script>
+  <script src="../js/mounts.js?v=6.4.0"></script>
+  <script src="../js/site-nav.js?v=6.4.0"></script>
 
   <main>
     <!-- ─── BACK ─── -->
@@ -1918,7 +1918,7 @@
 
   <!-- ─── FOOTER v2 ─── -->
   <div id="site-footer-mount"></div>
-  <script src="../js/site-footer.js?v=6.3.20"></script>
+  <script src="../js/site-footer.js?v=6.4.0"></script>
 
   <!-- ─── TREE DIALOG ─── -->
   <a id="tree" tabindex="-1" aria-hidden="true"></a>
@@ -1939,9 +1939,9 @@
   </dialog>
 
   <!-- ─── SCRIPTS ─── -->
-  <script src="../js/atlas-helpers.js?v=6.3.20"></script>
-  <script src="../js/skill-explorer.js?v=6.3.20"></script>
-  <script src="../js/ui.js?v=6.3.20"></script>
-  <script src="../js/page-ia.js?v=6.3.20"></script>
+  <script src="../js/atlas-helpers.js?v=6.4.0"></script>
+  <script src="../js/skill-explorer.js?v=6.4.0"></script>
+  <script src="../js/ui.js?v=6.4.0"></script>
+  <script src="../js/page-ia.js?v=6.4.0"></script>
 </body>
 </html>

--- a/docs/benchmarks/humaneval-v1/index.html
+++ b/docs/benchmarks/humaneval-v1/index.html
@@ -4,7 +4,7 @@
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <script>window.GAIA_VERSION = "6.3.20";</script>
+  <script>window.GAIA_VERSION = "6.4.0";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>HumanEval v1 &mdash; Methodology | Gaia Registry</title>
@@ -13,8 +13,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;500;600;700&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
   <script>window.gaiaIconBase = function () { return '../../assets/icons.svg'; };</script>
-  <link rel="stylesheet" href="../../css/tokens.css?v=6.3.20">
-  <link rel="stylesheet" href="../../css/styles.css?v=6.3.20">
+  <link rel="stylesheet" href="../../css/tokens.css?v=6.4.0">
+  <link rel="stylesheet" href="../../css/styles.css?v=6.4.0">
   <style>
     /* Shares the methodology-page prose shell voice. */
     .prose-shell {
@@ -185,8 +185,8 @@
 </head>
 <body>
   <nav id="site-nav"></nav>
-  <script src="../../js/mounts.js?v=6.3.20"></script>
-  <script src="../../js/site-nav.js?v=6.3.20"></script>
+  <script src="../../js/mounts.js?v=6.4.0"></script>
+  <script src="../../js/site-nav.js?v=6.4.0"></script>
   <main class="prose-shell">
     <span class="breadcrumb"><a href="../humaneval/">&larr; HumanEval Leaderboard</a></span>
 
@@ -343,6 +343,6 @@
     </footer>
   </main>
   <div id="site-footer-mount"></div>
-  <script src="../../js/site-footer.js?v=6.3.20"></script>
+  <script src="../../js/site-footer.js?v=6.4.0"></script>
 </body>
 </html>

--- a/docs/benchmarks/humaneval/index.html
+++ b/docs/benchmarks/humaneval/index.html
@@ -4,7 +4,7 @@
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <script>window.GAIA_VERSION = "6.3.20";</script>
+  <script>window.GAIA_VERSION = "6.4.0";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>HumanEval Leaderboard | Gaia Registry</title>
@@ -12,8 +12,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;500;600;700&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../../css/tokens.css?v=6.3.20">
-  <link rel="stylesheet" href="../../css/styles.css?v=6.3.20">
+  <link rel="stylesheet" href="../../css/tokens.css?v=6.4.0">
+  <link rel="stylesheet" href="../../css/styles.css?v=6.4.0">
   <script>
     window.gaiaIconBase = function () { return '../../assets/icons.svg'; };
   </script>
@@ -285,8 +285,8 @@
 </head>
 <body>
   <nav id="site-nav"></nav>
-  <script src="../../js/mounts.js?v=6.3.20"></script>
-  <script src="../../js/site-nav.js?v=6.3.20"></script>
+  <script src="../../js/mounts.js?v=6.4.0"></script>
+  <script src="../../js/site-nav.js?v=6.4.0"></script>
 
   <main class="lb-shell">
     <div class="lb-back"><a href="../">&larr; Benchmarks</a></div>
@@ -335,7 +335,7 @@
   </main>
 
   <div id="site-footer-mount"></div>
-  <script src="../../js/site-footer.js?v=6.3.20"></script>
-  <script src="../_shared/leaderboard.js?v=6.3.20" defer></script>
+  <script src="../../js/site-footer.js?v=6.4.0"></script>
+  <script src="../_shared/leaderboard.js?v=6.4.0" defer></script>
 </body>
 </html>

--- a/docs/benchmarks/index.html
+++ b/docs/benchmarks/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script>window.GAIA_VERSION = "6.3.20";</script>
+  <script>window.GAIA_VERSION = "6.4.0";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -14,8 +14,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;500;600;700&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
-  <link rel="stylesheet" href="../css/tokens.css?v=6.3.20">
-  <link rel="stylesheet" href="../css/styles.css?v=6.3.20">
+  <link rel="stylesheet" href="../css/tokens.css?v=6.4.0">
+  <link rel="stylesheet" href="../css/styles.css?v=6.4.0">
 
   <script>
     window.gaiaIconBase = function () { return '../assets/icons.svg'; };
@@ -405,8 +405,8 @@
 </head>
 <body>
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.3.20"></script>
-  <script src="../js/site-nav.js?v=6.3.20"></script>
+  <script src="../js/mounts.js?v=6.4.0"></script>
+  <script src="../js/site-nav.js?v=6.4.0"></script>
 
   <main class="bench-shell">
 
@@ -511,7 +511,7 @@
   </main>
 
   <div id="site-footer-mount"></div>
-  <script src="../js/site-footer.js?v=6.3.20"></script>
+  <script src="../js/site-footer.js?v=6.4.0"></script>
   <script>
   /* Mobile-first parallax on the GSB panel per DESIGN.md §Motion.
      - RAF-driven translateY, never background-attachment:fixed

--- a/docs/benchmarks/methodology/index.html
+++ b/docs/benchmarks/methodology/index.html
@@ -4,7 +4,7 @@
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <script>window.GAIA_VERSION = "6.3.20";</script>
+  <script>window.GAIA_VERSION = "6.4.0";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Benchmark Methodology | Gaia Registry</title>
@@ -13,8 +13,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;500;600;700&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
   <script>window.gaiaIconBase = function () { return '../../assets/icons.svg'; };</script>
-  <link rel="stylesheet" href="../../css/tokens.css?v=6.3.20">
-  <link rel="stylesheet" href="../../css/styles.css?v=6.3.20">
+  <link rel="stylesheet" href="../../css/tokens.css?v=6.4.0">
+  <link rel="stylesheet" href="../../css/styles.css?v=6.4.0">
   <style>
     /* ─────────────────────────────────────────────────────────────
        METHODOLOGY — long-form prose with typographic rhythm.
@@ -215,8 +215,8 @@
 </head>
 <body>
   <nav id="site-nav"></nav>
-  <script src="../../js/mounts.js?v=6.3.20"></script>
-  <script src="../../js/site-nav.js?v=6.3.20"></script>
+  <script src="../../js/mounts.js?v=6.4.0"></script>
+  <script src="../../js/site-nav.js?v=6.4.0"></script>
   <main class="prose-shell">
     <span class="breadcrumb"><a href="../">&larr; Benchmarks</a></span>
 
@@ -363,6 +363,6 @@
     </footer>
   </main>
   <div id="site-footer-mount"></div>
-  <script src="../../js/site-footer.js?v=6.3.20"></script>
+  <script src="../../js/site-footer.js?v=6.4.0"></script>
 </body>
 </html>

--- a/docs/benchmarks/mmlu-v1/index.html
+++ b/docs/benchmarks/mmlu-v1/index.html
@@ -4,7 +4,7 @@
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <script>window.GAIA_VERSION = "6.3.20";</script>
+  <script>window.GAIA_VERSION = "6.4.0";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>MMLU v1 &mdash; Methodology | Gaia Registry</title>
@@ -13,8 +13,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;500;600;700&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
   <script>window.gaiaIconBase = function () { return '../../assets/icons.svg'; };</script>
-  <link rel="stylesheet" href="../../css/tokens.css?v=6.3.20">
-  <link rel="stylesheet" href="../../css/styles.css?v=6.3.20">
+  <link rel="stylesheet" href="../../css/tokens.css?v=6.4.0">
+  <link rel="stylesheet" href="../../css/styles.css?v=6.4.0">
   <style>
     /* Shares the methodology-page prose shell voice. */
     .prose-shell {
@@ -201,8 +201,8 @@
 </head>
 <body>
   <nav id="site-nav"></nav>
-  <script src="../../js/mounts.js?v=6.3.20"></script>
-  <script src="../../js/site-nav.js?v=6.3.20"></script>
+  <script src="../../js/mounts.js?v=6.4.0"></script>
+  <script src="../../js/site-nav.js?v=6.4.0"></script>
   <main class="prose-shell">
     <span class="breadcrumb"><a href="../mmlu/">&larr; MMLU Leaderboard</a></span>
 
@@ -305,6 +305,6 @@
     </footer>
   </main>
   <div id="site-footer-mount"></div>
-  <script src="../../js/site-footer.js?v=6.3.20"></script>
+  <script src="../../js/site-footer.js?v=6.4.0"></script>
 </body>
 </html>

--- a/docs/benchmarks/mmlu/index.html
+++ b/docs/benchmarks/mmlu/index.html
@@ -4,7 +4,7 @@
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <script>window.GAIA_VERSION = "6.3.20";</script>
+  <script>window.GAIA_VERSION = "6.4.0";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>MMLU Leaderboard | Gaia Registry</title>
@@ -12,8 +12,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;500;600;700&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../../css/tokens.css?v=6.3.20">
-  <link rel="stylesheet" href="../../css/styles.css?v=6.3.20">
+  <link rel="stylesheet" href="../../css/tokens.css?v=6.4.0">
+  <link rel="stylesheet" href="../../css/styles.css?v=6.4.0">
   <script>
     window.gaiaIconBase = function () { return '../../assets/icons.svg'; };
   </script>
@@ -208,8 +208,8 @@
 </head>
 <body>
   <nav id="site-nav"></nav>
-  <script src="../../js/mounts.js?v=6.3.20"></script>
-  <script src="../../js/site-nav.js?v=6.3.20"></script>
+  <script src="../../js/mounts.js?v=6.4.0"></script>
+  <script src="../../js/site-nav.js?v=6.4.0"></script>
 
   <main class="lb-shell">
     <div class="lb-back"><a href="../">&larr; Benchmarks</a></div>
@@ -268,7 +268,7 @@
   </main>
 
   <div id="site-footer-mount"></div>
-  <script src="../../js/site-footer.js?v=6.3.20"></script>
-  <script src="../_shared/leaderboard.js?v=6.3.20" defer></script>
+  <script src="../../js/site-footer.js?v=6.4.0"></script>
+  <script src="../_shared/leaderboard.js?v=6.4.0" defer></script>
 </body>
 </html>

--- a/docs/codex.html
+++ b/docs/codex.html
@@ -2,7 +2,7 @@
 <!-- Codex updated to include gaia curate chain pipeline and interactive diagram -->
 <html lang="en">
 <head>
-  <script>window.GAIA_VERSION = "6.3.20";</script>
+  <script>window.GAIA_VERSION = "6.4.0";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -14,13 +14,13 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-<link rel="stylesheet" href="css/styles.css?v=6.3.20">
+<link rel="stylesheet" href="css/styles.css?v=6.4.0">
 <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-<script src="js/icons.js?v=6.3.20"></script>
+<script src="js/icons.js?v=6.4.0"></script>
 <!-- Stage 2 — shared rank-badge primitive. -->
-<script src="js/rank-badge.js?v=6.3.20"></script>
+<script src="js/rank-badge.js?v=6.4.0"></script>
 <!-- Stage 3 — plaque component family. -->
-<script src="js/plaque.js?v=6.3.20"></script>
+<script src="js/plaque.js?v=6.4.0"></script>
 <style>
 /* Curate Chain CSS definitions */
 .curate-chain-section {
@@ -430,7 +430,7 @@
   }
 }
 </style>
-  <link rel="stylesheet" href="css/plaque.css?v=6.3.20">
+  <link rel="stylesheet" href="css/plaque.css?v=6.4.0">
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -443,8 +443,8 @@
 <body class="process-page">
 
   <nav id="site-nav"></nav>
-  <script src="js/mounts.js?v=6.3.20"></script>
-  <script src="js/site-nav.js?v=6.3.20"></script>
+  <script src="js/mounts.js?v=6.4.0"></script>
+  <script src="js/site-nav.js?v=6.4.0"></script>
 
 <main>
   <!-- ─── BACK ─── -->
@@ -1078,7 +1078,7 @@
 
 <!-- ─── FOOTER v2 ─── -->
   <div id="site-footer-mount"></div>
-  <script src="js/site-footer.js?v=6.3.20"></script>
+  <script src="js/site-footer.js?v=6.4.0"></script>
 
   <!-- ─── TREE DIALOG ─── -->
   <a id="tree" tabindex="-1" aria-hidden="true"></a>
@@ -1102,10 +1102,10 @@
   </button>
 
   <!-- ─── SCRIPTS ─── -->
-  <script src="js/atlas-helpers.js?v=6.3.20"></script>
-  <script src="js/skill-explorer.js?v=6.3.20"></script>
-  <script src="js/ui.js?v=6.3.20"></script>
-  <script src="js/page-ia.js?v=6.3.20"></script>
+  <script src="js/atlas-helpers.js?v=6.4.0"></script>
+  <script src="js/skill-explorer.js?v=6.4.0"></script>
+  <script src="js/ui.js?v=6.4.0"></script>
+  <script src="js/page-ia.js?v=6.4.0"></script>
 
 <!-- impeccable-live-start -->
 <script src="http://localhost:8400/live.js"></script>

--- a/docs/codex/trust-methodology.html
+++ b/docs/codex/trust-methodology.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script>window.GAIA_VERSION = "6.3.20";</script>
+  <script>window.GAIA_VERSION = "6.4.0";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -12,8 +12,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../css/styles.css?v=6.3.20">
-  <script src="../js/icons.js?v=6.3.20"></script>
+  <link rel="stylesheet" href="../css/styles.css?v=6.4.0">
+  <script src="../js/icons.js?v=6.4.0"></script>
   <style>
     /* ── Trust Methodology page — minimal additions on top of process-page tokens ── */
     .tm-formula-block {
@@ -315,8 +315,8 @@
 <body class="process-page">
 
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.3.20"></script>
-  <script src="../js/site-nav.js?v=6.3.20"></script>
+  <script src="../js/mounts.js?v=6.4.0"></script>
+  <script src="../js/site-nav.js?v=6.4.0"></script>
 
   <main style="padding: 0 2rem; max-width: 1060px; margin: 0 auto;">
 
@@ -1334,7 +1334,7 @@
 
   <!-- ─── FOOTER ─── -->
   <div id="site-footer-mount"></div>
-  <script src="../js/site-footer.js?v=6.3.20"></script>
+  <script src="../js/site-footer.js?v=6.4.0"></script>
 
   <!-- ─── SCROLL TO TOP ─── -->
   <button id="scrollToTop" class="scroll-to-top" aria-label="Scroll to top">
@@ -1342,9 +1342,9 @@
   </button>
 
   <!-- ─── SCRIPTS ─── -->
-  <script src="../js/atlas-helpers.js?v=6.3.20"></script>
-  <script src="../js/ui.js?v=6.3.20"></script>
-  <script src="../js/page-ia.js?v=6.3.20"></script>
+  <script src="../js/atlas-helpers.js?v=6.4.0"></script>
+  <script src="../js/ui.js?v=6.4.0"></script>
+  <script src="../js/page-ia.js?v=6.4.0"></script>
 
 <!-- impeccable-live-start -->
 <script src="http://localhost:8400/live.js"></script>

--- a/docs/heroes/index.html
+++ b/docs/heroes/index.html
@@ -8,7 +8,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Hall of Heroes | Gaia Registry</title>
   <meta name="description" content="The registry's highest-achieving contributors, celebrated in a dark ceremonial gallery.">
-  <script>window.GAIA_VERSION = "6.3.20";</script>
+  <script>window.GAIA_VERSION = "6.4.0";</script>
 
   <!-- Fonts: EB Garamond (display), Bricolage Grotesque (body), Departure Mono -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -16,15 +16,15 @@
   <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;500;600;700&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
   <!-- Design tokens + plaque base -->
-  <link rel="stylesheet" href="../css/tokens.css?v=6.3.20">
-  <link rel="stylesheet" href="../css/styles.css?v=6.3.20">
-  <link rel="stylesheet" href="../css/plaque.css?v=6.3.20">
+  <link rel="stylesheet" href="../css/tokens.css?v=6.4.0">
+  <link rel="stylesheet" href="../css/styles.css?v=6.4.0">
+  <link rel="stylesheet" href="../css/plaque.css?v=6.4.0">
 
   <!-- Page styles -->
-  <link rel="stylesheet" href="heroes.css?v=6.3.20">
+  <link rel="stylesheet" href="heroes.css?v=6.4.0">
 
   <!-- Plaque renderer (needed for renderOg) -->
-  <script src="../js/plaque.js?v=6.3.20"></script>
+  <script src="../js/plaque.js?v=6.4.0"></script>
   <script>
     // gaiaIconBase for sub-page (depth=1)
     window.gaiaIconBase = function() { return '../assets/icons.svg'; };
@@ -41,8 +41,8 @@
 <body>
   <!-- Site navigation -->
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.3.20"></script>
-  <script src="../js/site-nav.js?v=6.3.20"></script>
+  <script src="../js/mounts.js?v=6.4.0"></script>
+  <script src="../js/site-nav.js?v=6.4.0"></script>
 
   <!-- ═══ GALLERY SHELL ═══ -->
   <main class="heroes-gallery" id="heroesGallery">
@@ -191,15 +191,15 @@
 
   <!-- Site footer -->
   <div id="site-footer-mount"></div>
-  <script src="../js/site-footer.js?v=6.3.20"></script>
+  <script src="../js/site-footer.js?v=6.4.0"></script>
 
   <!-- Share modal wiring -->
-  <script src="../js/hoh-modal.js?v=6.3.20"></script>
+  <script src="../js/hoh-modal.js?v=6.4.0"></script>
 
   <!-- Heroes orchestrator + animations + share enhancements -->
-  <script src="heroes.js?v=6.3.20"></script>
-  <script src="hero-animations.js?v=6.3.20"></script>
-  <script src="hero-share.js?v=6.3.20"></script>
+  <script src="heroes.js?v=6.4.0"></script>
+  <script src="hero-animations.js?v=6.4.0"></script>
+  <script src="hero-share.js?v=6.4.0"></script>
 <!-- impeccable-live-start -->
 <script src="http://localhost:8400/live.js"></script>
 <!-- impeccable-live-end -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 
 <head>
-  <script>window.GAIA_VERSION = "6.3.20";</script>
+  <script>window.GAIA_VERSION = "6.4.0";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -35,17 +35,17 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
   <link rel="icon" type="image/svg+xml" href="assets/marks/diamond-seal.svg">
-  <link rel="stylesheet" href="css/styles.css?v=6.3.20">
-  <link rel="stylesheet" href="css/plaque.css?v=6.3.20">
+  <link rel="stylesheet" href="css/styles.css?v=6.4.0">
+  <link rel="stylesheet" href="css/plaque.css?v=6.4.0">
   <!-- Universal AlphaRail (page-wide section + explorer index). -->
-  <link rel="stylesheet" href="css/alpha-rail.css?v=6.3.20">
+  <link rel="stylesheet" href="css/alpha-rail.css?v=6.4.0">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="js/icons.js?v=6.3.20"></script>
+  <script src="js/icons.js?v=6.4.0"></script>
   <!-- Stage 2 — shared rank-badge primitive, loaded after icons. -->
-  <script src="js/rank-badge.js?v=6.3.20"></script>
+  <script src="js/rank-badge.js?v=6.4.0"></script>
   <!-- Stage 3 — plaque component family, loaded after rank-badge. -->
-  <script src="js/tm-config.js?v=6.3.20"></script>
-  <script src="js/plaque.js?v=6.3.20"></script>
+  <script src="js/tm-config.js?v=6.4.0"></script>
+  <script src="js/plaque.js?v=6.4.0"></script>
   <style>
   /* Review Section & Side-by-Side Simulator styling */
   .review-showcase-section {
@@ -297,8 +297,8 @@
 
   <!-- ─── NAV ─── -->
   <nav id="site-nav"></nav>
-  <script src="js/mounts.js?v=6.3.20"></script>
-  <script src="js/site-nav.js?v=6.3.20"></script>
+  <script src="js/mounts.js?v=6.4.0"></script>
+  <script src="js/site-nav.js?v=6.4.0"></script>
 
   <!-- ─── HERO ─── -->
   <section id="hero">
@@ -518,13 +518,13 @@
       </a>
     </div>
   </section>
-  <link rel="stylesheet" href="trust/leaderboard/leaderboard.css?v=6.3.20">
+  <link rel="stylesheet" href="trust/leaderboard/leaderboard.css?v=6.4.0">
   <!-- Tooltip — required for SVG bar hover (delegated handlers in leaderboard.js
        short-circuit when this element is absent). position:fixed so it escapes
        any overflow:hidden ancestor. -->
   <div class="lb-tooltip" id="lbTooltip" hidden aria-hidden="true"></div>
   <script>window.GAIA_LB_EMBED_HOST = true;</script>
-  <script src="trust/leaderboard/leaderboard.js?v=6.3.20"></script>
+  <script src="trust/leaderboard/leaderboard.js?v=6.4.0"></script>
 
   <div class="section-divider"></div>
 
@@ -926,7 +926,7 @@
 
   <!-- ─── FOOTER ─── -->
   <div id="site-footer-mount"></div>
-  <script src="js/site-footer.js?v=6.3.20"></script>
+  <script src="js/site-footer.js?v=6.4.0"></script>
 
   <!-- ─── SKILL EXPLORER OVERLAY ─── -->
   <div id="skillExplorer" class="skill-explorer" role="dialog" aria-modal="true" aria-label="Skill Explorer" tabindex="-1">
@@ -1020,16 +1020,16 @@
 
   <!-- ─── SCRIPTS ─── -->
   <!-- icons.js already loaded in <head> so gaiaIcon() is available before any of these. -->
-  <script src="js/atlas-helpers.js?v=6.3.20"></script>
-  <script src="js/skill-graph.js?v=6.3.20"></script>
-  <script src="js/hud-toggle.js?v=6.3.20"></script>
-  <script src="js/scroll-reveal.js?v=6.3.20"></script>
+  <script src="js/atlas-helpers.js?v=6.4.0"></script>
+  <script src="js/skill-graph.js?v=6.4.0"></script>
+  <script src="js/hud-toggle.js?v=6.4.0"></script>
+  <script src="js/scroll-reveal.js?v=6.4.0"></script>
   <!-- Universal AlphaRail component + page-wide integration (section markers
        above the explorer; dynamic type/letter/tier markers inside it). -->
-  <script src="js/alpha-rail.js?v=6.3.20"></script>
-  <script src="js/ui.js?v=6.3.20"></script>
-  <script src="js/page-ia.js?v=6.3.20"></script>
-  <script src="js/plaque-reveal.js?v=6.3.20" defer></script>
+  <script src="js/alpha-rail.js?v=6.4.0"></script>
+  <script src="js/ui.js?v=6.4.0"></script>
+  <script src="js/page-ia.js?v=6.4.0"></script>
+  <script src="js/plaque-reveal.js?v=6.4.0" defer></script>
 
   <!-- ── Share modal (single instance) — opened from plaque__share-btn ── -->
   <div class="share-modal" hidden role="dialog" aria-modal="true" aria-labelledby="share-modal-title" id="shareModal">
@@ -1165,8 +1165,8 @@
 
   <div id="hohFsToast" class="hoh-fs-toast" role="status" aria-live="polite">Permalink copied!</div>
 
-  <script src="js/profile-share.js?v=6.3.20"></script>
-  <script src="js/hoh-modal.js?v=6.3.20"></script>
+  <script src="js/profile-share.js?v=6.4.0"></script>
+  <script src="js/hoh-modal.js?v=6.4.0"></script>
 
   <!-- ─── REVIEW SHOWCASE SIMULATOR ─── -->
   <script>

--- a/docs/meta.html
+++ b/docs/meta.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script>window.GAIA_VERSION = "6.3.20";</script>
+  <script>window.GAIA_VERSION = "6.4.0";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -13,14 +13,14 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-<link rel="stylesheet" href="css/styles.css?v=6.3.20">
+<link rel="stylesheet" href="css/styles.css?v=6.4.0">
 <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-<script src="js/icons.js?v=6.3.20"></script>
+<script src="js/icons.js?v=6.4.0"></script>
 <!-- Stage 2 — shared rank-badge primitive. -->
-<script src="js/rank-badge.js?v=6.3.20"></script>
+<script src="js/rank-badge.js?v=6.4.0"></script>
 <!-- Stage 3 — plaque component family. -->
-<script src="js/tm-config.js?v=6.3.20"></script>
-<script src="js/plaque.js?v=6.3.20"></script>
+<script src="js/tm-config.js?v=6.4.0"></script>
+<script src="js/plaque.js?v=6.4.0"></script>
 <style>
   .meta-report-grid {
     display: grid;
@@ -97,7 +97,7 @@
     border-color: #34d399;
   }
 </style>
-  <link rel="stylesheet" href="css/plaque.css?v=6.3.20">
+  <link rel="stylesheet" href="css/plaque.css?v=6.4.0">
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -110,8 +110,8 @@
 <body class="process-page">
 
   <nav id="site-nav"></nav>
-  <script src="js/mounts.js?v=6.3.20"></script>
-  <script src="js/site-nav.js?v=6.3.20"></script>
+  <script src="js/mounts.js?v=6.4.0"></script>
+  <script src="js/site-nav.js?v=6.4.0"></script>
 
 <main>
   <!-- ─── BACK ─── -->
@@ -255,7 +255,7 @@
 
 <!-- ─── FOOTER v2 ─── -->
   <div id="site-footer-mount"></div>
-  <script src="js/site-footer.js?v=6.3.20"></script>
+  <script src="js/site-footer.js?v=6.4.0"></script>
 
   <!-- ─── TREE DIALOG ─── -->
   <a id="tree" tabindex="-1" aria-hidden="true"></a>
@@ -280,10 +280,10 @@
   </button>
 
   <!-- ─── SCRIPTS ─── -->
-  <script src="js/atlas-helpers.js?v=6.3.20"></script>
-  <script src="js/skill-explorer.js?v=6.3.20"></script>
-  <script src="js/ui.js?v=6.3.20"></script>
-  <script src="js/page-ia.js?v=6.3.20"></script>
+  <script src="js/atlas-helpers.js?v=6.4.0"></script>
+  <script src="js/skill-explorer.js?v=6.4.0"></script>
+  <script src="js/ui.js?v=6.4.0"></script>
+  <script src="js/page-ia.js?v=6.4.0"></script>
   <script>
   function metaReportShare(btn) {
     const rel = btn.dataset.reportUrl;

--- a/docs/named/index.html
+++ b/docs/named/index.html
@@ -2,7 +2,7 @@
 <html lang="en" data-icon-base="../assets/icons.svg">
 
 <head>
-  <script>window.GAIA_VERSION = "6.3.20";</script>
+  <script>window.GAIA_VERSION = "6.4.0";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -21,20 +21,20 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
   <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
-  <link rel="stylesheet" href="../css/styles.css?v=6.3.20">
-  <link rel="stylesheet" href="../css/plaque.css?v=6.3.20">
+  <link rel="stylesheet" href="../css/styles.css?v=6.4.0">
+  <link rel="stylesheet" href="../css/plaque.css?v=6.4.0">
   <!-- AlphaRail temporarily disabled — keep the stylesheet reference here so
        re-enabling is one uncomment away. The page-wide rail script + integration
        are commented out near the bottom of <body>. -->
-  <!-- <link rel="stylesheet" href="../css/alpha-rail.css?v=6.3.20"> -->
+  <!-- <link rel="stylesheet" href="../css/alpha-rail.css?v=6.4.0"> -->
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../js/icons.js?v=6.3.20"></script>
-  <script src="../js/atlas-helpers.js?v=6.3.20"></script>
+  <script src="../js/icons.js?v=6.4.0"></script>
+  <script src="../js/atlas-helpers.js?v=6.4.0"></script>
   <!-- Stage 2 — shared rank-badge primitive, loaded after icons. -->
-  <script src="../js/rank-badge.js?v=6.3.20"></script>
+  <script src="../js/rank-badge.js?v=6.4.0"></script>
   <!-- Stage 3 — plaque component family, loaded after rank-badge. -->
-  <script src="../js/tm-config.js?v=6.3.20"></script>
-  <script src="../js/plaque.js?v=6.3.20"></script>
+  <script src="../js/tm-config.js?v=6.4.0"></script>
+  <script src="../js/plaque.js?v=6.4.0"></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -49,8 +49,8 @@
 
   <!-- ─── NAV ─── -->
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.3.20"></script>
-  <script src="../js/site-nav.js?v=6.3.20"></script>
+  <script src="../js/mounts.js?v=6.4.0"></script>
+  <script src="../js/site-nav.js?v=6.4.0"></script>
 
   <!-- ─── BACK ─── -->
   <div class="profile-back-row">
@@ -137,7 +137,7 @@
 
   <!-- ─── FOOTER v2 ─── -->
   <div id="site-footer-mount"></div>
-  <script src="../js/site-footer.js?v=6.3.20"></script>
+  <script src="../js/site-footer.js?v=6.4.0"></script>
 
   <!-- ─── SKILL EXPLORER OVERLAY ─── -->
   <div id="skillExplorer" class="skill-explorer" role="dialog" aria-modal="true" aria-label="Skill Explorer" tabindex="-1">
@@ -210,16 +210,16 @@
 
   <!-- ─── SCRIPTS ─── -->
   <!-- icons.js already loaded in <head> so gaiaIcon() is available before any of these. -->
-  <script src="../js/atlas-helpers.js?v=6.3.20"></script>
-  <script src="../js/scroll-reveal.js?v=6.3.20"></script>
-  <script src="../js/named-skills.js?v=6.3.20"></script>
+  <script src="../js/atlas-helpers.js?v=6.4.0"></script>
+  <script src="../js/scroll-reveal.js?v=6.4.0"></script>
+  <script src="../js/named-skills.js?v=6.4.0"></script>
   <!-- AlphaRail temporarily disabled. Uncomment both <script> tags to re-enable
        the section + dynamic letter/tier markers inside the explorer. -->
-  <!-- <script src="../js/alpha-rail.js?v=6.3.20"></script> -->
-  <!-- <script src="../js/index-rail.js?v=6.3.20"></script> -->
-  <script src="../js/skill-explorer.js?v=6.3.20"></script>
-  <script src="../js/ui.js?v=6.3.20"></script>
-  <script src="../js/plaque-reveal.js?v=6.3.20" defer></script>
+  <!-- <script src="../js/alpha-rail.js?v=6.4.0"></script> -->
+  <!-- <script src="../js/index-rail.js?v=6.4.0"></script> -->
+  <script src="../js/skill-explorer.js?v=6.4.0"></script>
+  <script src="../js/ui.js?v=6.4.0"></script>
+  <script src="../js/plaque-reveal.js?v=6.4.0" defer></script>
 
   <!-- ─── HALL OF HEROES FULLSCREEN OG VIEW ─── -->
   <div id="hohFullscreenModal" class="hoh-fs-modal" aria-hidden="true" tabindex="-1">
@@ -315,7 +315,7 @@
   </button>
 </div>
 
-  <script src="../js/hoh-modal.js?v=6.3.20"></script>
+  <script src="../js/hoh-modal.js?v=6.4.0"></script>
 
 <!-- impeccable-live-start -->
 <script src="http://localhost:8400/live.js"></script>

--- a/docs/named/report.html
+++ b/docs/named/report.html
@@ -2,7 +2,7 @@
 <html lang="en" data-icon-base="../assets/icons.svg">
 
 <head>
-  <script>window.GAIA_VERSION = "6.3.20";</script>
+  <script>window.GAIA_VERSION = "6.4.0";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -14,11 +14,11 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
   <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
-  <link rel="stylesheet" href="../css/styles.css?v=6.3.20">
-  <link rel="stylesheet" href="../css/plaque.css?v=6.3.20">
-  <script src="../js/icons.js?v=6.3.20"></script>
-  <script src="../js/atlas-helpers.js?v=6.3.20"></script>
-  <script src="../js/rank-badge.js?v=6.3.20"></script>
+  <link rel="stylesheet" href="../css/styles.css?v=6.4.0">
+  <link rel="stylesheet" href="../css/plaque.css?v=6.4.0">
+  <script src="../js/icons.js?v=6.4.0"></script>
+  <script src="../js/atlas-helpers.js?v=6.4.0"></script>
+  <script src="../js/rank-badge.js?v=6.4.0"></script>
 
   <style>
     /* ── Grade color tokens (mirrors GRADE_COLORS in src/gaia_cli/formatting.py) ── */
@@ -597,9 +597,9 @@
 
   <!-- ─── NAV ─── -->
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.3.20"></script>
-  <script src="../js/site-nav.js?v=6.3.20"></script>
-  <script src="../js/ui.js?v=6.3.20"></script>
+  <script src="../js/mounts.js?v=6.4.0"></script>
+  <script src="../js/site-nav.js?v=6.4.0"></script>
+  <script src="../js/ui.js?v=6.4.0"></script>
 
   <div class="report-back-row">
     <a class="report-back" href="./index.html" aria-label="Back to Named Skills">
@@ -616,7 +616,7 @@
 
   <!-- ─── FOOTER ─── -->
   <div id="site-footer-mount"></div>
-  <script src="../js/site-footer.js?v=6.3.20"></script>
+  <script src="../js/site-footer.js?v=6.4.0"></script>
 
   <script>
   (function () {

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script>window.GAIA_VERSION = "6.3.20";</script>
+  <script>window.GAIA_VERSION = "6.4.0";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -14,11 +14,11 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
   <link rel="icon" type="image/svg+xml" href="assets/marks/diamond-seal.svg">
-  <link rel="stylesheet" href="css/styles.css?v=6.3.20">
+  <link rel="stylesheet" href="css/styles.css?v=6.4.0">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="js/icons.js?v=6.3.20"></script>
+  <script src="js/icons.js?v=6.4.0"></script>
   <!-- Stage 2 — shared rank-badge primitive. -->
-  <script src="js/rank-badge.js?v=6.3.20"></script>
+  <script src="js/rank-badge.js?v=6.4.0"></script>
   <style>
     /* ── Privacy page local overrides ── */
     .privacy-hero {
@@ -129,7 +129,7 @@
     }
     .privacy-footer-note a { color: var(--color-accent, #c084fc); }
   </style>
-  <link rel="stylesheet" href="css/plaque.css?v=6.3.20">
+  <link rel="stylesheet" href="css/plaque.css?v=6.4.0">
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -143,8 +143,8 @@
 <body>
 
   <nav id="site-nav"></nav>
-  <script src="js/mounts.js?v=6.3.20"></script>
-  <script src="js/site-nav.js?v=6.3.20"></script>
+  <script src="js/mounts.js?v=6.4.0"></script>
+  <script src="js/site-nav.js?v=6.4.0"></script>
 
   <!-- ─── BACK ─── -->
   <div class="profile-back-row">
@@ -269,7 +269,7 @@
 
   <!-- ─── FOOTER v2 ─── -->
   <div id="site-footer-mount"></div>
-  <script src="js/site-footer.js?v=6.3.20"></script>
+  <script src="js/site-footer.js?v=6.4.0"></script>
 
   <!-- ─── TREE DIALOG ─── -->
   <a id="tree" tabindex="-1" aria-hidden="true"></a>
@@ -290,10 +290,10 @@
   </dialog>
 
   <!-- ─── SCRIPTS ─── -->
-  <script src="js/atlas-helpers.js?v=6.3.20"></script>
-  <script src="js/skill-explorer.js?v=6.3.20"></script>
-  <script src="js/ui.js?v=6.3.20"></script>
-  <script src="js/page-ia.js?v=6.3.20"></script>
+  <script src="js/atlas-helpers.js?v=6.4.0"></script>
+  <script src="js/skill-explorer.js?v=6.4.0"></script>
+  <script src="js/ui.js?v=6.4.0"></script>
+  <script src="js/page-ia.js?v=6.4.0"></script>
 
 <!-- impeccable-live-start -->
 <script src="http://localhost:8400/live.js"></script>

--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "6.3.20";</script>
+  <script>window.GAIA_VERSION = "6.4.0";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -20,8 +20,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;500;600;700&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
-  <link rel="stylesheet" href="../css/tokens.css?v=6.3.20">
-  <link rel="stylesheet" href="../css/styles.css?v=6.3.20">
+  <link rel="stylesheet" href="../css/tokens.css?v=6.4.0">
+  <link rel="stylesheet" href="../css/styles.css?v=6.4.0">
   <link rel="alternate" type="application/json" href="/api/v1/reports/index.json">
 
   <script>
@@ -305,8 +305,8 @@
 </head>
 <body>
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.3.20"></script>
-  <script src="../js/site-nav.js?v=6.3.20"></script>
+  <script src="../js/mounts.js?v=6.4.0"></script>
+  <script src="../js/site-nav.js?v=6.4.0"></script>
 
   <main class="reports-shell">
 
@@ -346,6 +346,6 @@
   </main>
 
   <div id="site-footer-mount"></div>
-  <script src="../js/site-footer.js?v=6.3.20"></script>
+  <script src="../js/site-footer.js?v=6.4.0"></script>
 </body>
 </html>

--- a/docs/share/index.html
+++ b/docs/share/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-icon-base="../assets/icons.svg">
 <head>
-  <script>window.GAIA_VERSION = "6.3.20";</script>
+  <script>window.GAIA_VERSION = "6.4.0";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -16,9 +16,9 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
   <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
   <!-- Site-wide tokens then styles, then page-specific overrides. -->
-  <link rel="stylesheet" href="../css/tokens.css?v=6.3.20">
-  <link rel="stylesheet" href="../css/styles.css?v=6.3.20">
-  <link rel="stylesheet" href="styles.css?v=6.3.20">
+  <link rel="stylesheet" href="../css/tokens.css?v=6.4.0">
+  <link rel="stylesheet" href="../css/styles.css?v=6.4.0">
+  <link rel="stylesheet" href="styles.css?v=6.4.0">
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -33,9 +33,9 @@
 
   <!-- ─── NAV ─── -->
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.3.20" defer></script>
-  <script src="../js/site-nav.js?v=6.3.20" defer></script>
-  <script src="../js/ui.js?v=6.3.20" defer></script>
+  <script src="../js/mounts.js?v=6.4.0" defer></script>
+  <script src="../js/site-nav.js?v=6.4.0" defer></script>
+  <script src="../js/ui.js?v=6.4.0" defer></script>
 
   <!-- ─── MAIN ─── -->
   <main class="share-main" id="share-main">
@@ -92,7 +92,7 @@
 
   <!-- ─── FOOTER ─── -->
   <div id="site-footer-mount"></div>
-  <script src="../js/site-footer.js?v=6.3.20" defer></script>
+  <script src="../js/site-footer.js?v=6.4.0" defer></script>
 
   <!-- ─── SHARE LOGIC ─── -->
   <!--
@@ -106,7 +106,7 @@
     See docs/share/sample.json for a ready-made fixture.
     PRODUCTION: the override is never set; share.js reads ?b= from the URL.
   -->
-  <script src="share.js?v=6.3.20"></script>
+  <script src="share.js?v=6.4.0"></script>
 
 <!-- impeccable-live-start -->
 <script src="http://localhost:8400/live.js"></script>

--- a/docs/skills/index.html
+++ b/docs/skills/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script>window.GAIA_VERSION = "6.3.20";</script>
+  <script>window.GAIA_VERSION = "6.4.0";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -20,12 +20,12 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
   <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
-  <link rel="stylesheet" href="../css/tokens.css?v=6.3.20">
-  <link rel="stylesheet" href="../css/styles.css?v=6.3.20">
+  <link rel="stylesheet" href="../css/tokens.css?v=6.4.0">
+  <link rel="stylesheet" href="../css/styles.css?v=6.4.0">
   <!-- Nav -->
-  <script src="../js/icons.js?v=6.3.20"></script>
-  <script src="../js/mounts.js?v=6.3.20"></script>
-  <script src="../js/site-nav.js?v=6.3.20"></script>
+  <script src="../js/icons.js?v=6.4.0"></script>
+  <script src="../js/mounts.js?v=6.4.0"></script>
+  <script src="../js/site-nav.js?v=6.4.0"></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -47,7 +47,7 @@
   </main>
 
   <div id="site-footer"></div>
-  <script src="../js/site-footer.js?v=6.3.20"></script>
-  <script src="index.js?v=6.3.20"></script>
+  <script src="../js/site-footer.js?v=6.4.0"></script>
+  <script src="index.js?v=6.4.0"></script>
 </body>
 </html>

--- a/docs/starless.html
+++ b/docs/starless.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script>window.GAIA_VERSION = "6.3.20";</script>
+  <script>window.GAIA_VERSION = "6.4.0";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -13,18 +13,18 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-<link rel="stylesheet" href="css/styles.css?v=6.3.20">
-<link rel="stylesheet" href="css/alpha-rail.css?v=6.3.20">
+<link rel="stylesheet" href="css/styles.css?v=6.4.0">
+<link rel="stylesheet" href="css/alpha-rail.css?v=6.4.0">
 <!-- plaque.css supplies the slate .plaque__redacted-handle styling for ≤1★ chips. -->
-<link rel="stylesheet" href="css/plaque.css?v=6.3.20">
+<link rel="stylesheet" href="css/plaque.css?v=6.4.0">
 <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-<script src="js/icons.js?v=6.3.20"></script>
+<script src="js/icons.js?v=6.4.0"></script>
 <!-- Stage 2 — shared rank-badge primitive. -->
-<script src="js/rank-badge.js?v=6.3.20"></script>
+<script src="js/rank-badge.js?v=6.4.0"></script>
 <!-- Stage 3 — plaque component family. -->
-<script src="js/plaque.js?v=6.3.20"></script>
+<script src="js/plaque.js?v=6.4.0"></script>
 <!-- Universal alphabetical scrubber component. -->
-<script src="js/alpha-rail.js?v=6.3.20"></script>
+<script src="js/alpha-rail.js?v=6.4.0"></script>
 <style>
   /* ───────────────────────────────────────────────────────────────────
      Starless taxonomy — a single-page ledger.
@@ -137,8 +137,8 @@
 <body class="process-page">
 
   <nav id="site-nav"></nav>
-  <script src="js/mounts.js?v=6.3.20"></script>
-  <script src="js/site-nav.js?v=6.3.20"></script>
+  <script src="js/mounts.js?v=6.4.0"></script>
+  <script src="js/site-nav.js?v=6.4.0"></script>
 
 <main>
   <!-- ─── BACK ─── -->
@@ -181,7 +181,7 @@
 
 <!-- ─── FOOTER v2 ─── -->
   <div id="site-footer-mount"></div>
-  <script src="js/site-footer.js?v=6.3.20"></script>
+  <script src="js/site-footer.js?v=6.4.0"></script>
 
   <!-- ─── TREE DIALOG ─── -->
   <a id="tree" tabindex="-1" aria-hidden="true"></a>
@@ -450,10 +450,10 @@
   </script>
 
   <!-- ─── SCRIPTS ─── -->
-  <script src="js/atlas-helpers.js?v=6.3.20"></script>
-  <script src="js/skill-explorer.js?v=6.3.20"></script>
-  <script src="js/ui.js?v=6.3.20"></script>
-  <script src="js/page-ia.js?v=6.3.20"></script>
+  <script src="js/atlas-helpers.js?v=6.4.0"></script>
+  <script src="js/skill-explorer.js?v=6.4.0"></script>
+  <script src="js/ui.js?v=6.4.0"></script>
+  <script src="js/page-ia.js?v=6.4.0"></script>
 
 <!-- impeccable-live-start -->
 <script src="http://localhost:8400/live.js"></script>

--- a/docs/trending/index.html
+++ b/docs/trending/index.html
@@ -2,7 +2,7 @@
 <html lang="en" data-icon-base="../assets/icons.svg">
 
 <head>
-  <script>window.GAIA_VERSION = "6.3.20";</script>
+  <script>window.GAIA_VERSION = "6.4.0";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -23,10 +23,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
   <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
-  <link rel="stylesheet" href="../css/styles.css?v=6.3.20">
-  <link rel="stylesheet" href="trending.css?v=6.3.20">
+  <link rel="stylesheet" href="../css/styles.css?v=6.4.0">
+  <link rel="stylesheet" href="trending.css?v=6.4.0">
   <!-- Icon sprite helper -->
-  <script src="../js/icons.js?v=6.3.20"></script>
+  <script src="../js/icons.js?v=6.4.0"></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -41,8 +41,8 @@
 
   <!-- ─── NAV ─── -->
   <nav id="site-nav"></nav>
-  <script src="../js/mounts.js?v=6.3.20"></script>
-  <script src="../js/site-nav.js?v=6.3.20"></script>
+  <script src="../js/mounts.js?v=6.4.0"></script>
+  <script src="../js/site-nav.js?v=6.4.0"></script>
 
   <!-- ─── MAIN ─── -->
   <main class="trending-main">
@@ -124,10 +124,10 @@
 
   <!-- ─── FOOTER ─── -->
   <div id="site-footer-mount"></div>
-  <script src="../js/site-footer.js?v=6.3.20"></script>
+  <script src="../js/site-footer.js?v=6.4.0"></script>
 
   <!-- ─── PAGE SCRIPT ─── -->
-  <script src="trending.js?v=6.3.20"></script>
+  <script src="trending.js?v=6.4.0"></script>
 
 <!-- impeccable-live-start -->
 <script src="http://localhost:8400/live.js"></script>

--- a/docs/trust/index.html
+++ b/docs/trust/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script>window.GAIA_VERSION = "6.3.20";</script>
+  <script>window.GAIA_VERSION = "6.4.0";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">

--- a/docs/trust/leaderboard/index.html
+++ b/docs/trust/leaderboard/index.html
@@ -4,7 +4,7 @@
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <script>window.GAIA_VERSION = "6.3.20";</script>
+  <script>window.GAIA_VERSION = "6.4.0";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Trust Leaderboard — Gaia</title>
@@ -12,8 +12,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap">
-  <link rel="stylesheet" href="../../css/styles.css?v=6.3.20">
-  <link rel="stylesheet" href="leaderboard.css?v=6.3.20">
+  <link rel="stylesheet" href="../../css/styles.css?v=6.4.0">
+  <link rel="stylesheet" href="leaderboard.css?v=6.4.0">
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -25,8 +25,8 @@
 </head>
 <body class="lb-dark-page">
   <nav id="site-nav"></nav>
-  <script src="../../js/mounts.js?v=6.3.20"></script>
-  <script src="../../js/site-nav.js?v=6.3.20"></script>
+  <script src="../../js/mounts.js?v=6.4.0"></script>
+  <script src="../../js/site-nav.js?v=6.4.0"></script>
 
   <div class="lb-shell">
     <nav class="lb-toc" aria-label="Page sections">
@@ -200,7 +200,7 @@
   <div class="lb-tooltip" id="lbTooltip" hidden aria-hidden="true"></div>
 
   <footer id="site-footer"></footer>
-  <script src="../../js/site-footer.js?v=6.3.20"></script>
-  <script src="leaderboard.js?v=6.3.20"></script>
+  <script src="../../js/site-footer.js?v=6.4.0"></script>
+  <script src="leaderboard.js?v=6.4.0"></script>
 </body>
 </html>

--- a/docs/trust/ledger/index.html
+++ b/docs/trust/ledger/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script>window.GAIA_VERSION = "6.3.20";</script>
+  <script>window.GAIA_VERSION = "6.4.0";</script>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -13,9 +13,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../../css/styles.css?v=6.3.20">
-  <link rel="stylesheet" href="ledger.css?v=6.3.20">
-  <script src="../../js/icons.js?v=6.3.20"></script>
+  <link rel="stylesheet" href="../../css/styles.css?v=6.4.0">
+  <link rel="stylesheet" href="ledger.css?v=6.4.0">
+  <script src="../../js/icons.js?v=6.4.0"></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -28,9 +28,9 @@
 <body class="process-page ledger-page">
 
   <nav id="site-nav"></nav>
-  <script src="../../js/mounts.js?v=6.3.20"></script>
-  <script src="../../js/site-nav.js?v=6.3.20"></script>
-  <script src="../../js/ui.js?v=6.3.20"></script>
+  <script src="../../js/mounts.js?v=6.4.0"></script>
+  <script src="../../js/site-nav.js?v=6.4.0"></script>
+  <script src="../../js/ui.js?v=6.4.0"></script>
 
   <main class="ledger-main">
 
@@ -127,6 +127,6 @@
 
   </main>
 
-  <script src="ledger.js?v=6.3.20"></script>
+  <script src="ledger.js?v=6.4.0"></script>
 </body>
 </html>

--- a/docs/u/index.html
+++ b/docs/u/index.html
@@ -4,7 +4,7 @@
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <script>window.GAIA_VERSION = "6.3.20";</script>
+  <script>window.GAIA_VERSION = "6.4.0";</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Contributors Directory — Gaia Skill Registry</title>
@@ -18,14 +18,14 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Bricolage+Grotesque:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
-  <link rel="stylesheet" href="../css/tokens.css?v=6.3.20">
-  <link rel="stylesheet" href="../css/styles.css?v=6.3.20">
-  <link rel="stylesheet" href="../css/plaque.css?v=6.3.20">
+  <link rel="stylesheet" href="../css/tokens.css?v=6.4.0">
+  <link rel="stylesheet" href="../css/styles.css?v=6.4.0">
+  <link rel="stylesheet" href="../css/plaque.css?v=6.4.0">
   <!-- Stage 1 — icon sprite helper, loaded BEFORE other UI scripts. -->
-  <script src="../js/icons.js?v=6.3.20"></script>
+  <script src="../js/icons.js?v=6.4.0"></script>
   <!-- Stage 2 — rank-badge component, loaded after icons.js. -->
-  <script src="../js/rank-badge.js?v=6.3.20"></script>
-  <script src="../js/ui.js?v=6.3.20" defer></script>
+  <script src="../js/rank-badge.js?v=6.4.0"></script>
+  <script src="../js/ui.js?v=6.4.0" defer></script>
 <script type="application/ld+json" data-injector="gaia-json-ld">
 {
   "@context": "https://schema.org",
@@ -38,8 +38,8 @@
 <body class="profile-directory-page">
 
   <nav id="site-nav"></nav>
-<script src="../js/mounts.js?v=6.3.20"></script>
-<script src="../js/site-nav.js?v=6.3.20"></script>
+<script src="../js/mounts.js?v=6.4.0"></script>
+<script src="../js/site-nav.js?v=6.4.0"></script>
 
   <!-- ─── PROFILE BACK ─── -->
   <div class="profile-back-row">
@@ -1418,7 +1418,7 @@
 
   <!-- ─── FOOTER ─── -->
 <div id="site-footer-mount"></div>
-<script src="../js/site-footer.js?v=6.3.20"></script>
+<script src="../js/site-footer.js?v=6.4.0"></script>
 
   <script>
     document.addEventListener('DOMContentLoaded', () => {

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -258,6 +258,33 @@ def build_readme(check: bool) -> bool:
     return changed
 
 
+def build_readme_version_only(check: bool) -> bool:
+    """Refresh ONLY the README version region (`gaia:version-start/end`).
+
+    Used by `gaia dev release --cache-bust-only` to fold the README version
+    string into the release commit without regenerating the registry-tree,
+    CLI-help, or layout regions — those depend on the gitignored
+    `registry/gaia.json` (Class P) and pulling a stale snapshot into README at
+    release time would either fail or manufacture drift. The version region
+    depends only on `pyproject.toml`, which is always present, so it is the one
+    region that is both version-derived and safe to refresh in a release
+    context. Mirrors the HTML `?v=` rewrite done by `build_html_cache_busting`.
+    """
+    path = ROOT / "README.md"
+    if not path.exists():
+        return False
+    text = path.read_text(encoding="utf-8")
+    start, end = "<!-- gaia:version-start -->", "<!-- gaia:version-end -->"
+    text, changed = _replace_region(text, start, end, _versions())
+    if changed:
+        if check:
+            print('diff', start, end, "(README version region stale)")
+        else:
+            path.write_text(text, encoding="utf-8")
+            print("cache-bust: updated README.md")
+    return changed
+
+
 def build_docs_index(check: bool) -> bool:
     path = ROOT / "docs" / "index.html"
     if not path.exists():
@@ -1441,7 +1468,15 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.cache_bust_only:
-        changed = build_html_cache_busting(check=False)
+        # Refresh every version-derived surface that `gaia dev docs --check`
+        # validates on a release commit: the HTML `?v=`/GAIA_VERSION strings AND
+        # the README version region. Both derive solely from pyproject.toml, so
+        # neither touches the gitignored Class P registry snapshot. Anything
+        # else (badges, gaia.json, profiles) is intentionally left untouched to
+        # avoid the 2026-06-24 stale-snapshot badge-wipe class of failure.
+        html_changed = build_html_cache_busting(check=False)
+        readme_changed = build_readme_version_only(check=False)
+        changed = html_changed or readme_changed
         print("Cache-bust strings updated." if changed else "Cache-bust strings already current.")
         return 0
 

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -496,6 +496,7 @@ def build_html_cache_busting(check: bool) -> bool:
                 print(f"diff docs/{filename} (cache busting / version stale)")
             else:
                 path.write_text(updated_text, encoding="utf-8")
+                print(f"cache-bust: updated docs/{filename}")
     return changed
 
 
@@ -1430,7 +1431,19 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Build generated Gaia docs regions.")
     parser.add_argument("--check", action="store_true", help="Fail if generated docs are stale")
     parser.add_argument("--auto-clean", action="store_true", help="(Opt-in) In write mode, remove left-only generated files in safe bundles (use cautiously)")
+    parser.add_argument(
+        "--cache-bust-only",
+        action="store_true",
+        help="Only rewrite HTML cache-bust/version strings (write mode). Used by "
+             "`gaia dev release` to fold version-string drift into the release commit "
+             "without regenerating badges or other Class S artifacts.",
+    )
     args = parser.parse_args(argv)
+
+    if args.cache_bust_only:
+        changed = build_html_cache_busting(check=False)
+        print("Cache-bust strings updated." if changed else "Cache-bust strings already current.")
+        return 0
 
     # Set the global AUTO_CLEAN flag for helper functions to consult.
     globals()["AUTO_CLEAN"] = bool(getattr(args, "auto_clean", False))

--- a/src/gaia_cli/impl.py
+++ b/src/gaia_cli/impl.py
@@ -3252,6 +3252,34 @@ def release_command(args):
 
     root = args.registry or "."
 
+    # Refresh HTML cache-bust strings before committing. validate.yml fires on the
+    # release commit (packages/cli-npm/** is in its path filter) and runs
+    # `gaia dev docs --check`, which fails when the ?v=X.Y.Z strings in tracked
+    # Class S docs/*.html still reference the old version. Rewrite them here so the
+    # release commit is self-consistent.
+    #
+    # IMPORTANT: run ONLY --cache-bust-only, never full `gaia dev docs`. A full
+    # regen rebuilds docs/badges/ from local registry state and can re-trigger the
+    # stale-snapshot badge wipe (CLAUDE.md, 2026-06-24 outage).
+    cache_bust_files = []
+    docs_script = os.path.join(root, "scripts", "build_docs.py")
+    if os.path.exists(docs_script):
+        print("Refreshing HTML cache-bust strings…")
+        proc = subprocess.run(
+            [sys.executable, docs_script, "--cache-bust-only"],
+            cwd=root, capture_output=True, text=True,
+        )
+        if proc.returncode != 0:
+            raise SystemExit(
+                "build_docs.py --cache-bust-only failed; aborting release:\n"
+                + (proc.stderr or proc.stdout or "").strip()
+            )
+        for line in (proc.stdout or "").splitlines():
+            if line.startswith("cache-bust: updated "):
+                cache_bust_files.append(line[len("cache-bust: updated "):].strip())
+        if proc.stdout:
+            print(proc.stdout.strip())
+
     # Commit the version bump, create an annotated tag, and push both so that
     # the GitHub Actions release workflow (triggered by 'push tags: v*') fires.
     #
@@ -3284,7 +3312,7 @@ def release_command(args):
         return result.stdout.strip()
 
     print("Creating release commit…")
-    _run_git("add", "--", *existing_version_files)
+    _run_git("add", "--", *existing_version_files, *cache_bust_files)
     _run_git(
         "commit",
         "-m",

--- a/src/gaia_cli/impl.py
+++ b/src/gaia_cli/impl.py
@@ -3252,19 +3252,24 @@ def release_command(args):
 
     root = args.registry or "."
 
-    # Refresh HTML cache-bust strings before committing. validate.yml fires on the
-    # release commit (packages/cli-npm/** is in its path filter) and runs
-    # `gaia dev docs --check`, which fails when the ?v=X.Y.Z strings in tracked
-    # Class S docs/*.html still reference the old version. Rewrite them here so the
-    # release commit is self-consistent.
+    # Refresh version-derived surfaces before committing. validate.yml fires on
+    # the release commit (packages/cli-npm/** is in its path filter) and runs
+    # `gaia dev docs --check`, which fails when version strings still reference
+    # the old version. Two surfaces are version-derived and validated:
+    #   1. the ?v=X.Y.Z / GAIA_VERSION strings in tracked Class S docs/*.html
+    #   2. the README version region (<!-- gaia:version-start --> … end)
+    # Both derive solely from pyproject.toml. Rewrite them here so the release
+    # commit is self-consistent (build_docs.py --cache-bust-only handles both
+    # and emits a "cache-bust: updated <path>" line per file it touches).
     #
     # IMPORTANT: run ONLY --cache-bust-only, never full `gaia dev docs`. A full
     # regen rebuilds docs/badges/ from local registry state and can re-trigger the
-    # stale-snapshot badge wipe (CLAUDE.md, 2026-06-24 outage).
+    # stale-snapshot badge wipe (CLAUDE.md, 2026-06-24 outage). --cache-bust-only
+    # never reads the gitignored Class P registry snapshot.
     cache_bust_files = []
     docs_script = os.path.join(root, "scripts", "build_docs.py")
     if os.path.exists(docs_script):
-        print("Refreshing HTML cache-bust strings…")
+        print("Refreshing version-derived surfaces (HTML cache-bust + README)…")
         proc = subprocess.run(
             [sys.executable, docs_script, "--cache-bust-only"],
             cwd=root, capture_output=True, text=True,

--- a/tests/test_build_docs_cache_bust_only.py
+++ b/tests/test_build_docs_cache_bust_only.py
@@ -1,0 +1,119 @@
+"""Tests for the ``--cache-bust-only`` mode in ``scripts/build_docs.py``.
+
+Pins the release-time version-sync contract (PR #1114): a release commit must
+be self-consistent for ``gaia dev docs --check``, which validates every
+version-derived surface. ``gaia dev release`` bumps ``pyproject.toml`` but the
+only surfaces it must additionally re-stamp are:
+
+  1. the ``?v=X.Y.Z`` / ``GAIA_VERSION`` strings in tracked Class S docs/*.html
+  2. the README version region (``<!-- gaia:version-start --> … end``)
+
+Both derive solely from ``pyproject.toml``. ``--cache-bust-only`` refreshes
+exactly those two and NOTHING else — in particular it must never read the
+gitignored Class P registry snapshot or rebuild badges (the 2026-06-24
+stale-snapshot badge-wipe class of failure).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "build_docs.py"
+
+
+def _load() -> object:
+    """Import ``build_docs`` by path (the script is not in a package)."""
+    sys.path.insert(0, str(REPO_ROOT / "scripts"))
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+    spec = importlib.util.spec_from_file_location("build_docs", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture()
+def bd():
+    return _load()
+
+
+def test_readme_version_only_rewrites_only_version_region(bd, tmp_path, monkeypatch):
+    """build_readme_version_only touches the version region and nothing else."""
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "# Title\n\n"
+        "<!-- gaia:version-start -->\n"
+        "Current Gaia CLI version: `1.0.0`.\n"
+        "<!-- gaia:version-end -->\n\n"
+        "<!-- gaia:registry-start -->\n"
+        "SACRED-TREE-CONTENT-DO-NOT-TOUCH\n"
+        "<!-- gaia:registry-end -->\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(bd, "ROOT", tmp_path)
+    monkeypatch.setattr(bd, "_read_version", lambda: "9.9.9")
+
+    changed = bd.build_readme_version_only(check=False)
+
+    text = readme.read_text(encoding="utf-8")
+    assert changed is True
+    assert "`9.9.9`" in text
+    assert "`1.0.0`" not in text
+    # The registry region must be left exactly as-is — version-only refresh must
+    # never touch registry-tree / CLI-help / layout (they need Class P gaia.json).
+    assert "SACRED-TREE-CONTENT-DO-NOT-TOUCH" in text
+
+
+def test_readme_version_only_idempotent(bd, tmp_path, monkeypatch):
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "<!-- gaia:version-start -->\n"
+        "Current Gaia CLI version: `9.9.9`.\n"
+        "<!-- gaia:version-end -->\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(bd, "ROOT", tmp_path)
+    monkeypatch.setattr(bd, "_read_version", lambda: "9.9.9")
+
+    # _versions() emits the full install-instructions body, so seed a realistic
+    # already-current region and assert a second pass is a no-op.
+    bd.build_readme_version_only(check=False)
+    before = readme.read_text(encoding="utf-8")
+    changed = bd.build_readme_version_only(check=False)
+    after = readme.read_text(encoding="utf-8")
+    assert changed is False
+    assert before == after
+
+
+def test_readme_version_only_missing_file_is_noop(bd, tmp_path, monkeypatch):
+    monkeypatch.setattr(bd, "ROOT", tmp_path)  # no README.md present
+    assert bd.build_readme_version_only(check=False) is False
+
+
+def test_cache_bust_only_main_refreshes_html_and_readme(bd, monkeypatch):
+    """--cache-bust-only runs BOTH refreshers and never the full pipeline."""
+    calls = []
+    monkeypatch.setattr(
+        bd, "build_html_cache_busting", lambda check: calls.append(("html", check)) or True
+    )
+    monkeypatch.setattr(
+        bd, "build_readme_version_only", lambda check: calls.append(("readme", check)) or False
+    )
+    # Guard: a full-pipeline step must NOT run in cache-bust-only mode.
+    monkeypatch.setattr(
+        bd, "build_badges", lambda check: (_ for _ in ()).throw(
+            AssertionError("build_badges must not run under --cache-bust-only")
+        )
+    )
+
+    rc = bd.main(["--cache-bust-only"])
+
+    assert rc == 0
+    assert ("html", False) in calls
+    assert ("readme", False) in calls


### PR DESCRIPTION
## Problem

`validate.yml` fires on every release commit (`packages/cli-npm/**` is in its path filter) and runs `gaia dev docs --check`. The check fails because `gaia dev release` bumps `pyproject.toml`/`package.json` but never updates the `?v=X.Y.Z` strings in the 26 tracked Class S `docs/*.html` files — so the version in those strings lags by one release every time.

Root cause confirmed by the v6.4.0 failure ([run 29053497042](https://github.com/gaia-research/gaia-skill-tree/actions/runs/29053497042)): all 26 HTML files still had `?v=6.3.x` after the v6.4.0 release commit landed.

## Fix (Opus-reviewed)

- **`scripts/build_docs.py` — `--cache-bust-only` mode**: runs only `build_html_cache_busting` in write mode, prints `cache-bust: updated <path>` for each file touched, exits 0. Never regenerates badges, `gaia.json`, or other Class S artifacts — avoids the 2026-06-24 stale-snapshot badge wipe risk associated with full `gaia dev docs`.
- **`src/gaia_cli/impl.py` — `release_command`**: calls `build_docs.py --cache-bust-only` after `bump_versions` and stages the rewritten HTML files into the release commit alongside `pyproject.toml` and the `package.json` files.

Also fixes the **existing v6.4.0 drift** on `main` (all 26 HTML files still had `?v=6.3.x`).

## Why not Option B (skip the check on `[skip-gen]` commits)?

The `?v=X.Y.Z` strings gate real browser asset fetches — they are functional cache-busting, not decoration. Skipping the check would mean a release, the one moment new CSS/JS ships, is exactly when cache-busting silently fails to fire on cached browsers.

## What is NOT touched

- `release.yml` — PyPI fix from PR #1112 is untouched
- `validate.yml` — no changes to the check
- `sync-artifacts.yml` — `[skip-gen]` skip still applies; no badge regen risk

## Entrypoints

N/A — CI and CLI tooling only, no new user-facing surface.