### PR TITLE
docs(taxonomy): Yggdrasil II v2 prose ratification — META, CONTEXT, trust-methodology

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,13 +12,13 @@ _See also: `PRODUCT.md` for audience, product purpose, and the design-principle 
 A primitive, indivisible capability — the genome of every agent. In catalog section headers, write **Basics** verbatim.
 _Avoid_: primitive, atomic skill, Atomic Basics, Unwired Basics, Pure / Undeveloped (as a section label — conflates the tier and stars axes).
 
-**Extra Skill (◇)**:
-A capability that emerges when two or more lower-tier skills fuse; can itself fuse with other **Extra Skills** to produce more complex Extras. In catalog section headers, write **Extras** verbatim.
-_Avoid_: composite skill, compound skill.
+**Extra Skill (◇)** _(legacy — Yggdrasil I taxonomy word; superseded under Yggdrasil II by **Fusion Skill**)_:
+A capability that emerged when two or more lower-tier skills fused. Under **Yggdrasil II** (2026-07-07), `Extra` retires as a taxonomy word; the structural role collapses into `type=fusion`. The 4★ Suite-branch rank is also named **Extra** (rank sense only, not taxonomy). In legacy catalog section headers, **Extras** verbatim.
+_Avoid_: using "Extra Skill" as a taxonomy category (post-Yggdrasil II); composite skill, compound skill.
 
 **Unique Skill (◉)**:
-A graph-isolated **Basic Skill** that reached elite mastery through depth alone, with no fusion path forward. In catalog section headers, write **Uniques** verbatim.
-_Avoid_: standalone skill, solo skill, graph-isolated singularities.
+A 4★+ named skill on the **Unique branch** — a skill whose generic parent has no `suiteComponents`, reaching high mastery through depth alone. Under **Yggdrasil II**, "Unique" is a valid **branch** word (progression path) rather than a `type` value; the Yggdrasil I structural meaning (`type=unique`) is retired. In catalog section headers, write **Uniques** verbatim.
+_Avoid_: standalone skill, solo skill, graph-isolated singularities; treating "Unique" as a `type` value (post-Yggdrasil II).
 
 **Ultimate Skill (◆)** _(legacy — Yggdrasil I taxonomy word; retiring under Yggdrasil II)_:
 A high-complexity emergent capability. Historically the taxonomy word for `type=ultimate` starless nodes (0.5-prereq structural rule). Under **Yggdrasil II** (2026-07-07), `Ultimate` retires as a taxonomy word and becomes the **5★ rank name**; the structural role collapses into `type=fusion`. See § Taxonomy v6 (Yggdrasil II) below.
@@ -41,7 +41,7 @@ Values: `basic` (0 prerequisites) or `fusion` (≥1 prerequisite). Lives on star
 _Avoid_: writing `type` on a named-skill frontmatter; using the legacy values `extra`, `ultimate`, `unique` on new nodes (bulk rewrite: `extra`→`fusion`, `ultimate`→`fusion`, `unique`→`basic`).
 
 **Branch axis** (progression — named only):
-Values: `standard`, `unique`, `suite`. Derived at read-time by `computeBranch(named)` from `(generic.type, generic.suiteComponents present?, named.level)`. **Never declared on nodes; always computed.**
+Values: `standard`, `unique`, `suite`. Derived at read-time by `computeBranch(named)` from `(generic.suiteComponents present?, named.level)`. **Never declared on nodes; always computed.**
 _Avoid_: writing a `branch` field to a node; treating branch as user-editable.
 
 **Standard branch**:
@@ -71,11 +71,11 @@ The `prerequisites` graph of a starless node — the fusion-recipe origin edges 
 _Avoid_: conflating fusion structure with suite components.
 
 **`computeBranch(named)`**:
-The read-time helper that walks `named → genericSkillRef → generic.{type, suiteComponents}` and returns the branch label given the named skill's current level. Lives in `src/gaia_cli/trustMagnitude.py` (post-implementation).
+The read-time helper that walks `named → genericSkillRef → generic.suiteComponents` and returns the branch label given the named skill's current level. (`generic.type` is accessed by the separate type-inheritance walk — **Option D** — not by branch derivation.) Lives in `src/gaia_cli/trustMagnitude.py` (post-implementation).
 _Avoid_: reading `branch` from a node; caching the result across level changes.
 
 **Option D** _(Yggdrasil II design choice)_:
