### PR TITLE
Yggdrasil II · Schema — collapse type enum to {basic, fusion} (#995)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -8,11 +8,11 @@ _See also: `PRODUCT.md` for audience, product purpose, and the design-principle 
 
 ### Skill taxonomy (the categories)
 
-**Basic Skill (○)**:
+**Basic (○)**:
 A primitive, indivisible capability — the genome of every agent. In catalog section headers, write **Basics** verbatim.
 _Avoid_: primitive, atomic skill, Atomic Basics, Unwired Basics, Pure / Undeveloped (as a section label — conflates the tier and stars axes).
 
-**Extra Skill (◇)** _(legacy — Yggdrasil I taxonomy word; superseded under Yggdrasil II by **Fusion Skill**)_:
+**Extra Skill (◇)** _(legacy — Yggdrasil I taxonomy word; superseded under Yggdrasil II by **Fusion**)_:
 A capability that emerged when two or more lower-tier skills fused. Under **Yggdrasil II** (2026-07-07), `Extra` retires as a taxonomy word; the structural role collapses into `type=fusion`. The 4★ Suite-branch rank is also named **Extra** (rank sense only, not taxonomy). In legacy catalog section headers, **Extras** verbatim.
 _Avoid_: using "Extra Skill" as a taxonomy category (post-Yggdrasil II); composite skill, compound skill.
 
@@ -28,7 +28,7 @@ _Avoid_: legendary skill, top-tier skill, mythic, "Ultimate skill" in the taxono
 The act of combining two or more skills into a single higher-complexity skill, formalised in the registry via `gaia fuse`. Under Yggdrasil II, every non-Basic starless node carries `type=fusion`; a fusion is any skill with ≥1 prerequisite.
 _Avoid_: combination, merge, composition.
 
-**Fusion Skill (◇)** _(Yggdrasil II canonical — replaces Extra Skill and taxonomy-Ultimate)_:
+**Fusion (◇)** _(Yggdrasil II canonical — replaces Extra Skill and taxonomy-Ultimate)_:
 The unified taxonomy label for starless nodes with `type=fusion` (any skill with ≥1 prerequisite). Replaces the Yggdrasil I trio `Extra` + `Ultimate` (taxonomy sense) + `Unique` (structural sense) with a single structural category. Ranks and branches live on named skills, not on the starless taxonomy. In catalog section headers, write **Fusions** verbatim (Yggdrasil II) or **Extras** verbatim (legacy Yggdrasil I copy).
 _Avoid_: composite skill, compound skill, extra skill (post-Yggdrasil II).
 
@@ -39,6 +39,8 @@ Ratified 2026-07-07 (`founder/handovers/YGGDRASIL_II_RATIFICATION_2026-07-07.md`
 **Type axis** (structural — starless only):
 Values: `basic` (0 prerequisites) or `fusion` (≥1 prerequisite). Lives on starless nodes only. **Named skills have no `type` field** — they inherit via `genericSkillRef` walk (**Option D**). Simplifies both axes: starless is purely structural, named is purely progression.
 _Avoid_: writing `type` on a named-skill frontmatter; using the legacy values `extra`, `ultimate`, `unique` on new nodes (bulk rewrite: `extra`→`fusion`, `ultimate`→`fusion`, `unique`→`basic`).
+
+**Nomenclature — the "Skill" suffix** (Yggdrasil II): the proper-noun suffix "Skill" attaches to **rank** names only — **Extra Skill**, **Unique Skill**, **Ultimate Skill**, **Apex Skill** (e.g. "Ultimate Skill: garrytan/gsstack"). **Type** words stand bare: **Basic** and **Fusion** — never "Basic Skill" or "Fusion Skill". Types are structural categories, not ranks.
 
 **Branch axis** (progression — named only):
 Values: `standard`, `unique`, `suite`. Derived at read-time by `computeBranch(named)` from `(generic.suiteComponents present?, named.level)`. **Never declared on nodes; always computed.**
@@ -226,8 +228,8 @@ current rank, or the build fails.
 
 _Yggdrasil II (2026-07-07) updates these relationships. Legacy Yggdrasil I copy retained where still accurate._
 
-- A **Basic Skill** (`type=basic`, 0 prerequisites) fuses with other Basic Skills to produce a **Fusion Skill** (`type=fusion`, ≥1 prerequisite). Legacy Yggdrasil I called these "Extras".
-- A **Fusion Skill** can fuse with other Fusion Skills to produce a more complex Fusion Skill.
+- A **Basic** (`type=basic`, 0 prerequisites) fuses with other Basics to produce a **Fusion** (`type=fusion`, ≥1 prerequisite). Legacy Yggdrasil I called these "Extras".
+- A **Fusion** can fuse with other Fusions to produce a more complex Fusion.
 - A named skill lives on one of three **branches** (derived, never declared): **Standard** (1★–3★), **Unique** (4★+ non-suite; the Yggdrasil I "Unique" tier now lives here as a *progression path*), or **Suite** (4★+ suite-based; the Yggdrasil I "Extra 4★" + "Ultimate 5★+" ranks now live here).
 - A skill becomes a **Named Skill** at 2★, attaching it to its **Origin Contributor**.
 - Every star above 1★ requires graded evidence — an **Evidence Grade** (the deprecated **Evidence Class** axis it replaces). Ranking up gates on **Trust Magnitude** (TM Index (2026 Q2)); the legacy per-star **Evidence Floor** column is retired under Yggdrasil II.
@@ -444,18 +446,20 @@ Single source of truth for CI grep. Any term below appearing in user-facing copy
 
 - `apex tier` (as taxonomy-Ultimate synonym) — the old "Apex is stars-axis, Ultimate is taxonomy-axis" rule retires under Yggdrasil II. **Ultimate is now the 5★ rank name; Apex is the 6★ Suite-branch rank name.** Never use "apex tier" as a taxonomy synonym.
 - `Atomic Basics` — section label; use **Basics**
-- `Atomic skill` / `atomic skill` — tier synonym; use **Basic Skill**
+- `Atomic skill` / `atomic skill` — tier synonym; use **Basic**
+- `Basic Skill` (as a type term) — the "Skill" suffix is a rank-word convention; the `type=basic` label stands bare. Use **Basic**.
 - `card` — for plaque; use **Plaque**
 - `claimers` — collective noun for contributors; use **Named Contributors**
 - `claimed skill` — use **Named Skill**
 - `common` — never a **tier** or **rank** name (it was a rarity-axis value; see Rarity section above — never surfaced in user-facing copy)
-- `composite skill` / `compound skill` — for Fusion Skill; use **Fusion Skill** (Yggdrasil II) or **Extra Skill** (legacy)
+- `composite skill` / `compound skill` — for Fusion; use **Fusion** (Yggdrasil II) or **Extra Skill** (legacy)
 - `Connect MCP` / `Add Gaia to your agent` — MCP install copy; use **Bond your agent**
 - `dashboard` / `profile` (as skill-tree synonym) — use **Skill Tree** or **Your Tree**
 - `database` / `catalog` / `index` — for Registry; use **Registry**
 - `Documentation` / `How we do things` / `How We Work` — page name; use **The Codex**
-- `Extra skill` / `type=extra` — legacy Yggdrasil I taxonomy word; use **Fusion Skill** / `type=fusion` (Yggdrasil II)
+- `Extra skill` / `type=extra` — legacy Yggdrasil I taxonomy word; use **Fusion** / `type=fusion` (Yggdrasil II)
 - `Field view` is the **only** user-facing label for the immersive canvas toggle — banned alternatives: `View as HUD`, `HUD mode`, `Heads-up display`, `Open HUD`, `Constellation view`
+- `Fusion Skill` (as a type term) — the "Skill" suffix is a rank-word convention; the `type=fusion` label stands bare. Use **Fusion**.
 - `G7` / `G8` (in external / public docs) — use **TM Index (2026 Q2)** / **TM Index (2026 Q3)**; the G-series is internal engineering codename only
 - `Get started` / `Quickstart` / `Onboarding` — setup copy; use **The Initiate's Rite**
 - `graph-isolated singularities` — for Unique section; use **Uniques**
@@ -467,7 +471,7 @@ Single source of truth for CI grep. Any term below appearing in user-facing copy
 - `owners list` — collective; use **Named Contributors**
 - `owner` / `author` / `creator` — for Origin Contributor; use **Origin Contributor**
 - `Pokédex` / `RPG site` / `game UI` / `anime UI` — brand-stance violations
-- `primitive` — for Basic Skill; use **Basic Skill**
+- `primitive` — for Basic; use **Basic**
 - `Pure / Undeveloped` — section label that conflates tier and stars axes; section header is **Basics**, and a 0★ skill can carry the **Pure** pill inline
 - `Pure skill` — as tier synonym; "Pure" is only a 0★ stars-axis descriptor
 - `rank` / `level` / `tier` — when used alone to mean the **stars axis** (these are reserved for the rank-name label, the verbs, and the tier taxonomy respectively)
@@ -480,7 +484,7 @@ Single source of truth for CI grep. Any term below appearing in user-facing copy
 - `Transcendent` (as rank name) — deprecated under Yggdrasil II; use **Ultimate** (5★ Suite) / **Unique Ultimate** (5★ Unique)
 - `Transcendent ★` (as rank name) — deprecated under Yggdrasil II; use **Apex** (6★ Suite) / **Unique Impossible** (6★ Unique)
 - `trophy` (as plaque synonym in copy) — use **Plaque**
-- `Ultimate skill` (in the taxonomy sense — post-Yggdrasil II) — "Ultimate" is now a 5★ rank name only; the taxonomy word retires. Use **Fusion Skill** for the structural role.
+- `Ultimate skill` (in the taxonomy sense — post-Yggdrasil II) — "Ultimate" is now a 5★ rank name only; the taxonomy word retires. Use **Fusion** for the structural role.
 - `Undeveloped` — pejorative; not in vocabulary
 - `Unwired Basics` — section label; use **Basics**
 - `upgrade` / `promote-up` — for rank-up verb; use **Rank up** or **Level up**

--- a/docs/examples/example_basic_skill.md
+++ b/docs/examples/example_basic_skill.md
@@ -1,10 +1,10 @@
-# Example: New Basic Skill Submission
+# Example: New Basic-type Skill Submission
 
 This is a filled-out example of a `new_basic_skill.md` PR for reference.
 
 ---
 
-## New Basic Skill
+## New Basic-type Skill
 
 ### Skill Details
 - **ID:** `parseCsv`

--- a/founder/ORCHESTRATOR.md
+++ b/founder/ORCHESTRATOR.md
@@ -35,6 +35,19 @@ If Marcus asks you directly to "just write it," push back once:
 Then delegate. This is not a refusal pattern. Code questions are fine. Code authorship is
 delegated.
 
+### Superadmin mode (root `*.md` + `founder/`) — default ON
+
+The delegate-don't-type rule governs **code**. It does **not** govern founder-owned documentation. You hold standing **direct-edit authority** — no delegation, no asking permission — over:
+
+- **Root-level `*.md`** docs: `CONTEXT.md`, `README.md`, `META.md`, `CLAUDE.md`, `AGENTS.md`, `GOVERNANCE.md`, `CONTRIBUTING.md`, and siblings.
+- **Everything under `founder/`**: handovers, `MEMORY.md`, `ORCHESTRATOR.md`, `founder/CLAUDE.md`, session state.
+
+These are governance and documentation surfaces, not executable artifacts — editing them inline *is* the orchestrator's job (nomenclature rulings, handover authoring, memory snapshots, persona maintenance). Superadmin mode is default-on for them.
+
+What still delegates to a worker (code authorship, unchanged): `src/`, `scripts/`, `registry/` (node data **and** schema JSON), `docs/js/`, `docs/**/*.html`, `.github/workflows/`, and any executable, config, or generated artifact. If a doc edit and a code edit are entangled in one PR, you author the doc part directly and hand the code part to a worker.
+
+The `dev/*` staging branch accepts these founder/root-md fixes as normal orchestrator stewardship — route them through a `dev/*` feature branch PR like any other change; you are simply the author rather than the delegator.
+
 ---
 
 ## Post-Compact Bootstrap (read after every auto-compact or session resume)
@@ -49,9 +62,9 @@ Auto-compact summaries describe what happened but do NOT re-activate loaded skil
 5. Resume from the last open task listed in that snapshot.
 
 **Invariants that survive any sprint:**
-- Never commit directly to `main` or the integration branch (`dev/<sprint-name>`). All work goes through a feature branch PR.
+- Never commit directly to `main` or the integration branch (`dev/<sprint-name>`). All work goes through a feature branch PR. Exception under superadmin mode: founder-owned docs (root `*.md`, `founder/`) may be authored directly by the orchestrator, but still land via a `dev/*` feature branch PR — never a direct push to `main`.
 - The integration branch PR is the aggregate; the feature branch PR is the workstream. Keep them distinct.
-- Orchestrator mode: delegate all code to workers via the Agent tool. Only plan, review, and run `git`/`gh` CLI directly.
+- Orchestrator mode: delegate all **code** to workers via the Agent tool. Author founder docs (root `*.md`, `founder/`) directly under superadmin mode. Plan, review, and run `git`/`gh` CLI directly.
 
 ---
 

--- a/founder/handovers/YGGDRASIL_II_RATIFICATION_2026-07-07.md
+++ b/founder/handovers/YGGDRASIL_II_RATIFICATION_2026-07-07.md
@@ -1,5 +1,44 @@
 # Yggdrasil II — Meta Schema Ratification (2026-07-07)
 
+---
+
+## v2 Amendment — 2026-07-14 (Branch decoupled from Type)
+
+> This amendment supersedes **Q2** and the **Unique branch**, **Suite branch**, and **`computeBranch`** entries in the Ubiquitous Language section below. Original text for each is preserved with an inline `[SUPERSEDED]` marker.
+
+### Changes from v1
+
+1. **Branch is derived from `suiteComponents` + rank — NOT from `type`.** `type` is removed from every branch-derivation formula and from the definition of Unique.
+2. **The unique↔suite fork is recognised ONLY at 4★+.** At 1★–3★ there is NO branch distinction — all skills share the ladder: 1★ Awakened, 2★ Named, 3★ Evolved.
+3. **"Transcendent" is DROPPED.** The two 4★+ ladders are:
+   - **Suite** (generic parent HAS `suiteComponents`): 4★ **Extra**, 5★ **Ultimate**, 6★ **Apex**
+   - **Unique** (generic parent has NO `suiteComponents`): 4★ **Unique**, 5★ **Unique Ultimate**, 6★ **Unique Impossible**
+
+### Branch-derivation rule (canonical)
+
+`branch = f(suiteComponents present?, rank)`
+
+- rank 1–3 → shared ladder (Awakened / Named / Evolved), no branch
+- rank ≥ 4 AND suiteComponents present → Suite ladder (Extra / Ultimate / Apex)
+- rank ≥ 4 AND no suiteComponents → Unique ladder (Unique / Unique Ultimate / Unique Impossible)
+
+### Rank ladder
+
+| Stars | Shared (no branch) | Suite branch | Unique branch |
+|---|---|---|---|
+| 1★ | **Awakened** | — | — |
+| 2★ | **Named** | — | — |
+| 3★ | **Evolved** | — | — |
+| 4★ | — | **Extra** | **Unique** |
+| 5★ | — | **Ultimate** | **Unique Ultimate** |
+| 6★ | — | **Apex** | **Unique Impossible** |
+
+### Orthogonality assertion
+
+> Type and Branch are orthogonal. `type` (basic|fusion) is pure structural metadata — a starless/generic node is `fusion` iff it has prerequisites — and is NEVER consulted for branch. Branch is driven solely by `suiteComponents` presence and rank. In practice fusion and suiteComponents usually coincide, but they are independent fields: a `fusion` node with no `suiteComponents` is Unique branch, and a `basic` node carrying `suiteComponents` is Suite branch. `suiteComponents` remains an input to downstream Trust Magnitude computation as well.
+
+---
+
 > **This document is a ratification handover, not an implementation plan.** It records the decisions, names the Meta Shift, defines the staging-branch protocol, and scopes the follow-up (TM Index 2026 Q3). Implementation PRs are staged separately after ratification lands and all target the same staging branch.
 
 ---
@@ -91,13 +130,16 @@ The following terms are the shared vocabulary of Yggdrasil II. They live authori
 - **Branch axis** — progression, on named skills only. Values: `standard` (1★–3★), `unique` (4★–6★ non-suite), `suite` (4★–6★ suite-based). Always derived, never declared.
 - **Standard branch** — 1★ Awakened → 2★ Named → 3★ Evolved. The default; every named skill starts here.
 - **Unique branch** — 4★ Unique → 5★ Unique Ultimate → 6★ Unique Impossible. For skills that reach 4★+ *without* being a suite (their generic parent has no `suiteComponents`). Standalone prestige track. Impeccable is the archetype.
+  > **[SUPERSEDED by v2 Amendment 2026-07-14]** Branch no longer reads `type`; derived from `(suiteComponents present?, rank)`, fork at 4★+.
 - **Suite branch** — 4★ Extra → 5★ Ultimate → 6★ Apex. For skills whose generic parent carries `suiteComponents` (structural fusion of grouped components). Group prestige track.
+  > **[SUPERSEDED by v2 Amendment 2026-07-14]** Branch no longer reads `type`; derived from `(suiteComponents present?, rank)`, fork at 4★+.
 - **Ultimate** — the 5★ rank name. Universal across branches (Suite: **Ultimate**, Unique: **Unique Ultimate**). Intentional gacha-anchor collision — every 5★ skill is "Ultimate". Deprecates the legacy `type=ultimate` taxonomy usage.
 - **Apex** — the 6★ Suite-branch rank name (preserved from Yggdrasil I).
 - **Unique Impossible** — the 6★ Unique-branch rank name (new). Provisional 5-predicate gate (Apex minus `directNestedSuiteGte1`); formal ratification deferred.
 - **Fusion structure** — the `prerequisites` graph of a starless node (fusion-recipe origin edges). Contrasted with `suiteComponents` (co-located sibling components of a Suite). Unique gates count origins in fusion structure; Suite gates count origins in `suiteComponents`.
 - **Fusion Skill** — the new taxonomy label for what was previously "Extra" / "Ultimate" (starless side). Retires "Extra Skill" and the taxonomy usage of "Ultimate Skill".
 - **`computeBranch(named)`** — read-time helper that walks `named → genericSkillRef → generic.{type, suiteComponents}` and returns the branch label given the named skill's current level.
+  > **[SUPERSEDED by v2 Amendment 2026-07-14]** Branch no longer reads `type`; derived from `(suiteComponents present?, rank)`, fork at 4★+.
 - **Option D** — the named-skill-type-by-inheritance rule. Starless nodes carry `type`; named skills do not. Simplifies both axes: starless is purely structural, named is purely progression.
 - **Meta Schema RFC** — Series A (Yggdrasil I, II, III, …). Schema-type Meta Shifts that reshape the tree's structure or vocabulary.
 - **TM Index** — Series B (TM Index (2026 Q2) = G7; TM Index (2026 Q3) = planned). Trust Magnitude scoring engine, versioned by quarter.
@@ -110,7 +152,7 @@ The following terms are the shared vocabulary of Yggdrasil II. They live authori
 | # | Branch | Decision |
 |---|---|---|
 | Q1 | 5★ naming collision | "Ultimate" = 5★ rank universally (Suite: **Ultimate**, Unique: **Unique Ultimate**). Intentional gacha-anchor. The old taxonomy usage retires. |
-| Q2 | Branch declaration | Branch is completely derived from `(generic.type, generic.suiteComponents present?, named.level)`. Never declared on nodes; always computed at read-time. |
+| Q2 | Branch declaration | Branch is completely derived from `(generic.type, generic.suiteComponents present?, named.level)`. Never declared on nodes; always computed at read-time.<br>**[SUPERSEDED by v2 Amendment 2026-07-14]** Branch no longer reads `type`; derived from `(suiteComponents present?, rank)`, fork at 4★+. |
 | Q3 | Unique gates | **4★ Unique**: Origin + TM ≥ 100 (A). **5★ Unique Ultimate**: Origin + TM ≥ 250 (S). Origin counted in **fusion structure** (`prerequisites`), not `suiteComponents`. `suiteRef` membership does NOT disqualify from Unique — a "world-renowned handoff skill" that happens to live inside a suite is still Unique. |
 | Q4 | Type field on named skills | **Option D**: type lives on starless only, named inherits via `genericSkillRef` walk. Bulk rewrite: `extra`→`fusion`, `ultimate`→`fusion`, `unique`→`basic`. |
 | Q5 | Suite 5★ gate | **Preserved per #935** (Origin in suiteComponents + 5 A-graded origins in suiteComponents + TM ≥ 250). Asymmetric-by-design — Unique counts fusion-structure origins; Suite counts suiteComponents origins. The 5 existing 5★ Suites keep rank. |

--- a/founder/handovers/design-v6.1.1-world-tree-semantic-topology.md
+++ b/founder/handovers/design-v6.1.1-world-tree-semantic-topology.md
@@ -1,5 +1,6 @@
-# World Tree — Semantic Topology (Hero 2D + 3D Explorer)
+# World Tree — Semantic Topology (Hero 2D + 3D Explorer) — v2
 
+> **Version:** v2 · **Changelog:** 2026-07-14 — v2: branch derivation decoupled from `type`; driven by `suiteComponents` + rank; fork at 4★+; Transcendent dropped.
 > **Status:** ratified in session (2026-07-12), implementation handover.
 > **Target branch:** `design/homepage-gaia-tree-hero` (PR #1125 → `dev/yggdrasil-ii-staging`).
 > **Scope:** `docs/` + `*.md` only (design branch scope). No `src/`, no schema, no build-pipeline changes.
@@ -80,11 +81,13 @@ resolveSemantics(node, effectiveRank) → {
 | `basic` | `basic` | **root** | ○ basic | — |
 | `extra` | `fusion` | **crown** | ◇ fusion | — |
 | `ultimate` | `fusion` | **crown** | ◆ suite | I: `type==='ultimate'` · II: `suiteComponents` present |
-| `unique` | `basic` | **outside** | ◉ unique | I: `type==='unique'` · II: `type==='basic' && effRank≥4★ && !suiteComponents` |
+| `unique` | `basic` | **outside** | ◉ unique | I: `type==='unique'` · II: `effRank≥4★ && !suiteComponents` |
+
+> **Orthogonality (v2):** Type and Branch are orthogonal. `type` (basic|fusion) is pure structural metadata — a starless/generic node is `fusion` iff it has prerequisites — and is NEVER consulted for branch. Branch is driven solely by `suiteComponents` presence and rank. In practice fusion and suiteComponents usually coincide, but they are independent fields: a `fusion` node with no `suiteComponents` is Unique branch, and a `basic` node carrying `suiteComponents` is Suite branch. `suiteComponents` remains an input to downstream Trust Magnitude computation as well.
 
 ### 3.2 Read order (critical)
 
-1. **Detect `isUnique` first → hemisphere `outside`.** (This is why a Ygg II Unique being `type=basic` does NOT fall into roots — short-circuit before the hemisphere-by-type step.)
+1. **Detect `isUnique` first → hemisphere `outside`.** (This is why a Ygg II Unique — identified by `effRank≥4★ && !suiteComponents`, not `type` — does NOT fall into roots; the short-circuit fires before the hemisphere-by-type step.)
 2. Detect `isSuite`.
 3. Hemisphere by type (`basic`→root, `fusion`/`extra`/`ultimate`→crown).
 4. `coreness` = normalized effective rank (see §4).

--- a/registry/schema/meta.json
+++ b/registry/schema/meta.json
@@ -16,7 +16,7 @@
       "1★": "Awakened",
       "2★": "Named",
       "3★": "Evolved",
-      "4★": "Hardened",
+      "4★": "Extra",
       "5★": "Ultimate",
       "6★": "Apex"
     },

--- a/registry/schema/meta.json
+++ b/registry/schema/meta.json
@@ -17,7 +17,7 @@
       "2★": "Named",
       "3★": "Evolved",
       "4★": "Hardened",
-      "5★": "Transcendent",
+      "5★": "Ultimate",
       "6★": "Apex"
     },
     "colors": {
@@ -56,74 +56,34 @@
         "bg": "rgba(251,191,36,.22)",
         "border": "rgba(251,191,36,.55)"
       }
-    },
-    "evidenceFloors": {
-      "0★": null,
-      "1★": null,
-      "2★": [
-        "C",
-        "B",
-        "A"
-      ],
-      "3★": [
-        "B",
-        "A"
-      ],
-      "4★": [
-        "B",
-        "A"
-      ],
-      "5★": [
-        "B",
-        "A"
-      ],
-      "6★": [
-        "A"
-      ]
     }
   },
   "types": {
     "order": [
       "basic",
-      "extra",
-      "unique",
-      "ultimate"
+      "fusion"
     ],
     "labels": {
-      "basic": "Basic Skill",
-      "extra": "Extra Skill",
-      "unique": "Unique Skill",
-      "ultimate": "Ultimate Skill"
+      "basic": "Basic",
+      "fusion": "Fusion"
     },
     "symbols": {
       "basic": "○",
-      "extra": "◇",
-      "unique": "◉",
-      "ultimate": "◆"
+      "fusion": "◆"
     },
     "colors": {
       "basic": {
         "hex": "#38bdf8",
         "rgb": "56,189,248"
       },
-      "extra": {
-        "hex": "#c084fc",
-        "rgb": "192,132,252"
-      },
-      "unique": {
-        "hex": "#7c3aed",
-        "rgb": "124,58,237"
-      },
-      "ultimate": {
+      "fusion": {
         "hex": "#f59e0b",
         "rgb": "245,158,11"
       }
     },
     "minPrereqs": {
       "basic": 0,
-      "extra": 2,
-      "unique": 0,
-      "ultimate": 5
+      "fusion": 1
     },
     "ultimateFusionCriteria": {
       "description": "All prerequisites must be named skills. The proposer must hold origin status on at least 1 of them.",

--- a/registry/schema/skill.schema.json
+++ b/registry/schema/skill.schema.json
@@ -37,11 +37,9 @@
       "type": "string",
       "enum": [
         "basic",
-        "extra",
-        "unique",
-        "ultimate"
+        "fusion"
       ],
-      "description": "Skill classification type."
+      "description": "Skill classification type: basic (no prerequisites) or fusion (≥1 prerequisite)."
     },
     "summary": {
       "type": "string",
@@ -260,7 +258,7 @@
         "type": {
           "type": "string",
           "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
-          "description": "Evidence Type — the provenance of the demonstration (where it came from, not how strong it is). Kebab-case, validated against meta.json evidence.types (initially arxiv, repo, github-stars); list-driven so new types can be added in meta.json without a schema change. Carries the provenance meaning that the deprecated `class` field used to conflate. Distinct from the skill `type` taxonomy (basic/extra/unique/ultimate)."
+          "description": "Evidence Type — the provenance of the demonstration (where it came from, not how strong it is). Kebab-case, validated against meta.json evidence.types (initially arxiv, repo, github-stars); list-driven so new types can be added in meta.json without a schema change. Carries the provenance meaning that the deprecated `class` field used to conflate. Distinct from the skill `type` taxonomy (basic/fusion)."
         },
         "grade": {
           "type": "string",
@@ -578,54 +576,6 @@
         "properties": {
           "type": {
             "const": "basic"
-          }
-        }
-      },
-      "then": {
-        "properties": {
-          "prerequisites": {
-            "maxItems": 0
-          }
-        }
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": {
-            "const": "extra"
-          }
-        }
-      },
-      "then": {
-        "properties": {
-          "prerequisites": {
-            "minItems": 2
-          }
-        }
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": {
-            "const": "ultimate"
-          }
-        }
-      },
-      "then": {
-        "properties": {
-          "prerequisites": {
-            "minItems": 3
-          }
-        }
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": {
-            "const": "unique"
           }
         }
       },

