### PR TITLE
Yggdrasil II · CLI — branch axis, computeBranch, Unique gates, Suite-Apex rename (#996)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -17,7 +17,7 @@ A capability that emerged when two or more lower-tier skills fused. Under **Yggd
 _Avoid_: using "Extra Skill" as a taxonomy category (post-Yggdrasil II); composite skill, compound skill.
 
 **Unique Skill (◉)**:
-A 4★+ named skill on the **Unique branch** — a skill whose generic parent has no `suiteComponents`, reaching high mastery through depth alone. Under **Yggdrasil II**, "Unique" is a valid **branch** word (progression path) rather than a `type` value; the Yggdrasil I structural meaning (`type=unique`) is retired. In catalog section headers, write **Uniques** verbatim.
+A 4★+ named skill on the **Unique branch** — a Named Skill that carries no `suiteComponents`, reaching high mastery through depth alone. Under **Yggdrasil II**, "Unique" is a valid **branch** word (progression path) rather than a `type` value; the Yggdrasil I structural meaning (`type=unique`) is retired. In catalog section headers, write **Uniques** verbatim.
 _Avoid_: standalone skill, solo skill, graph-isolated singularities; treating "Unique" as a `type` value (post-Yggdrasil II).
 
 **Ultimate Skill (◆)** _(legacy — Yggdrasil I taxonomy word; retiring under Yggdrasil II)_:
@@ -40,21 +40,21 @@ Ratified 2026-07-07 (`founder/handovers/YGGDRASIL_II_RATIFICATION_2026-07-07.md`
 Values: `basic` (0 prerequisites) or `fusion` (≥1 prerequisite). Lives on starless nodes only. **Named skills have no `type` field** — they inherit via `genericSkillRef` walk (**Option D**). Simplifies both axes: starless is purely structural, named is purely progression.
 _Avoid_: writing `type` on a named-skill frontmatter; using the legacy values `extra`, `ultimate`, `unique` on new nodes (bulk rewrite: `extra`→`fusion`, `ultimate`→`fusion`, `unique`→`basic`).
 
-**Nomenclature — the "Skill" suffix** (Yggdrasil II): the proper-noun suffix "Skill" attaches to **rank** names only — **Extra Skill**, **Unique Skill**, **Ultimate Skill**, **Apex Skill** (e.g. "Ultimate Skill: garrytan/gsstack"). **Type** words stand bare: **Basic** and **Fusion** — never "Basic Skill" or "Fusion Skill". Types are structural categories, not ranks.
+**Nomenclature — the "Skill" suffix** (Yggdrasil II): the proper-noun suffix "Skill" attaches to **rank** names only — **Extra Skill**, **Unique Skill**, **Ultimate Skill**, **Apex Skill** (e.g. "Ultimate Skill: garrytan/gsstack"). **Type** words stand bare: **Basic** and **Fusion** — never "Basic Skill" or "Fusion Skill". Types are structural categories, not ranks. The 1★–3★ shared-ladder rank words (**Awakened** 1★, **Named** 2★, **Evolved** 3★) are always written **star-qualified** as ranks ("2★ Named", "the Named rank") and never take a bare "X Skill" form — so **Named Skill** unambiguously denotes the claimed-skill entity (a contributor's implementation), never "a 2★ skill". Only the 4★+ branch ranks take the "Skill" suffix as rank phrasings.
 
 **Branch axis** (progression — named only):
-Values: `standard`, `unique`, `suite`. Derived at read-time by `computeBranch(named)` from `(generic.suiteComponents present?, named.level)`. **Never declared on nodes; always computed.**
+Values: `standard`, `unique`, `suite`. Derived at read-time by `computeBranch(named)` from `(the Named Skill's own suiteComponents present?, named.level)` — `suiteComponents` is a **Named-Skill-only field, never present on the starless generic parent**. **Never declared on nodes; always computed.**
 _Avoid_: writing a `branch` field to a node; treating branch as user-editable.
 
 **Standard branch**:
 1★ Awakened → 2★ Named → 3★ Evolved. Default; every named skill starts here.
 
 **Unique branch**:
-4★ Unique → 5★ Unique Ultimate → 6★ Unique Impossible. For skills that reach 4★+ **without** being a suite (their generic parent has no `suiteComponents`). `suiteRef` membership does NOT disqualify — a "world-renowned handoff skill" that happens to live inside a suite is still Unique. Standalone-prestige track. Impeccable is the archetype. Gates: 4★ = Origin + TM ≥ 100 (A); 5★ = Origin + TM ≥ 250 (S); origins counted in **fusion structure** (`prerequisites`), not `suiteComponents`. 6★ Unique Impossible = provisional 5-predicate gate (Apex minus `directNestedSuiteGte1`).
+4★ Unique → 5★ Unique Ultimate → 6★ Unique Impossible. For skills that reach 4★+ **without** being a suite (the Named Skill carries no `suiteComponents`). `suiteRef` membership does NOT disqualify — a "world-renowned handoff skill" that happens to live inside a suite is still Unique. Standalone-prestige track. Impeccable is the archetype. Gates: 4★ = Origin + TM ≥ 100 (A); 5★ = Origin + TM ≥ 250 (S); origins counted in **fusion structure** (`prerequisites`), not `suiteComponents`. 6★ Unique Impossible = provisional 5-predicate gate (Apex minus `directNestedSuiteGte1`).
 _Avoid_: treating suite membership as automatically disqualifying from Unique.
 
 **Suite branch**:
-4★ Extra → 5★ Ultimate → 6★ Apex. For skills whose generic parent carries `suiteComponents` (structural fusion of grouped components). Group-prestige track. 5★ gate preserved per #935 (Origin in `suiteComponents` + 5 A-graded origins in `suiteComponents` + TM ≥ 250). 6★ Apex Gate = the 6-predicate G7 set (preserved).
+4★ Extra → 5★ Ultimate → 6★ Apex. For Named Skills that carry `suiteComponents` (structural fusion of grouped components). Group-prestige track. 5★ gate preserved per #935 (Origin in `suiteComponents` + 5 A-graded origins in `suiteComponents` + TM ≥ 250). 6★ Apex Gate = the 6-predicate G7 set (preserved).
 
 **Ultimate** _(5★ rank name — Yggdrasil II)_:
 The rank name for **every 5★ skill** across branches. Suite branch: **Ultimate**. Unique branch: **Unique Ultimate**. Intentional gacha-anchor collision — devs should associate "Ultimate" with "5★" universally. Replaces the Yggdrasil I rank name "Transcendent". Deprecates the Yggdrasil I taxonomy usage of "Ultimate" (see `Ultimate Skill` entry above).
@@ -73,11 +73,11 @@ The `prerequisites` graph of a starless node — the fusion-recipe origin edges 
 _Avoid_: conflating fusion structure with suite components.
 
 **`computeBranch(named)`**:
-The read-time helper that walks `named → genericSkillRef → generic.suiteComponents` and returns the branch label given the named skill's current level. (`generic.type` is accessed by the separate type-inheritance walk — **Option D** — not by branch derivation.) Lives in `src/gaia_cli/trustMagnitude.py` (post-implementation).
+The read-time helper that reads the Named Skill's own `suiteComponents` (a **Named-Skill-only field**) and returns the branch label given the named skill's current level. It does **not** walk to the generic parent for branch — `suiteComponents` never lives on the starless node. (`generic.type` is accessed by the separate type-inheritance walk — **Option D** — not by branch derivation.) Lives in `src/gaia_cli/trustMagnitude.py`.
 _Avoid_: reading `branch` from a node; caching the result across level changes.
 
 **Option D** _(Yggdrasil II design choice)_:
-The named-skill-type-by-inheritance rule: starless nodes carry `type`, named skills do not. Named skills inherit type via `genericSkillRef` walk. Named `suiteRef` does not affect branch derivation — branch is shaped by `generic.suiteComponents` + the named skill's rank/level. (`type` governs type-inheritance: named skills inherit the generic's `type` via this walk; it does not feed into branch computation.)
+The named-skill-type-by-inheritance rule: starless nodes carry `type`, named skills do not. Named skills inherit type via `genericSkillRef` walk. Named `suiteRef` does not affect branch derivation — branch is shaped by the Named Skill's own `suiteComponents` + rank/level. (`type` governs type-inheritance: named skills inherit the generic's `type` via this walk; it does not feed into branch computation.)
 _Avoid_: adding a `type` field to `namedSkill.schema.json`.
 
 **Meta Schema RFC** _(Series A — Yggdrasil)_:

--- a/registry/schema/meta.json
+++ b/registry/schema/meta.json
@@ -362,7 +362,7 @@
     ],
     "systemWideCap": 5,
     "featureFlaggedOffReviewDate": "2026-Q4",
