### PR TITLE
fix(schema): allow top-level fromFile in intake batches (#1151)

### DIFF
--- a/registry/schema/skillBatch.schema.json
+++ b/registry/schema/skillBatch.schema.json
@@ -7,6 +7,7 @@
   "required": ["batchId", "userId", "sourceRepo", "generatedAt", "knownSkills", "proposedSkills", "similarity"],
   "additionalProperties": false,
   "properties": {
+    "fromFile": { "type": "boolean" },
     "batchId": { "type": "string", "minLength": 1 },
     "userId": { "type": "string", "minLength": 1 },
     "sourceRepo": { "type": "string", "minLength": 1 },

--- a/src/gaia_cli/data/registry/schema/skillBatch.schema.json
+++ b/src/gaia_cli/data/registry/schema/skillBatch.schema.json
@@ -7,6 +7,7 @@
   "required": ["batchId", "userId", "sourceRepo", "generatedAt", "knownSkills", "proposedSkills", "similarity"],
   "additionalProperties": false,
   "properties": {
+    "fromFile": { "type": "boolean" },
     "batchId": { "type": "string", "minLength": 1 },
     "userId": { "type": "string", "minLength": 1 },
     "sourceRepo": { "type": "string", "minLength": 1 },

--- a/tests/test_intake_fromfile.py
+++ b/tests/test_intake_fromfile.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import json
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+from scripts.validate_intake import validate_schema
+
+def load_schema():
+    schema_path = os.path.join(REPO_ROOT, "registry", "schema", "skillBatch.schema.json")
+    with open(schema_path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+def test_fromfile_valid():
+    batch = {
+        "fromFile": True,
+        "batchId": "test-batch",
+        "userId": "tester",
+        "sourceRepo": "tester/repo",
+        "generatedAt": "2026-07-14T00:00:00Z",
+        "knownSkills": [],
+        "proposedSkills": [],
+        "similarity": []
+    }
+    schema = load_schema()
+    errors = validate_schema(batch, schema, "test-path")
+    assert not errors
+
+def test_fromfile_invalid_bogus_key():
+    batch = {
+        "fromFile": True,
+        "bogus": 1,
+        "batchId": "test-batch",
+        "userId": "tester",
+        "sourceRepo": "tester/repo",
+        "generatedAt": "2026-07-14T00:00:00Z",
+        "knownSkills": [],
+        "proposedSkills": [],
+        "similarity": []
+    }
+    schema = load_schema()
+    errors = validate_schema(batch, schema, "test-path")
+    assert len(errors) > 0
+    assert "schema error" in errors[0]


### PR DESCRIPTION
Closes #1151.

`gaia push --from-file` emits a top-level boolean `fromFile` key, but `registry/schema/skillBatch.schema.json` declared `additionalProperties: false` without listing it, so `gaia validate --intake` rejected every `--from-file` batch (`Additional properties are not allowed (fromFile was unexpected)`). Adds `fromFile` as an optional boolean property; the strict gate still rejects unknown keys.

Schema is the one loaded by the intake path (`scripts/validate_intake.py:178`, reached via `gaia_cli.impl.validate_command`).

**Verification:** new `tests/test_intake_fromfile.py` — a `fromFile` batch **fails on the original schema → passes with the fix**; a batch with an unknown `bogus` key still fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