--- a/scripts/check_rank_vocabulary.py
+++ b/scripts/check_rank_vocabulary.py
@@ -11,14 +11,15 @@ EXIT CODES
   1  — one or more hard violations found in non-allowlisted files
 
 BANNED PATTERNS
-  \\bTranscendent\\b      — old 5★ rank name; now "Ultimate" (Suite) / "Unique Ultimate" (Unique)
-  \\bHardened\\b          — old 4★ rank name; now "Extra" (Suite) / "Unique" (Unique branch)
-  \\bExtra\\s+Skill\\b    — old taxonomy type label; now "Fusion Skill" / type=fusion
-  \\bUltimate\\s+Skill\\b — old taxonomy type label; same replacement
+  \\bTranscendent\\b    — old 5★ rank name; now "Ultimate" (Suite) / "Unique Ultimate" (Unique)
+  \\bHardened\\b        — old 4★ rank name; now "Extra" (Suite) / "Unique" (Unique branch)
+  \\bFusion\\s+Skill\\b — type words stand bare; the "Skill" suffix is a rank-word convention. Use "Fusion".
+  \\bBasic\\s+Skill\\b  — type words stand bare; the "Skill" suffix is a rank-word convention. Use "Basic".
 
-  NOTE: "Extra" alone and "Ultimate" alone are VALID Yggdrasil II rank words and
-  are NOT banned.  The regexes above use word-boundary matching so a bare "Ultimate"
-  in "5★ Ultimate" passes, while "Ultimate Skill" fails.
+  NOTE: The "Skill" suffix attaches to RANK words only — "Extra Skill", "Unique Skill",
+  "Ultimate Skill", "Apex Skill" are all VALID rank phrasings. TYPE words stand bare:
+  "Basic" and "Fusion" (never "Basic Skill" / "Fusion Skill"). Bare "Extra"/"Ultimate"
+  as rank names are valid too (word-boundary matching).
 
 ALLOWED (v2 vocabulary — never flagged)
   1★ Awakened · 2★ Named · 3★ Evolved