-The named-skill-type-by-inheritance rule: starless nodes carry `type`, named skills do not. Named skills inherit type via `genericSkillRef` walk. Named `suiteRef` does not affect branch derivation — only the parent generic's `type` + `suiteComponents` shape branch.
+The named-skill-type-by-inheritance rule: starless nodes carry `type`, named skills do not. Named skills inherit type via `genericSkillRef` walk. Named `suiteRef` does not affect branch derivation — branch is shaped by `generic.suiteComponents` + the named skill's rank/level. (`type` governs type-inheritance: named skills inherit the generic's `type` via this walk; it does not feed into branch computation.)
 _Avoid_: adding a `type` field to `namedSkill.schema.json`.
 
 **Meta Schema RFC** _(Series A — Yggdrasil)_:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -97,10 +97,10 @@ A skill's verified maturity on a 0★ to 6★ axis, derived from evidence — ne
 _Avoid_: rank (the axis), level (the axis), tier (tier means the taxonomy above).
 
 **Rank**:
-The named label for a specific star value, valid only when paired with the name. Examples: "the Hardened rank", "Transcendent rank". Never used as the axis name.
+The named label for a specific star value, valid only when paired with the name. Examples: "the Evolved rank", "the Apex rank". Never used as the axis name.
 _Avoid_: using "rank" alone to mean stars; using "rank" as a verb (the verb is rank up).
 
-The rank names, in order (Yggdrasil II, 2026-07-07): **Unawakened** (0★), **Awakened** (1★), **Named** (2★), **Evolved** (3★), **Hardened** (4★, Suite: **Extra**, Unique: **Unique**), **Ultimate** (5★ Suite) / **Unique Ultimate** (5★ Unique), **Apex** (6★ Suite) / **Unique Impossible** (6★ Unique). The Yggdrasil I labels "Transcendent" (5★) and "Transcendent ★" (6★) are deprecated — Ultimate replaces Transcendent as the canonical 5★ word; Apex remains for 6★ Suite; Unique Impossible is the new 6★ Unique label. See § Taxonomy v6 (Yggdrasil II).
+The rank names, in order (Yggdrasil II, 2026-07-07): **Unawakened** (0★), **Awakened** (1★), **Named** (2★), **Evolved** (3★), **Extra** (4★ Suite) / **Unique** (4★ Unique branch), **Ultimate** (5★ Suite) / **Unique Ultimate** (5★ Unique branch), **Apex** (6★ Suite) / **Unique Impossible** (6★ Unique branch). The Yggdrasil I labels "Hardened" (4★), "Transcendent" (5★), and "Transcendent ★" (6★) are deprecated — Extra/Unique replace Hardened at 4★; Ultimate replaces Transcendent at 5★; Apex remains for 6★ Suite; Unique Impossible is the new 6★ Unique label. See § Taxonomy v6 (Yggdrasil II).
 
 **Apex**:
 Brand-voice shorthand for the **6★ Suite-branch** rank (post-Yggdrasil II, 2026-07-07). Pair with the rank symbol on first mention on a surface (e.g. `6★ Apex`); the bare word is reserved for hero / ceremonial copy and section endpoints (e.g. the Ascension Cycle terminus). Long-form documentation uses **Apex** in full. Under Yggdrasil II, Apex is Suite-branch-only — the 6★ Unique-branch rank is **Unique Impossible**.
@@ -143,7 +143,7 @@ A skill's *aggregate* standing — the accumulation of its individual **Evidence
 _Avoid_: storing it on a node; conflating it with one entry's Evidence Grade; "trust rating".
 
 **rank tenure**:
