### PR TITLE
docs: add AGENTS.md at repo root for agent-discovery of intake flow (#1124)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,67 @@
+# AGENTS.md
+
+Discovery surface for AI agents. Human maintainers: read [`CLAUDE.md`](./CLAUDE.md) and [`CONTRIBUTING.md`](./CONTRIBUTING.md) instead.
+
+If you are an agent that landed in this repo and needs to know **the fastest correct path to do a thing**, this file routes you. It does not replace the deeper docs; it points at them.
+
+## The two things agents actually do here
+
+### 1. Submit a skill I discovered → `gaia push`
+
+You have found a real capability in a real repo and want to nominate it for the registry. Do not open a bare issue. Do not hand-write JSON into `registry/`. Do this:
+
+    gaia push --from-file skills.yml               # writes batch + opens intake issue
+    gaia push --from-file skills.yml --dry-run     # preview
+    gaia push --from-file skills.yml --no-issue    # write batch, no issue
+
+The `skills.yml` schema is documented in the issue template. Minimum viable content:
+
+    skills:
+      - id: kebab-case-id
+        name: Human Readable Name
+        type: basic
+        prerequisites: []
+        description: >-
+          One paragraph. Precise. Falsifiable.
+        attribution:
+          upstream_author: github-handle
+          skill_file_url: https://github.com/owner/repo/blob/main/SKILL.md
+          type: self-made
+        evidence:
+          - grade: B
+            type: repo
+            url: https://github.com/owner/repo
+            notes: "brief context"
+
+Canonical worked examples: intake #1020 (mixed basic/fusion) and intake #1123 (named implementation on existing provisional generic).
+
+If the CLI is unavailable: paste the same YAML into the new skill intake issue form.
+
+### 2. Modify the registry as a reviewer / maintainer
+
+Not you if you are a fresh visiting agent. Playbook lives in `docs/agent.md` §5 and `CLAUDE.md`.
+
+## Full context, in order of density
+
+| Read | Purpose |
+|---|---|
+| This file | Route agents to the right entry point |
+| `docs/agent.md` | Structured context sheet |
+| `.github/ISSUE_TEMPLATE/new_skill_intake.yml` | The intake schema in full |
+| `CONTRIBUTING.md` | Human contributor guide |
+| `CLAUDE.md` | Non-obvious workflow discipline |
+| `GOVERNANCE.md` | Curation policy |
+
+## Do not
+
+- Do not commit directly to `main`.
+- Do not open a bare issue titled "add my skill".
+- Do not include branch, title, or `catalogRef` in an intake YAML.
+- Do not invent evidence rows.
+- Do not touch files under "Agent-Managed Files (Hermes Ownership)" in `docs/agent.md`.
+
+## MCP
+
+If your harness speaks MCP:
+
+    claude mcp add gaia -- npx @gaia-registry/mcp-server


### PR DESCRIPTION
## Summary

Implements issue #1124 — adds a single new file `AGENTS.md` at the repo root so AI agents that land cold in `gaia-skill-tree` can discover the intake flow without reading four separate docs first.

The file routes (does not duplicate) existing docs: the `gaia push --from-file` one-liner, a minimum-viable copy-paste YAML template, pointers into `docs/agent.md` and `CLAUDE.md`, a density-ordered context table, a "Do not" list of common intake mistakes, and the MCP setup one-liner.

All example values were verified against the real CLI schema (`src/gaia_cli/commands/pushFromFile.py`): `type: basic`, `attribution.type: self-made`, `evidence.grade: B`, `evidence.type: repo`, and the `upstream_author` / `skill_file_url` attribution fields all pass validation.

## Definition of done (per #1124)

- [x] PR adding `AGENTS.md` at repo root
- [x] No changes to `CLAUDE.md`, `docs/agent.md`, `CONTRIBUTING.md`, or the issue template
- [x] No doc renames, so no "Full context" table row edits required

## Scope / Entrypoints

This is a root-level Markdown discovery file for agents — not a user-facing site page — so the Design Entrypoints rule (nav/footer/homepage tiles) does not apply. No `docs/<section>/` directory, no nav mount, no regen of Class S artifacts.

## Verification

- Plain Markdown, no JS/HTML — Guard D (`check_nav_mounts.py`) not applicable.
- No registry/timeline mutations — Meta Guard and CI Guard E not applicable.
- No `gaia dev docs` regen performed (surgical, doc-only).