@@ -69,8 +70,8 @@ BANNED_PATTERNS = [
     # Pattern,  human label,  rationale
     (re.compile(r'\bTranscendent\b'),     'Transcendent',    'old 5★ rank name — use Ultimate / Unique Ultimate'),
     (re.compile(r'\bHardened\b'),         'Hardened',        'old 4★ rank name — use Extra (Suite) / Unique (Unique branch)'),
-    (re.compile(r'\bExtra\s+Skill\b'),    'Extra Skill',     'old taxonomy type label — use Fusion Skill / type=fusion'),
-    (re.compile(r'\bUltimate\s+Skill\b'), 'Ultimate Skill',  'old taxonomy type label — use Fusion Skill / type=fusion'),
+    (re.compile(r'\bFusion\s+Skill\b'), 'Fusion Skill',  'type words stand bare — the "Skill" suffix is reserved for rank words; use "Fusion"'),
+    (re.compile(r'\bBasic\s+Skill\b'),  'Basic Skill',   'type words stand bare — the "Skill" suffix is reserved for rank words; use "Basic"'),
 ]
 
 # ---------------------------------------------------------------------------
@@ -149,6 +150,7 @@ ALLOWLIST_PATHS = {
     'founder/handovers/design-v6.1.1-ascension-overdrive-shape-v2.md',
     'founder/handovers/design-v6.1.1-ascension-overdrive-shape-v3.md',
     'founder/handovers/YGGDRASIL_II_RATIFICATION_2026-07-07.md',  # Ratification doc references both old and new terms
+    'founder/handovers/design-v6.1.1-world-tree-semantic-topology.md',  # v2 topology; changelog names the dropped "Transcendent" term
     'founder/handovers/done/TRUST_METHODOLOGY_REPORT.md',         # Historical report
     'founder/handovers/done/g7-mattpocock-audit/_workflow_notes.md',  # Historical workflow notes
     'founder/handovers/phase-1.5/issues/I8.md',                   # Historical issue doc
@@ -258,8 +260,8 @@ def main():
 
     print('=== Yggdrasil II Rank Vocabulary Guard  (Refs #999) ===')
     print(f'Repo root : {repo_root}')
-    print(f'Banned    : Transcendent, Hardened, "Extra Skill", "Ultimate Skill"')
-    print(f'Allowed   : Extra, Ultimate, (all other Yggdrasil II rank words)')
+    print(f'Banned    : Transcendent, Hardened, "Basic Skill", "Fusion Skill"')
+    print(f'Allowed   : Extra/Ultimate + rank+Skill phrasings ("Extra Skill" etc.); Basic, Fusion (bare types)')
     print()
 
     hard, soft = scan(repo_root)

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -62,7 +62,7 @@ def _load_meta():
 
 
 _META = _load_meta()
-EVIDENCE_FLOOR = {k: set(v) if v else None for k, v in _META["levels"]["evidenceFloors"].items()}
+EVIDENCE_FLOOR = {k: set(v) if v else None for k, v in _META["levels"].get("evidenceFloors", {}).items()}
 MIN_PREREQS = _META["types"]["minPrereqs"]
 DEMERIT_IDS = set(_META.get("demerits", {}).get("order", []))
 DEMERIT_ELIGIBLE_LEVELS = set(_META.get("demerits", {}).get("eligibleLevels", []))

--- a/src/gaia_cli/data/registry/schema/meta.json
+++ b/src/gaia_cli/data/registry/schema/meta.json
@@ -16,7 +16,7 @@
       "1★": "Awakened",
       "2★": "Named",
       "3★": "Evolved",
-      "4★": "Hardened",
+      "4★": "Extra",
       "5★": "Ultimate",
       "6★": "Apex"
     },