-How long a skill has held its current stars, derived from its timeline `rank_up` / `demote` events and rendered as "held the *[rank name]* rank since *[date]*." Computed, never stored. In copy always pair the word "rank" with the rank name (e.g. "the Hardened rank since 2026-03-01"); never write "rank" alone to mean the stars axis.
+How long a skill has held its current stars, derived from its timeline `rank_up` / `demote` events and rendered as "held the *[rank name]* rank since *[date]*." Computed, never stored. In copy always pair the word "rank" with the rank name (e.g. "the Evolved rank since 2026-03-01"); never write "rank" alone to mean the stars axis.
 _Avoid_: "rank since" with no rank name; storing tenure on a node; "rank age".
 
 **Verification levels**:
@@ -244,8 +244,8 @@ _Yggdrasil II (2026-07-07) updates these relationships. Legacy Yggdrasil I copy 
 
 ## Flagged ambiguities
 
-- "Rank" was used loosely as both the axis name and the label name. Resolved: **stars** is the axis (0★–6★); **rank** is only valid as a noun paired with the rank name (e.g. "the Hardened rank").
-- "Level" was used loosely for both stars and the taxonomic categories (Basic/Extra/Unique/Ultimate). Resolved: stars is the maturity axis; **tier** or the specific category name (Basic/Extra/Unique/Ultimate) is the taxonomy axis. "Level up" as a verb is fine and is synonymous with **rank up**.
+- "Rank" was used loosely as both the axis name and the label name. Resolved: **stars** is the axis (0★–6★); **rank** is only valid as a noun paired with the rank name (e.g. "the Apex rank").
+- "Level" was used loosely for both stars and the taxonomic categories (Basic/Extra/Unique/Ultimate). Resolved: stars is the maturity axis; **type** (`basic` / `fusion`) is the structural taxonomy (Yggdrasil II); named-skill progression is captured by the derived **branch** axis (`standard` / `suite` / `unique`). "Level up" as a verb is fine and is synonymous with **rank up**.
 - "Claim" is the brand-voice verb a visitor sees; **Propose** is the canonical CLI command beneath it. The two refer to the same action against an unclaimed Ultimate.
 
 ---
@@ -273,7 +273,7 @@ The role token for contributor handles wherever they appear (`#ef4444`). The sin
 _Avoid_: contributor red, name red.
 
 **Apex Gold**:
-The role token for the 6★ Transcendent ★ tier, Ultimate accent moments, the Diamond Seal mark, and other apex affordances (`#fbbf24`, deepening to `hsl(45,100%,45%)` at fringes per `drawNodeVI`). Never used as a decorative accent on lower tiers.
+The role token for the 6★ Apex tier, Ultimate accent moments, the Diamond Seal mark, and other apex affordances (`#fbbf24`, deepening to `hsl(45,100%,45%)` at fringes per `drawNodeVI`). Never used as a decorative accent on lower tiers.
 _Avoid_: Ultimate gold, accent gold.
 
 ### Nomenclature decisions
@@ -356,7 +356,7 @@ _Avoid_: Dual CTA, A/B paths.
 | **Name · Be named** | The 2★ moment a skill claims its Origin Contributor; uses honor red | `gaia push` (when accepted) |
 | **Fuse** | Combine two or more skills into a higher-complexity skill | `gaia fuse` |
 | **Claim · Propose** | Take an unclaimed Ultimate (Claim = brand voice; Propose = CLI) | `gaia propose` |
-| **Ascend** | Reach Apex (6★ Transcendent ★) | (no CLI verb — emerges from `gaia promote` reaching 6★) |
+| **Ascend** | Reach Apex (6★, Suite branch) or Unique Impossible (6★, Unique branch) | (no CLI verb — emerges from `gaia promote` reaching 6★) |
 | **Bond** | Link an AI agent to Gaia via MCP | `gaia mcp` install flow |
 | **Register** | First connect a repo to Gaia | `gaia init` |
 | **Scan** | Detect demonstrated skills in a repo | `gaia scan` |

--- a/META.md
+++ b/META.md
@@ -12,23 +12,32 @@ Gaia uses a tiered star system (`0★`–`6★`) to rank skills. Levels are both
 
 ### 1.1 Star Tiers & Rank Labels (named implementations)
 
