### PR TITLE
docs(en): modular fixed-nav clearance so titles clear the site nav

### DIFF
--- a/docs/en/DOCS.md
+++ b/docs/en/DOCS.md
@@ -36,7 +36,20 @@ Secondary: Open-source contributors wanting to claim a Named Skill.
 ## Design System
 
 Inherits from `docs/css/tokens.css` and `docs/css/styles.css`.
-All pages link `../css/tokens.css`, `../css/styles.css`.
+All pages link `../css/tokens.css`, `../css/styles.css`, then **`docs-en-shell.css`** (same directory).
+
+### Fixed-nav clearance (`docs-en-shell.css`)
+
+The site-wide nav is `position: fixed` (~58px). Global `styles.css` hides the legacy in-page `.docs-nav` when `#site-nav` is present but does not offset content, so titles would sit under the bar.
+
+`docs-en-shell.css` is the modular fix for `/en` only (no edits outside this folder):
+
+| Token | Default | Role |
+|---|---|---|
+| `--docs-en-site-nav-height` | `3.625rem` | Sticky sidebar / scroll-margin baseline |
+| `--docs-en-nav-clearance` | `5rem` | Top clearance for content shells (fixed-nav ladder base) |
+
+Rules target body-child shells: `.page-layout`, `.docs-layout`, and index `.docs-hero`. New pages under `docs/en/` must load this sheet after `styles.css`.
 
 Fonts: EB Garamond (display headings), Bricolage Grotesque (body), JetBrains Mono (code).
 Background: `#030712` (`--bg`). Surface: `#0f172a` (`--surface`). Border: `#1e293b`.

--- a/docs/en/cli-reference.html
+++ b/docs/en/cli-reference.html
@@ -14,6 +14,7 @@
   <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
   <link rel="stylesheet" href="../css/tokens.css">
   <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="docs-en-shell.css">
   <style>
     *,
     *::before,

--- a/docs/en/contributing.html
+++ b/docs/en/contributing.html
@@ -11,6 +11,7 @@
   <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
   <link rel="stylesheet" href="../css/tokens.css">
   <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="docs-en-shell.css">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 