--- a/src/gaia_cli/data/registry/schema/meta.json
+++ b/src/gaia_cli/data/registry/schema/meta.json
@@ -17,7 +17,7 @@
       "2★": "Named",
       "3★": "Evolved",
       "4★": "Hardened",
-      "5★": "Transcendent",
+      "5★": "Ultimate",
       "6★": "Apex"
     },
     "colors": {
@@ -56,74 +56,34 @@
         "bg": "rgba(251,191,36,.22)",
         "border": "rgba(251,191,36,.55)"
       }
-    },
-    "evidenceFloors": {
-      "0★": null,
-      "1★": null,
-      "2★": [
-        "C",
-        "B",
-        "A"
-      ],
-      "3★": [
-        "B",
-        "A"
-      ],
-      "4★": [
-        "B",
-        "A"
-      ],
-      "5★": [
-        "B",
-        "A"
-      ],
-      "6★": [
-        "A"
-      ]
     }
   },
   "types": {
     "order": [
       "basic",
-      "extra",
-      "unique",
-      "ultimate"
+      "fusion"
     ],
     "labels": {
-      "basic": "Basic Skill",
-      "extra": "Extra Skill",
-      "unique": "Unique Skill",
-      "ultimate": "Ultimate Skill"
+      "basic": "Basic",
+      "fusion": "Fusion"
     },
     "symbols": {
       "basic": "○",
-      "extra": "◇",
-      "unique": "◉",
-      "ultimate": "◆"
+      "fusion": "◆"
     },
     "colors": {
       "basic": {
         "hex": "#38bdf8",
         "rgb": "56,189,248"
       },
-      "extra": {
-        "hex": "#c084fc",
-        "rgb": "192,132,252"
-      },
-      "unique": {
-        "hex": "#7c3aed",
-        "rgb": "124,58,237"
-      },
-      "ultimate": {
+      "fusion": {
         "hex": "#f59e0b",
         "rgb": "245,158,11"
       }
     },
     "minPrereqs": {
       "basic": 0,
-      "extra": 2,
-      "unique": 0,
-      "ultimate": 5
+      "fusion": 1
     },
     "ultimateFusionCriteria": {
       "description": "All prerequisites must be named skills. The proposer must hold origin status on at least 1 of them.",

--- a/src/gaia_cli/data/registry/schema/skill.schema.json
+++ b/src/gaia_cli/data/registry/schema/skill.schema.json
@@ -37,11 +37,9 @@
       "type": "string",
       "enum": [
         "basic",
-        "extra",
-        "unique",
-        "ultimate"
+        "fusion"
       ],
-      "description": "Skill classification type."
+      "description": "Skill classification type: basic (no prerequisites) or fusion (≥1 prerequisite)."
     },
     "summary": {
       "type": "string",
@@ -260,7 +258,7 @@
         "type": {
           "type": "string",
           "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
-          "description": "Evidence Type — the provenance of the demonstration (where it came from, not how strong it is). Kebab-case, validated against meta.json evidence.types (initially arxiv, repo, github-stars); list-driven so new types can be added in meta.json without a schema change. Carries the provenance meaning that the deprecated `class` field used to conflate. Distinct from the skill `type` taxonomy (basic/extra/unique/ultimate)."
+          "description": "Evidence Type — the provenance of the demonstration (where it came from, not how strong it is). Kebab-case, validated against meta.json evidence.types (initially arxiv, repo, github-stars); list-driven so new types can be added in meta.json without a schema change. Carries the provenance meaning that the deprecated `class` field used to conflate. Distinct from the skill `type` taxonomy (basic/fusion)."
         },
         "grade": {
           "type": "string",
@@ -578,54 +576,6 @@
         "properties": {
           "type": {
             "const": "basic"
-          }
-        }
-      },
-      "then": {
-        "properties": {
-          "prerequisites": {
-            "maxItems": 0
-          }
-        }
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": {
-            "const": "extra"
-          }
-        }
-      },
-      "then": {
-        "properties": {
-          "prerequisites": {
-            "minItems": 2
-          }
-        }
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": {
-            "const": "ultimate"
-          }
-        }
-      },
-      "then": {
-        "properties": {
-          "prerequisites": {
-            "minItems": 3
-          }
-        }
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": {
-            "const": "unique"
           }
         }
       },