-> **Evidence Floor reads from `grade` first.** Per the G7 Trust Taxonomy RFC (`founder/handovers/G7_TRUST_TAXONOMY_RFC.md`, ratified 2026-06-16), evidence rows now carry a `grade` field (S/A/B/C, S strongest) as the primary quality signal. The promotion engine (`src/gaia_cli/promotion.py`) reads `grade` first and falls back to the deprecated `class` field (A/B/C legacy) during the migration window. The two axes are distinct — Grade A is not Class A; never conflate them. See `CONTEXT.md` § Evidence Class for the deprecation notice and §2.1b below for the full dual-axis description.
+> **Evidence Floor retired — Trust Magnitude is the sole gate.** Per the Yggdrasil II ratification (2026-07-07), the per-star **Evidence Floor** column is removed; **Trust Magnitude (TM)** is the sole promotion gate. Evidence rows carry a `grade` field (S/A/B/C, Platinum → Bronze) as a quality signal that feeds TM scoring. The promotion engine (`src/gaia_cli/promotion.py`) reads `grade` first and falls back to the deprecated `class` field (A/B/C legacy) during the migration window — Grade A ≠ Class A; never conflate them. See §2.1b for the TM formula and `CONTEXT.md` § Evidence Class for the deprecation notice.
 
-| Level | Label | Significance | Evidence Floor | Verification Tier (max) |
-|---|---|---|---|---|
-| **0★** | **Basic** | Pre-named primitive — a freshly scanned candidate against a starless reference. | None | — |
-| **1★** | **Awakened** | Verified candidate, not yet named. | None | — |
-| **2★** | **Named** | Minimum level for named implementations. | Grade C+ | community-verified |
-| **3★** | **Evolved** | Demonstrates reproducibility and stability. | Grade B+ | community-verified / benchmark-verified |
-| **4★** | **Hardened** | Production-ready, well-documented, reliable. | Grade B+ (rank-floor protected) | up to security-reviewed |
-| **5★** | **Transcendent** | Mastery level, often an Ultimate capstone. | Grade B+ (rank-floor protected) | up to enterprise-ready |
-| **6★** | **Apex** | The pinnacle of Gaia; extreme ecosystem impact. | Grade S + 6-predicate gate (was 9, see §4.3) | enterprise-ready required |
+| Level | Label | Significance | Verification Tier (max) |
+|---|---|---|---|
+| **0★** | **Basic** | Pre-named primitive — a freshly scanned candidate against a starless reference. | — |
+| **1★** | **Awakened** | Verified candidate, not yet named. | — |
+| **2★** | **Named** | Minimum level for named implementations. | community-verified |
+| **3★** | **Evolved** | Demonstrates reproducibility and stability. | community-verified / benchmark-verified |
+| **4★** | **Extra** (Suite branch) / **Unique** (Unique branch) | Proved at production depth; branch forks here. TM gate: ≥ 100 (A-grade). | up to security-reviewed |
+| **5★** | **Ultimate** (Suite branch) / **Unique Ultimate** (Unique branch) | Mastery level — 'Ultimate' is the universal 5★ word. TM gate: ≥ 250 (S-grade). | up to enterprise-ready |
+| **6★** | **Apex** (Suite branch) / **Unique Impossible** (Unique branch) | The pinnacle of Gaia; extreme ecosystem impact. 6-predicate Apex gate (§4.3). | enterprise-ready required |
 
