### PR TITLE
docs(gaia-curate): clarify generic mapping and evidence metrics

### DIFF
--- a/.agents/skills/gaia-curate-chain/SKILL.md
+++ b/.agents/skills/gaia-curate-chain/SKILL.md
@@ -1,309 +1,65 @@
 ---
 name: gaia-curate-chain
 description: >-
-  Prompt-chaining curation for the Gaia registry — six discrete links (Scope,
-  Research, Design, Human Review, Mutate, Ship), each handed to a fresh
-  sub-agent, with a programmatic gate between every link that must pass before
-  the chain advances. Use when evidence quality and schema correctness matter
-  more than speed: "curate the tree carefully", "add skills with gates",
-  "step-by-step registry expansion", "gated curation", "auditable curation",
-  "chain the curation", "curate incrementally", "add skills without mistakes",
-  "high-quality skill additions", "small batch precision curation". Also
-  triggers on /gaia-curate-chain. For a fast single-pass run use /gaia-curate;
-  for a wide domain sweep with parallel sub-agents use /gaia-curate-dynamic.
-version: 1.1.0
+  Gated curation extension. Runs the canonical Gaia curation core first, then
+  adds fixed-topology subagents, deterministic gates, and bounded retries.
+  Use for small batches where schema correctness and auditability matter.
+version: 2.0.0
 argument-hint: "<topic-or-source-to-curate>"
 ---
 
-# gaia-curate-chain
+# Gaia Curate Chain
 
-A **prompt-chaining** implementation of Gaia registry curation, following the
-pattern described in Anthropic's
-[Building Effective Agents](https://www.anthropic.com/engineering/building-effective-agents).
+This is an extension of `/gaia-curate`, not a second curation methodology.
+Read and execute `.agents/skills/gaia-curate/CURATION-CORE.md` first. The core
+owns source loading, discovery, generic lookup, generic/named mapping, evidence
+capture, proposal design, human review, and mutation boundaries. Keep the core
+packet intact; do not reimplement those steps with alternate taxonomy or
+ evidence rules.
 
-> *Prompt chaining decomposes a task into a sequence of steps, where each LLM
-> call processes the output of the previous one. You can add programmatic checks
-> (gates) on any intermediate step to ensure the process stays on track.*
+## Extension workflow
 
-Curation is a natural fit: it's a linear pipeline (research → design → review
-→ mutate → ship), each phase is easier to get right in isolation, and catching
-a bad evidence URL or invalid schema shape at a gate is far cheaper than
-discovering it after `gaia validate` or CI fails. The trade-off is latency for
-accuracy.
+After the core produces an approved preliminary packet:
 
-```
-L1 Scope ──g1──▶ L2 Research ──g2──▶ L3 Map/Design ──g3──▶ L4 Human Review
-                                                                  │ g4
-                                                                  ▼
-                          ◀── ship ── L6 Regenerate+PR ◀──g5── L5 Mutate
-```
+1. Persist state to `generated-output/curate-chain-state.json` (gitignored).
+2. Dispatch fresh subagents for the approved research/design units when
+   independent context is valuable.
+3. Run deterministic gates between links: packet shape, generic ref resolution,
+   evidence URL presence, DAG validity, and `gaia validate`.
+4. On failure, route back one link with the concrete failure; allow at most two
+   retries per gate.
+5. Record the contract version/digest in state. If the core contract changes,
+   revalidate mappings and mutation plans before resuming.
+6. Perform the approved CLI mutations, regenerate docs, validate, and ship one
+   PR.
 
-Each `Ln` is one sub-agent call. Each `gn` is a **programmatic gate** the
-orchestrator runs itself — a deterministic shell/jq check, not an LLM
-judgement. The chain advances only when the gate passes. On failure the gate
-**routes back one link** with the failure reason, bounded to 2 retries per
-gate, then stops and asks the user.
-
-## Which curation skill to use
-
-| Skill | Pattern | When to use |
-|-------|---------|-------------|
-| `gaia-curate` | Single linear pass | Fast, low-stakes batches |
-| **`gaia-curate-chain`** | **Fixed topology + programmatic gates** | Small batch where schema correctness must be verified at each step |
-| `gaia-curate-dynamic` | Runtime-composed, massively parallel, convergent | Wide domain sweeps; high-stakes verification at scale |
-
-## Orchestrator responsibility
-
-You (the orchestrator) own three things: holding the chain state file, dispatching each link as a sub-agent, and running each gate. You do **not** do a link's research/design/mutation work — that belongs to the sub-agent. The one exception is gate execution (deterministic shell), which is always yours to run.
-
-## Chain state
-
-Persist one JSON blob to `generated-output/curate-chain-state.json` (gitignored)
-so each sub-agent can read prior output without re-deriving it.
+## State minimum
 
 ```json
 {
-  "topic": "<argument>",
+  "contractVersion": "core-v1",
+  "corePacket": "generated-output/curation-core-packet.json",
   "link": 1,
-  "existingIds": ["..."],
-  "targets": ["..."],
-  "candidates": [ { "id": "...", "name": "...", "evidence": [], "typeGuess": "" } ],
-  "batch": [ { "id": "...", "type": "", "level": null, "named": false, "status": "", "prereqs": [], "evidence": [], "decision": "" } ],
+  "gates": [],
   "mutations": [],
   "prUrl": null
 }
 ```
 
----
-
-## L1 — Scope & dedupe
-
-Dispatch a sub-agent (lightweight reasoning is enough) with:
-
-> Read `registry/skill-sources.md` (the authoritative source list) and
-> `registry/gaia.json`. Emit: (a) `existingIds` — every skill ID already in
-> the graph, and (b) `targets` — 5–15 concrete research targets for topic
-> `{{topic}}`, each a marketplace/org/repo/paper lead drawn from the sources
-> file. If you find a source not yet listed, note it for inclusion in the PR.
-> Write both arrays into the chain state. Do no research yet.
-
-**Gate g1** (orchestrator runs):
-```bash
-jq -e '(.existingIds|length>0) and (.targets|length>0)' \
-  generated-output/curate-chain-state.json
-```
-Fail → re-dispatch L1 with the reason. Pass → L2.
-
----
-
-## L2 — Research & evidence
-
-Dispatch a fresh sub-agent per cluster of targets. These are independent, so
-they may run in parallel (*sectioning* — a sibling pattern described in the
-article):
-
-> For each target, gather concrete evidence. **Local runs**: use the `gh` CLI
-> (`gh search repos --topic=… --sort=stars`), then inspect for a `skills/`
-> directory and use the **raw `blob/<branch>/<subpath>/SKILL.md` URL** as the
-> source — never a bare repo root. **Cloud/remote runs (no `gh`)**: use the
-> GitHub MCP tools (`search_repositories`, `get_file_contents`) — never claim
-> `gh` is unavailable without checking MCP first. Supplement with SkillsMP
-> (`https://skillsmp.com/api/v1/skills/search?q=…`, Class C) and arXiv abs
-> URLs (Class A) for Level II+ candidates. Emit `candidates[]` with an
-> `evidence[]` array of `{class, source}` per candidate. Every `source` must
-> be a real, resolvable URL.
-
-**Gate g2 — evidence gate** (the primary quality gate of the chain):
-```bash
-# Every candidate has >=1 evidence URL; Level II+ candidates have >=1 Class A or B source
-jq -e 'all(.candidates[];
-        (.evidence|length>0) and
-        ((.typeGuess|test("basic|generic")) or
-         ([.evidence[].class]|any(.=="A" or .=="B"))))' \
-  generated-output/curate-chain-state.json
-```
-Fail → route back to L2 for the failing candidates only (carry their IDs in the
-reason). Drop any candidate that still has no resolvable evidence after retry.
-
----
-
-## L3 — Schema mapping & batch design
-
-Dispatch a design sub-agent (heavier reasoning preferred here — schema errors
-caught now are far cheaper than retrying after g5 fails):
-
-> Turn `candidates[]` into a `batch[]` ready for the CLI. For each candidate:
->
-> - **Fusion-First**: map multiple vendor implementations of one concept onto a
->   single generic (e.g. don't mint `pubmed`/`arxiv`/`biorxiv` separately — use
->   `literature-search`). Orchestrate specialised capabilities as an `extra`
->   with the basics as prerequisites.
-> - Assign `type`: `basic`/`unique` (0 prereqs), `extra` (≥2), `ultimate` (≥3).
-> - `named`: true if it is a specific named implementation. Named skills MUST
->   be submitted with `status: "awakened"` — only reviewers later promote to
->   `named` and assign `title`/`catalogRef`; never set those here. Generic
->   nodes use `status: "provisional"`.
-> - `level`: named only, `2★–6★`; omit entirely for generics (the schema
->   rejects a level on a generic node).
-> - Demerit check (`heavyweight-dependency`/`niche-integration`/`experimental-feature`)
->   applies only at 3★+.
->
-> Emit the full `batch[]` and a review table.
-
-**Gate g3 — schema pre-flight gate** (catches invalid shapes before any
-mutation touches the registry — this is why the gate exists):
-```bash
-jq -e '
- def gidok: test("^[a-z][a-z0-9]*(-[a-z0-9]+)*$");
- def nidok: test("^[a-z0-9][a-z0-9_-]*/[a-z0-9][a-z0-9_-]*$");
- all(.batch[];
-   (if .named then (.id|nidok) else (.id|gidok) end)
-   and (if .type=="basic" or .type=="unique" then (.prereqs|length)==0
-        elif .type=="extra"  then (.prereqs|length)>=2
-        elif .type=="ultimate" then (.prereqs|length)>=3 else false end)
-   and (if .named then (.status=="awakened")
-        else (.status=="provisional" and (.level==null)) end))' \
-  generated-output/curate-chain-state.json
-```
-Also confirm no prerequisite cycle — every prereq must be an `existingId` or
-another batch entry, and the union must form a DAG. Fail → route back to L3
-with the offending field. Pass → L3.5.
-
----
-
-## L3.5 — Trust appraisal dry run
-
-Before the human review gate, run `/trust-appraise` for any proposed named
-suite or high-star named implementation whose rank could be distorted by repo
-stars, mothership discount, or fusion-recipe math. This is a non-mutating
-appraisal step: it informs review, but never auto-promotes.
-
-For suite candidates, record:
-
-- component count used for the dry run;
-- `github-stars-own`, `repo-own`, and `fusion-recipe` contributions;
-- whether the components are already curated/graded origins or merely proposed;
-- any archive/installability caveats.
-
-Example:
+## Required gates
 
 ```bash
-PYTHONPATH=src python3 scripts/trust_appraise.py \
-  --repo gsd-build/get-shit-done \
-  --components 5 \
-  --evidence-path docs/INVENTORY.md
+test -s generated-output/curation-core-packet.json
+gaia validate
+gaia dev docs --check
 ```
 
-**Gate g3.5 — appraisal sanity gate**:
-```bash
-# Any suite candidate must have an appraisal note before L4.
-jq -e 'all(.batch[] | select(.type=="ultimate" or (.suiteComponents|length>0));
-        (.trustAppraisal != null))' \
-  generated-output/curate-chain-state.json
-```
-Fail → route back to L3 to add the appraisal note or downgrade/defer the suite.
-Pass → L4.
+Validate named IDs in preferred `contributor/skill-name` form and resolve
+`genericSkillRef` (CLI: `--generic-ref`) against `gaia dev list --generic
+--json`. Do not use deprecated `--class`, manual trust values, or duplicate the
+core's evidence scoring logic.
 