--- a/src/gaia_cli/promotion.py
+++ b/src/gaia_cli/promotion.py
@@ -33,7 +33,7 @@ def _load_meta():
 _META = _load_meta()
 LEVEL_ORDER = _META["levels"]["order"]
 LEVEL_NAMES = _META["levels"]["labels"]
-EVIDENCE_FLOOR = {k: set(v) if v else None for k, v in _META["levels"]["evidenceFloors"].items()}
+EVIDENCE_FLOOR = {k: set(v) if v else None for k, v in _META["levels"].get("evidenceFloors", {}).items()}
 
 
 def next_level(current: str) -> str | None:


### PR DESCRIPTION
## Yggdrasil II · Schema (#995)

Base: \`dev/yggdrasil-ii-staging\` (staging protocol — NOT main).

Collapses the starless \`type\` enum from 4 values → 2 and completes Evidence Floor removal (TM is now the sole gate).

### Changes
- **\`registry/schema/skill.schema.json\`** (+ src/gaia_cli mirror, byte-identical): \`type\` enum → \`["basic","fusion"]\`; deleted the \`extra\`/\`unique\`/\`ultimate\` \`allOf\` conditional invariants; kept the \`basic\` (prerequisites maxItems:0) guard.
- **\`registry/schema/meta.json\`** (+ mirror): \`types\` block → {basic, fusion}, bare labels \`"Basic"\`/\`"Fusion"\` (no "Skill" suffix), \`fusion\` minPrereqs=1; \`levels.labels\` 5★ "Transcendent"→"Ultimate" (6★ stays "Apex"); dropped \`levels.evidenceFloors\`.
- **\`src/gaia_cli/promotion.py\` + \`scripts/validate.py\`**: guarded the \`evidenceFloors\` readers (\`.get("evidenceFloors", {})\`) so the toolchain runs with Evidence Floor disabled — the correct post-removal behavior.
- **\`CONTEXT.md\`**: reserve the "Skill" suffix for rank words (Extra/Unique/Ultimate/Apex Skill); type words stand bare (Basic, Fusion). Convention note + banned-synonym entries.
- **\`founder/ORCHESTRATOR.md\`**: codify orchestrator superadmin mode (direct-edit authority over root \`*.md\` + \`founder/\`).

### Not touched (by design)
- \`namedSkill.schema.json\` — unchanged (Option D: named skills inherit type via \`genericSkillRef\`).
- \`registry/nodes/**\` — data migration is #997.

### Expected state (Option C)
\`python scripts/validate.py\` runs cleanly (no tracebacks) but reports **129 legacy-enum node errors** (124 \`extra\` + 5 \`ultimate\`). This is **expected** — registry data stays invalid against the new enum until the #997 bulk type-migration lands on staging. Not a defect of this PR.

Refs #995, #1002 (EPIC).