--- a/docs/en/docs-en-shell.css
+++ b/docs/en/docs-en-shell.css
@@ -1,0 +1,44 @@
+/**
+ * docs-en-shell.css — fixed site-nav clearance for /en pages only.
+ *
+ * Why this lives under docs/en/:
+ *   Global styles.css hides the legacy in-page <nav class="docs-nav"> when
+ *   <nav id="site-nav"> is present, but sets body padding-top: 0, so titles
+ *   start under the fixed bar (~58px). This sheet restores clearance without
+ *   editing docs/css/ or docs/js/.
+ *
+ * Values follow docs/agents/fixed-nav-clearance.md (base 5rem ladder).
+ * Load after ../css/styles.css on every docs/en HTML page.
+ */
+
+:root {
+  --docs-en-site-nav-height: 3.625rem; /* ~58px fixed site-nav */
+  --docs-en-nav-clearance: 5rem;       /* base ladder: 80px breathing room */
+}
+
+/* Outermost content shells after #site-nav (.docs-nav is display:none globally) */
+body:has(> nav#site-nav) > .page-layout,
+body:has(> nav#site-nav) > .docs-layout {
+  padding-top: var(--docs-en-nav-clearance);
+  box-sizing: border-box;
+}
+
+/* Index: hero is the first content block (not page-layout) */
+body:has(> nav#site-nav) > .docs-hero {
+  margin-top: var(--docs-en-nav-clearance);
+}
+
+/* Sticky side rails stick below site-nav, not the hidden 52px docs-nav */
+body:has(> nav#site-nav) .sidebar,
+body:has(> nav#site-nav) .docs-sidebar {
+  top: var(--docs-en-site-nav-height);
+}
+
+body:has(> nav#site-nav) .sidebar {
+  height: calc(100vh - var(--docs-en-site-nav-height));
+}
+
+/* In-page anchors clear the fixed bar */
+body:has(> nav#site-nav) :is(h1, h2, h3, [id]) {
+  scroll-margin-top: calc(var(--docs-en-site-nav-height) + 0.75rem);
+}

--- a/docs/en/evidence-classes.html
+++ b/docs/en/evidence-classes.html
@@ -11,6 +11,7 @@
   <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
   <link rel="stylesheet" href="../css/tokens.css">
   <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="docs-en-shell.css">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
     body {

--- a/docs/en/faq.html
+++ b/docs/en/faq.html
@@ -11,6 +11,7 @@
   <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
   <link rel="stylesheet" href="../css/tokens.css">
   <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="docs-en-shell.css">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 

--- a/docs/en/fusion.html
+++ b/docs/en/fusion.html
@@ -11,6 +11,7 @@
   <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
   <link rel="stylesheet" href="../css/tokens.css">
   <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="docs-en-shell.css">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 

--- a/docs/en/getting-started.html
+++ b/docs/en/getting-started.html
@@ -11,6 +11,7 @@
   <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
   <link rel="stylesheet" href="../css/tokens.css">
   <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="docs-en-shell.css">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 

--- a/docs/en/index.html
+++ b/docs/en/index.html
@@ -11,6 +11,7 @@
   <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
   <link rel="stylesheet" href="../css/tokens.css">
   <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="docs-en-shell.css">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 

--- a/docs/en/mcp-server.html
+++ b/docs/en/mcp-server.html
@@ -11,6 +11,7 @@
   <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
   <link rel="stylesheet" href="../css/tokens.css">
   <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="docs-en-shell.css">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 

--- a/docs/en/named-skills.html
+++ b/docs/en/named-skills.html
@@ -11,6 +11,7 @@
   <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
   <link rel="stylesheet" href="../css/tokens.css">
   <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="docs-en-shell.css">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 

--- a/docs/en/share-bundles.html
+++ b/docs/en/share-bundles.html
@@ -11,6 +11,7 @@
   <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
   <link rel="stylesheet" href="../css/tokens.css">
   <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="docs-en-shell.css">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 

--- a/docs/en/skill-hierarchy.html
+++ b/docs/en/skill-hierarchy.html
@@ -11,6 +11,7 @@
   <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
   <link rel="stylesheet" href="../css/tokens.css">
   <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="docs-en-shell.css">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 

--- a/docs/en/timeline-audit.html
+++ b/docs/en/timeline-audit.html
@@ -11,6 +11,7 @@
   <link rel="icon" type="image/svg+xml" href="../assets/marks/diamond-seal.svg">
   <link rel="stylesheet" href="../css/tokens.css">
   <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="docs-en-shell.css">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 


### PR DESCRIPTION
## Summary

- Adds `docs/en/docs-en-shell.css`, a shared shell stylesheet that restores fixed site-nav clearance for English docs pages only.
- Links it from all 12 `docs/en/*.html` pages (after `styles.css`).
- Documents the convention in `docs/en/DOCS.md`.

**Why:** Global `styles.css` hides the legacy in-page `.docs-nav` when `#site-nav` is present but sets `body { padding-top: 0 }`, so page titles sat under the fixed ~58px nav. This PR does not touch `docs/css/` or run any regen — fix stays modular under `docs/en/`.

## What it does

| Token / rule | Effect |
|---|---|
| `--docs-en-nav-clearance` (`5rem`) | Top padding on `.page-layout` / `.docs-layout`; top margin on index `.docs-hero` |
| `--docs-en-site-nav-height` (`3.625rem`) | Sticky sidebar offset + heading `scroll-margin-top` |

## Scope

- **Only** `docs/en/**` (14 files)
- No rebuild / Class S regen
- No changes outside `docs/en/`

## Test plan

- [ ] Open `/en/` and a content page (e.g. `/en/getting-started.html`) scrolled to top — titles fully below site nav with breathing room
- [ ] Check mobile (&lt;768px) and desktop
- [ ] Click a sidebar anchor on a long page — heading not hidden under nav
- [ ] Sticky sidebar sticks just under site nav

## Token spend

```
2026-07-11 Grok 4.5 (this session): ~85k in, ~28k out. Plan + implement + draft PR. ~$0.40–0.70 est.
```