----
+## Ship boundary
 
-## L4 — Human review gate
-
-The orchestrator presents the L3 table directly to the user. This gate is a
-person, not a script — it exists because the registry is a shared resource and
-schema-valid does not mean semantically correct.
-
-| ID | Name | Type | Stars | Prereqs | Demerits | Named? | Status |
-|----|------|------|-------|---------|----------|--------|--------|
-
-For each row the user marks: `accept` / `rename <new-id>` / `duplicate` /
-`needs-evidence` / `reject`. Apply renames in place, drop everything that is
-not `accept`/`rename`, and write the resolved `decision` per batch entry.
-
-**Gate g4**: proceed only if ≥1 `accept` remains. Otherwise stop and report.
-Do not advance to L5 without explicit user review — this is the one gate
-that can never be automated away.
-
----
-
-## L5 — Execute mutations (CLI only)
-
-Dispatch as a sub-agent (or run as orchestrator — this link is deterministic
-CLI). All mutations go through `gaia dev`; hand-editing `registry/nodes/` skips
-timeline logging and corrupts the audit trail.
-
-For each accepted batch entry:
-
-Generic (no `--level` — the schema rejects a level on a generic):
-```bash
-gaia dev add "Skill Name" --id <id> --type <type> --description "..."
-```
-
-Named (awakened intake — reviewer assigns title/catalogRef/stars later):
-```bash
-gaia dev add "Skill Name" --id <id> --named --contributor <user> \
-  --generic-ref <ref> --status awakened
-```
-
-Evidence:
-```bash
-gaia dev evidence <skill-id> "<url>" --class <A|B|C>
-```
-
-Relationships via `gaia dev link` / `gaia dev merge` / `gaia dev split`.
-Record each command run into `mutations[]`.
-
-**Gate g5 — validation gate**:
-```bash
-gaia validate && echo GATE_G5_PASS
-```
-Run `gaia validate --intake` too if the run produced an intake batch. Fail →
-route back to L5 with the validator output. After 2 failed retries, stop and
-surface the error — never push a registry that fails validation.
-
----
-
-## L6 — Regenerate & ship
-
-Final link (deterministic enough for the orchestrator to run directly):
-
-1. `gaia dev docs` — regenerate `docs/`, projections, and Class S artifacts.
-2. Branch `review/meta/<slug>`, commit:
-   ```bash
-   git add registry/ docs/ README.md
-   git commit -m "[meta] Add <topic> skills — chained curation"
-   git commit -am "chore(docs): regenerate after registry edits [skip-gen]" || true
-   ```
-3. Push `-u origin review/meta/<slug>` (retry on network error: 2s/4s/8s/16s).
-4. Open the PR via GitHub MCP `create_pull_request`. Auto-triage CI classifies
-   it; ultimates and `needs-review` items require maintainer approval.
-5. Add the contributor to `## Contributors` in `README.md` (`| @username | Brief description |`).
-
-**Gate g6 — ship gate**:
-```bash
-gaia dev docs --check && echo GATE_G6_PASS
-```
-Plus version lockstep across the four manifests. Fail → fix and re-run before
-pushing — a stale-docs branch will fail CI.
-
----
-
-## Constraints
-
-| Rule | Reason |
-|------|--------|
-| **Fixed topology** | Links run L1→L6. A gate may route back one link (max 2 retries) but never skip forward — forward skips defeat the purpose of the gates. |
-| **Gates are programmatic** | Every `gn` except g4 is a deterministic shell/jq check. LLM opinion is not a substitute here — jq either passes or it doesn't. |
-| **Programmatic-First** | Mutations via `gaia dev add/merge/split/evidence` only. Hand-edits skip timeline logging and corrupt the audit trail. |
-| **Named = awakened** | Named skills submitted `status: "awakened"`; `title`/`catalogRef` are reviewer-only. Generics use `provisional` and carry no level. |
-| **Evidence reality** | Every `source` is a real, resolvable URL: arXiv abs = Class A, reproducible repo blob URL = Class B, vendor/community = Class C. |
-| **Edges** | `sourceSkillId`/`targetSkillId`; `edgeType ∈ {prerequisite, corequisite, enhances}`. No `derivative` — use `enhances`. |
-| **Encoding** | All Python `open()` uses `encoding='utf-8'` to avoid CP-1252 drift on Windows. |
-| **Orchestrator scope** | Dispatches links and runs gates only — does not do a link's research/design/mutation work itself. |
-| **Single PR** | One PR per chain run. |
-
-## Invocation
-
-```
-/gaia-curate-chain <topic-or-source>
-```
-If the topic is omitted, ask which area to curate before starting L1.
+Use only `gaia dev` mutations. Regenerate with `gaia dev docs`, run
+`gaia validate` and `gaia dev docs --check`, then push a single review PR.

--- a/.agents/skills/gaia-curate-dynamic/SKILL.md
+++ b/.agents/skills/gaia-curate-dynamic/SKILL.md
@@ -1,156 +1,65 @@
 ---
 name: gaia-curate-dynamic
 description: >-
-  Dynamic-workflow curation for the Gaia registry. Use this skill — not
-  /gaia-curate or /gaia-curate-chain — when the scope is wide, open-ended, or
-  high-stakes: "sweep every source for agent skills", "curate the whole
-  <domain> space", "find everything new since <date>", "do a deep verification
-  pass", "run a parallel curation sweep", "high-stakes registry expansion",
-  "fan out across all sources", or /gaia-curate-dynamic. At runtime the
-  orchestrator writes its own execution plan, fans out tens-to-hundreds of
-  parallel sub-agents across sources and candidates, and validates every
-  proposal convergently — a proposer argues for the skill while an independent
-  refuter tries to disprove it, iterating until they agree. All state persists
-  in a resumable ledger so a multi-hour sweep survives interruption. For a
-  quick single-pass, use /gaia-curate. For a small gated batch where schema
-  correctness matters more than speed, use /gaia-curate-chain.
-version: 1.0.0
+  Wide-sweep curation extension. Runs the canonical Gaia curation core first,
+  then adds runtime source sharding, proposer/refuter convergence, and a
+  resumable ledger. Use for broad or high-stakes sweeps.
+version: 2.0.0
 argument-hint: "<broad-curation-goal>"
 ---
 
-# gaia-curate-dynamic
+# Gaia Curate Dynamic
 
-A **dynamic-workflow** registry curation skill. Unlike `/gaia-curate` (one linear pass) and `/gaia-curate-chain` (fixed six-link chain), this skill is **composed at runtime**: the orchestrator reads the goal and the registry, writes its own execution plan, dispatches many sub-agents in parallel, and converges their findings adversarially. Built for breadth (every source at once) and for trust (nothing ships until a refuter fails to break it).
+This is an extension of `/gaia-curate`, not an independent curation workflow.
+Execute `.agents/skills/gaia-curate/CURATION-CORE.md` for every source cluster
+first. The core owns canonical source handling, generic lookup, mapping,
+evidence representation, proposal taxonomy, review, and mutation rules.
+Dynamic orchestration may parallelize those core units, but must use the same
+packet contract and must not invent alternate rules.
 
-## Choosing the right curation skill
+## Extension-only stages
 
-| Skill | Pattern | Best for |
-|-------|---------|----------|
-| `gaia-curate` | Single pass, one agent | Fast, low-stakes batches |
-| `gaia-curate-chain` | Fixed six-link prompt chain | Small batch, schema-critical |
-| **`gaia-curate-dynamic`** | **Runtime-composed, massively parallel, convergent** | Wide sweeps, high-stakes verification |
+1. **Plan:** choose source shards, candidate concurrency, and convergence-round
+   budget; record the core contract version/digest.
+2. **Discover in parallel:** dispatch source-shard workers and merge only
+   normalized core candidates.
+3. **Adversarial convergence:** dispatch an independent proposer and refuter for
+   each candidate. Iterate up to the configured round limit; unresolved cases
+   become `needs-evidence` for human review.
+4. **Synthesize:** apply the core's existing-generic-first mapping and preserve
+   `contributor/skill-name` named IDs plus `genericSkillRef`.
+5. **Human checkpoint:** present converged accepts and unresolved disputes using
+   the core review table. Require explicit decisions.
+6. **Mutate and ship:** use `gaia dev`, validate, regenerate, and open one PR.
 
----
+## Resumable ledger
 
-## Core design principles
-
-**Runtime composition** — there is no hard-coded phase list. The orchestrator writes a run plan for *this* goal (which sources to shard, how many agents, how many validation rounds) and adapts it as findings arrive. A rich source gets more shards; a dry one gets fewer.
-
-**Parallel fan-out** — independent work runs concurrently because serial processing of a large sweep wastes the session budget. Dispatch all discovery sub-agents in a single turn. One sub-agent per source shard during discovery, one per candidate during deep-dive.
-
-**Convergent validation** — every surviving candidate is argued by a proposer and independently attacked by a refuter. The refuter must not see the proposer's reasoning (only its claims), so it can surface genuine objections rather than rubber-stamping. They iterate until they converge, or until the round budget runs out and the human breaks the tie. Single-verdict decisions are the failure mode this eliminates.
-
-**Persistent, resumable ledger** — all state lives in `generated-output/curate-dynamic-ledger.json` (gitignored). Every stage writes atomically. On every invocation, read the ledger first: if `stage` is not `ship`, print a one-line resume summary and continue from the earliest unfinished stage without redoing finished work.
-
----
-
-## Ledger shape
+Store state in `generated-output/curate-dynamic-ledger.json` (gitignored):
 
 ```json
 {
-  "goal": "<argument>",
-  "startedAt": "<iso>",
-  "stage": "plan|discover|deepdive|converge|synthesize|review|ship",
-  "plan": { "sources": [], "discoverShards": 0, "validationRounds": 2 },
-  "existingIds": [],
-  "discoveries": [ { "source": "...", "rawCandidates": [] } ],
-  "candidates": [
-    { "id": "...", "name": "...", "evidence": [],
-      "proposer": { "verdict": "", "type": "", "level": null },
-      "refuter":  { "verdict": "", "objections": [] },
-      "converged": false, "rounds": 0, "decision": "" }
-  ],
-  "batch": [],
-  "prUrl": null
+  "contractVersion": "core-v1",
+  "stage": "plan|discover|converge|review|ship",
+  "corePacket": "generated-output/curation-core-packet.json",
+  "plan": {"sources": [], "validationRounds": 2},
+  "discoveries": [], "candidates": [], "decisions": [], "prUrl": null
 }
 ```
 
----
+Resume must revalidate the contract and generic mappings. Schema/context drift
+invalidates mappings and mutation plans, but does not require discarding raw
+discovery evidence.
 
-## Stage 0 — Plan synthesis (orchestrator)
+## Gates
 