-### 1.2 Skill Types
-- **○ Basic Skill**: Root primitives. 0 prerequisites.
-- **◇ Extra Skill**: Composite workflows. Requires ≥ 2 prerequisites.
-- **◉ Unique Skill**: Specialized depth. Level 4★+, 0 prerequisites, graph-isolated.
-- **◆ Ultimate Skill**: Platform capstones. Requires ≥ 5 named prerequisites + Origin Fusion. **Requirement**: ≥ 10k repository stars.
+### 1.2 Node Types and Branch Axis (Yggdrasil II, 2026-07-07)
+
+**Type axis** — starless / generic nodes only. Named skills carry no `type` field; they inherit via `genericSkillRef` walk:
+- **`basic`** — 0 prerequisites. Root primitive nodes.
+- **`fusion`** — ≥ 1 prerequisite. Any non-basic starless node. PURE STRUCTURE — `type` does **not** determine a named skill's branch. Legacy values `extra`, `ultimate`, and `unique` are retired; all non-basic nodes are `fusion`.
+
+**`suiteComponents`** — the parent-level list of co-located suite components. Its **presence** on a generic node drives the branch fork for all named skills attached to that node and feeds downstream Trust Magnitude (§4.3 depth-2 walker). Independent of `type`.
+
+**Branch axis** — named skills only, **derived at read-time, never declared**. Rule: `branch = f(suiteComponents present?, rank)`:
+- **`standard`** — rank 1–3. Shared ladder: 1★ Awakened → 2★ Named → 3★ Evolved. Every named skill starts here regardless of parent `type`.
+- **`suite`** — rank ≥ 4 AND the generic parent carries `suiteComponents`. Suite ladder: 4★ **Extra** → 5★ **Ultimate** → 6★ **Apex**.
+- **`unique`** — rank ≥ 4 AND the generic parent has **no** `suiteComponents`. Unique ladder: 4★ **Unique** → 5★ **Unique Ultimate** → 6★ **Unique Impossible**.
+
+**Orthogonality**: type and branch are fully independent. A `fusion` node without `suiteComponents` yields Unique-branch named skills; a `basic` node with `suiteComponents` yields Suite-branch named skills. Never consult `type` to determine branch.
 
 ### 1.3 Redaction of Pre-Named & Demoted Handles
 
@@ -119,12 +128,12 @@ Per G7 RFC §10.14: every non-fusion-recipe evidence row must be **physically pr
 
 ### 2.2 The "Prestige Pivot" Roadmap (RFC #457)
 
-- **Web of Trust**: Contributors holding a **4★ (Hardened)** skill may act as "Verifiers" for new evidence, reducing reliance on central maintainers. Verified evidence is marked in the schema and visualized in the Skill Explorer history.
+- **Web of Trust**: Contributors holding a **4★+** skill may act as "Verifiers" for new evidence, reducing reliance on central maintainers. Verified evidence is marked in the schema and visualized in the Skill Explorer history.
 - **Liveness Heartbeat**: Automated monthly checks for URL health and repository activity. Dead or inactive repositories are flagged for demotion. Stable, "finished" software with Class A/B evidence is protected from rot demerits.
 - **Specialist Path**: A rubric allowing vendor-locked skills (e.g., Palantir, Salesforce) to reach 4★+ by proving "Depth of Integration" (robustness and production usage) rather than general portability.
 
 ### 2.3 Specialist Path Rubric (4★+ Promotion)
-To reach Hardened (4★) or higher as a Specialist (vendor-locked) skill, the implementation must meet the **Depth of Integration** bar:
+To reach 4★ or higher as a Specialist (vendor-locked) skill, the implementation must meet the **Depth of Integration** bar:
 1. **Production Evidence**: Documented usage in a real-world production environment (Case study, blog post, or Class A/B evidence).
 2. **Robustness**: Comprehensive test suite covering edge cases of the vendor's API/Platform.
 3. **Documentation**: Detailed "How-to" and "Reference" docs specifically for the vendor-locked context.
@@ -161,9 +170,9 @@ The **Canonical Level** (e.g., 4★) is the claimed tier based on evidence. The 
 - **Named**: Promoted by a reviewer once a unique RPG `title` or `catalogRef` is assigned.
 - **Origin Status**: The **most renowned** implementation in a generic bucket earns "Origin" — the highest-rated named skill (ties broken by most-attributed / Trust Score), **not** necessarily the earliest. An early implementation may be **superseded** when a stronger one earns the rank. Origin is a mark of merit granted to the implementation that earned it, in keeping with the product motif. Exactly one Origin exists per bucket. *(Updated 2026-06-02: Origin is merit-based; this supersedes the earlier "first contributor / earliest" rule, since an early entry can be outclassed by a better one.)*
 
