### PR TITLE
feat(scan): add repeatable --dir flag for nonstandard skill roots (#1159)

### DIFF
--- a/src/gaia_cli/commands/scan.py
+++ b/src/gaia_cli/commands/scan.py
@@ -19,6 +19,10 @@ class ScanCommand(Command):
             action="store_true",
             help="Scan globally installed skills in addition to the local repository",
         )
+        parser.add_argument(
+            "--dir", action="append", dest="dir", metavar="DIR",
+            help="Extra skill root to scan (repeatable). Sticky equivalent: .gaia/config.toml skillDirs=[...]"
+        )
 
     def execute(self, args: argparse.Namespace) -> int | None:
         from gaia_cli.main import scan_command

--- a/src/gaia_cli/impl.py
+++ b/src/gaia_cli/impl.py
@@ -734,7 +734,13 @@ def scan_command(args):
     scanned_ids = set(paths.get("detectedIds", [])) | set(paths.get("novelIds", []))
 
     # 2. Scan filesystem for custom skill metadata (SKILL.md)
-    all_installed_skills = scan_skill_mds(global_search=global_search)
+    import sys
+    extra = getattr(args, "dir", None)
+    for d in (extra or []):
+        if not os.path.isdir(os.path.expanduser(d)):
+            print(f"warning: --dir path not found: {d}", file=sys.stderr)
+
+    all_installed_skills = scan_skill_mds(global_search=global_search, extra_dirs=extra)
 
     # 3. Filter: Only keep skills that are actually referenced in the code
     installed_skills = []

--- a/src/gaia_cli/scanner.py
+++ b/src/gaia_cli/scanner.py
@@ -174,7 +174,7 @@ def _read_skill_md(filepath):
     return fm
 
 
-def _skill_search_dirs(root: str = ".", global_search: bool = False) -> list[str]:
+def _skill_search_dirs(root: str = ".", global_search: bool = False, extra_dirs: list[str] = None) -> list[str]:
     """Return all directories to search for skill subdirectories, deduplicated by real path.
 
     Priority order:
@@ -209,6 +209,13 @@ def _skill_search_dirs(root: str = ".", global_search: bool = False) -> list[str
     config = load_config()
     if config:
         for d in config.get("skillDirs", []):
+            expanded = os.path.expanduser(d)
+            if not os.path.isabs(expanded):
+                expanded = os.path.join(root, expanded)
+            candidates.append(expanded)
+
+    if extra_dirs:
+        for d in extra_dirs:
             expanded = os.path.expanduser(d)
             if not os.path.isabs(expanded):
                 expanded = os.path.join(root, expanded)
@@ -249,7 +256,7 @@ def _should_prune_dir(d: str) -> bool:
     return False
 
 
-def scan_skill_mds(root: str = ".", global_search: bool = False) -> list:
+def scan_skill_mds(root: str = ".", global_search: bool = False, extra_dirs: list = None) -> list:
     """Detect installed custom skills recursively from all known search paths.
 
     Checks project's parent directory (..) and all standard/configured skill search directories.
@@ -264,7 +271,7 @@ def scan_skill_mds(root: str = ".", global_search: bool = False) -> list:
     visited_real_paths = set()
 
     # Determine standard skill directories
-    standard_dirs = [os.path.realpath(d) for d in _skill_search_dirs(root, global_search)]
+    standard_dirs = [os.path.realpath(d) for d in _skill_search_dirs(root, global_search, extra_dirs=extra_dirs)]
     # The repo root itself is a mixed container, not a standard depth-1 skill container
     root_real = os.path.realpath(root)
     standard_containers = [d for d in standard_dirs if d != root_real]
@@ -278,7 +285,7 @@ def scan_skill_mds(root: str = ".", global_search: bool = False) -> list:
         else:
             search_roots = [os.path.abspath(root)]
     
-    for d in _skill_search_dirs(root, global_search):
+    for d in _skill_search_dirs(root, global_search, extra_dirs=extra_dirs):
         if "PYTEST_CURRENT_TEST" in os.environ:
             # Containment check: use the realpath of d's *parent* joined with
             # d's basename so that a symlink *located* under root (but pointing

--- a/tests/test_scan_dir_flag.py
+++ b/tests/test_scan_dir_flag.py
@@ -1,0 +1,22 @@
+import os
+from gaia_cli.scanner import scan_skill_mds
+
+def test_scan_dir_flag(tmp_path, monkeypatch):
+    skills_dir = tmp_path / "skills"
+    demo_skill_dir = skills_dir / "demo-skill"
+    demo_skill_dir.mkdir(parents=True)
+    
+    skill_md = demo_skill_dir / "SKILL.md"
+    skill_md.write_text("---\nid: demo-skill\nname: Demo\ndescription: demo skill for scan --dir test\n---\n")
+    
+    monkeypatch.chdir(tmp_path)
+    
+    # scan without --dir
+    found_without_dir = scan_skill_mds(".")
+    ids_without_dir = [item["id"] for item in found_without_dir]
+    assert "/demo-skill" not in ids_without_dir
+    
+    # scan with --dir
+    found_with_dir = scan_skill_mds(".", extra_dirs=["skills"])
+    ids_with_dir = [item["id"] for item in found_with_dir]
+    assert "/demo-skill" in ids_with_dir


### PR DESCRIPTION
Closes #1159.

Adds a minimal escape hatch so `gaia scan` can see `SKILL.md` packages outside the default agent roots, without expanding defaults or adding recursive discovery.

- `scanner.py`: `_skill_search_dirs()` and `scan_skill_mds()` gain an optional `extra_dirs` list, appended **after** config `skillDirs`, expanded (`~`/relative/absolute) and realpath-deduped like existing dirs.
- `impl.py` `scan_command`: threads `args.dir` through; a `--dir` path that isn't a directory warns to stderr and is skipped.
- `commands/scan.py`: repeatable `--dir DIR` flag (`action="append"`); help text points at the sticky `.gaia/config.toml` `skillDirs` equivalent.

No change to default roots, token-intersection, promote, or install behavior (all explicit non-goals).

**Verification:** new `tests/test_scan_dir_flag.py` — `skills/demo-skill/SKILL.md` is invisible to a bare scan but discovered with `--dir skills`; reverting the scanner change fails the test. Existing scan tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