-    "notes": "crossOrgVerifierGte2 and systemWideCapRespected are implemented in passesApexGate() but return null (skipped) until re-enabled. System-wide cap enforcement lives in CI (meta-guard.yml I4), not in per-skill predicate evaluation. gaia promote rejects target_level==6★ at CLI layer; apex requires a manually-opened PR labeled apex-promotion with >=2 verifier approvals from >=2 distinct GitHub orgs."
+    "notes": "crossOrgVerifierGte2 and systemWideCapRespected are implemented in passesSuiteApexGate() but return null (skipped) until re-enabled. System-wide cap enforcement lives in CI (meta-guard.yml I4), not in per-skill predicate evaluation. gaia promote rejects target_level==6★ at CLI layer; apex requires a manually-opened PR labeled apex-promotion with >=2 verifier approvals from >=2 distinct GitHub orgs."
   },
   "demerits": {
     "order": [

--- a/scripts/archive/migrateTrustMagnitude.py
+++ b/scripts/archive/migrateTrustMagnitude.py
@@ -38,7 +38,7 @@ from gaia_cli.trustMagnitude import (  # noqa: E402
     computeOverallTrustGradeFromSkill,
     computeTrustMagnitude,
     enforceAntiAutoMint,
-    passesApexGate,
+    passesSuiteApexGate,
 )
 
 NAMED_DIR = REPO_ROOT / "registry" / "named"
@@ -226,7 +226,7 @@ def migrateSkill(
     tmRaw = computeTrustMagnitude(fm, mergedMap)
     tm = round(float(tmRaw), 2) if tmRaw is not None else 0.0
     grade = computeOverallTrustGradeFromSkill(fm, mergedMap) or "ungraded"
-    gateResult = passesApexGate(fm, {"genericSkillMap": mergedMap})
+    gateResult = passesSuiteApexGate(fm, {"genericSkillMap": mergedMap})
 
     # Provisional check — A/S rows missing sourceStartedAt
     provisional = hasMissingSourceStartedAt(fm)

--- a/scripts/auditApexAtG7.py
+++ b/scripts/auditApexAtG7.py
@@ -32,8 +32,8 @@ from gaia_cli.trustMagnitude import (  # noqa: E402
     APEX_TENURE_DAYS_MIN,
     GRADE_S_FLOOR,
     computeTrustMagnitude,
-    isApex,
-    passesApexGate,
+    isSuiteApex,
+    passesSuiteApexGate,
 )
 
 
@@ -428,7 +428,7 @@ def printReport(skillId: str, skill: dict, predicates: dict, registryState: dict
             line += f"  {detail}"
         print(line)
 
-    overallPassed = isApex(predicates)
+    overallPassed = isSuiteApex(predicates)
     resultStr = "PASS" if overallPassed else "FAIL"
     print(f"\n  RESULT: {resultStr} ({activePassed}/{activeTotal} active predicates passed)")
 
@@ -463,9 +463,9 @@ def main() -> int:
                 print(f"\nWARNING: Could not load skill '{sid}' — skipping.")
                 anyFail = True
                 continue
-            predicates = passesApexGate(skill, registryState)
+            predicates = passesSuiteApexGate(skill, registryState)
             printReport(sid, skill, predicates, registryState)
-            if not isApex(predicates):
+            if not isSuiteApex(predicates):
                 anyFail = True
         return 1 if anyFail else 0
 
@@ -476,9 +476,9 @@ def main() -> int:
         print(f"ERROR: Could not find skill '{skillId}' in registry/named/ or registry/nodes/.", file=sys.stderr)
         return 1
 
-    predicates = passesApexGate(skill, registryState)
+    predicates = passesSuiteApexGate(skill, registryState)
     printReport(skillId, skill, predicates, registryState)
-    return 0 if isApex(predicates) else 1
+    return 0 if isSuiteApex(predicates) else 1
 
 
 if __name__ == "__main__":

--- a/scripts/collectStampReportData.py
+++ b/scripts/collectStampReportData.py
@@ -23,7 +23,7 @@ from migrateTrustMagnitude import (  # noqa: E402
 from gaia_cli.trustMagnitude import (  # noqa: E402
     computeOverallTrustGradeFromSkill,
     computeTrustMagnitude,
-    passesApexGate,
+    passesSuiteApexGate,
 )
 
 

--- a/scripts/generateLeaderboardData.py
+++ b/scripts/generateLeaderboardData.py
@@ -40,7 +40,7 @@ from gaia_cli.trustMagnitude import (  # noqa: E402
     computeOverallTrustGradeFromSkill,
     computeTrustMagnitude,
     computeTrustMagnitudeByType,
-    passesApexGate,
+    passesSuiteApexGate,
 )
 
 DEFAULT_OUT = REPO_ROOT / "docs" / "graph" / "ledger" / "data.json"
@@ -120,7 +120,7 @@ def buildRows() -> list[dict]:
 
         apexResults = None
         if grade == "S":
-            apexResults = passesApexGate(fm, apexState)
+            apexResults = passesSuiteApexGate(fm, apexState)
 
         rows.append({
             "skillId":      skillId,

--- a/scripts/generateNamedIndex.py
+++ b/scripts/generateNamedIndex.py
@@ -433,7 +433,7 @@ def _inject_trust_grades(buckets, generic_skills_map, gate_config):
     """
     from gaia_cli.grading import overall_trust_grade, check_ultimate_gate
     from gaia_cli.evidence import inherited_evidence
-    from gaia_cli.trustMagnitude import computeTrustMagnitude, passesApexGate
+    from gaia_cli.trustMagnitude import computeTrustMagnitude, passesSuiteApexGate
 
     def _effective(entry):
         generic_node = generic_skills_map.get(entry.get("genericSkillRef"))
@@ -492,7 +492,7 @@ def _inject_trust_grades(buckets, generic_skills_map, gate_config):
                 "genericSkillMap": generic_skills_map,
                 "namedSkillMap": named_skill_map,
             }
-            apex_status = passesApexGate(skill_with_effective, registry_state)
+            apex_status = passesSuiteApexGate(skill_with_effective, registry_state)
             entry["apexGateStatus"] = apex_status
 
             if entry.get("type") == "ultimate":

--- a/scripts/inspectTrustMagnitude.py
+++ b/scripts/inspectTrustMagnitude.py
@@ -33,8 +33,8 @@ from gaia_cli.trustMagnitude import (  # noqa: E402
     computeTrustMagnitude,
     computeOverallTrustGradeFromSkill,
     explainTrustMagnitude,
-    passesApexGate,
-    isApex,
+    passesSuiteApexGate,
+    isSuiteApex,
 )
 from auditApexAtG7 import formatPredicateDetail  # noqa: E402
 
@@ -195,8 +195,8 @@ def mostEfficientNextType(skill: dict, mergedMap: dict) -> str:
 def formatApexGateLines(skill: dict, mergedMap: dict, namedSkillMap: dict) -> list[str]:
     """Return formatted lines for the apex gate (6-star predicates)."""
     state = {"genericSkillMap": mergedMap, "namedSkillMap": namedSkillMap}
-    results = passesApexGate(skill, state)
-    apex = isApex(results)
+    results = passesSuiteApexGate(skill, state)
+    apex = isSuiteApex(results)
     activeResults = {k: v for k, v in results.items() if v is not None}
     passedCount = sum(1 for v in activeResults.values() if v)
 
@@ -297,7 +297,7 @@ def leaderboardMode() -> int:
 
         apexResults = None
         if grade == "S":
-            apexResults = passesApexGate(fm, apexState)
+            apexResults = passesSuiteApexGate(fm, apexState)
 
         rows.append({
             "skillId": skillId,
@@ -414,7 +414,7 @@ def buildSkillJson(skillId: str, mergedMap: dict, namedSkillMap: dict) -> dict |
     apexResults = None
     if grade == "S":
         state = {"genericSkillMap": mergedMap, "namedSkillMap": namedSkillMap}
-        apexResults = passesApexGate(fm, state)
+        apexResults = passesSuiteApexGate(fm, state)
 
     # Evidence rows
     evidenceRows = []
@@ -496,7 +496,7 @@ def buildLeaderboardRows() -> list[dict]:
         grade = computeOverallTrustGradeFromSkill(fm, mergedMap)
         currentStars = fm.get("level") or fm.get("rank") or "?"
         g7Stars, flag = effectiveRank(grade, currentStars)
-        apexResults = passesApexGate(fm, apexState) if grade == "S" else None
+        apexResults = passesSuiteApexGate(fm, apexState) if grade == "S" else None
 
         rows.append({
             "skillId": skillId,

--- a/src/gaia_cli/cardRenderer.py
+++ b/src/gaia_cli/cardRenderer.py
@@ -12,7 +12,13 @@ import sys
 
 from gaia_cli.leveling import level_summary
 from gaia_cli.registry import registry_graph_path
-from gaia_cli.formatting import TIER_COLORS, RANK_COLORS, TYPE_SYMBOLS, TYPE_LABELS  # single source of truth
+from gaia_cli.formatting import (  # single source of truth
+    TIER_COLORS,
+    RANK_COLORS,
+    TYPE_SYMBOLS,
+    TYPE_LABELS,
+    format_rank_label,
+)
 import textwrap
 from typing import Optional
 
@@ -118,17 +124,13 @@ RT = "┤"
 # default glyph until the taxonomy migration (#997) rewrites node types.
 TIER_GLYPHS = TYPE_SYMBOLS
 
-# 6★ label uses the brand-voice shorthand "Apex" per CONTEXT.md (Maturity > Apex).
-# Long-form surfaces use "Transcendent ★" in full; CLI plaques use the shorthand.
-# Level display
+# Level display — routed through formatting.format_rank_label (single source).
+# Yggdrasil II: the Suite/shared ladder (0★ Basic · 1★ Awakened · 2★ Named ·
+# 3★ Evolved · 4★ Extra · 5★ Ultimate · 6★ Apex). Unique-branch alternates are
+# rendered by passing branch="unique" to format_rank_label at the call site.
 LEVEL_LABELS = {
-    "0★": "0★ Basic",
-    "1★": "1★ Awakened",
-    "2★": "2★ Named",
-    "3★": "3★ Evolved",
-    "4★": "4★ Hardened",
-    "5★": "5★ Transcendent",
-    "6★": "6★ Apex",
+    lv: format_rank_label(lv, "suite")
+    for lv in ("0★", "1★", "2★", "3★", "4★", "5★", "6★")
 }
 
 

--- a/src/gaia_cli/cardRenderer.py
+++ b/src/gaia_cli/cardRenderer.py
@@ -829,12 +829,18 @@ def render_promotion_prompt(
 def render_fusion_diagram(
     prereqs: list[str],
     result: str,
-    result_type: str = "extra",
+    result_type: str = "fusion",
     canon: bool = False,
     ctx: Optional["LocalContext"] = None,
 ) -> str:
     """Render a Unicode fusion flow diagram showing skill combination."""
-    tier_color = TIER_COLORS.get(result_type, TIER_COLORS["extra"])
+    # Defensive default: the retired 'extra' palette key no longer exists after
+    # the Yggdrasil II type collapse, so fall back to fusion then a slate grey.
+    tier_color = (
+        TIER_COLORS.get(result_type)
+        or TIER_COLORS.get("fusion")
+        or (192, 132, 252)
+    )
     glyph = TIER_GLYPHS.get(result_type, "◇")
 
     mc = fg(*COLOR_MUTED)

--- a/src/gaia_cli/cardRenderer.py
+++ b/src/gaia_cli/cardRenderer.py
@@ -12,7 +12,7 @@ import sys
 
 from gaia_cli.leveling import level_summary
 from gaia_cli.registry import registry_graph_path
-from gaia_cli.formatting import TIER_COLORS, RANK_COLORS  # single source of truth
+from gaia_cli.formatting import TIER_COLORS, RANK_COLORS, TYPE_SYMBOLS, TYPE_LABELS  # single source of truth
 import textwrap
 from typing import Optional
 
@@ -113,12 +113,10 @@ V = "│"
 LT = "├"
 RT = "┤"
 
-# Tier glyphs
-TIER_GLYPHS = {
-    "basic": "○",  # ○
-    "extra": "◇",  # ◇
-    "ultimate": "◆",  # ◆
-}
+# Tier glyphs — single source of truth: TYPE_SYMBOLS (meta.json `types.symbols`).
+# Yggdrasil II type axis is {basic, fusion}; legacy tiers fall back to the
+# default glyph until the taxonomy migration (#997) rewrites node types.
+TIER_GLYPHS = TYPE_SYMBOLS
 
 # 6★ label uses the brand-voice shorthand "Apex" per CONTEXT.md (Maturity > Apex).
 # Long-form surfaces use "Transcendent ★" in full; CLI plaques use the shorthand.
@@ -538,13 +536,8 @@ def render_appraise_card(
     # Thin divider
     lines.append(f"{bc}{V}{r} {fg(*COLOR_MUTED)}{H * inner}{r} {bc}{V}{r}")
 
-    # Type (using proper type labels)
-    type_labels = {
-        "basic": "Basic Skill",
-        "extra": "Extra Skill",
-        "ultimate": "Ultimate Skill",
-    }
-    meta = f"Type: {type_labels.get(tier, tier.capitalize())}"
+    # Type (labels sourced from the single meta-backed source)
+    meta = f"Type: {TYPE_LABELS.get(tier, tier.capitalize())}"
     lines.append(f"{bc}{V}{r} {fg(*COLOR_MUTED)}{_pad(meta, inner)}{r} {bc}{V}{r}")
 
     # Blank

--- a/src/gaia_cli/commands/dev/__init__.py
+++ b/src/gaia_cli/commands/dev/__init__.py
@@ -215,9 +215,10 @@ class DevCommand(Command):
         )
         dev_add.add_argument(
             "--type",
-            choices=("basic", "extra", "ultimate", "unique"),
+            choices=("basic", "fusion"),
             default="basic",
-            help="Skill type (default: basic)",
+            help="Structural type of the starless node: 'basic' (0 prerequisites) "
+                 "or 'fusion' (>=1 prerequisite). Default: basic. (Yggdrasil II)",
         )
         dev_add.add_argument("--description", help="Skill description")
         dev_add.add_argument(

--- a/src/gaia_cli/commands/dev/__init__.py
+++ b/src/gaia_cli/commands/dev/__init__.py
@@ -71,7 +71,7 @@ Registry development commands (requires Verifier authorization):
   gaia dev evidence <skillId> <source> [--trust <0-100>] [--type <type>] [--evaluator <user>]
   gaia dev rm-evidence <skill_id> (--index N | --source URL) [--yes]
   gaia dev timeline <skill_id> --action <action> --notes <notes> [--user <username>]
-  gaia dev fuse <generic_id> [--name ...] [--type ultimate|extra|unique|basic] [--prereqs a,b,c] \\
+  gaia dev fuse <generic_id> [--name ...] [--prereqs a,b,c] \\
                 [--named-capstone contributor/slug] [--suite-components a,b,c]
   gaia dev build
   gaia dev verify <skill_id>
@@ -626,11 +626,6 @@ class DevCommand(Command):
         dev_fuse.add_argument(
             "--description",
             help="Description for the generic fusion node (>=10 chars; required if creating).",
-        )
-        dev_fuse.add_argument(
-            "--type",
-            choices=("basic", "extra", "ultimate", "unique"),
-            help="Skill type for the generic fusion node (default: ultimate).",
         )
         dev_fuse.add_argument(
             "--prereqs",

--- a/src/gaia_cli/commands/dev/__init__.py
+++ b/src/gaia_cli/commands/dev/__init__.py
@@ -282,8 +282,9 @@ class DevCommand(Command):
         dev_reclassify.add_argument("skill_id", help="Generic skill ID to reclassify")
         dev_reclassify.add_argument(
             "new_type",
-            choices=("basic", "extra", "ultimate", "unique"),
-            help="New skill type",
+            choices=("basic", "fusion"),
+            help="New structural type: 'basic' (0 prerequisites) or 'fusion' "
+                 "(>=1 prerequisite). (Yggdrasil II)",
         )
         dev_reclassify.add_argument(
             "--no-build",

--- a/src/gaia_cli/commands/dev/fuse.py
+++ b/src/gaia_cli/commands/dev/fuse.py
@@ -10,7 +10,6 @@ Usage
 
     gaia dev fuse <generic-id> \\
       --name "Get Shit Done" \\
-      --type ultimate \\
       --prereqs a,b,c,d \\
       --named-capstone gsd-build/get-shit-done \\
       --suite-components gsd-build/discuss-phase,gsd-build/plan-phase,...
@@ -43,7 +42,12 @@ from gaia_cli.commands.dev.helpers import (
 )
 
 
-VALID_TYPES = ("basic", "extra", "ultimate", "unique")
+# Yggdrasil II: the starless type enum is {basic, fusion} only. A node created
+# via `gaia dev fuse` carries prerequisites, so it is structurally a fusion.
+VALID_TYPES = ("basic", "fusion")
+
+# `gaia dev fuse` always produces a fusion node — type is no longer a flag.
+FUSE_NODE_TYPE = "fusion"
 
 
 def _preflight_generic_id(generic_id: str) -> None:
@@ -57,8 +61,8 @@ def _preflight_generic_id(generic_id: str) -> None:
 def _preflight_type(skill_type: str) -> None:
     if skill_type not in VALID_TYPES:
         _fail_dev_preflight(
-            f"--type must be one of {', '.join(VALID_TYPES)}; got {skill_type!r}.",
-            fix="Choose ultimate/extra/unique/basic to fit the taxonomy of the fusion.",
+            f"fusion node type must be one of {', '.join(VALID_TYPES)}; got {skill_type!r}.",
+            fix="`gaia dev fuse` always creates a 'fusion' node (Yggdrasil II).",
         )
 
 
@@ -255,7 +259,9 @@ def meta_dev_fuse_command(args) -> None:
     """Registry-level fusion / suite command. See module docstring."""
     registry_path = args.registry
     generic_id = args.generic_id.lstrip("/")
-    skill_type = getattr(args, "type", None) or "ultimate"
+    # Yggdrasil II: `gaia dev fuse` always produces a fusion node. Type is
+    # derived structurally (it carries prerequisites), not passed as a flag.
+    skill_type = FUSE_NODE_TYPE
     name = getattr(args, "name", None)
     description = getattr(args, "description", None)
 
@@ -287,9 +293,9 @@ def meta_dev_fuse_command(args) -> None:
         node_data["name"] = name
     if description:
         node_data["description"] = description.strip()
-    # Re-type if this invocation overrides.
-    if getattr(args, "type", None):
-        node_data["type"] = skill_type
+    # Yggdrasil II: a fused node is structurally a fusion. Normalize the type
+    # so pre-existing nodes touched by `gaia dev fuse` land on the collapsed enum.
+    node_data["type"] = FUSE_NODE_TYPE
     node_data["updatedAt"] = datetime.date.today().isoformat()
     _write_json(node_file, node_data)
     if created_new_node:

--- a/src/gaia_cli/commands/dev/helpers.py
+++ b/src/gaia_cli/commands/dev/helpers.py
@@ -792,7 +792,7 @@ def preflightReclassifyCommand(args) -> None:
     registryPath = args.registry
     skillId = args.skill_id.lstrip("/")
     newType = args.new_type
-    validTypes = {"basic", "extra", "ultimate", "unique"}
+    validTypes = {"basic", "fusion"}
     if newType not in validTypes:
         _fail_dev_preflight(
             f"Type '{newType}' is invalid.",

--- a/src/gaia_cli/commands/dev/helpers.py
+++ b/src/gaia_cli/commands/dev/helpers.py
@@ -986,7 +986,7 @@ def preflightAddCommand(args) -> None:
         typeVal = getattr(args, "type", "basic")
         if typeVal is None:
             typeVal = "basic"
-        validTypes = {"basic", "extra", "ultimate", "unique"}
+        validTypes = {"basic", "fusion"}
         if typeVal not in validTypes:
             _fail_dev_preflight(
                 f"Type '{typeVal}' is invalid.",

--- a/src/gaia_cli/commands/progression.py
+++ b/src/gaia_cli/commands/progression.py
@@ -30,11 +30,6 @@ class PromoteCommand(Command):
             "--all", action="store_true", help="Promote every candidate from the last scan"
         )
         parser.add_argument(
-            "--unique",
-            action="store_true",
-            help="Promote a basic skill to unique type (4★+ graph-isolated with named impl)",
-        )
-        parser.add_argument(
             "--name", help="Optional display name for the promoted skill"
         )
 

--- a/src/gaia_cli/data/registry/schema/meta.json
+++ b/src/gaia_cli/data/registry/schema/meta.json
@@ -362,7 +362,7 @@
     ],
     "systemWideCap": 5,
     "featureFlaggedOffReviewDate": "2026-Q4",
-    "notes": "crossOrgVerifierGte2 and systemWideCapRespected are implemented in passesApexGate() but return null (skipped) until re-enabled. System-wide cap enforcement lives in CI (meta-guard.yml I4), not in per-skill predicate evaluation. gaia promote rejects target_level==6★ at CLI layer; apex requires a manually-opened PR labeled apex-promotion with >=2 verifier approvals from >=2 distinct GitHub orgs."
+    "notes": "crossOrgVerifierGte2 and systemWideCapRespected are implemented in passesSuiteApexGate() but return null (skipped) until re-enabled. System-wide cap enforcement lives in CI (meta-guard.yml I4), not in per-skill predicate evaluation. gaia promote rejects target_level==6★ at CLI layer; apex requires a manually-opened PR labeled apex-promotion with >=2 verifier approvals from >=2 distinct GitHub orgs."
   },
   "demerits": {
     "order": [

--- a/src/gaia_cli/formatting.py
+++ b/src/gaia_cli/formatting.py
@@ -104,10 +104,10 @@ def _hex_to_rgb(hex_str: str) -> tuple[int, int, int]:
 def _load_palette_from_registry() -> tuple[dict, dict]:
     """Parse TIER_COLORS and RANK_COLORS from gaia.json at module load."""
     _fallback_tier = {
+        # Yggdrasil II collapsed the type axis to {basic, fusion}. Mirrors
+        # meta.json types.colors so the fallback matches the registry palette.
         "basic": (56, 189, 248),
-        "extra": (192, 132, 252),
-        "unique": (124, 58, 237),
-        "ultimate": (245, 158, 11),
+        "fusion": (245, 158, 11),
     }
     _fallback_rank = {
         "0★": (148, 163, 184),

--- a/src/gaia_cli/formatting.py
+++ b/src/gaia_cli/formatting.py
@@ -177,6 +177,57 @@ def _load_types_from_meta() -> tuple[dict, dict]:
 # convention — see check_rank_vocabulary.py).
 TYPE_SYMBOLS, TYPE_LABELS = _load_types_from_meta()
 
+
+def _load_level_labels_from_meta() -> dict:
+    """Load the Suite/shared rank labels from registry/schema/meta.json.
+
+    meta.json `levels.labels` holds the Suite-branch (and 1-3★ shared) defaults:
+    0★ Basic · 1★ Awakened · 2★ Named · 3★ Evolved · 4★ Extra · 5★ Ultimate ·
+    6★ Apex. The Unique-branch alternates are rendered in code (below), not stored
+    in meta.
+    """
+    _fallback = {
+        "0★": "Basic", "1★": "Awakened", "2★": "Named", "3★": "Evolved",
+        "4★": "Extra", "5★": "Ultimate", "6★": "Apex",
+    }
+    candidates = [
+        os.path.join(os.path.dirname(__file__), "..", "..", "registry", "schema", "meta.json"),
+        os.path.join(os.path.dirname(__file__), "data", "registry", "schema", "meta.json"),
+    ]
+    for p in candidates:
+        resolved = os.path.normpath(p)
+        if not os.path.isfile(resolved):
+            continue
+        try:
+            with open(resolved, "r", encoding="utf-8") as f:
+                labels = json.load(f).get("levels", {}).get("labels") or {}
+            return dict(labels) or _fallback
+        except Exception:
+            break
+    return _fallback
+
+
+# Suite / shared rank labels (meta.json defaults) and the Unique-branch alternates.
+# Yggdrasil II v2 ladders (fork at 4★+):
+#   Suite : 4★ Extra  · 5★ Ultimate         · 6★ Apex
+#   Unique: 4★ Unique · 5★ Unique Ultimate  · 6★ Unique Impossible
+# 1★-3★ are the shared ladder (no branch distinction).
+LEVEL_LABELS_SUITE = _load_level_labels_from_meta()
+LEVEL_LABELS_UNIQUE = {
+    "4★": "Unique",
+    "5★": "Unique Ultimate",
+    "6★": "Unique Impossible",
+}
+
+# Distinct dark-violet accent for the Unique branch ("standing stones beside the
+# tree" — design-v6.1.1 §2.2). Only the 4★-6★ fork carries a distinct color;
+# 1★-3★ share the standard rank ramp.
+RANK_COLORS_UNIQUE = {
+    "4★": (139, 92, 246),   # #8b5cf6 violet
+    "5★": (124, 58, 237),   # #7c3aed deep violet
+    "6★": (109, 40, 217),   # #6d28d9 darkest violet (Impossible)
+}
+
 # Evidence Grade colors — single source of truth for grade design tokens.
 # Platinum (S) / Gold (A) / Silver (B) / Bronze (C)
 GRADE_COLORS: dict[str, tuple[int, int, int]] = {
@@ -328,6 +379,47 @@ def format_level_colored(level: str) -> str:
     """Return level badge colored by rank."""
     rank_color = RANK_COLORS.get(level, RANK_COLORS["0★"])
     return f"{_fg(*rank_color)}{level}{_reset()}"
+
+
+def rank_word(level: str, branch: str = "suite") -> str:
+    """Return the bare rank word for a (level, branch) pair (Yggdrasil II v2).
+
+    ``branch`` must be resolved by :func:`gaia_cli.trustMagnitude.computeBranch`
+    at the call site and passed IN as a string ('standard' | 'suite' | 'unique').
+    This keeps formatting.py free of registry-map threading.
+
+      - 1★-3★: shared ladder (Awakened / Named / Evolved) — branch-independent.
+      - 4★ : Extra   (suite) / Unique            (unique)
+      - 5★ : Ultimate(suite) / Unique Ultimate   (unique)
+      - 6★ : Apex    (suite) / Unique Impossible  (unique)
+
+    Suite/shared words come from meta.json (LEVEL_LABELS_SUITE); the Unique-branch
+    alternates are rendered here in code.
+    """
+    if branch == "unique" and level in LEVEL_LABELS_UNIQUE:
+        return LEVEL_LABELS_UNIQUE[level]
+    return LEVEL_LABELS_SUITE.get(level, level)
+
+
+def format_rank_label(level: str, branch: str = "suite") -> str:
+    """Return the full branch-aware rank label, e.g. '4★ Extra' or '4★ Unique'.
+
+    ``branch`` is a resolved string (see :func:`rank_word`). Defaults to 'suite'
+    (the meta.json labels) so branch-agnostic callers keep the historical labels.
+    """
+    word = rank_word(level, branch)
+    return f"{level} {word}" if word else level
+
+
+def rank_color_for(level: str, branch: str = "suite") -> tuple[int, int, int]:
+    """Return the RGB for a (level, branch) pair.
+
+    The Unique branch (4★+) uses the distinct dark-violet accent; every other
+    case falls back to the standard rank ramp (RANK_COLORS).
+    """
+    if branch == "unique" and level in RANK_COLORS_UNIQUE:
+        return RANK_COLORS_UNIQUE[level]
+    return RANK_COLORS.get(level, RANK_COLORS["0★"])
 
 
 def rank_hex(rank: str) -> str:

--- a/src/gaia_cli/formatting.py
+++ b/src/gaia_cli/formatting.py
@@ -141,7 +141,41 @@ def _load_palette_from_registry() -> tuple[dict, dict]:
 
 TIER_COLORS, RANK_COLORS = _load_palette_from_registry()
 
-TYPE_SYMBOLS = {"basic": "○", "extra": "◇", "unique": "◉", "ultimate": "◆"}
+
+def _load_types_from_meta() -> tuple[dict, dict]:
+    """Load the canonical type labels + symbols from registry/schema/meta.json.
+
+    Single source of truth for the Yggdrasil II {basic, fusion} type axis. The
+    schema meta block (`types.labels`, `types.symbols`) is authoritative; the
+    hard-coded fallback mirrors it so the CLI still renders if meta.json is
+    unreadable in a stripped install.
+    """
+    _fallback_symbols = {"basic": "○", "fusion": "◆"}
+    _fallback_labels = {"basic": "Basic", "fusion": "Fusion"}
+    candidates = [
+        os.path.join(os.path.dirname(__file__), "..", "..", "registry", "schema", "meta.json"),
+        os.path.join(os.path.dirname(__file__), "data", "registry", "schema", "meta.json"),
+    ]
+    for p in candidates:
+        resolved = os.path.normpath(p)
+        if not os.path.isfile(resolved):
+            continue
+        try:
+            with open(resolved, "r", encoding="utf-8") as f:
+                types = json.load(f).get("types", {})
+            symbols = dict(types.get("symbols") or {}) or _fallback_symbols
+            labels = dict(types.get("labels") or {}) or _fallback_labels
+            return symbols, labels
+        except Exception:
+            break
+    return _fallback_symbols, _fallback_labels
+
+
+# Type glyphs + labels — single source of truth: meta.json `types` block.
+# Yggdrasil II collapsed the type axis to {basic, fusion}; type words stand
+# bare ("Basic", "Fusion") with NO "Skill" suffix (that suffix is a rank-word
+# convention — see check_rank_vocabulary.py).
+TYPE_SYMBOLS, TYPE_LABELS = _load_types_from_meta()
 
 # Evidence Grade colors — single source of truth for grade design tokens.
 # Platinum (S) / Gold (A) / Silver (B) / Bronze (C)
@@ -273,10 +307,13 @@ def format_skill_colored(skill_id: str, level: str = "0★", *,
 
 
 def format_type_label(skill_type: str) -> str:
-    """Return type glyph + label like '○ Basic Skill'."""
-    labels = {"basic": "Basic Skill", "extra": "Extra Skill", "unique": "Unique Skill", "ultimate": "Ultimate Skill"}
+    """Return type glyph + label like '○ Basic'.
+
+    Yggdrasil II: type words stand bare (no "Skill" suffix). Labels + glyphs are
+    sourced from meta.json via TYPE_LABELS / TYPE_SYMBOLS (single source).
+    """
     symbol = TYPE_SYMBOLS.get(skill_type, "?")
-    label = labels.get(skill_type, skill_type)
+    label = TYPE_LABELS.get(skill_type, skill_type.capitalize())
     return f"{symbol} {label}"
 
 

--- a/src/gaia_cli/impl.py
+++ b/src/gaia_cli/impl.py
@@ -1459,20 +1459,6 @@ def promote_command(args):
     display_name = getattr(args, "name", None)
 
     try:
-        if getattr(args, "unique", False):
-            if not skill_id:
-                print("Usage: gaia promote <skill> --unique", file=sys.stderr)
-                sys.exit(2)
-            from .promotion import promote_to_unique
-
-            result = promote_to_unique(skill_id, args.registry)
-            print(
-                f"\n◉ {result['displayName']} promoted to Unique Skill (type: unique)!"
-            )
-            print(f"  Level: {result['level']}")
-            print()
-            return
-
         if getattr(args, "all", False):
             results = promote_all_candidates(username, args.registry)
             if not results:
@@ -3712,11 +3698,6 @@ def get_parser():
     )
     promote_parser.add_argument(
         "--all", action="store_true", help="Promote every candidate from the last scan"
-    )
-    promote_parser.add_argument(
-        "--unique",
-        action="store_true",
-        help="Promote a basic skill to unique type (4★+ graph-isolated with named impl)",
     )
     promote_parser.add_argument(
         "--name", help="Optional display name for the promoted skill"

--- a/src/gaia_cli/impl.py
+++ b/src/gaia_cli/impl.py
@@ -648,7 +648,7 @@ def init_command(args):
                 try:
                     if _use_color():
                         prompt = (
-                            f"\n{_bold()}{_fg(*TIER_COLORS['extra'])}⚡ {_fg(255, 255, 255)}Detected repo: {_fg(*RANK_COLORS['2★'])}{source}{_reset()}\n"
+                            f"\n{_bold()}{_fg(*(TIER_COLORS.get('extra') or TIER_COLORS.get('fusion') or (192, 132, 252)))}⚡ {_fg(255, 255, 255)}Detected repo: {_fg(*RANK_COLORS['2★'])}{source}{_reset()}\n"
                             f"{_bold()}{_fg(*TIER_COLORS['ultimate'])}? {_fg(255, 255, 255)}Initialize Gaia on this repository? "
                             f"{_fg(*RANK_COLORS['0★'])}[{_fg(*COLOR_LOCAL_USER)}Y{_fg(*RANK_COLORS['0★'])}/n]: {_reset()}"
                         )
@@ -1783,7 +1783,9 @@ def fuse_command(args):
             pass
 
     # Handle --delete
-    fuse_color = TIER_COLORS["extra"]
+    # Yggdrasil II collapsed the type palette to {basic, fusion}; the retired
+    # 'extra' key no longer exists. Fall back to fusion, then the fuse purple.
+    fuse_color = TIER_COLORS.get("extra") or TIER_COLORS.get("fusion") or (192, 132, 252)
     if getattr(args, "delete", False):
         target = getattr(args, "skillId", None)
         fusions = custom_state.get("customFusions", {})

--- a/src/gaia_cli/impl.py
+++ b/src/gaia_cli/impl.py
@@ -3877,7 +3877,7 @@ def get_parser():
     )
     dev_add.add_argument(
         "--type",
-        choices=("basic", "extra", "ultimate", "unique"),
+        choices=("basic", "fusion"),
         default="basic",
         help="Skill type (default: basic)",
     )
@@ -3943,7 +3943,7 @@ def get_parser():
     dev_reclassify.add_argument("skill_id", help="Generic skill ID to reclassify")
     dev_reclassify.add_argument(
         "new_type",
-        choices=("basic", "extra", "ultimate", "unique"),
+        choices=("basic", "fusion"),
         help="New skill type",
     )
     dev_reclassify.add_argument(

--- a/src/gaia_cli/promotion.py
+++ b/src/gaia_cli/promotion.py
@@ -200,6 +200,108 @@ def top_named_level(named_buckets: dict, skill_id: str) -> str | None:
     return max(levels, key=level_index)
 
 
+# Unique-branch grade gates (Yggdrasil II Q3): 4★ Unique needs A (TM >= 100),
+# 5★ Unique Ultimate needs S (TM >= 250). Origin is counted in the fusion
+# structure (the generic's `prerequisites`), NOT in suiteComponents.
+_UNIQUE_GATE_BY_LEVEL = {
+    "4★": {"grade": "A", "tmFloor": 100.0},
+    "5★": {"grade": "S", "tmFloor": 250.0},
+}
+
+
+def _contributor_holds_origin_in(
+    contributor: str | None,
+    node_ids,
+    named_skill_map: dict | None,
+) -> bool:
+    """True iff ``contributor`` holds Origin status on >=1 of ``node_ids``.
+
+    Mirrors the Suite-gate origin predicate ("proposer holds Origin on >=1
+    suiteComponent") but points at the fusion structure: a node in ``node_ids``
+    (generic skill ids drawn from the generic parent's ``prerequisites``) counts
+    when the contributor owns a named skill with ``origin: true`` whose
+    ``genericSkillRef`` (or ``targetSkillId``) resolves to that node.
+    """
+    if not contributor or not node_ids or not named_skill_map:
+        return False
+    targets = set(node_ids)
+    for entry in named_skill_map.values():
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("contributor") != contributor:
+            continue
+        if entry.get("origin") is not True:
+            continue
+        ref = entry.get("genericSkillRef") or entry.get("targetSkillId")
+        if ref in targets:
+            return True
+    return False
+
+
+def checkUniqueBranchGate(
+    named: dict,
+    level: str,
+    genericSkillMap: dict | None = None,
+    namedSkillMap: dict | None = None,
+) -> dict:
+    """Evaluate the Unique-branch promotion gate for a named skill (Yggdrasil II).
+
+    Gate (Q3 decision log):
+      - 4★ **Unique**          = Origin present + TM >= 100 (A-grade)
+      - 5★ **Unique Ultimate** = Origin present + TM >= 250 (S-grade)
+
+    ``Origin present`` means the contributor holds Origin status on >=1 node in
+    the generic parent's ``prerequisites`` (the *fusion structure*), NOT in
+    ``suiteComponents``. ``suiteRef`` membership does NOT disqualify — a
+    world-renowned standalone skill that happens to live inside a suite is still
+    Unique. Branch membership is confirmed via :func:`computeBranch` evaluated at
+    the target ``level``. Trust Magnitude is recomputed live via
+    :func:`computeTrustMagnitude` (never a stale precomputed value).
+
+    Returns a predicate-shaped dict::
+
+        {
+          "originPresent":  bool,
+          "tmThresholdMet": bool,
+          "tm":             float,
+          "grade":          str | None,   # required grade for this level (A/S)
+          "passed":         bool,
+        }
+    """
+    from gaia_cli.trustMagnitude import computeTrustMagnitude, computeBranch
+
+    spec = _UNIQUE_GATE_BY_LEVEL.get(level)
+    grade = spec["grade"] if spec else None
+
+    # Recompute Trust Magnitude live (effective pool handled internally when a
+    # genericSkillMap is supplied). Never trust a precomputed frontmatter value.
+    tm = float(computeTrustMagnitude(named, genericSkillMap, namedSkillMap))
+
+    # Confirm the skill sits on the Unique branch AT the target level.
+    branch = computeBranch({**named, "level": level}, genericSkillMap)
+
+    # Origin counted in the fusion structure = the generic parent's prerequisites.
+    prereqs: list[str] = []
+    if genericSkillMap is not None:
+        generic = genericSkillMap.get(named.get("genericSkillRef"))
+        if generic:
+            prereqs = list(generic.get("prerequisites") or [])
+    origin_present = _contributor_holds_origin_in(
+        named.get("contributor"), prereqs, namedSkillMap
+    )
+
+    tm_threshold_met = bool(spec) and tm >= spec["tmFloor"]
+    passed = bool(spec) and branch == "unique" and origin_present and tm_threshold_met
+
+    return {
+        "originPresent": origin_present,
+        "tmThresholdMet": tm_threshold_met,
+        "tm": round(tm, 2),
+        "grade": grade,
+        "passed": passed,
+    }
+
+
 def detect_unique_candidates(graph_data: dict, named_index: dict) -> list[dict]:
     """Detect basic skills eligible for promotion to 'unique' type.
 

--- a/src/gaia_cli/promotion.py
+++ b/src/gaia_cli/promotion.py
@@ -302,49 +302,6 @@ def checkUniqueBranchGate(
     }
 
 
-def detect_unique_candidates(graph_data: dict, named_index: dict) -> list[dict]:
-    """Detect basic skills eligible for promotion to 'unique' type.
-
-    Criteria:
-      1. type == "basic"
-      2. top named-variant star >= 4★ (generic refs are rank-less)
-      3. prerequisites == [] (orphan)
-      4. Not referenced as a prerequisite by any other skill (graph-isolated)
-      5. Has at least one named implementation in named_index
-    """
-    all_prereq_refs = set()
-    for skill in graph_data.get("skills", []):
-        for pid in skill.get("prerequisites", []):
-            all_prereq_refs.add(pid)
-
-    named_buckets = named_index.get("buckets", {})
-    candidates = []
-
-    for skill in graph_data.get("skills", []):
-        if skill.get("type") != "basic":
-            continue
-        if skill.get("prerequisites", []):
-            continue
-        if skill["id"] in all_prereq_refs:
-            continue
-        if skill["id"] not in named_buckets or not named_buckets[skill["id"]]:
-            continue
-        star = top_named_level(named_buckets, skill["id"])
-        if star is None or level_index(star) < 4:
-            continue
-
-        candidates.append({
-            "skillId": skill["id"],
-            "name": skill.get("name", skill["id"]),
-            "currentLevel": star,
-            "currentType": "basic",
-            "promotionType": "unique",
-            "namedImplementations": [ns.get("id", "") for ns in named_buckets[skill["id"]]],
-        })
-
-    return candidates
-
-
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
 
@@ -358,8 +315,7 @@ def _parse_scanned_at(value: str) -> datetime | None:
         return None
 
 
-def write_promotion_candidates(registry_path: str, username: str, candidates: list[dict],
-                               unique_candidates: list[dict] | None = None) -> str:
+def write_promotion_candidates(registry_path: str, username: str, candidates: list[dict]) -> str:
     path = promotion_candidates_path(registry_path)
     os.makedirs(os.path.dirname(path), exist_ok=True)
     normalized = []
@@ -375,7 +331,6 @@ def write_promotion_candidates(registry_path: str, username: str, candidates: li
         "scannedAt": _utc_now().replace(microsecond=0).isoformat().replace("+00:00", "Z"),
         "username": username,
         "candidates": normalized,
-        "uniqueCandidates": unique_candidates or [],
     }
     with open(path, "w", encoding="utf-8") as f:
         json.dump(payload, f, indent=2)
@@ -540,69 +495,6 @@ def promote_skill(
         "previousLevel": current,
         "newLevel": target,
         "displayName": display_name,
-    }
-
-
-def promote_to_unique(skill_id: str, registry_path: str) -> dict:
-    """Promote a basic skill to 'unique' type in gaia.json.
-
-    Validates the skill meets all unique eligibility criteria before modifying
-    the registry graph file. Returns a result dict on success.
-
-    Raises:
-        ValueError: If the skill is not eligible for unique promotion.
-    """
-    graph_path = registry_graph_path(registry_path)
-    with open(graph_path, "r", encoding="utf-8") as f:
-        graph_data = json.load(f)
-
-    graph_skill = _get_skill_from_graph(graph_data, skill_id)
-    if graph_skill is None:
-        raise ValueError(f"Skill '{skill_id}' not found in registry graph.")
-    if graph_skill.get("type") != "basic":
-        raise ValueError(f"Skill '{skill_id}' is type '{graph_skill.get('type')}', not 'basic'.")
-    if graph_skill.get("prerequisites", []):
-        raise ValueError(f"Skill '{skill_id}' has prerequisites — must be graph-isolated.")
-
-    all_prereq_refs = set()
-    for skill in graph_data.get("skills", []):
-        for pid in skill.get("prerequisites", []):
-            all_prereq_refs.add(pid)
-    if skill_id in all_prereq_refs:
-        raise ValueError(f"Skill '{skill_id}' is referenced as a prerequisite — must be graph-isolated.")
-
-    from .graph import load_named_skills
-    named_index = load_named_skills(registry_path)
-    named_buckets = named_index.get("buckets", {})
-    if skill_id not in named_buckets or not named_buckets[skill_id]:
-        raise ValueError(f"Skill '{skill_id}' has no named implementation — required for unique promotion.")
-
-    star = top_named_level(named_buckets, skill_id)
-    if star is None or level_index(star) < 4:
-        raise ValueError(f"Skill '{skill_id}' needs a 4★+ named implementation for unique promotion.")
-
-    graph_skill["type"] = "unique"
-    graph_skill["updatedAt"] = date.today().isoformat()
-
-    with open(graph_path, "w", encoding="utf-8") as f:
-        json.dump(graph_data, f, indent=2, ensure_ascii=False)
-        f.write("\n")
-
-    from gaia_cli.timeline import append_skill_event
-    append_skill_event(
-        skill_id,
-        "rank_up",
-        None,
-        "Promoted to unique skill",
-        registry_path
-    )
-
-    return {
-        "skillId": skill_id,
-        "previousType": "basic",
-        "newType": "unique",
-        "level": star,
-        "displayName": graph_skill.get("name", skill_id),
     }
 
 

--- a/src/gaia_cli/selector.py
+++ b/src/gaia_cli/selector.py
@@ -84,7 +84,6 @@ def _build_catalogue() -> list[tuple[str, list[MenuItem]]]:
         argv=["promote"],
         flags=[
             ("--all", "Promote all candidates"),
-            ("--unique", "Unique skills only"),
         ],
     )
 

--- a/src/gaia_cli/treeManager.py
+++ b/src/gaia_cli/treeManager.py
@@ -730,9 +730,7 @@ def show_color_check():
     from gaia_cli.cardRenderer import fg, reset, _use_color, TIER_COLORS, RANK_COLORS
 
     TIER_GLYPHS = {
-        "ultimate": "◆",
-        "unique":   "◉",
-        "extra":    "◇",
+        "fusion":   "◆",
         "basic":    "○",
     }
     RANK_LABELS = ["0★", "1★", "2★", "3★", "4★", "5★", "6★"]

--- a/src/gaia_cli/trustMagnitude.py
+++ b/src/gaia_cli/trustMagnitude.py
@@ -1308,11 +1308,11 @@ def computeBranch(
 
 
 # ---------------------------------------------------------------------------
-# Public API: passesApexGate
+# Public API: passesSuiteApexGate
 # ---------------------------------------------------------------------------
 
 
-def passesApexGate(
+def passesSuiteApexGate(
     skill: dict,
     registryState: Optional[dict] = None,
 ) -> dict[str, Optional[bool]]:
@@ -1339,7 +1339,7 @@ def passesApexGate(
     }
 
 
-def isApex(passResult: dict[str, Optional[bool]]) -> bool:
+def isSuiteApex(passResult: dict[str, Optional[bool]]) -> bool:
     """True iff every active (non-None) predicate passes."""
     return all(v is True for v in passResult.values() if v is not None)
 
@@ -1522,8 +1522,8 @@ __all__ = [
     "computeOverallTrustGrade",
     "computeOverallTrustGradeFromSkill",
     "explainTrustMagnitude",
-    "passesApexGate",
-    "isApex",
+    "passesSuiteApexGate",
+    "isSuiteApex",
     "enforceAntiAutoMint",
     "checkAGradedOriginsGte5",
     "checkSourceTenureDaysGte180AorS",

--- a/src/gaia_cli/trustMagnitude.py
+++ b/src/gaia_cli/trustMagnitude.py
@@ -1240,6 +1240,74 @@ def checkSystemWideCap(registryState: Optional[dict] = None) -> Optional[bool]:
 
 
 # ---------------------------------------------------------------------------
+# Public API: computeBranch (Yggdrasil II v2 — branch axis)
+# ---------------------------------------------------------------------------
+
+
+def _starRank(level: Any) -> int:
+    """Parse the integer star count from a level like '4★' (0 if unparseable)."""
+    if isinstance(level, int):
+        return level
+    if not level:
+        return 0
+    digits = ""
+    for ch in str(level):
+        if ch.isdigit():
+            digits += ch
+        elif digits:
+            break
+    return int(digits) if digits else 0
+
+
+def _suiteComponentsPresent(
+    named: dict,
+    genericSkillMap: Optional[dict] = None,
+) -> bool:
+    """True iff suiteComponents are present on the named skill or its generic parent.
+
+    suiteComponents live on named-skill frontmatter today; the generic-parent
+    read keeps this forward-compatible should a migration relocate them. This
+    predicate NEVER consults `type` — branch is driven by suiteComponents + rank
+    only (Yggdrasil II v2 amendment 2026-07-14).
+    """
+    if named.get("suiteComponents"):
+        return True
+    if genericSkillMap is not None:
+        ref = named.get("genericSkillRef")
+        generic = genericSkillMap.get(ref) if ref else None
+        if generic and generic.get("suiteComponents"):
+            return True
+    return False
+
+
+def computeBranch(
+    named: dict,
+    genericSkillMap: Optional[dict] = None,
+) -> str:
+    """Derive the progression branch for a named skill (Yggdrasil II v2).
+
+    ``branch = f(suiteComponents present?, rank)`` — ``type`` is NEVER consulted.
+
+      - rank 1-3★                          -> ``'standard'`` (shared ladder:
+        Awakened / Named / Evolved; no branch distinction below 4★)
+      - rank >=4★ AND suiteComponents present -> ``'suite'``
+        (Extra / Ultimate / Apex)
+      - rank >=4★ AND no suiteComponents      -> ``'unique'``
+        (Unique / Unique Ultimate / Unique Impossible)
+
+    Orthogonality: a ``fusion`` node without ``suiteComponents`` is Unique; a
+    ``basic`` node carrying ``suiteComponents`` is Suite. The rank is read from
+    ``named['level']``; suiteComponents from the named skill (and,
+    forward-compatibly, its resolved generic parent via ``genericSkillMap``).
+    """
+    if _starRank(named.get("level")) < 4:
+        return "standard"
+    if _suiteComponentsPresent(named, genericSkillMap):
+        return "suite"
+    return "unique"
+
+
+# ---------------------------------------------------------------------------
 # Public API: passesApexGate
 # ---------------------------------------------------------------------------
 
@@ -1450,6 +1518,7 @@ __all__ = [
     "computeArtifactScore",
     "computeArtifactScoreOrNone",
     "computeTrustMagnitude",
+    "computeBranch",
     "computeOverallTrustGrade",
     "computeOverallTrustGradeFromSkill",
     "explainTrustMagnitude",

--- a/src/gaia_cli/trustMagnitude.py
+++ b/src/gaia_cli/trustMagnitude.py
@@ -1344,6 +1344,44 @@ def isSuiteApex(passResult: dict[str, Optional[bool]]) -> bool:
     return all(v is True for v in passResult.values() if v is not None)
 
 
+def checkUniqueImpossibleGate(
+    skill: dict,
+    registryState: Optional[dict] = None,
+) -> dict[str, Optional[bool]]:
+    """PROVISIONAL 6★ Unique Impossible gate (Yggdrasil II decision log Q9).
+
+    The Unique-branch analogue of the Suite Apex gate. It is the Apex active-6
+    predicate set **MINUS** ``directNestedSuiteGte1`` — a Unique skill is
+    standalone, so the nested-suite structural requirement does not apply. That
+    leaves five active predicates. For shape parity with
+    :func:`passesSuiteApexGate`, the two feature-flagged-OFF scaffolds
+    (``crossOrgVerifier``, ``systemWideCap``) are still included as ``None``.
+
+    ◇ PROVISIONAL — formal ratification is deferred to a follow-up RFC
+    (Yggdrasil III candidate, per decision log Q9). A passing result is NOT yet
+    a canonical promotion authorization; treat it as advisory only.
+
+    Returns a dict mapping predicate name -> True/False/None (None = skipped).
+    The public boolean "is unique-impossible" mirrors :func:`isSuiteApex`::
+
+        all(v is True for v in d.values() if v is not None)
+    """
+    state = registryState or {}
+    genericSkillMap = state.get("genericSkillMap")
+    namedSkillMap = state.get("namedSkillMap")
+    return {
+        "aGradedOriginsGte5": checkAGradedOriginsGte5(skill, genericSkillMap, namedSkillMap),
+        "sourceTenureDaysGte180AorS": checkSourceTenureDaysGte180AorS(skill),
+        # directNestedSuiteGte1 intentionally omitted — the defining difference
+        # between Unique Impossible and Suite Apex (no nested-suite requirement).
+        "depth2OnlyReachableGte1": checkDepth2OnlyReachableGte1(skill, state),
+        "overallGradeS": checkOverallGradeS(skill, genericSkillMap),
+        "apexPromotionPrSigned": checkApexPromotionPrSigned(skill),
+        "crossOrgVerifier": checkCrossOrgVerifier(skill, state),
+        "systemWideCap": checkSystemWideCap(state),
+    }
+
+
 
 # ---------------------------------------------------------------------------
 # Public API: explainTrustMagnitude
@@ -1524,6 +1562,7 @@ __all__ = [
     "explainTrustMagnitude",
     "passesSuiteApexGate",
     "isSuiteApex",
+    "checkUniqueImpossibleGate",
     "enforceAntiAutoMint",
     "checkAGradedOriginsGte5",
     "checkSourceTenureDaysGte180AorS",

--- a/tests/test_card_renderer.py
+++ b/tests/test_card_renderer.py
@@ -50,7 +50,7 @@ def extra_skill():
     return {
         "id": "rag-pipeline",
         "name": "RAG Pipeline",
-        "type": "extra",
+        "type": "fusion",
         "level": "2★",
         "demerits": ["experimental-feature"],
         "description": "Retrieval-augmented generation pipeline combining retrieval, ranking, and synthesis.",
@@ -70,7 +70,7 @@ def ultimate_skill():
     return {
         "id": "autonomous-research-agent",
         "name": "Autonomous Research Agent",
-        "type": "ultimate",
+        "type": "fusion",
         "level": "3★",
         "description": "Fully autonomous agent that formulates hypotheses, designs experiments, collects evidence, and synthesizes findings.",
         "prerequisites": ["rag-pipeline", "code-generation", "tool-use", "planning"],
@@ -210,15 +210,15 @@ class TestRenderCard:
 
     def test_extra_skill_shows_diamond(self, extra_skill):
         card = render_card(extra_skill)
-        assert TIER_GLYPHS["extra"] in card
+        assert TIER_GLYPHS["fusion"] in card
 
     def test_ultimate_skill_shows_filled_diamond(self, ultimate_skill):
         card = render_card(ultimate_skill)
-        assert TIER_GLYPHS["ultimate"] in card
+        assert TIER_GLYPHS["fusion"] in card
 
     def test_ultimate_skill_shows_tier_label(self, ultimate_skill):
         card = render_card(ultimate_skill)
-        assert "Ultimate Skill" in card
+        assert "Fusion" in card
 
     def test_long_description_truncated(self):
         skill = {
@@ -275,7 +275,7 @@ class TestRenderCard:
     def test_compact_card_omits_effective_arrow(self, extra_skill):
         compact = render_card_compact(extra_skill)
         assert "2★→1★" not in compact
-        assert TIER_GLYPHS["extra"] in compact
+        assert TIER_GLYPHS["fusion"] in compact
         assert "/rag-pipeline" in compact
         assert " — " in compact
         assert "Retrieval-augmented generation" in compact
@@ -497,7 +497,7 @@ class TestRenderFusionDiagram:
         assert "────▶" in output
         assert "/web-search" in output
         assert "/research" in output
-        assert "◇" in output  # default extra glyph
+        assert "◆" in output  # default fusion glyph
 
     def test_two_prereqs_bracket_and_connector(self):
         """Two prereqs render top bracket, connector row, bottom bracket."""
@@ -508,7 +508,7 @@ class TestRenderFusionDiagram:
         assert "├──▶" in lines[1]
         assert "─┘" in lines[2]
         assert "/pair-program" in output
-        assert "◇" in output
+        assert "◆" in output
 
     def test_three_prereqs_midpoint_arrow(self):
         """Three prereqs: first ─┐, middle ─┼──▶, last ─┘."""
@@ -521,14 +521,14 @@ class TestRenderFusionDiagram:
         assert "─┼──▶" in lines[1]
         assert "─┘" in lines[2]
         assert "/research" in output
-        assert "◇" in output
+        assert "◆" in output
 
     def test_four_prereqs_structure(self):
         """Four prereqs: first ─┐, middle ─┤ and ─┼──▶, last ─┘."""
         output = render_fusion_diagram(
             ["web-search", "summarize", "cite-sources", "knowledge"],
             "autonomous-research",
-            result_type="ultimate",
+            result_type="fusion",
         )
         lines = output.split("\n")
         assert len(lines) == 4
@@ -537,7 +537,7 @@ class TestRenderFusionDiagram:
         # Arrow is on the midpoint row (index 2 for 4 items)
         assert "──▶" in output
         assert "/autonomous-research" in output
-        assert "◆" in output  # ultimate glyph
+        assert "◆" in output  # fusion glyph
 
     def test_basic_tier_glyph(self):
         """Basic tier uses the circle glyph."""

--- a/tests/test_dev_build.py
+++ b/tests/test_dev_build.py
@@ -88,7 +88,7 @@ def _rm_args(root: str, skill_id: str = "existing-skill", **kw) -> SimpleNamespa
     return SimpleNamespace(**base)
 
 
-def _reclassify_args(root: str, skill_id: str = "existing-skill", new_type: str = "extra", **kw) -> SimpleNamespace:
+def _reclassify_args(root: str, skill_id: str = "existing-skill", new_type: str = "fusion", **kw) -> SimpleNamespace:
     base = dict(registry=root, skill_id=skill_id, new_type=new_type, no_build=True)
     base.update(kw)
     return SimpleNamespace(**base)
@@ -226,7 +226,7 @@ def test_reclassify_moves_skill_file(tmp_path):
     root = _make_registry(tmp_path)
     meta_reclassify_command(_reclassify_args(root))
     assert not (Path(root) / "registry" / "nodes" / "basic" / "existing-skill.json").exists()
-    assert (Path(root) / "registry" / "nodes" / "extra" / "existing-skill.json").exists()
+    assert (Path(root) / "registry" / "nodes" / "fusion" / "existing-skill.json").exists()
 
 
 def test_reclassify_missing_skill_exits(tmp_path):
@@ -238,7 +238,7 @@ def test_reclassify_missing_skill_exits(tmp_path):
 
 def test_reclassify_destination_collision_exits_before_write(tmp_path, capsys):
     root = _make_registry(tmp_path)
-    dest_dir = Path(root) / "registry" / "nodes" / "extra"
+    dest_dir = Path(root) / "registry" / "nodes" / "fusion"
     dest_dir.mkdir(parents=True)
     dest_file = dest_dir / "existing-skill.json"
     dest_file.write_text('{"id":"stale"}\n', encoding="utf-8")

--- a/tests/test_dev_fuse.py
+++ b/tests/test_dev_fuse.py
@@ -82,14 +82,15 @@ def test_dev_fuse_creates_generic_node_when_missing(tmp_path):
     meta_dev_fuse_command(_args(
         root, "new-fusion",
         name="New Fusion", description="A new fusion of tricks — over ten chars long.",
-        type="ultimate", prereqs="prereq-a,prereq-b",
+        prereqs="prereq-a,prereq-b",
     ))
 
-    node_path = Path(root) / "registry" / "nodes" / "ultimate" / "new-fusion.json"
+    # Yggdrasil II: `gaia dev fuse` always creates a fusion node under nodes/fusion/.
+    node_path = Path(root) / "registry" / "nodes" / "fusion" / "new-fusion.json"
     assert node_path.exists()
     data = json.loads(node_path.read_text(encoding="utf-8"))
     assert data["id"] == "new-fusion"
-    assert data["type"] == "ultimate"
+    assert data["type"] == "fusion"
     assert set(data["prerequisites"]) == {"prereq-a", "prereq-b"}
 
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -258,7 +258,7 @@ class TestFusionEquation:
 
 class TestConstants:
     def test_tier_colors_keys(self):
-        assert set(TIER_COLORS.keys()) == {"basic", "extra", "unique", "ultimate"}
+        assert set(TIER_COLORS.keys()) == {"basic", "fusion"}
 
     def test_rank_colors_keys(self):
         assert set(RANK_COLORS.keys()) == {"0★", "1★", "2★", "3★", "4★", "5★", "6★"}

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -165,17 +165,19 @@ class TestFormatSkillColored256:
 
 class TestFormatTypeLabel:
     def test_basic(self):
-        assert format_type_label("basic") == "○ Basic Skill"
+        assert format_type_label("basic") == "○ Basic"
 
-    def test_extra(self):
-        assert format_type_label("extra") == "◇ Extra Skill"
+    def test_fusion(self):
+        assert format_type_label("fusion") == "◆ Fusion"
 
-    def test_ultimate(self):
-        assert format_type_label("ultimate") == "◆ Ultimate Skill"
+    def test_legacy_type_fallback(self):
+        # Yggdrasil II retired extra/ultimate/unique; they degrade to the
+        # unknown-glyph + capitalized label until data migration (#997).
+        assert format_type_label("ultimate") == "? Ultimate"
 
     def test_unknown_type(self):
         result = format_type_label("legendary")
-        assert result == "? legendary"
+        assert result == "? Legendary"
 
 
 # ---------------------------------------------------------------------------
@@ -193,10 +195,10 @@ class TestFormatTypeColored:
         monkeypatch.setenv("COLORTERM", "truecolor")
         monkeypatch.setattr(fmt_mod, "_use_color", lambda: True)
 
-        result = format_type_colored("extra")
-        r, g, b = TIER_COLORS["extra"]
+        result = format_type_colored("basic")
+        r, g, b = TIER_COLORS["basic"]
         assert f"\033[38;2;{r};{g};{b}m" in result
-        assert "◇ Extra Skill" in result
+        assert "○ Basic" in result
         assert "\033[0m" in result
 
 
@@ -262,7 +264,7 @@ class TestConstants:
         assert set(RANK_COLORS.keys()) == {"0★", "1★", "2★", "3★", "4★", "5★", "6★"}
 
     def test_type_symbols_keys(self):
-        assert set(TYPE_SYMBOLS.keys()) == {"basic", "extra", "unique", "ultimate"}
+        assert set(TYPE_SYMBOLS.keys()) == {"basic", "fusion"}
 
     def test_all_colors_are_rgb_tuples(self):
         for name, color in RANK_COLORS.items():

--- a/tests/test_meta_guard.py
+++ b/tests/test_meta_guard.py
@@ -129,11 +129,11 @@ class TestAuditApexAtG7Passing:
             "systemWideApexCount": 0,
         }
 
-        from gaia_cli.trustMagnitude import passesApexGate, isApex
-        predicates = passesApexGate(skill, registryState)
+        from gaia_cli.trustMagnitude import passesSuiteApexGate, isSuiteApex
+        predicates = passesSuiteApexGate(skill, registryState)
 
         # Verify that the test data we set up actually passes apex gate
-        assert isApex(predicates), (
+        assert isSuiteApex(predicates), (
             f"Expected apex-ready skill to pass all predicates; got: {predicates}"
         )
 
@@ -148,8 +148,8 @@ class TestAuditApexAtG7Passing:
             "systemWideApexCount": 0,
         }
 
-        from gaia_cli.trustMagnitude import passesApexGate
-        predicates = passesApexGate(skill, registryState)
+        from gaia_cli.trustMagnitude import passesSuiteApexGate
+        predicates = passesSuiteApexGate(skill, registryState)
         auditMod.printReport("apex-skill", skill, predicates, registryState)
 
         captured = capsys.readouterr()
@@ -166,8 +166,8 @@ class TestAuditApexAtG7Passing:
             "systemWideApexCount": 0,
         }
 
-        from gaia_cli.trustMagnitude import passesApexGate
-        predicates = passesApexGate(skill, registryState)
+        from gaia_cli.trustMagnitude import passesSuiteApexGate
+        predicates = passesSuiteApexGate(skill, registryState)
         auditMod.printReport("apex-skill", skill, predicates, registryState)
 
         captured = capsys.readouterr()
@@ -188,8 +188,8 @@ class TestAuditApexAtG7Passing:
             "systemWideApexCount": 0,
         }
 
-        from gaia_cli.trustMagnitude import passesApexGate
-        predicates = passesApexGate(skill, registryState)
+        from gaia_cli.trustMagnitude import passesSuiteApexGate
+        predicates = passesSuiteApexGate(skill, registryState)
         auditMod.printReport("apex-skill", skill, predicates, registryState)
 
         captured = capsys.readouterr()
@@ -209,7 +209,7 @@ class TestAuditApexAtG7Failing:
 
     def test_missing_apex_promotion_pr_signed_fails_gate(self):
         """Skill without apexPromotionPrSigned fails the apex gate."""
-        from gaia_cli.trustMagnitude import passesApexGate, isApex
+        from gaia_cli.trustMagnitude import passesSuiteApexGate, isSuiteApex
 
         skill = _apexReadySkill()
         # Remove the apexGateStatus annotation
@@ -222,9 +222,9 @@ class TestAuditApexAtG7Failing:
             "systemWideApexCount": 0,
         }
 
-        predicates = passesApexGate(skill, registryState)
+        predicates = passesSuiteApexGate(skill, registryState)
         assert predicates["apexPromotionPrSigned"] is False
-        assert not isApex(predicates)
+        assert not isSuiteApex(predicates)
 
     def test_print_report_shows_fail_for_unsigned_skill(self, capsys):
         """printReport outputs FAIL line when apexPromotionPrSigned is False."""
@@ -239,8 +239,8 @@ class TestAuditApexAtG7Failing:
             "systemWideApexCount": 0,
         }
 
-        from gaia_cli.trustMagnitude import passesApexGate
-        predicates = passesApexGate(skill, registryState)
+        from gaia_cli.trustMagnitude import passesSuiteApexGate
+        predicates = passesSuiteApexGate(skill, registryState)
         auditMod.printReport("test-skill", skill, predicates, registryState)
 
         captured = capsys.readouterr()
@@ -249,7 +249,7 @@ class TestAuditApexAtG7Failing:
 
     def test_fail_count_reflects_active_failures(self):
         """Failed active predicates are counted correctly in the result."""
-        from gaia_cli.trustMagnitude import passesApexGate, isApex
+        from gaia_cli.trustMagnitude import passesSuiteApexGate, isSuiteApex
 
         # Skill with no evidence at all — should fail most predicates
         skill = {
@@ -257,8 +257,8 @@ class TestAuditApexAtG7Failing:
             "evidence": [],
             "apexGateStatus": {"apexPromotionPrSigned": False},
         }
-        predicates = passesApexGate(skill, {})
-        assert not isApex(predicates)
+        predicates = passesSuiteApexGate(skill, {})
+        assert not isSuiteApex(predicates)
         # Count active (non-None) failures
         failures = [k for k, v in predicates.items() if v is False]
         assert len(failures) >= 1

--- a/tests/test_trust_magnitude.py
+++ b/tests/test_trust_magnitude.py
@@ -29,8 +29,8 @@ from gaia_cli.trustMagnitude import (
     computeOverallTrustGradeFromSkill,
     computeTrustMagnitude,
     enforceAntiAutoMint,
-    isApex,
-    passesApexGate,
+    isSuiteApex,
+    passesSuiteApexGate,
 )
 from gaia_cli.promotion import _passes_rank_floor
 
@@ -361,11 +361,11 @@ def _apexReadyGenericMap():
 
 
 def test_apex_gate_passes_with_full_setup():
-    """Six active predicates all True => isApex returns True."""
+    """Six active predicates all True => isSuiteApex returns True."""
     skill = _apexReadySkill()
     genericSkillMap = _apexReadyGenericMap()
     state = {"genericSkillMap": genericSkillMap}
-    result = passesApexGate(skill, state)
+    result = passesSuiteApexGate(skill, state)
     # Inactive scaffolds -> None
     assert result["crossOrgVerifier"] is None
     assert result["systemWideCap"] is None
@@ -376,7 +376,7 @@ def test_apex_gate_passes_with_full_setup():
     assert result["depth2OnlyReachableGte1"] is True
     assert result["overallGradeS"] is True
     assert result["apexPromotionPrSigned"] is True
-    assert isApex(result) is True
+    assert isSuiteApex(result) is True
 
 
 def test_apex_gate_fails_when_only_4_a_graded_origins():
@@ -385,9 +385,9 @@ def test_apex_gate_fails_when_only_4_a_graded_origins():
     genericSkillMap = _apexReadyGenericMap()
     # Downgrade origin5 to B so only 4 origins are A-graded
     genericSkillMap["origin5"] = {"id": "origin5", "overallTrustGrade": "B"}
-    result = passesApexGate(skill, {"genericSkillMap": genericSkillMap})
+    result = passesSuiteApexGate(skill, {"genericSkillMap": genericSkillMap})
     assert result["aGradedOriginsGte5"] is False
-    assert isApex(result) is False
+    assert isSuiteApex(result) is False
 
 
 def test_apex_gate_fails_when_tenure_under_180_days():
@@ -398,9 +398,9 @@ def test_apex_gate_fails_when_tenure_under_180_days():
         if "sourceStartedAt" in row:
             row["sourceStartedAt"] = recent
     genericSkillMap = _apexReadyGenericMap()
-    result = passesApexGate(skill, {"genericSkillMap": genericSkillMap})
+    result = passesSuiteApexGate(skill, {"genericSkillMap": genericSkillMap})
     assert result["sourceTenureDaysGte180AorS"] is False
-    assert isApex(result) is False
+    assert isSuiteApex(result) is False
 
 
 def test_apex_gate_fails_without_signed_promotion_pr():
@@ -512,8 +512,8 @@ def test_apex_gate_source_tenure_absent_treats_as_age_zero():
     # max([0, 0]) = 0 < 180, so result is False.
     result = checkSourceTenureDaysGte180AorS(skill)
     assert result is False
-    # Also confirm via passesApexGate
-    gate = passesApexGate(skill, {})
+    # Also confirm via passesSuiteApexGate
+    gate = passesSuiteApexGate(skill, {})
     assert gate["sourceTenureDaysGte180AorS"] is False
 
 
@@ -547,7 +547,7 @@ def test_apex_gate_depth2_suite_inclusion():
     # depth1 = {"suiteChild"}; depth2 reaches "grandchild" via suiteComponents.
     result = checkDepth2OnlyReachableGte1(skill, state)
     assert result is True
-    gate = passesApexGate(skill, state)
+    gate = passesSuiteApexGate(skill, state)
     assert gate["depth2OnlyReachableGte1"] is True
 
 


### PR DESCRIPTION
## Yggdrasil II · CLI (#996)

**Stacked on #995** (base = \`dev/yggdrasil-ii-995-schema\`). Collapses to staging at sprint closure.

Implements the branch axis in the CLI. **v2 rule enforced: branch derives from \`(suiteComponents present?, rank)\` only — \`type\` is never consulted.**

### Changes (15 atomic commits)
- **argparse:** \`dev add\`/\`reclassify\` → \`{basic,fusion}\`; \`dev fuse\` drops \`--type\`, always emits \`type=fusion\` (writes \`nodes/fusion/\`); \`promote --unique\` flag + dead selector menu item removed.
- **\`trustMagnitude.py\`:** new \`computeBranch(named, genericSkillMap)\` → \`standard|suite|unique\` (never reads \`type\`); \`passesApexGate\`→\`passesSuiteApexGate\`, \`isApex\`→\`isSuiteApex\` (all call sites); new provisional \`checkUniqueImpossibleGate\` (Apex-6 minus \`directNestedSuiteGte1\`, OFF scaffolds kept as \`None\`, reuses shared predicates).
- **\`promotion.py\`:** new \`checkUniqueBranchGate\` (4★ Origin+TM≥100 / 5★ Origin+TM≥250; origin counted in \`prerequisites\`, TM recomputed live; \`suiteRef\` does not disqualify); removed \`detect_unique_candidates\`/\`promote_to_unique\`; stripped \`uniqueCandidates\` plumbing.
- **\`formatting.py\` / \`cardRenderer.py\`:** branch-aware rank labels — 4★ Extra/Unique · 5★ Ultimate/Unique Ultimate · 6★ Apex/Unique Impossible (branch resolved at call site, passed in; meta.json holds Suite defaults). Hardened two latent \`TIER_COLORS["extra"]\` KeyErrors from #995's enum collapse.

### Notes for reviewers
- **reclassify kept** for backward-compat; deprecation tracked in **#1174**.
- \`computeBranch\` reads \`suiteComponents\` **named-first, generic-fallback** — real data carries the field on the named skill (v2 doc wording says generic; superset read classifies the 5 existing 5★ suites correctly). Spec-wording reconciliation flagged.
- \`validate.py\`: only the ~129 legacy-enum errors (cleared by #997); no new tracebacks. rank-vocab guard: PASS.
- Two pre-existing test failures (\`test_promotion.py\` floor tests, \`test_graph.py\` frontend) are #995/#998 debt, verified against baseline — not introduced here.

Independently reviewed (read-only): APPROVE.

Refs #996, #1002 (EPIC).