-### 4.2 Ultimate & Apex Pathways
-- **Ultimate Fusion**: Proposer must hold Origin status on at least 1 of the 5+ named prerequisites. Requires ≥ 10k repository stars.
-- **The Ascension Cycle (6★ Apex)**: Reaching the **Apex** rank requires Grade A evidence AND that the skill is the product of a fusion involving at least one **Origin 5★ Transcendent** skill. Additionally, any skill currently recorded at 6★ before the G7 cutover will be subject to demotion review against the new 9-predicate gate (§4.3) at migration time.
+### 4.2 Suite-Branch 5★/6★ Pathways
+- **Suite 5★ Ultimate pathway**: Proposer must hold Origin status on at least 1 of the ≥ 5 `suiteComponents`. Trust Magnitude ≥ 250 (S-grade) required. The legacy "≥ 10k repository stars" hard-requirement is retired under Yggdrasil II; TM is the sole numeric gate.
+- **The Ascension Cycle (6★ Apex, Suite branch)**: Reaching **Apex** requires TM ≥ 250 (S-grade) and the full 6-predicate gate (§4.3), including at least one direct component that is itself a suite. Any skill recorded at 6★ before the G7 cutover was subject to demotion review against the original 9-predicate gate at migration time; the active set is now 6 predicates (§4.3).
 
 ### 4.3 Apex (6★) Gate — 6-Predicate Requirements (active set, post-2026-06-17 delta)
 
@@ -219,7 +228,7 @@ The following `action` values are defined in `registry/schema/skill.schema.json`
 - **`evidence_removed`**: Recorded when an evidence row is retracted.
 - **`evidence_graded`**: Recorded when an evidence row's grade is updated.
 - **`security_scan_passed`**: Recorded when a skill's content passes the defensive security scanner clean. Read by the `security-reviewed` verification tier (G4). The scanner-to-timeline emit wiring is a follow-up PR; the action enum entry is live in the schema as of PR #709.
-- **`type_change`**: Recorded when the skill's taxonomy type changes (e.g. `basic` → `unique`).
+- **`type_change`**: Recorded when the skill's taxonomy type changes (e.g. `basic` → `fusion`). Under Yggdrasil II the only valid type values for starless nodes are `basic` and `fusion`.
 - **`apex_pr_signed`**: Recorded when a verifier signs the apex-promotion PR for a 6★ candidate (G7 RFC §11.12.8). Sets `apexGateStatus.apexPromotionPrSigned` on the named skill. Ratified in v3 (`founder/handovers/G7_RFC_V3_RATIFICATION_2026-06-20.md`).
 
 ---
@@ -234,8 +243,8 @@ To maintain high prestige and avoid "Vendor Bloat," Gaia employs a proactive pru
 - Other implementations remain accessible as variants but do not clutter the primary graph view.
 
 ### 6.2 Semantic Fusion
-- When multiple distinct named skills represent specialized capabilities that can be orchestrated in a single high-level workflow, they are fused into a new **Extra (Master)** generic skill.
-- The original basic skills are linked as prerequisites, and the composite named implementations are promoted to higher star tiers (3★ or 4★).
+- When multiple distinct named skills represent specialized capabilities that can be orchestrated in a single high-level workflow, they are fused into a new **`fusion`-type** generic skill.
+- The original `basic` nodes are linked as prerequisites, and the composite named implementations are promoted to higher star tiers (3★ or 4★).
 
 ---
 
@@ -258,8 +267,8 @@ To maintain high prestige and avoid "Vendor Bloat," Gaia employs a proactive pru
 |---|---|---|
 | Star Tiers (0★–6★) | ✅ Implemented | `registry/schema/meta.json` |
 | Demerits & Effective Level | ✅ Implemented | `GOVERNANCE.md` |
