### PR TITLE
docs(index): temporarily disable above-the-fold entrypoints

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -368,6 +368,8 @@
        one line, ledger typography. Additive to the canonical CTAs in
        #evidence-cycle further down; this is the near-the-fold surface. -->
   <aside class="hero-ledger-flash" aria-label="Latest evidence">
+    <!-- Temporarily disabled; waiting for the epic 1002 redesign -->
+    <!--
     <a href="reports/" class="hlf-link">
       <span class="hlf-glyph" aria-hidden="true">◇</span>
       <span>Latest weekly report</span>
@@ -379,6 +381,7 @@
       <span>Benchmarks leaderboard</span>
       <span class="hlf-tail" aria-hidden="true">→</span>
     </a>
+    -->
   </aside>
 
   <!-- ─── HALL OF HEROES ─── -->


### PR DESCRIPTION
Temporarily disables 'Latest weekly report' and 'Benchmarks leaderboard' in the above-the-fold entrypoint on docs/index.html while they are being built. Re-enabling is tracked in issue #1130 after epic 1002.