-1. Read `registry/skill-sources.md` and `registry/gaia.json`; record `existingIds` into the ledger for deduplication.
-2. Write the run plan: which sources to shard, how many discovery sub-agents, and the validation round budget (default 2; raise to 3 for Level II+ or ultimate proposals). Store under `plan`.
-3. Print a one-paragraph plan summary so the user sees the shape of the run before fan-out begins.
-
-## Stage 1 — Parallel discovery (one sub-agent per source shard)
-
-Dispatch all discovery sub-agents in a single turn. Each shard receives one source and this brief:
-
-> Enumerate skill-shaped artifacts in `{{source}}` relevant to `{{goal}}`. For local runs use the `gh` CLI and inspect each repo's `skills/` directory, recording raw `blob/<branch>/<subpath>/SKILL.md` URLs. For cloud/remote runs use GitHub MCP tools — do not claim GitHub is unreachable without checking MCP. Supplement with SkillsMP and arXiv. Return `rawCandidates[]` with `{name, source, url, oneLineCapability}`. Do not judge or rank — harvest only. Drop anything whose `name` slug already appears in `existingIds`.
-
-Write each shard's output to `discoveries[]` as it returns.
-
-## Stage 2 — Parallel candidate deep-dive (one proposer per candidate)
-
-Flatten and dedupe `discoveries` into a candidate set. Dispatch a **proposer** sub-agent per candidate in one batched turn:
-
-> Build the strongest honest case for adding `{{candidate}}` to Gaia. Gather evidence as `{class, source}` — arXiv abs = A, reproducible repo blob URL = B, vendor/community = C; every URL must resolve. Propose `type` (basic/extra/ultimate), `named` (+ `genericSkillRef`), and a star level for named skills. Emit a proposer verdict. Be concrete — unsupported claims will be attacked in the next stage.
-
-## Stage 3 — Convergent validation (proposer ⇄ refuter until they agree)
-
-For each candidate with a proposer verdict, dispatch an **independent refuter** (fresh context; must not see the proposer's reasoning, only its claims):
-
-> Try to break the case for `{{candidate}}`. Check: does each evidence URL resolve and is it on-topic? Is this a duplicate of an existing Gaia skill or another candidate? Is the level inflated for the evidence class? Is it vendor-locked or non-novel — should it collapse into an existing generic via Fusion-First? Return `objections[]` and a verdict: `uphold` / `lower-level` / `merge-into <id>` / `reject`.
-
-The orchestrator reconciles each round:
-- **Converged** when proposer and refuter agree on accept + type + level (or both agree to reject/merge). Mark `converged: true`, set `decision`.
-- **Not converged** — run another round: proposer answers the objections, refuter re-attacks. Repeat up to `plan.validationRounds`. If still split after the budget, mark `decision: needs-evidence` and carry both views to the human checkpoint.
-
-Independent shards run in parallel; only divergent candidates consume extra rounds.
-
-## Stage 4 — Synthesis and Fusion-First (orchestrator)
-
-Merge converged candidates into `batch[]`:
-- Apply **Fusion-First**: collapse vendor variants onto one generic (`literature-search`, not `pubmed`+`arxiv`+`biorxiv`); specialised capabilities become `extra` skills with the generic as a prerequisite.
-- Set schema-correct fields: `type` ↔ prereq arity (basic/unique = 0, extra ≥ 2, ultimate ≥ 3); generics carry no level; named skills get `status: awakened`.
-- Run pre-flight checks: IDs match their pattern, no DAG cycles. Surface any violations before presenting to the human.
-
-## Stage 5 — Single human checkpoint
-
-Present one consolidated table — converged accepts, plus any `needs-evidence` rows with the proposer/refuter split shown. Collect `accept`/`rename`/`duplicate`/`needs-evidence`/`reject` per row. One approval gate for the whole sweep. Proceed only with ≥ 1 `accept`.
-
-## Stage 6 — Mutation, validation, and ship
-
-All mutations via CLI — never hand-edit `registry/nodes/` or `gaia.json` directly, because direct edits skip timeline logging and can produce states that fail `gaia validate`.
+Every candidate must have a resolvable evidence source before review. Every
+named candidate must resolve `genericSkillRef` (CLI: `--generic-ref`) against
+`gaia dev list --generic --json`. Run:
 
 ```bash
-# generic (no --level)
-gaia dev add "Skill Name" --id <id> --type <type> --description "..."
-# named (awakened intake; reviewer assigns title/catalogRef/stars later)
-gaia dev add "Skill Name" --id <id> --named --contributor <user> \
-  --generic-ref <ref> --status awakened
-gaia dev evidence <skill-id> "<url>" --class <A|B|C>
-
-gaia validate                      # must exit 0
-gaia docs build                    # regenerate docs/projections
-gaia docs build --check            # must be clean before push
+gaia validate
+gaia dev docs --check
 ```
 
-Branch `review/meta/<slug>`, commit `[meta] <title>` plus a `[skip-gen]` docs commit, push (retry on network error with 2s/4s/8s/16s backoff), open the PR, and add the contributor to `README.md ## Contributors`.
-
-Report: ledger path, fan-out counts (sources sharded, candidates deep-dived, rounds spent), converged vs dropped tallies, and the PR URL.
-
----
-
-## Key constraints (with reasoning)
-
-**Convergence is the bar** — no candidate ships on a single verdict. A proposer and an independent refuter must converge because single-agent judgment is systematically optimistic; the refuter finds the gaps the proposer rationalised away.
-
-**Refuters must not see proposer reasoning** — only claims. Exposing the reasoning anchors the refuter to the proposer's framing, defeating the adversarial purpose. Fresh context means genuine independence.
-
-**Parallelism over serial dispatch** — dispatch independent sub-agents in one turn. Serial dispatch of 50 candidates would exhaust the session before converging; parallel dispatch finishes in fractions of the time.
-
-**Named skills enter as `awakened`** — `title`, `catalogRef`, and star levels are reviewer-only assignments. Submitting anything higher bypasses the human review gate that the awakened status enforces.
-
-**Evidence URLs must resolve and use `blob/` not `tree/`** — the installer only recognises `blob/<branch>/<subpath>` URLs; a `tree/` URL or a bare repo root produces an undiscoverable symlink.
-
-**One PR per sweep** — the whole batch lands for review together so the human can assess Fusion-First decisions and naming consistency across the set.
-
-## Invocation
-
-```
-/gaia-curate-dynamic <broad-curation-goal>
-```
-
-If the goal is omitted, ask what domain or time-window to sweep before writing the run plan.
+Do not use deprecated `--class`, manually authored trust values, or copied
+legacy taxonomy checks. Derived evidence scoring remains Gaia's responsibility.

--- a/.agents/skills/gaia-curate/CURATION-CORE.md
+++ b/.agents/skills/gaia-curate/CURATION-CORE.md
@@ -1,0 +1,75 @@
+# Gaia Curation Core
+
+This is the canonical preliminary curation contract. `/gaia-curate`, `/gaia-curate-chain`, and `/gaia-curate-dynamic` all begin here. Extension workflows must not restate or override these rules; they may add orchestration, gates, or adversarial review after the core packet is produced.
+
+## Core sequence
+
+1. Read `registry/skill-sources.md` and the canonical registry.
+2. Search and inspect candidate upstream implementations. Use specific `blob/<branch>/.../SKILL.md` URLs when available.
+3. Run the generic lookup before designing entries:
+
+   ```bash
+   gaia dev list --generic --description
+   # machine-readable form:
+   gaia dev list --generic --json
+   ```
+
+4. Map each implementation to an existing generic parent whenever possible.
+5. Create a new starless generic only when no suitable vendor-neutral, reusable, falsifiable parent exists.
+6. Propose named implementations separately, using preferred IDs in `contributor/skill-name` form and a resolving `genericSkillRef` (CLI spelling: `--generic-ref`).
+7. Capture evidence sources and raw source measurements. Do not assign derived trust values or deprecated classes.
+8. Present the review table and stop for explicit decisions before mutation.
+
+## Proposal model
+
+| Name | Starless (generic) | Named (`/slash-skill`) | Type | Generic ref | Action |
+|---|---|---|---|---|---|
+| Capability | existing or proposed generic | — | basic/fusion | — | accept/rename/etc. |
+| Implementation | existing generic parent | `/implementation` | named | `contributor/generic-id` | accept/rename/etc. |
+
+A generic row must be vendor-neutral and starless. A named row is a specific implementation and must resolve to an existing generic parent. An upstream slash skill is evidence/attribution, not automatically a new generic.
+
+## Evidence contract
+
+Record source facts, not computed scores:
+
+- `repo-own`: `commits`, `contributors`;
+- `github-stars-own`: `stars`, and `skillCountInRepo` when applicable;
+- use the specific implementation `blob/` URL where available;
+- record evidence type, source URL, provenance, and notes.
+
+Never author `class`, `trustNumber`, `trustMagnitude`, `artifact_score`, or manual A/B/C grades. Gaia computes derived scores and grades.
+
+Example:
+
+```bash
+gaia dev evidence contributor/skill-name <blob-url> \
+  --type repo-own --commits N --contributors N
+
+gaia dev evidence contributor/skill-name <repo-url> \
+  --type github-stars-own --stars N --skill-count-in-repo N
+```
+
+Do not pass `--trust` or the deprecated `--class` option.
+
+## Core packet
+
+Extensions should persist or pass a packet containing at least:
+
+```json
+{
+  "existingIds": [],
+  "genericMappings": [],
+  "candidates": [],
+  "batch": [],
+  "decisions": [],
+  "evidence": [],
+  "contractVersion": "core-v1"
+}
+```
+
+The packet is preliminary work, not approval. Extensions must preserve its evidence and decisions, then add their own state without silently remapping candidates.
+
+## Mutation boundary
+
+After explicit approval, mutate only through `gaia dev` commands. Validate with `gaia validate`; regenerate with `gaia dev docs` and check with `gaia dev docs --check`. Never hand-edit canonical or generated registry files.

--- a/.agents/skills/gaia-curate/SKILL.md
+++ b/.agents/skills/gaia-curate/SKILL.md
@@ -91,21 +91,39 @@ Upgrading weak existing skills delivers more value than pure breadth expansion.
 
 ## Step 2 — Design the batch
 
+### Registry terminology and generic-ref gate
+
+- An **upstream skill** is a `SKILL.md` found in another repository (for example, Anthropic's `mcp-builder`). It is evidence, not automatically a Gaia entry.
+- A **starless (generic) skill** is a reusable, vendor-neutral capability. Its Gaia ID must be generic enough to cover multiple implementations and must not be copied from an upstream slash skill name merely because that name is convenient.
+- A **named skill** is a specific implementation attributed to a contributor or repository. It is represented by a slash-style skill setup such as `/mcp-builder`, while its `--generic-ref` must point to an existing starless (generic) Gaia ID such as `mcp-server-development`.
+- Before proposing a named skill, verify that its generic ref already exists and is the correct generic skill type. Use `gaia dev list --generic --description` (or `gaia dev list --generic --json`) as the source of truth. If it does not exist, decide whether to create the starless (generic) parent; do not use the implementation's name as a substitute generic ref.
+- Never use an upstream repository name, slash skill name, or `SKILL.md` filename as a generic ref unless it independently satisfies the vendor-neutral generic taxonomy.
+
+#### Generic-parent decision tree
+
+1. **Exact generic exists** — reuse its ID; do not create a duplicate.
+2. **Equivalent generic exists under a broader name** — reuse it when the implementation is a valid specialization; propose a named entry mapped to that parent.
+3. **Only a vendor-specific or implementation-specific node exists** — do not reuse it as a generic parent; propose a vendor-neutral starless parent first.
+4. **No suitable generic exists** — create a starless parent only when the capability is reusable across multiple implementations, has a precise falsifiable definition, and is not merely a product, repository, or slash skill name.
+5. **Capability is too narrow or has only one inseparable implementation** — do not create a generic; hold or reject the named proposal pending evidence of broader applicability.
+
+The normal curation path is therefore: list generics programmatically → map each upstream implementation to an existing parent where possible → create a new starless parent only when the decision tree requires it → propose the named implementation with that parent's `generic-ref`.
+
 For each candidate, decide:
 
 **Taxonomy tier** (what type of skill is it?):
 - `basic` — primitive capability, no prerequisites
 - `extra` — emerges from ≥2 prerequisite basics
-- `ultimate` — high-complexity emergent, ≥3 prerequisites, ≥3 Evidence Grade A/B entries
+- `ultimate` — high-complexity emergent, ≥3 prerequisites, and multiple independent evidence artifacts
 - `unique` — graph-isolated basic that reached 4★+ through depth alone
 
 **Fusion-first design** — Resist the temptation to create one generic skill per vendor API. Multiple named implementations of the same concept (e.g. `pubmed`, `arxiv`, `biorxiv`) should map to a single elegant generic (e.g. `literature-search`). This keeps the global graph readable and prevents registry bloat.
 
 **Composite extras** — When multiple distinct skills combine into a multi-step workflow, design a composite Extra that names them as prerequisites. Calibrate the named implementations at 3★–4★ max, referencing the composite.
 
-**Generic skill levels** — Generic (starless) skills have no star level. Only named implementations receive stars (2★–6★). Omit `--level` from `gaia dev add` for generics.
+**Generic skill levels** — Starless (generic) skills have no star level. Only named implementations receive stars (2★–6★). Omit `--level` from `gaia dev add` for starless (generic) skills.
 
-**Named promotion** — If a specific implementation warrants its own entry in `registry/named/`, mark it for named promotion and submit with `status: awakened`. Never hand-set `title` or `catalogRef` during curation — those are set by a reviewer at Named promotion time.
+**Named promotion** — If a specific implementation warrants its own entry in `registry/named/`, mark it for named promotion and show its slash skill setup (for example, `/mcp-builder`) separately from its generic ref. Submit with `status: awakened`. Never hand-set `title` or `catalogRef` during curation — those are set by a reviewer at Named promotion time.
 
 **Demerit checks** — Only apply `heavyweight-dependency`, `niche-integration`, or `experimental-feature` demerits to skills at 3★+. Cross-platform universal skills at high levels should omit demerits.
 
@@ -117,15 +135,19 @@ For each candidate, decide:
 
 Before writing anything to disk, show the full proposed batch:
 
-| ID | Name | Type | Stars | Prereqs | Demerits | Named? |
-|---|---|---|---|---|---|---|
+| Name | Starless (generic) | Named (`/slash-skill`) | Type | Stars | Prereqs | Generic ref | Action |
+|---|---|---|---|---:|---|---|---|
+| Example Capability | Example Capability | — | starless (generic) | — | — | — | accept |
+| Example Implementation | Example Capability | `/example-implementation` | named | 2★–6★ | — | `example-capability` | accept |
 | … | … | … | … | … | … | … |
 
 For each row, ask the user to mark one of:
 - `accept` — proceed as designed
+- For every `named` row, confirm that the listed generic ref already exists and is the correct generic skill type.
+- For every `starless (generic)` row, confirm that the name is vendor-neutral and broad enough to support multiple named implementations.
 - `rename <new-id>` — change the ID before generating
 - `duplicate` — already covered; drop it
-- `needs-evidence` — hold until an Evidence Grade A/B source is supplied
+- `needs-evidence` — hold until a valid, resolvable evidence artifact is supplied
 - `reject` — remove entirely
 
 Do not proceed to Step 4 until the user has reviewed and at least one skill is marked `accept`. Apply all `rename` decisions before writing. Drop everything not `accept`/`rename`.
@@ -164,8 +186,7 @@ Commit message format: `[type] Title — brief description`
 
 ## Step 6 — Open the PR
 
-Push the branch and open a PR via the GitHub API. The auto-triage CI classifies it:
-- Evidence Grade A/B score ≥ 60 from a bot actor → eligible for auto-merge
+Push the branch and open a PR via the GitHub API. The auto-triage CI classifies it using computed evidence artifact scores and provenance; do not manually assign a class, trust grade, or aggregate trust value.
 - `draft-skills` or `needs-review` labels → routed to a human reviewer
 - Ultimate skill proposals → always require maintainer approval
 
@@ -203,7 +224,7 @@ gaia validate --intake
 ## Hard constraints
 
 - Never hand-edit `registry/nodes/` or `registry/gaia.json`. Use `gaia dev add`, `gaia dev merge`, `gaia dev split`, `gaia dev evidence`.
-- All evidence `source` values must be real, resolvable URLs (arXiv abs pages or GitHub repos). SkillsMP URLs are acceptable only as supplementary Evidence Grade C.
+- All evidence source URLs must be real and resolvable. Record the evidence type, source URL, provenance, and concise notes; artifact scores and per-row grades are computed by the registry tooling. Never hand-author deprecated `class` values or aggregate trust fields.
 - Ultimate skills must land as `provisional` — the maintainer sets `validated` after review.
 - No cycles in the DAG. No orphaned composite nodes.
 - Skill IDs: `lowercase-dash` format (`^[a-z][a-z0-9]*(-[a-z0-9]+)*$`). No camelCase, no vendor names, no unexplained abbreviations.
@@ -212,13 +233,37 @@ gaia validate --intake
 
 ---
 
-## Evidence grade reference
+## Evidence recording reference
 
-| Grade | Standard | Typical source |
+| Artifact type | Typical source | Curation treatment |
 |---|---|---|
-| A (Gold) | Peer-reviewed, benchmarked | `https://arxiv.org/abs/<id>` |
-| B (Silver) | Reproducible open-source demo | GitHub repo or skill file URL |
-| C (Bronze) | Credible vendor/community demo | Sufficient only for Level ≤ II |
+| `arxiv` | `https://arxiv.org/abs/<id>` | Record as a directly relevant paper artifact |
+| `repo` | GitHub repository or specific `blob/` skill file | Record as a reproducible implementation artifact |
+| `registryCuration` | Curation batch or documented demonstration | Record only when the curation work produced new evidence |
+| community/vendor artifact | SkillsMP or vendor documentation | Supplementary evidence only |
+
+The registry computes artifact scores, freshness, provenance weighting, per-row grades, and overall trust grades. Curation proposes evidence artifacts and their raw source measurements; it does not assign `class`, `trustNumber`, `trustMagnitude`, `artifact_score`, or manual A/B/C grades.
+
+### Repository-owned source measurements
+
+For a named implementation backed by its own upstream repository, record the raw measurements that the scoring formulas consume:
+
+- `repo-own`: `commits` and `contributors`
+- `github-stars-own`: `stars` and, when applicable, `skillCountInRepo`
+
+Use the specific implementation `blob/` URL as the source where available. These are source facts, not trust grades. Capture them with `gaia dev evidence`:
+
+```bash
+gaia dev evidence <skill-id> <source-url> \\
+  --type repo-own --commits <n> --contributors <n> \\
+  --notes "source measurements captured <date>"
+
+gaia dev evidence <skill-id> <repo-url> \\
+  --type github-stars-own --stars <n> --skill-count-in-repo <n> \\
+  --notes "GitHub source measurements captured <date>"
+```
+
+Do not pass `--trust`; the CLI computes derived values. If the implementation is submitted through intake, preserve these raw measurements in its evidence entries or named evidence payload so maintainers can reproduce the calculation.
 
 ---
 

--- a/.claude/skills/gaia-curate-chain/SKILL.md
+++ b/.claude/skills/gaia-curate-chain/SKILL.md
@@ -1,274 +1,65 @@
 ---
 name: gaia-curate-chain
 description: >-
-  Prompt-chaining curation for the Gaia registry — six discrete links (Scope,
-  Research, Design, Human Review, Mutate, Ship), each handed to a fresh
-  sub-agent, with a programmatic gate between every link that must pass before
-  the chain advances. Use when evidence quality and schema correctness matter
-  more than speed: "curate the tree carefully", "add skills with gates",
-  "step-by-step registry expansion", "gated curation", "auditable curation",
-  "chain the curation", "curate incrementally", "add skills without mistakes",
-  "high-quality skill additions", "small batch precision curation". Also
-  triggers on /gaia-curate-chain. For a fast single-pass run use /gaia-curate;
-  for a wide domain sweep with parallel sub-agents use /gaia-curate-dynamic.
-version: 1.1.0
+  Gated curation extension. Runs the canonical Gaia curation core first, then
+  adds fixed-topology subagents, deterministic gates, and bounded retries.
+  Use for small batches where schema correctness and auditability matter.
+version: 2.0.0
 argument-hint: "<topic-or-source-to-curate>"
 ---
 
-# gaia-curate-chain
+# Gaia Curate Chain
 
-A **prompt-chaining** implementation of Gaia registry curation, following the
-pattern described in Anthropic's
-[Building Effective Agents](https://www.anthropic.com/engineering/building-effective-agents).
+This is an extension of `/gaia-curate`, not a second curation methodology.
+Read and execute `.agents/skills/gaia-curate/CURATION-CORE.md` first. The core
+owns source loading, discovery, generic lookup, generic/named mapping, evidence
+capture, proposal design, human review, and mutation boundaries. Keep the core
+packet intact; do not reimplement those steps with alternate taxonomy or
+ evidence rules.
 
-> *Prompt chaining decomposes a task into a sequence of steps, where each LLM
-> call processes the output of the previous one. You can add programmatic checks
-> (gates) on any intermediate step to ensure the process stays on track.*
+## Extension workflow
 
-Curation is a natural fit: it's a linear pipeline (research → design → review
-→ mutate → ship), each phase is easier to get right in isolation, and catching
-a bad evidence URL or invalid schema shape at a gate is far cheaper than
-discovering it after `gaia validate` or CI fails. The trade-off is latency for
-accuracy.
+After the core produces an approved preliminary packet:
 
-```
-L1 Scope ──g1──▶ L2 Research ──g2──▶ L3 Map/Design ──g3──▶ L4 Human Review
-                                                                  │ g4
-                                                                  ▼
-                          ◀── ship ── L6 Regenerate+PR ◀──g5── L5 Mutate
-```
+1. Persist state to `generated-output/curate-chain-state.json` (gitignored).
+2. Dispatch fresh subagents for the approved research/design units when
+   independent context is valuable.
+3. Run deterministic gates between links: packet shape, generic ref resolution,
+   evidence URL presence, DAG validity, and `gaia validate`.
+4. On failure, route back one link with the concrete failure; allow at most two
+   retries per gate.
+5. Record the contract version/digest in state. If the core contract changes,
+   revalidate mappings and mutation plans before resuming.
+6. Perform the approved CLI mutations, regenerate docs, validate, and ship one
+   PR.
 
-Each `Ln` is one sub-agent call. Each `gn` is a **programmatic gate** the
-orchestrator runs itself — a deterministic shell/jq check, not an LLM
-judgement. The chain advances only when the gate passes. On failure the gate
-**routes back one link** with the failure reason, bounded to 2 retries per
-gate, then stops and asks the user.
-
-## Which curation skill to use
-
-| Skill | Pattern | When to use |
-|-------|---------|-------------|
-| `gaia-curate` | Single linear pass | Fast, low-stakes batches |
-| **`gaia-curate-chain`** | **Fixed topology + programmatic gates** | Small batch where schema correctness must be verified at each step |
-| `gaia-curate-dynamic` | Runtime-composed, massively parallel, convergent | Wide domain sweeps; high-stakes verification at scale |
-
-## Orchestrator responsibility
-
-You (the orchestrator) own three things: holding the chain state file, dispatching each link as a sub-agent, and running each gate. You do **not** do a link's research/design/mutation work — that belongs to the sub-agent. The one exception is gate execution (deterministic shell), which is always yours to run.
-
-## Chain state
-
-Persist one JSON blob to `generated-output/curate-chain-state.json` (gitignored)
-so each sub-agent can read prior output without re-deriving it.
+## State minimum
 
 ```json
 {
-  "topic": "<argument>",
+  "contractVersion": "core-v1",
+  "corePacket": "generated-output/curation-core-packet.json",
   "link": 1,
-  "existingIds": ["..."],
-  "targets": ["..."],
-  "candidates": [ { "id": "...", "name": "...", "evidence": [], "typeGuess": "" } ],
-  "batch": [ { "id": "...", "type": "", "level": null, "named": false, "status": "", "prereqs": [], "evidence": [], "decision": "" } ],
+  "gates": [],
   "mutations": [],
   "prUrl": null
 }
 ```
 
----
+## Required gates
 
-## L1 — Scope & dedupe
-
-Dispatch a sub-agent (lightweight reasoning is enough) with:
-
-> Read `registry/skill-sources.md` (the authoritative source list) and
-> `registry/gaia.json`. Emit: (a) `existingIds` — every skill ID already in
-> the graph, and (b) `targets` — 5–15 concrete research targets for topic
-> `{{topic}}`, each a marketplace/org/repo/paper lead drawn from the sources
-> file. If you find a source not yet listed, note it for inclusion in the PR.
-> Write both arrays into the chain state. Do no research yet.
-
-**Gate g1** (orchestrator runs):
 ```bash
-jq -e '(.existingIds|length>0) and (.targets|length>0)' \
-  generated-output/curate-chain-state.json
-```
-Fail → re-dispatch L1 with the reason. Pass → L2.
-
----
-
-## L2 — Research & evidence
-
-Dispatch a fresh sub-agent per cluster of targets. These are independent, so
-they may run in parallel (*sectioning* — a sibling pattern described in the
-article):
-
-> For each target, gather concrete evidence. **Local runs**: use the `gh` CLI
-> (`gh search repos --topic=… --sort=stars`), then inspect for a `skills/`
-> directory and use the **raw `blob/<branch>/<subpath>/SKILL.md` URL** as the
-> source — never a bare repo root. **Cloud/remote runs (no `gh`)**: use the
-> GitHub MCP tools (`search_repositories`, `get_file_contents`) — never claim
-> `gh` is unavailable without checking MCP first. Supplement with SkillsMP
-> (`https://skillsmp.com/api/v1/skills/search?q=…`, Class C) and arXiv abs
-> URLs (Class A) for Level II+ candidates. Emit `candidates[]` with an
-> `evidence[]` array of `{class, source}` per candidate. Every `source` must
-> be a real, resolvable URL.
-
-**Gate g2 — evidence gate** (the primary quality gate of the chain):
-```bash
-# Every candidate has >=1 evidence URL; Level II+ candidates have >=1 Class A or B source
-jq -e 'all(.candidates[];
-        (.evidence|length>0) and
-        ((.typeGuess|test("basic|generic")) or
-         ([.evidence[].class]|any(.=="A" or .=="B"))))' \
-  generated-output/curate-chain-state.json
-```
-Fail → route back to L2 for the failing candidates only (carry their IDs in the
-reason). Drop any candidate that still has no resolvable evidence after retry.
-
----
-
-## L3 — Schema mapping & batch design
-
-Dispatch a design sub-agent (heavier reasoning preferred here — schema errors
-caught now are far cheaper than retrying after g5 fails):
-
-> Turn `candidates[]` into a `batch[]` ready for the CLI. For each candidate:
->
-> - **Fusion-First**: map multiple vendor implementations of one concept onto a
->   single generic (e.g. don't mint `pubmed`/`arxiv`/`biorxiv` separately — use
->   `literature-search`). Orchestrate specialised capabilities as an `extra`
->   with the basics as prerequisites.
-> - Assign `type`: `basic`/`unique` (0 prereqs), `extra` (≥2), `ultimate` (≥3).
-> - `named`: true if it is a specific named implementation. Named skills MUST
->   be submitted with `status: "awakened"` — only reviewers later promote to
->   `named` and assign `title`/`catalogRef`; never set those here. Generic
->   nodes use `status: "provisional"`.
-> - `level`: named only, `2★–6★`; omit entirely for generics (the schema
->   rejects a level on a generic node).
-> - Demerit check (`heavyweight-dependency`/`niche-integration`/`experimental-feature`)
->   applies only at 3★+.
->
-> Emit the full `batch[]` and a review table.
-
-**Gate g3 — schema pre-flight gate** (catches invalid shapes before any
-mutation touches the registry — this is why the gate exists):
-```bash
-jq -e '
- def gidok: test("^[a-z][a-z0-9]*(-[a-z0-9]+)*$");
- def nidok: test("^[a-z0-9][a-z0-9_-]*/[a-z0-9][a-z0-9_-]*$");
- all(.batch[];
-   (if .named then (.id|nidok) else (.id|gidok) end)
-   and (if .type=="basic" or .type=="unique" then (.prereqs|length)==0
-        elif .type=="extra"  then (.prereqs|length)>=2
-        elif .type=="ultimate" then (.prereqs|length)>=3 else false end)
-   and (if .named then (.status=="awakened")
-        else (.status=="provisional" and (.level==null)) end))' \
-  generated-output/curate-chain-state.json
-```
-Also confirm no prerequisite cycle — every prereq must be an `existingId` or
-another batch entry, and the union must form a DAG. Fail → route back to L3
-with the offending field. Pass → L4.
-
----
-
-## L4 — Human review gate
-
-The orchestrator presents the L3 table directly to the user. This gate is a
-person, not a script — it exists because the registry is a shared resource and
-schema-valid does not mean semantically correct.
-
-| ID | Name | Type | Stars | Prereqs | Demerits | Named? | Status |
-|----|------|------|-------|---------|----------|--------|--------|
-
-For each row the user marks: `accept` / `rename <new-id>` / `duplicate` /
-`needs-evidence` / `reject`. Apply renames in place, drop everything that is
-not `accept`/`rename`, and write the resolved `decision` per batch entry.
-
-**Gate g4**: proceed only if ≥1 `accept` remains. Otherwise stop and report.
-Do not advance to L5 without explicit user review — this is the one gate
-that can never be automated away.
-
----
-
-## L5 — Execute mutations (CLI only)
-
-Dispatch as a sub-agent (or run as orchestrator — this link is deterministic
-CLI). All mutations go through `gaia dev`; hand-editing `registry/nodes/` skips
-timeline logging and corrupts the audit trail.
-
-For each accepted batch entry:
-
-Generic (no `--level` — the schema rejects a level on a generic):
-```bash
-gaia dev add "Skill Name" --id <id> --type <type> --description "..."
+test -s generated-output/curation-core-packet.json
+gaia validate
+gaia dev docs --check
 ```
 
-Named (awakened intake — reviewer assigns title/catalogRef/stars later):
-```bash
-gaia dev add "Skill Name" --id <id> --named --contributor <user> \
-  --generic-ref <ref> --status awakened
-```
+Validate named IDs in preferred `contributor/skill-name` form and resolve
+`genericSkillRef` (CLI: `--generic-ref`) against `gaia dev list --generic
+--json`. Do not use deprecated `--class`, manual trust values, or duplicate the
+core's evidence scoring logic.
 
-Evidence:
-```bash
-gaia dev evidence <skill-id> "<url>" --class <A|B|C>
-```
+## Ship boundary
 
-Relationships via `gaia dev link` / `gaia dev merge` / `gaia dev split`.
-Record each command run into `mutations[]`.
-
-**Gate g5 — validation gate**:
-```bash
-gaia validate && echo GATE_G5_PASS
-```
-Run `gaia validate --intake` too if the run produced an intake batch. Fail →
-route back to L5 with the validator output. After 2 failed retries, stop and
-surface the error — never push a registry that fails validation.
-
----
-
-## L6 — Regenerate & ship
-
-Final link (deterministic enough for the orchestrator to run directly):
-
-1. `gaia dev docs` — regenerate `docs/`, projections, and Class S artifacts.
-2. Branch `review/meta/<slug>`, commit:
-   ```bash
-   git add registry/ docs/ README.md
-   git commit -m "[meta] Add <topic> skills — chained curation"
-   git commit -am "chore(docs): regenerate after registry edits [skip-gen]" || true
-   ```
-3. Push `-u origin review/meta/<slug>` (retry on network error: 2s/4s/8s/16s).
-4. Open the PR via GitHub MCP `create_pull_request`. Auto-triage CI classifies
-   it; ultimates and `needs-review` items require maintainer approval.
-5. Add the contributor to `## Contributors` in `README.md` (`| @username | Brief description |`).
-
-**Gate g6 — ship gate**:
-```bash
-gaia dev docs --check && echo GATE_G6_PASS
-```
-Plus version lockstep across the four manifests. Fail → fix and re-run before
-pushing — a stale-docs branch will fail CI.
-
----
-
-## Constraints
-
-| Rule | Reason |
-|------|--------|
-| **Fixed topology** | Links run L1→L6. A gate may route back one link (max 2 retries) but never skip forward — forward skips defeat the purpose of the gates. |
-| **Gates are programmatic** | Every `gn` except g4 is a deterministic shell/jq check. LLM opinion is not a substitute here — jq either passes or it doesn't. |
-| **Programmatic-First** | Mutations via `gaia dev add/merge/split/evidence` only. Hand-edits skip timeline logging and corrupt the audit trail. |
-| **Named = awakened** | Named skills submitted `status: "awakened"`; `title`/`catalogRef` are reviewer-only. Generics use `provisional` and carry no level. |
-| **Evidence reality** | Every `source` is a real, resolvable URL: arXiv abs = Class A, reproducible repo blob URL = Class B, vendor/community = Class C. |
-| **Edges** | `sourceSkillId`/`targetSkillId`; `edgeType ∈ {prerequisite, corequisite, enhances}`. No `derivative` — use `enhances`. |
-| **Encoding** | All Python `open()` uses `encoding='utf-8'` to avoid CP-1252 drift on Windows. |
-| **Orchestrator scope** | Dispatches links and runs gates only — does not do a link's research/design/mutation work itself. |
-| **Single PR** | One PR per chain run. |
-
-## Invocation
-
-```
-/gaia-curate-chain <topic-or-source>
-```
-If the topic is omitted, ask which area to curate before starting L1.
+Use only `gaia dev` mutations. Regenerate with `gaia dev docs`, run
+`gaia validate` and `gaia dev docs --check`, then push a single review PR.

--- a/.claude/skills/gaia-curate-dynamic/SKILL.md
+++ b/.claude/skills/gaia-curate-dynamic/SKILL.md
@@ -1,156 +1,65 @@
 ---
 name: gaia-curate-dynamic
 description: >-
-  Dynamic-workflow curation for the Gaia registry. Use this skill — not
-  /gaia-curate or /gaia-curate-chain — when the scope is wide, open-ended, or
-  high-stakes: "sweep every source for agent skills", "curate the whole
-  <domain> space", "find everything new since <date>", "do a deep verification
-  pass", "run a parallel curation sweep", "high-stakes registry expansion",
-  "fan out across all sources", or /gaia-curate-dynamic. At runtime the
-  orchestrator writes its own execution plan, fans out tens-to-hundreds of
-  parallel sub-agents across sources and candidates, and validates every
-  proposal convergently — a proposer argues for the skill while an independent
-  refuter tries to disprove it, iterating until they agree. All state persists
-  in a resumable ledger so a multi-hour sweep survives interruption. For a
-  quick single-pass, use /gaia-curate. For a small gated batch where schema
-  correctness matters more than speed, use /gaia-curate-chain.
-version: 1.0.0
+  Wide-sweep curation extension. Runs the canonical Gaia curation core first,
+  then adds runtime source sharding, proposer/refuter convergence, and a
+  resumable ledger. Use for broad or high-stakes sweeps.
+version: 2.0.0
 argument-hint: "<broad-curation-goal>"
 ---
 
-# gaia-curate-dynamic
+# Gaia Curate Dynamic
 
-A **dynamic-workflow** registry curation skill. Unlike `/gaia-curate` (one linear pass) and `/gaia-curate-chain` (fixed six-link chain), this skill is **composed at runtime**: the orchestrator reads the goal and the registry, writes its own execution plan, dispatches many sub-agents in parallel, and converges their findings adversarially. Built for breadth (every source at once) and for trust (nothing ships until a refuter fails to break it).
+This is an extension of `/gaia-curate`, not an independent curation workflow.
+Execute `.agents/skills/gaia-curate/CURATION-CORE.md` for every source cluster
+first. The core owns canonical source handling, generic lookup, mapping,
+evidence representation, proposal taxonomy, review, and mutation rules.
+Dynamic orchestration may parallelize those core units, but must use the same
+packet contract and must not invent alternate rules.
 
-## Choosing the right curation skill
+## Extension-only stages
 
-| Skill | Pattern | Best for |
-|-------|---------|----------|
-| `gaia-curate` | Single pass, one agent | Fast, low-stakes batches |
-| `gaia-curate-chain` | Fixed six-link prompt chain | Small batch, schema-critical |
-| **`gaia-curate-dynamic`** | **Runtime-composed, massively parallel, convergent** | Wide sweeps, high-stakes verification |
+1. **Plan:** choose source shards, candidate concurrency, and convergence-round
+   budget; record the core contract version/digest.
+2. **Discover in parallel:** dispatch source-shard workers and merge only
+   normalized core candidates.
+3. **Adversarial convergence:** dispatch an independent proposer and refuter for
+   each candidate. Iterate up to the configured round limit; unresolved cases
+   become `needs-evidence` for human review.
+4. **Synthesize:** apply the core's existing-generic-first mapping and preserve
+   `contributor/skill-name` named IDs plus `genericSkillRef`.
+5. **Human checkpoint:** present converged accepts and unresolved disputes using
+   the core review table. Require explicit decisions.
+6. **Mutate and ship:** use `gaia dev`, validate, regenerate, and open one PR.
 
----
+## Resumable ledger
 
-## Core design principles
-
-**Runtime composition** — there is no hard-coded phase list. The orchestrator writes a run plan for *this* goal (which sources to shard, how many agents, how many validation rounds) and adapts it as findings arrive. A rich source gets more shards; a dry one gets fewer.
-
-**Parallel fan-out** — independent work runs concurrently because serial processing of a large sweep wastes the session budget. Dispatch all discovery sub-agents in a single turn. One sub-agent per source shard during discovery, one per candidate during deep-dive.
-
-**Convergent validation** — every surviving candidate is argued by a proposer and independently attacked by a refuter. The refuter must not see the proposer's reasoning (only its claims), so it can surface genuine objections rather than rubber-stamping. They iterate until they converge, or until the round budget runs out and the human breaks the tie. Single-verdict decisions are the failure mode this eliminates.
-
-**Persistent, resumable ledger** — all state lives in `generated-output/curate-dynamic-ledger.json` (gitignored). Every stage writes atomically. On every invocation, read the ledger first: if `stage` is not `ship`, print a one-line resume summary and continue from the earliest unfinished stage without redoing finished work.
-
----
-
-## Ledger shape
+Store state in `generated-output/curate-dynamic-ledger.json` (gitignored):
 
 ```json
 {
-  "goal": "<argument>",
-  "startedAt": "<iso>",
-  "stage": "plan|discover|deepdive|converge|synthesize|review|ship",
-  "plan": { "sources": [], "discoverShards": 0, "validationRounds": 2 },
-  "existingIds": [],
-  "discoveries": [ { "source": "...", "rawCandidates": [] } ],
-  "candidates": [
-    { "id": "...", "name": "...", "evidence": [],
-      "proposer": { "verdict": "", "type": "", "level": null },
-      "refuter":  { "verdict": "", "objections": [] },
-      "converged": false, "rounds": 0, "decision": "" }
-  ],
-  "batch": [],
-  "prUrl": null
+  "contractVersion": "core-v1",
+  "stage": "plan|discover|converge|review|ship",
+  "corePacket": "generated-output/curation-core-packet.json",
+  "plan": {"sources": [], "validationRounds": 2},
+  "discoveries": [], "candidates": [], "decisions": [], "prUrl": null
 }
 ```
 
----
+Resume must revalidate the contract and generic mappings. Schema/context drift
+invalidates mappings and mutation plans, but does not require discarding raw
+discovery evidence.
 
-## Stage 0 — Plan synthesis (orchestrator)
+## Gates
 
-1. Read `registry/skill-sources.md` and `registry/gaia.json`; record `existingIds` into the ledger for deduplication.
-2. Write the run plan: which sources to shard, how many discovery sub-agents, and the validation round budget (default 2; raise to 3 for Level II+ or ultimate proposals). Store under `plan`.
-3. Print a one-paragraph plan summary so the user sees the shape of the run before fan-out begins.
-
-## Stage 1 — Parallel discovery (one sub-agent per source shard)
-
-Dispatch all discovery sub-agents in a single turn. Each shard receives one source and this brief:
-
-> Enumerate skill-shaped artifacts in `{{source}}` relevant to `{{goal}}`. For local runs use the `gh` CLI and inspect each repo's `skills/` directory, recording raw `blob/<branch>/<subpath>/SKILL.md` URLs. For cloud/remote runs use GitHub MCP tools — do not claim GitHub is unreachable without checking MCP. Supplement with SkillsMP and arXiv. Return `rawCandidates[]` with `{name, source, url, oneLineCapability}`. Do not judge or rank — harvest only. Drop anything whose `name` slug already appears in `existingIds`.
-
-Write each shard's output to `discoveries[]` as it returns.
-
-## Stage 2 — Parallel candidate deep-dive (one proposer per candidate)
-
-Flatten and dedupe `discoveries` into a candidate set. Dispatch a **proposer** sub-agent per candidate in one batched turn:
-
-> Build the strongest honest case for adding `{{candidate}}` to Gaia. Gather evidence as `{class, source}` — arXiv abs = A, reproducible repo blob URL = B, vendor/community = C; every URL must resolve. Propose `type` (basic/extra/ultimate), `named` (+ `genericSkillRef`), and a star level for named skills. Emit a proposer verdict. Be concrete — unsupported claims will be attacked in the next stage.
-
-## Stage 3 — Convergent validation (proposer ⇄ refuter until they agree)
-
-For each candidate with a proposer verdict, dispatch an **independent refuter** (fresh context; must not see the proposer's reasoning, only its claims):
-
-> Try to break the case for `{{candidate}}`. Check: does each evidence URL resolve and is it on-topic? Is this a duplicate of an existing Gaia skill or another candidate? Is the level inflated for the evidence class? Is it vendor-locked or non-novel — should it collapse into an existing generic via Fusion-First? Return `objections[]` and a verdict: `uphold` / `lower-level` / `merge-into <id>` / `reject`.
-
-The orchestrator reconciles each round:
-- **Converged** when proposer and refuter agree on accept + type + level (or both agree to reject/merge). Mark `converged: true`, set `decision`.
-- **Not converged** — run another round: proposer answers the objections, refuter re-attacks. Repeat up to `plan.validationRounds`. If still split after the budget, mark `decision: needs-evidence` and carry both views to the human checkpoint.
-
-Independent shards run in parallel; only divergent candidates consume extra rounds.
-
-## Stage 4 — Synthesis and Fusion-First (orchestrator)
-
-Merge converged candidates into `batch[]`:
-- Apply **Fusion-First**: collapse vendor variants onto one generic (`literature-search`, not `pubmed`+`arxiv`+`biorxiv`); specialised capabilities become `extra` skills with the generic as a prerequisite.
-- Set schema-correct fields: `type` ↔ prereq arity (basic/unique = 0, extra ≥ 2, ultimate ≥ 3); generics carry no level; named skills get `status: awakened`.
-- Run pre-flight checks: IDs match their pattern, no DAG cycles. Surface any violations before presenting to the human.
-
-## Stage 5 — Single human checkpoint
-
-Present one consolidated table — converged accepts, plus any `needs-evidence` rows with the proposer/refuter split shown. Collect `accept`/`rename`/`duplicate`/`needs-evidence`/`reject` per row. One approval gate for the whole sweep. Proceed only with ≥ 1 `accept`.
-
-## Stage 6 — Mutation, validation, and ship
-
-All mutations via CLI — never hand-edit `registry/nodes/` or `gaia.json` directly, because direct edits skip timeline logging and can produce states that fail `gaia validate`.
+Every candidate must have a resolvable evidence source before review. Every
+named candidate must resolve `genericSkillRef` (CLI: `--generic-ref`) against
+`gaia dev list --generic --json`. Run:
 
 ```bash
-# generic (no --level)
-gaia dev add "Skill Name" --id <id> --type <type> --description "..."
-# named (awakened intake; reviewer assigns title/catalogRef/stars later)
-gaia dev add "Skill Name" --id <id> --named --contributor <user> \
-  --generic-ref <ref> --status awakened
-gaia dev evidence <skill-id> "<url>" --class <A|B|C>
-
-gaia validate                      # must exit 0
-gaia docs build                    # regenerate docs/projections
-gaia docs build --check            # must be clean before push
+gaia validate
+gaia dev docs --check
 ```
 
-Branch `review/meta/<slug>`, commit `[meta] <title>` plus a `[skip-gen]` docs commit, push (retry on network error with 2s/4s/8s/16s backoff), open the PR, and add the contributor to `README.md ## Contributors`.
-
-Report: ledger path, fan-out counts (sources sharded, candidates deep-dived, rounds spent), converged vs dropped tallies, and the PR URL.
-
----
-
-## Key constraints (with reasoning)
-
-**Convergence is the bar** — no candidate ships on a single verdict. A proposer and an independent refuter must converge because single-agent judgment is systematically optimistic; the refuter finds the gaps the proposer rationalised away.
-
-**Refuters must not see proposer reasoning** — only claims. Exposing the reasoning anchors the refuter to the proposer's framing, defeating the adversarial purpose. Fresh context means genuine independence.
-
-**Parallelism over serial dispatch** — dispatch independent sub-agents in one turn. Serial dispatch of 50 candidates would exhaust the session before converging; parallel dispatch finishes in fractions of the time.
-
-**Named skills enter as `awakened`** — `title`, `catalogRef`, and star levels are reviewer-only assignments. Submitting anything higher bypasses the human review gate that the awakened status enforces.
-
-**Evidence URLs must resolve and use `blob/` not `tree/`** — the installer only recognises `blob/<branch>/<subpath>` URLs; a `tree/` URL or a bare repo root produces an undiscoverable symlink.
-
-**One PR per sweep** — the whole batch lands for review together so the human can assess Fusion-First decisions and naming consistency across the set.
-
-## Invocation
-
-```
-/gaia-curate-dynamic <broad-curation-goal>
-```
-
-If the goal is omitted, ask what domain or time-window to sweep before writing the run plan.
+Do not use deprecated `--class`, manually authored trust values, or copied
+legacy taxonomy checks. Derived evidence scoring remains Gaia's responsibility.

--- a/.claude/skills/gaia-curate/CURATION-CORE.md
+++ b/.claude/skills/gaia-curate/CURATION-CORE.md
@@ -1,0 +1,75 @@
+# Gaia Curation Core
+
+This is the canonical preliminary curation contract. `/gaia-curate`, `/gaia-curate-chain`, and `/gaia-curate-dynamic` all begin here. Extension workflows must not restate or override these rules; they may add orchestration, gates, or adversarial review after the core packet is produced.
+
+## Core sequence
+
+1. Read `registry/skill-sources.md` and the canonical registry.
+2. Search and inspect candidate upstream implementations. Use specific `blob/<branch>/.../SKILL.md` URLs when available.
+3. Run the generic lookup before designing entries:
+
+   ```bash
+   gaia dev list --generic --description
+   # machine-readable form:
+   gaia dev list --generic --json
+   ```
+
+4. Map each implementation to an existing generic parent whenever possible.
+5. Create a new starless generic only when no suitable vendor-neutral, reusable, falsifiable parent exists.
+6. Propose named implementations separately, using preferred IDs in `contributor/skill-name` form and a resolving `genericSkillRef` (CLI spelling: `--generic-ref`).
+7. Capture evidence sources and raw source measurements. Do not assign derived trust values or deprecated classes.
+8. Present the review table and stop for explicit decisions before mutation.
+
+## Proposal model
+
+| Name | Starless (generic) | Named (`/slash-skill`) | Type | Generic ref | Action |
+|---|---|---|---|---|---|
+| Capability | existing or proposed generic | — | basic/fusion | — | accept/rename/etc. |
+| Implementation | existing generic parent | `/implementation` | named | `contributor/generic-id` | accept/rename/etc. |
+
+A generic row must be vendor-neutral and starless. A named row is a specific implementation and must resolve to an existing generic parent. An upstream slash skill is evidence/attribution, not automatically a new generic.
+
+## Evidence contract
+
+Record source facts, not computed scores:
+
+- `repo-own`: `commits`, `contributors`;
+- `github-stars-own`: `stars`, and `skillCountInRepo` when applicable;
+- use the specific implementation `blob/` URL where available;
+- record evidence type, source URL, provenance, and notes.
+
+Never author `class`, `trustNumber`, `trustMagnitude`, `artifact_score`, or manual A/B/C grades. Gaia computes derived scores and grades.
+
+Example:
+
+```bash
+gaia dev evidence contributor/skill-name <blob-url> \
+  --type repo-own --commits N --contributors N
+
+gaia dev evidence contributor/skill-name <repo-url> \
+  --type github-stars-own --stars N --skill-count-in-repo N
+```
+
+Do not pass `--trust` or the deprecated `--class` option.
+
+## Core packet
+
+Extensions should persist or pass a packet containing at least:
+
+```json
+{
+  "existingIds": [],
+  "genericMappings": [],
+  "candidates": [],
+  "batch": [],
+  "decisions": [],
+  "evidence": [],
+  "contractVersion": "core-v1"
+}
+```
+
+The packet is preliminary work, not approval. Extensions must preserve its evidence and decisions, then add their own state without silently remapping candidates.
+
+## Mutation boundary
+
+After explicit approval, mutate only through `gaia dev` commands. Validate with `gaia validate`; regenerate with `gaia dev docs` and check with `gaia dev docs --check`. Never hand-edit canonical or generated registry files.

--- a/.claude/skills/gaia-curate/SKILL.md
+++ b/.claude/skills/gaia-curate/SKILL.md
@@ -45,7 +45,7 @@ Qualifying bar: stars > 50, last commit < 1 year, has README + license. Prefer r
 
 ```bash
 gh api repos/{owner}/{repo}/contents/skills --jq '.[].name'
-gh api repos/{owner}/{repo}/contents/.claude/skills --jq '.[].name'
+gh api repos/{owner}/{repo}/contents/.Codex/skills --jq '.[].name'
 gh api repos/{owner}/{repo}/contents/codex/skills --jq '.[].name'
 gh api repos/{owner}/{repo}/contents/.codex/skills --jq '.[].name'
 gh api repos/{owner}/{repo}/contents/cursor/skills --jq '.[].name'
@@ -91,21 +91,39 @@ Upgrading weak existing skills delivers more value than pure breadth expansion.
 
 ## Step 2 — Design the batch
 
+### Registry terminology and generic-ref gate
+
+- An **upstream skill** is a `SKILL.md` found in another repository (for example, Anthropic's `mcp-builder`). It is evidence, not automatically a Gaia entry.
+- A **starless (generic) skill** is a reusable, vendor-neutral capability. Its Gaia ID must be generic enough to cover multiple implementations and must not be copied from an upstream slash skill name merely because that name is convenient.
+- A **named skill** is a specific implementation attributed to a contributor or repository. It is represented by a slash-style skill setup such as `/mcp-builder`, while its `--generic-ref` must point to an existing starless (generic) Gaia ID such as `mcp-server-development`.
+- Before proposing a named skill, verify that its generic ref already exists and is the correct generic skill type. Use `gaia dev list --generic --description` (or `gaia dev list --generic --json`) as the source of truth. If it does not exist, decide whether to create the starless (generic) parent; do not use the implementation's name as a substitute generic ref.
+- Never use an upstream repository name, slash skill name, or `SKILL.md` filename as a generic ref unless it independently satisfies the vendor-neutral generic taxonomy.
+
+#### Generic-parent decision tree
+
+1. **Exact generic exists** — reuse its ID; do not create a duplicate.
+2. **Equivalent generic exists under a broader name** — reuse it when the implementation is a valid specialization; propose a named entry mapped to that parent.
+3. **Only a vendor-specific or implementation-specific node exists** — do not reuse it as a generic parent; propose a vendor-neutral starless parent first.
+4. **No suitable generic exists** — create a starless parent only when the capability is reusable across multiple implementations, has a precise falsifiable definition, and is not merely a product, repository, or slash skill name.
+5. **Capability is too narrow or has only one inseparable implementation** — do not create a generic; hold or reject the named proposal pending evidence of broader applicability.
+
+The normal curation path is therefore: list generics programmatically → map each upstream implementation to an existing parent where possible → create a new starless parent only when the decision tree requires it → propose the named implementation with that parent's `generic-ref`.
+
 For each candidate, decide:
 
 **Taxonomy tier** (what type of skill is it?):
 - `basic` — primitive capability, no prerequisites
 - `extra` — emerges from ≥2 prerequisite basics
-- `ultimate` — high-complexity emergent, ≥3 prerequisites, ≥3 Evidence Grade A/B entries
+- `ultimate` — high-complexity emergent, ≥3 prerequisites, and multiple independent evidence artifacts
 - `unique` — graph-isolated basic that reached 4★+ through depth alone
 
 **Fusion-first design** — Resist the temptation to create one generic skill per vendor API. Multiple named implementations of the same concept (e.g. `pubmed`, `arxiv`, `biorxiv`) should map to a single elegant generic (e.g. `literature-search`). This keeps the global graph readable and prevents registry bloat.
 
 **Composite extras** — When multiple distinct skills combine into a multi-step workflow, design a composite Extra that names them as prerequisites. Calibrate the named implementations at 3★–4★ max, referencing the composite.
 
-**Generic skill levels** — Generic (starless) skills have no star level. Only named implementations receive stars (2★–6★). Omit `--level` from `gaia dev add` for generics.
+**Generic skill levels** — Starless (generic) skills have no star level. Only named implementations receive stars (2★–6★). Omit `--level` from `gaia dev add` for starless (generic) skills.
 
-**Named promotion** — If a specific implementation warrants its own entry in `registry/named/`, mark it for named promotion and submit with `status: awakened`. Never hand-set `title` or `catalogRef` during curation — those are set by a reviewer at Named promotion time.
+**Named promotion** — If a specific implementation warrants its own entry in `registry/named/`, mark it for named promotion and show its slash skill setup (for example, `/mcp-builder`) separately from its generic ref. Submit with `status: awakened`. Never hand-set `title` or `catalogRef` during curation — those are set by a reviewer at Named promotion time.
 
 **Demerit checks** — Only apply `heavyweight-dependency`, `niche-integration`, or `experimental-feature` demerits to skills at 3★+. Cross-platform universal skills at high levels should omit demerits.
 
@@ -117,15 +135,19 @@ For each candidate, decide:
 
 Before writing anything to disk, show the full proposed batch:
 
-| ID | Name | Type | Stars | Prereqs | Demerits | Named? |
-|---|---|---|---|---|---|---|
+| Name | Starless (generic) | Named (`/slash-skill`) | Type | Stars | Prereqs | Generic ref | Action |
+|---|---|---|---|---:|---|---|---|
+| Example Capability | Example Capability | — | starless (generic) | — | — | — | accept |
+| Example Implementation | Example Capability | `/example-implementation` | named | 2★–6★ | — | `example-capability` | accept |
 | … | … | … | … | … | … | … |
 
 For each row, ask the user to mark one of:
 - `accept` — proceed as designed
+- For every `named` row, confirm that the listed generic ref already exists and is the correct generic skill type.
+- For every `starless (generic)` row, confirm that the name is vendor-neutral and broad enough to support multiple named implementations.
 - `rename <new-id>` — change the ID before generating
 - `duplicate` — already covered; drop it
-- `needs-evidence` — hold until an Evidence Grade A/B source is supplied
+- `needs-evidence` — hold until a valid, resolvable evidence artifact is supplied
 - `reject` — remove entirely
 
 Do not proceed to Step 4 until the user has reviewed and at least one skill is marked `accept`. Apply all `rename` decisions before writing. Drop everything not `accept`/`rename`.
@@ -164,8 +186,7 @@ Commit message format: `[type] Title — brief description`
 
 ## Step 6 — Open the PR
 
-Push the branch and open a PR via the GitHub API. The auto-triage CI classifies it:
-- Evidence Grade A/B score ≥ 60 from a bot actor → eligible for auto-merge
+Push the branch and open a PR via the GitHub API. The auto-triage CI classifies it using computed evidence artifact scores and provenance; do not manually assign a class, trust grade, or aggregate trust value.
 - `draft-skills` or `needs-review` labels → routed to a human reviewer
 - Ultimate skill proposals → always require maintainer approval
 
@@ -203,7 +224,7 @@ gaia validate --intake
 ## Hard constraints
 
 - Never hand-edit `registry/nodes/` or `registry/gaia.json`. Use `gaia dev add`, `gaia dev merge`, `gaia dev split`, `gaia dev evidence`.
-- All evidence `source` values must be real, resolvable URLs (arXiv abs pages or GitHub repos). SkillsMP URLs are acceptable only as supplementary Evidence Grade C.
+- All evidence source URLs must be real and resolvable. Record the evidence type, source URL, provenance, and concise notes; artifact scores and per-row grades are computed by the registry tooling. Never hand-author deprecated `class` values or aggregate trust fields.
 - Ultimate skills must land as `provisional` — the maintainer sets `validated` after review.
 - No cycles in the DAG. No orphaned composite nodes.
 - Skill IDs: `lowercase-dash` format (`^[a-z][a-z0-9]*(-[a-z0-9]+)*$`). No camelCase, no vendor names, no unexplained abbreviations.
@@ -212,13 +233,37 @@ gaia validate --intake
 
 ---
 
-## Evidence grade reference
+## Evidence recording reference
 
-| Grade | Standard | Typical source |
+| Artifact type | Typical source | Curation treatment |
 |---|---|---|
-| A (Gold) | Peer-reviewed, benchmarked | `https://arxiv.org/abs/<id>` |
-| B (Silver) | Reproducible open-source demo | GitHub repo or skill file URL |
-| C (Bronze) | Credible vendor/community demo | Sufficient only for Level ≤ II |
+| `arxiv` | `https://arxiv.org/abs/<id>` | Record as a directly relevant paper artifact |
+| `repo` | GitHub repository or specific `blob/` skill file | Record as a reproducible implementation artifact |
+| `registryCuration` | Curation batch or documented demonstration | Record only when the curation work produced new evidence |
+| community/vendor artifact | SkillsMP or vendor documentation | Supplementary evidence only |
+
+The registry computes artifact scores, freshness, provenance weighting, per-row grades, and overall trust grades. Curation proposes evidence artifacts and their raw source measurements; it does not assign `class`, `trustNumber`, `trustMagnitude`, `artifact_score`, or manual A/B/C grades.
+
+### Repository-owned source measurements
+
+For a named implementation backed by its own upstream repository, record the raw measurements that the scoring formulas consume:
+
+- `repo-own`: `commits` and `contributors`
+- `github-stars-own`: `stars` and, when applicable, `skillCountInRepo`
+
+Use the specific implementation `blob/` URL as the source where available. These are source facts, not trust grades. Capture them with `gaia dev evidence`:
+
+```bash
+gaia dev evidence <skill-id> <source-url> \\
+  --type repo-own --commits <n> --contributors <n> \\
+  --notes "source measurements captured <date>"
+
+gaia dev evidence <skill-id> <repo-url> \\
+  --type github-stars-own --stars <n> --skill-count-in-repo <n> \\
+  --notes "GitHub source measurements captured <date>"
+```
+
+Do not pass `--trust`; the CLI computes derived values. If the implementation is submitted through intake, preserve these raw measurements in its evidence entries or named evidence payload so maintainers can reproduce the calculation.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ gaia dev list --generic --named
 gaia dev add "Skill Name" --type basic --description "At least 10 chars description"
 gaia dev merge target-id source-ids...
 gaia dev split source-id target-ids...
-gaia dev evidence skill-id "url" --class B
+gaia dev evidence skill-id "url" --type repo-own --commits N --contributors N
 gaia dev fuse generic-id --name "..." --type ultimate --prereqs a,b,c \
               --named-capstone contributor/slug --suite-components a,b,c
 ```
@@ -273,11 +273,11 @@ The **rarity** axis (`common`/`uncommon`/`rare`/`epic`/`legendary`) is **depreca
 
 ## Agent Skills
 
-All project skills live in `.claude/skills/`. There is no `.agents/` directory. Keep skills in sync with `CONTEXT.md` nomenclature.
+Project skills are delivered in both `.claude/skills/` and `.agents/skills/`; keep mirrored copies synchronized. Shared curation contracts live beside the canonical skill in both trees.
 
-- `gaia-curate/` — `/gaia-curate`: expand registry with new skills, open a PR (single linear pass).
-- `gaia-curate-chain/` — `/gaia-curate-chain`: same work as **prompt-chaining** (six gated links, one sub-agent per link). Use when evidence quality/schema correctness matter more than latency.
-- `gaia-curate-dynamic/` — `/gaia-curate-dynamic`: curation as a **dynamic workflow** (runtime-composed plan, parallel fan-out, proposer⇄refuter convergent validation, resumable ledger). Use for wide sweeps and high-stakes verification.
+- `gaia-curate/` — `/gaia-curate`: canonical preliminary curation; read its `CURATION-CORE.md` contract.
+- `gaia-curate-chain/` — `/gaia-curate-chain`: extends `/gaia-curate` with fixed topology, deterministic gates, bounded retries, and audit state.
+- `gaia-curate-dynamic/` — `/gaia-curate-dynamic`: extends `/gaia-curate` with dynamic sharding, proposer⇄refuter convergence, and a resumable ledger.
 - `gaia-meta-audit/` — `/gaia-meta-audit`: prioritized queue of skills/catalog items needing review.
 - `gaia-audit/` — `/gaia-audit`: focused source-level correction for one target.
 - `gaia-trace-timeline/` — `/gaia-trace-timeline`: audit & repair user-tree timelines so each skill's rank is explained by its Hero's Journey (backfills demote/rank_up events). Backed by `scripts/trace_timeline.py`; enforced by `scripts/validate_timelines.py` (via `gaia dev validate` + release CI).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,9 +18,9 @@ These slash-commands are available to AI agents (and maintainers) working in thi
 
 | Skill | When to use |
 |---|---|
-| `/gaia-curate-chain` | Expanding the registry with new skills — six gated links (scope → research → design → L4 review → mutate → ship). Use when evidence quality and schema correctness matter. Default for maintainer curation. |
-| `/gaia-curate` | Quick single-pass curation for small, trusted, low-stakes batches. Less gated than the chain. |
-| `/gaia-curate-dynamic` | Wide sweeps with parallel sub-agent fan-out and proposer↔refuter validation. Use for large batches or high-stakes verification. |
+| `/gaia-curate` | Canonical preliminary curation: source loading, generic lookup, generic/named mapping, evidence capture, review, and mutation plan. |
+| `/gaia-curate-chain` | Extends `/gaia-curate` with fixed links, deterministic gates, bounded retries, and audit state. |
+| `/gaia-curate-dynamic` | Extends `/gaia-curate` with source sharding, proposer↔refuter convergence, and a resumable ledger. |
 | `/gaia-meta-audit` | Prioritized queue of skills needing review — overlap checks, missing evidence, stale status. |
 | `/gaia-audit` | Focused source-level correction for one target skill. |
 | `/gaia-intake-close` | Post-merge intake closing — posts standardized pipeline findings, /trust-appraise TM output, decisions rationale, path-to-promotion, and badge status on the PR and each linked issue. Run after L4 review is complete. |
@@ -40,7 +40,7 @@ These slash-commands are available to AI agents (and maintainers) working in thi
 Pick by what you're doing:
 
 - **Submitting a skill you discovered?** Use `gaia push` (A).
-- **A reviewer expanding or restructuring the registry?** Use the gated curation pipeline `/gaia-curate-chain` (B) — the recommended path for maintainer-run curation.
+- **A reviewer expanding or restructuring the registry?** Start with `/gaia-curate`; choose `/gaia-curate-chain` or `/gaia-curate-dynamic` when additional gates or convergence are needed.
 - **Making a one-off correction** (a single merge, split, reclassify, or evidence add)? Use the direct CLI meta shifts (C).
 
 ### A) Submit discovered skills
@@ -59,15 +59,16 @@ python3 scripts/validate_intake.py
 
 Use this when proposing skills via `registry-for-review/skill-batches/*.json`.
 
-### B) Curate with gates — `/gaia-curate-chain` (recommended for reviewers)
+### B) Curate using the canonical core
 
-```
-/gaia-curate-chain <topic-or-source>
-```
+Begin with `/gaia-curate <topic-or-source>`. It produces the preliminary packet: source and registry loading, existing-generic lookup, generic/named mapping, raw evidence measurements, and the review table. See `.agents/skills/gaia-curate/CURATION-CORE.md`.
 
-Runs curation as six gated links — scope → research → design → human review → mutate → ship — one sub-agent per link, with a programmatic check between each. Source URLs are verified resolvable, schema shapes and the prerequisite DAG are checked **before** any mutation touches the registry, and `gaia dev validate` must pass before the branch ships. Prefer this whenever evidence quality and schema correctness matter; it is the default for maintainer-run registry expansion. See `.agents/skills/gaia-curate-chain/SKILL.md`.
+| Extension | Adds to the core |
+|---|---|
+| `/gaia-curate-chain` | Fixed topology, deterministic gates, bounded retries, and audit state. |
+| `/gaia-curate-dynamic` | Runtime source sharding, proposer/refuter convergence, and a resumable ledger. |
 
-The flat **`/gaia-curate`** (single linear pass, `.agents/skills/gaia-curate/`) still works and is quicker, but is **less gated** — reserve it for small, trusted, low-stakes batches. Both skills route every change through the same `gaia dev` commands documented in (C), so the underlying mutations are identical — the chain just checks them at each step.
+Extensions consume the core packet; they do not redefine preliminary curation.
 
 ### C) Update the canonical graph directly (Meta Shifts)
 
@@ -94,8 +95,9 @@ gaia dev add "New Skill Name" --type basic --description "..." [--status awakene
 # Reclassify a generic skill (change type)
 gaia dev reclassify skill-id ultimate
 
-# Add evidence
-gaia dev evidence skill-id "https://example.com/demo" --class B --notes "..."
+# Add evidence with raw source measurements; Gaia computes derived scores
+gaia dev evidence skill-id "https://example.com/demo" \
+  --type repo-own --commits 43 --contributors 14 --notes "source measurements"
 
 # Add evidence with G7 dual-axis fields (Evidence Type + Grade) and numeric payload
 gaia dev evidence skill-id "https://example.com/paper" \


### PR DESCRIPTION
## Summary

Refactors Gaia curation guidance so `/gaia-curate` is the canonical preliminary workflow and the gated/dynamic workflows extend it rather than duplicating it.

## Changes

- Added shared `CURATION-CORE.md` in both `.agents` and `.claude` skill trees.
- Documented the canonical preliminary sequence: source loading, generic lookup, generic/named mapping, evidence capture, review, and mutation boundaries.
- Made `gaia-curate-chain` an extension for fixed topology, deterministic gates, bounded retries, and audit state.
- Made `gaia-curate-dynamic` an extension for source sharding, proposer/refuter convergence, and resumable ledgers.
- Preserved preferred `contributor/skill-name` named IDs and canonical `genericSkillRef` mappings.
- Replaced deprecated manual evidence class/trust guidance with raw source measurements and computed scoring.
- Updated `CLAUDE.md` and `CONTRIBUTING.md` to document the shared-core hierarchy and current evidence commands.
- Synchronized corresponding `.agents` and `.claude` skill files.

## Scope

Documentation and agent workflow instructions only. No registry or generated artifacts were changed. No new CLI commands are introduced by this PR.

## Validation

- `git diff --check`
- Confirmed the branch diff contains only curation guidance files.

## Session token spend

- Main session: 241,020 input / 26,676 output / 7,805,440 cache-read tokens
- Recorded Terra planner run: 199,822 input / 18,594 output / 1,310,720 cache-read tokens
- Terra model cost was not estimated because non-Antigravity pricing is intentionally excluded.