-| Unique Skill Promotion | ✅ Implemented | `CONTRIBUTING.md` |
-| Ultimate Fusion Criteria (5-Prereq) | ✅ Implemented | `GOVERNANCE.md` |
+| Unique-branch Promotion (4★+, no `suiteComponents` on parent) | ✅ Implemented | `CONTRIBUTING.md` |
+| Suite-branch 5★ gate (`suiteComponents`, TM ≥ 250) | ✅ Implemented | `GOVERNANCE.md` |
 | Timeline Schema | ✅ Implemented | `registry/schema/namedSkill.schema.json` |
 | Web of Trust / Verification | ✅ Implemented | [Issue #457](https://github.com/gaia-research/gaia-skill-tree/issues/457) |
 | Liveness Heartbeat Script | ✅ Implemented | `scripts/verify_evidence.py` |

--- a/docs/meta/2026-06-trust-methodology.md
+++ b/docs/meta/2026-06-trust-methodology.md
@@ -18,12 +18,12 @@ A registry that ranks skills invites a tempting shortcut: reduce every skill to 
 
 The model instead keeps the human-legible signal — a skill's **stars**, on the 0★–6★ maturity axis — as the headline, and grounds it in graded evidence. The internal **trust number** still exists, but only as the input a grade is derived from; it is never shown in copy. Surfaces display the **grade** the number yields, not the raw number.
 
-## Two Standing Axes: Tier and Stars
+## Two Standing Axes: Type and Stars
 
-Every skill sits on two orthogonal axes that predate the trust model and remain unchanged:
+Every skill sits on two structural axes that predate the trust model and remain unchanged:
 
-- **Tier** — the taxonomy of what a skill *is*: Basic, Extra, Unique, or Ultimate.
-- **Stars** — verified maturity from 0★ to 6★, derived from evidence and never declared. Each star value has a **rank name** used only when paired (for example, "the Hardened rank"); the bare word is never used for the axis itself.
+- **Type** — the structural taxonomy of a *starless* (generic) node: `basic` (0 prerequisites) or `fusion` (≥ 1 prerequisite). Named skills carry no `type` field; they inherit via `genericSkillRef` walk. Under Yggdrasil II (ratified 2026-07-07), the legacy type values `extra`, `ultimate`, and `unique` are retired; all non-basic starless nodes carry `fusion`. Note that **branch** — the named-skill progression path (`standard` / `suite` / `unique`, derived at read-time) — is independent of `type`; it is driven by whether the parent generic carries `suiteComponents` and by the named skill's current rank.
+- **Stars** — verified maturity from 0★ to 6★, derived from evidence and never declared. Each star value has a **rank name** used only when paired (for example, "the Named rank" or "the Apex rank"); the bare word is never used for the axis itself.
 
 The trust model does not touch these axes. It governs the *evidence* that justifies a skill's stars, and the aggregate standing that evidence implies.
 
@@ -103,9 +103,9 @@ After resolving each component to its **named** effective evidence:
 
 The gate now reports real, actionable gaps — "needs one component graded S" — instead of the lookup artifact.
 
-## Suite Ultimates: the Pillar Gate
+## Suite-Branch 5★ Gate: the Pillar Rule
 
-An **Ultimate**-tier skill that fuses a suite of components is held to a pillar rule, expressed in `meta.json` `evidence.ultimateGate`: at least **three** components carrying graded evidence, of which at least **one** is graded S and at least **two** are graded A or better, with **no** component below the C floor. The gate scores each component by its child effective grade, not the shared parent grade, so a suite's standing reflects the real strength of its implementations.
+A **Suite-branch** skill (4★+; its generic parent carries `suiteComponents`) seeking to reach 5★ Ultimate is held to a pillar rule, expressed in `meta.json` `evidence.ultimateGate`: at least **three** components carrying graded evidence, of which at least **one** is graded S and at least **two** are graded A or better, with **no** component below the C floor. The gate scores each component by its child effective grade, not the shared parent grade, so a suite's standing reflects the real strength of its implementations.
 
 By design, mechanical backfill alone does not let any suite pass: clearing the gate requires at least one component graded S, and awarding S is an editorial judgement reserved for a 4★+ Verifier reviewing a genuine demonstration. A gate that has not yet been cleared now reports an accurate gap (for example, "needs one component graded S") rather than a lookup artifact.
 


### PR DESCRIPTION
## Summary

Ratifies the Yggdrasil II v2 taxonomy model across the three canonical prose docs. All stale Yggdrasil I references have been removed; the documents now faithfully encode the ratified model.

---

## (a) Docs changed and key edits

### `META.md`
- **§1.1 rank table**: removed `Evidence Floor` column (floor retired; TM is sole gate); updated 4★/5★/6★ labels to branch-split names: **Extra/Unique** (4★), **Ultimate/Unique Ultimate** (5★), **Apex/Unique Impossible** (6★); replaced intro blockquote to state TM is the sole promotion gate
- **§1.2 Skill Types → Node Types and Branch Axis**: complete rewrite from Yggdrasil I (○Basic/◇Extra/◉Unique/◆Ultimate) to v2 model — type axis (`basic`|`fusion`, starless nodes only), `suiteComponents` drives branch fork, branch axis derived at read-time (`standard`/`suite`/`unique`), orthogonality note
- **§2.2/2.3**: removed `4★ (Hardened)` label; uses `4★+` generically
- **§4.2**: renamed to "Suite-Branch 5★/6★ Pathways"; replaced "Origin 5★ Transcendent" with TM ≥ 250 gate; retired `≥ 10k repository stars` hard-requirement
- **§5.1**: `type_change` example `basic → unique` → `basic → fusion`
- **§6.2**: `Extra (Master)` → `fusion-type`; basic nodes terminology updated
- **§8**: tracker rows renamed to Unique-branch Promotion and Suite-branch 5★ gate

### `CONTEXT.md`
- **Rank definition examples**: `Hardened rank` / `Transcendent rank` → `Evolved rank` / `Apex rank`
- **Rank names list**: collapsed `Hardened (4★, Suite: Extra, Unique: Unique)` umbrella; now shows `Extra (4★ Suite) / Unique (4★ Unique)` directly; added Hardened/Transcendent/Transcendent★ to deprecated list
- **Ascend verb**: `Reach Apex (6★ Transcendent ★)` → `Reach Apex (6★, Suite branch) or Unique Impossible (6★, Unique branch)`
- **rank tenure example**: `Hardened rank since 2026-03-01` → `Evolved rank since 2026-03-01`
- **Apex Gold**: `6★ Transcendent ★ tier` → `6★ Apex tier`
- **Flagged ambiguities**: tier/taxonomy entry updated to reference `type` (`basic`/`fusion`) and `branch` (`standard`/`suite`/`unique`)

### `docs/meta/2026-06-trust-methodology.md`
- **§ Two Standing Axes**: retitled to "Type and Stars"; replaced legacy `Tier (Basic/Extra/Unique/Ultimate)` bullet with v2 `Type` (`basic`/`fusion`) + `Branch` description; explicitly states branch is independent of type and driven by `suiteComponents` + rank
- **Suite Ultimates → Suite-Branch 5★ Gate**: retitled section and opening sentence; replaced `Ultimate-tier skill` with `Suite-branch skill (4★+; parent carries `suiteComponents`)`

---

## (b) Cherry-pick vs. rewrite decision

**Decision: full hand-rewrite.**

Compared both `origin/main` and `origin/design/yggdrasil-ii-aov-v3` against the base (`origin/dev/yggdrasil-ii-staging`):

```
git log --oneline origin/dev/yggdrasil-ii-staging..origin/main -- META.md CONTEXT.md
# (no output)

git log --oneline origin/dev/yggdrasil-ii-staging..origin/design/yggdrasil-ii-aov-v3 -- META.md CONTEXT.md
# (no output)
```

Neither branch had any new commits touching these files. However, `git diff origin/dev/yggdrasil-ii-staging origin/main` revealed that **main has actually reverted significant Yggdrasil II content** in CONTEXT.md — restoring `Transcendent`, removing the Fusion Skill section, and re-introducing the old rank names list. Cherry-picking from main would have been actively harmful. The staging branch (`dev/yggdrasil-ii-staging`) holds the correct forward-facing model; this PR applies the remaining v2 alignment directly.

---

## (c) Deferred (out of scope)

The following stale references were found in excluded files and are left for separate sub-issues:

- **`DESIGN.md`** — explicitly excluded per task spec (#998 handles design files); contains `Hardened`, `Transcendent`, `type === 'extra'`, `type === 'unique'`, `type === 'ultimate'`, and CSS glow tokens named for old rank names
- **`docs/agent.md`** — `4★+ (Hardened/Transcendent)` and `6★ (Transcendent ★ / Apex)` references
- **`DEV.md`** — `type ∈ basic|extra|ultimate|unique` in the `reclassify` command docs
- **`CONTRIBUTING.md`** — `Skill types in graph: basic, extra, ultimate`
- **`GOVERNANCE.md`** — `4★ (Hardened)` in Verifiers section

---

Refs #994