### PR TITLE
ci: restrict GITHUB_TOKEN to contents:read in sdk-tests + license-check (#1144)

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,4 +1,8 @@
 name: License Compatibility Check
+
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:

--- a/.github/workflows/sdk-tests.yml
+++ b/.github/workflows/sdk-tests.yml
@@ -1,5 +1,8 @@
 name: SDK Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:

--- a/tests/test_workflow_permissions.py
+++ b/tests/test_workflow_permissions.py
@@ -1,0 +1,38 @@
+"""Regression test for issue #1144.
+
+The SDK-test and license-check workflows must declare an explicit top-level
+read-only ``permissions`` block so they do not inherit repository-default
+read-write GITHUB_TOKEN scopes (principle of least privilege).
+
+Scoped intentionally to the two workflows named in #1144: other workflows
+(labels-sync, meta-guard, pr-author-identity, ...) legitimately require write
+scopes and are out of scope for this fix.
+"""
+
+import pathlib
+
+import yaml
+
+WORKFLOWS_DIR = pathlib.Path(__file__).resolve().parents[1] / ".github" / "workflows"
+
+# Workflows named in issue #1144 that run read-only jobs (tests / license check).
+READ_ONLY_WORKFLOWS = ["sdk-tests.yml", "license-check.yml"]
+
+
+def _load(name):
+    with open(WORKFLOWS_DIR / name) as fh:
+        return yaml.safe_load(fh)
+
+
+def test_named_workflows_declare_top_level_permissions():
+    for name in READ_ONLY_WORKFLOWS:
+        doc = _load(name)
+        assert "permissions" in doc, f"{name} is missing a top-level permissions block"
+
+
+def test_named_workflows_default_to_contents_read():
+    for name in READ_ONLY_WORKFLOWS:
+        perms = _load(name)["permissions"]
+        assert perms == {"contents": "read"}, (
+            f"{name} should default to read-only contents access, got {perms!r}"
+        )


### PR DESCRIPTION
Closes #1144.

Adds an explicit top-level `permissions: { contents: read }` block to `.github/workflows/sdk-tests.yml` and `.github/workflows/license-check.yml`. Both run read-only jobs (SDK tests / license validation), so read-only is sufficient.

Scoped deliberately to the two workflows named in the issue. Eight other workflows also lack a top-level block (`meta-guard`, `labels-sync`, `pr-author-identity`, …) but legitimately require write scopes, so a blanket change would break them — out of scope here.

**Verification:** new `tests/test_workflow_permissions.py` asserts both workflows declare `contents: read`. 2 failed on unpatched `main` → 2 passed with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
