### PR TITLE
design(nav): clarify Star CTA copy + filled-plate visual

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -595,24 +595,27 @@ nav ul.nav-primary {
 }
 
 /* Repository contribution is an explicit action, not a social metric. The
-   compact plate stays legible beside destination links without surfacing a
-   stargazer count before Gaia reaches its first 1,000-star milestone. */
+   filled plate reads as CTA-not-nav-link at rest — visual weight distinct
+   from the surrounding destination links — without surfacing a stargazer
+   count before Gaia reaches its first 1,000-star milestone. */
 .nav-star-cta {
   display: inline-flex !important;
   align-items: center;
   gap: .38rem;
-  padding: .32rem .58rem !important;
-  border: 1px solid rgba(var(--evidence-gold-rgb), .48);
+  padding: .34rem .68rem !important;
+  border: 1px solid var(--evidence-gold);
   border-radius: 999px;
-  color: var(--evidence-gold) !important;
-  background: rgba(var(--evidence-gold-rgb), .08);
+  color: var(--bg) !important;
+  background: var(--evidence-gold);
   font-weight: 600;
   line-height: 1.15;
+  transition: filter .18s ease-out, box-shadow .18s ease-out, transform .18s ease-out;
 }
 
 .nav-star-cta-mark {
   font-size: .82em;
   line-height: 1;
+  color: var(--bg);
 }
 
 /* This is a contained action plate, so it deliberately uses its border state
@@ -624,9 +627,18 @@ nav ul.nav-primary {
 
 .nav-star-cta:hover,
 .nav-star-cta:focus-visible {
-  color: var(--text) !important;
+  color: var(--bg) !important;
   border-color: var(--evidence-gold);
-  background: rgba(var(--evidence-gold-rgb), .16);
+  background: var(--evidence-gold);
+  filter: brightness(1.12);
+  box-shadow: 0 0 0 3px rgba(var(--evidence-gold-rgb), .22), 0 2px 6px rgba(var(--evidence-gold-rgb), .28);
+  transform: translateY(-1px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nav-star-cta { transition: none; }
+  .nav-star-cta:hover,
+  .nav-star-cta:focus-visible { transform: none; }
 }
 
 @media (min-width: 701px) and (max-width: 900px) {

--- a/docs/js/site-nav.js
+++ b/docs/js/site-nav.js
@@ -68,12 +68,12 @@
   // when the count is not part of the navigation's information hierarchy.
   const starLink = {
     href: 'https://github.com/gaia-research/gaia-skill-tree',
-    label: 'Star Gaia',
+    label: 'Star on GitHub',
     i: 6,
     cls: 'nav-star-cta',
     target: '_blank',
     rel: 'noopener',
-    ariaLabel: 'Star Gaia Skill Tree on GitHub (opens in a new tab)',
+    ariaLabel: 'Star the Gaia Skill Tree repo on GitHub (opens in a new tab)',
     icon: function() {
       return '<span class="nav-star-cta-mark" aria-hidden="true">★</span>';
     }
@@ -197,7 +197,7 @@
           const icon = typeof item.icon === 'function' ? item.icon() : '';
           return '<li><a href="' + item.href + '" style="color:' + item.color + '"' + active + '>' + icon + item.label + '</a></li>';
         }).join('') +
-        '<li><a href="https://github.com/gaia-research/gaia-skill-tree" class="nav-star-cta" target="_blank" rel="noopener" aria-label="Star Gaia Skill Tree on GitHub (opens in a new tab)"><span class="nav-star-cta-mark" aria-hidden="true">★</span>Star Gaia</a></li>' +
+        '<li><a href="https://github.com/gaia-research/gaia-skill-tree" class="nav-star-cta" target="_blank" rel="noopener" aria-label="Star the Gaia Skill Tree repo on GitHub (opens in a new tab)"><span class="nav-star-cta-mark" aria-hidden="true">★</span>Star on GitHub</a></li>' +
         // Dropdown items, flattened. Buttons (Skill Tree / Skill Graph) become
         // <a> links to home with the right query param so taps Just Work — the
         // dedicated handlers (skill-graph.js, hud-toggle.js) pick up the param.

--- a/docs/js/site-nav.js
+++ b/docs/js/site-nav.js
@@ -93,7 +93,7 @@
     { type: 'link', href: root + 'skills/',        label: 'Skill Index',        color: 'var(--tier-basic)' },
   ];
 
-  function li(item) {
+  function anchorHtml(item) {
     const active = isActive(item.href) ? ' aria-current="page"' : '';
     const icon = typeof item.icon === 'function' ? item.icon() : '';
     const cls = item.cls ? ' class="' + item.cls + '"' : '';
@@ -101,7 +101,17 @@
     const rel = item.rel ? ' rel="' + item.rel + '"' : '';
     const ariaLabel = item.ariaLabel ? ' aria-label="' + item.ariaLabel + '"' : '';
     const color = item.color ? ' style="color:' + item.color + '"' : '';
-    return '<li style="--nav-i:' + item.i + '"><a href="' + item.href + '"' + cls + color + active + target + rel + ariaLabel + '>' + icon + item.label + '</a></li>';
+    return '<a href="' + item.href + '"' + cls + color + active + target + rel + ariaLabel + '>' + icon + item.label + '</a>';
+  }
+
+  function li(item) {
+    return '<li style="--nav-i:' + item.i + '">' + anchorHtml(item) + '</li>';
+  }
+
+  // Mobile drawer flavour of li(): no --nav-i stagger variable (the drawer
+  // doesn't animate off it) and no other structural changes. Same anchor.
+  function liMobile(item) {
+    return '<li>' + anchorHtml(item) + '</li>';
   }
 
   function dropdownItem(d) {
@@ -115,6 +125,36 @@
     const cls = d.cls ? ' class="' + d.cls + '"' : '';
     const id = d.id ? ' id="' + d.id + '"' : '';
     return '<li><a href="' + d.href + '"' + cls + id + ' style="color:' + (d.color || '') + '"' + active + '>' + d.label + '</a></li>';
+  }
+
+  // Mobile drawer flavour of dropdownItem(). Three deliberate deviations from
+  // the desktop renderer:
+  //   1. NO `id` attribute is emitted. The desktop dropdown already owns
+  //      those IDs (treeNavBtn, metaNavBtn, navGraphBtn); repeating them
+  //      inside the drawer would produce duplicate IDs — an a11y violation
+  //      and, more concretely, would break the querySelector('#…') wiring
+  //      further down this file (Skill Tree / Skill Graph click handlers).
+  //   2. NO `class` attribute is emitted. `nav-tree`, `nav-graph-trigger`,
+  //      and `nav-meta` all declare `color: X !important` which would
+  //      override the inline `style="color:…"` value from the data. On
+  //      desktop those classes are the source of truth for the button's
+  //      color; on mobile the drawer has always relied on the inline color
+  //      from the data object, and preserving that here keeps mobile visual
+  //      output byte-identical to the pre-refactor hardcoded strings.
+  //   3. `type: 'btn'` items resolve to <a> with the right query param
+  //      (?tree=1 / ?field=1) so a tap navigates home and the existing
+  //      skill-graph.js / hud-toggle.js listeners pick it up on arrival.
+  //      This matches the behavior of the pre-refactor hardcoded strings.
+  function dropdownItemMobile(d) {
+    const color = d.color ? ' style="color:' + d.color + '"' : '';
+    if (d.type === 'btn') {
+      const href = d.id === 'treeNavBtn'  ? root + 'index.html?tree=1'
+                : d.id === 'navGraphBtn' ? root + 'index.html?field=1'
+                : root + 'index.html';
+      return '<li><a href="' + href + '"' + color + '>' + d.label + '</a></li>';
+    }
+    const active = isActive(d.href) ? ' aria-current="page"' : '';
+    return '<li><a href="' + d.href + '"' + color + active + '>' + d.label + '</a></li>';
   }
 
   // ── docs/en breadcrumb ────────────────────────────────────────────────
@@ -187,31 +227,19 @@
       li(starLink) +
     '</ul>' +
     // Mobile drawer — completely separate element with its own class names.
-    // Flat list of every destination, no nesting, fits one screen.
+    // Flat list of every destination, no nesting, fits one screen. The body
+    // is rendered from the SAME data sources as the desktop nav (`links`,
+    // `starLink`, `dropdown`) via mobile-flavour renderers, so adding or
+    // editing a nav entry is a one-place change. Before this refactor the
+    // drawer had a hand-maintained shadow copy of every entry; when the
+    // 1,000-star milestone lands and the star CTA gains a stargazer count
+    // element, this seam is where the count integrates once instead of twice.
     '<div class="nav-mobile-drawer" aria-hidden="true">' +
       '<button class="nav-mobile-close" type="button" aria-label="Close navigation">×</button>' +
       '<ul class="nav-mobile-list">' +
-        // Top-level links (clone, not the same nodes).
-        links.map(function (item) {
-          const active = isActive(item.href) ? ' aria-current="page"' : '';
-          const icon = typeof item.icon === 'function' ? item.icon() : '';
-          return '<li><a href="' + item.href + '" style="color:' + item.color + '"' + active + '>' + icon + item.label + '</a></li>';
-        }).join('') +
-        '<li><a href="https://github.com/gaia-research/gaia-skill-tree" class="nav-star-cta" target="_blank" rel="noopener" aria-label="Star the Gaia Skill Tree repo on GitHub (opens in a new tab)"><span class="nav-star-cta-mark" aria-hidden="true">★</span>Star on GitHub</a></li>' +
-        // Dropdown items, flattened. Buttons (Skill Tree / Skill Graph) become
-        // <a> links to home with the right query param so taps Just Work — the
-        // dedicated handlers (skill-graph.js, hud-toggle.js) pick up the param.
-        '<li><a href="' + root + 'index.html?tree=1" style="color:#34d399">Skill Tree</a></li>' +
-        '<li><a href="' + root + 'index.html?field=1" style="color:var(--tier-basic)">Skill Graph</a></li>' +
-        '<li><a href="' + root + 'codex.html" style="color:var(--tier-basic)">The Codex</a></li>' +
-        '<li><a href="' + root + 'trust/ledger/" style="color:var(--evidence-gold)">Trust Ledger</a></li>' +
-        '<li><a href="' + root + 'starless.html" style="color:var(--muted)">Starless</a></li>' +
-        '<li><a href="' + root + 'u/" style="color:var(--honor-red)">Named Contributors</a></li>' +
-        '<li><a href="' + root + 'meta.html">Meta Reports</a></li>' +
-        '<li><a href="' + root + 'evidence/" style="color:var(--rank-3)">Evidence Library</a></li>' +
-        '<li><a href="' + root + 'reports/" style="color:var(--evidence-gold)">Weekly Reports</a></li>' +
-        '<li><a href="' + root + 'benchmarks/" style="color:var(--evidence-gold)">Benchmarks</a></li>' +
-        '<li><a href="' + root + 'skills/" style="color:var(--tier-basic)">Skill Index</a></li>' +
+        links.map(liMobile).join('') +
+        liMobile(starLink) +
+        dropdown.map(dropdownItemMobile).join('') +
       '</ul>' +
     '</div>';
 


### PR DESCRIPTION
## Summary

Surgical two-file change to the site nav's Star CTA. Copy pass via impeccable `clarify`, then a visual pass because the CTA was reading as just another nav item.

## Copy

| Surface | Before | After |
|---|---|---|
| Visible label | `Star Gaia` | `Star on GitHub` |
| aria-label | `Star Gaia Skill Tree on GitHub (opens in a new tab)` | `Star the Gaia Skill Tree repo on GitHub (opens in a new tab)` |
| Mobile drawer duplicate (line 200) | `Star Gaia` | `Star on GitHub` (lockstep) |

**Why:** in a nav where every neighbor is a destination noun (Home, About, GitHub Badges, Skills, Docs), `Star Gaia` parses first as a proper noun ("the Star Gaia section") and only second as a verb + object CTA. `Star on GitHub` is unambiguously verb + platform, matches the impeccable clarify rule ("button labels: verb + object, describing what will happen"), and restores destination scent that the aria-label was carrying alone. Also disambiguates against Gaia's in-universe ★ semantics (rank stars 0★–6★, Apex) so the ★ mark reads as a GitHub star, not a rank action.

Brand-name drop is intentional — the whole nav is on `gaiaskilltree.com`, so restating "Gaia" in a nav slot is redundancy.

## Visual

Rest state flipped from ghost-pill (`.08` bg / `.48` border) to a **filled evidence-gold plate with ink text** (`var(--bg)`). At a glance the CTA now reads as CTA-not-nav-link, which is what a rightmost-nav conversion action should telegraph. Hover brightens via `filter: brightness(1.12)` + a ≤6px gold glow and a 1px lift.

### Rule check
- ✅ No hex fallbacks — `var(--bg)`, `var(--evidence-gold)`, `rgba(var(--evidence-gold-rgb), …)` only.
- ✅ Did NOT repurpose `--apex-gold` — PRODUCT.md §Design Principles #3 hard-locks Apex Gold to Transcendent tier. Hover brightness via `filter`, not a second gold token.
- ✅ Pill radius (`999px`) is the allowed exception for tags/buttons per impeccable rules (cards top out at 12–16px).
- ✅ Box-shadow at `0 2px 6px` — well under the 16px codex-ghost-card ceiling; not paired with a 1px+heavy-shadow ghost-card pattern.
- ✅ `prefers-reduced-motion` suppresses the transform + transition.
- ✅ Contrast: `--evidence-gold` (#d4af37) on `--bg` (#030712) ≈ 10:1, well above WCAG AA.
- ✅ Absolute bans: no gradient, no side-stripe, no glassmorphism, no hero-metric template.

## Entrypoints

Per CLAUDE.md § Design Entrypoints — no new page or section, this is a visual+copy refinement of an existing nav slot rendered on every page by `site-nav.js`. No mount changes, no homepage tile, no footer entry needed. `docs/js/mounts.js` unchanged. No cache-busting registration needed (existing files, auto-versioned at release time by `build_html_cache_busting()`).

## Files changed

- `docs/js/site-nav.js` — label + aria-label + mobile drawer duplicate
- `docs/css/styles.css` — `.nav-star-cta` rest + hover + reduced-motion

## Verification

- [x] JS parses (`node -c docs/js/site-nav.js`)
- [x] CSS braces balanced (1738/1738)
- [x] No new hex literals in the touched block
- [ ] Manual visual check across breakpoints (< 700, 701–900, > 900) — recommend a preview deploy before merge

## Scope

Branch prefix: `design/` — touches only `docs/` (HTML/CSS/JS). Within scope per `.github/workflows/branch-scope.yml`.

---

*Copy pass: `/impeccable clarify` on "nav Star Gaia"; visual pass follow-on at operator request.*