### PR TITLE
docs: document safe PR description creation

### DIFF
--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -78,13 +78,31 @@ This will prompt you for:
 - **Assignees** — optional
 - **Labels** — optional
 
-Or specify details inline:
+For multiline descriptions, use a body file with real newlines. Do **not** pass literal `\\n` sequences or rely on shell `$'...'` quoting; malformed quoting can make GitHub display `\\n` (and sometimes a stray `$`).
+
+```bash
+cat > /tmp/pr-body.md <<'EOF'
+## Summary
+
+Describe the change here.
+EOF
+gh pr create --draft --title "Your PR Title" --body-file /tmp/pr-body.md
+```
+
+After creating or editing the PR, verify the stored body:
+
+```bash
+gh pr view <number> --json body --jq .body
+```
+
+Or specify details inline for a one-line body:
 ```bash
 gh pr create --draft --title "Your PR Title" --body "Description here"
 ```
 
 ## Tips
 
+- **Accidental staging leakage:** if a PR contains unrelated staging changes, do not force-push blindly. Start a clean branch from current `origin/main`, apply only the intended files, verify `git diff --stat origin/main...HEAD`, then push and create a replacement draft PR. Close the contaminated PR and cross-reference the replacement in a comment.
 - **Draft PRs** show as "Draft" and won't trigger auto-merge workflows
 - **Rebase before final PR** — `git rebase -i origin/main` to clean up commits
 - **Ready to review?** — Use `gh pr ready` to convert from draft to ready-for-review

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -78,13 +78,31 @@ This will prompt you for:
 - **Assignees** — optional
 - **Labels** — optional
 
-Or specify details inline:
+For multiline descriptions, use a body file with real newlines. Do **not** pass literal `\\n` sequences or rely on shell `$'...'` quoting; malformed quoting can make GitHub display `\\n` (and sometimes a stray `$`).
+
+```bash
+cat > /tmp/pr-body.md <<'EOF'
+## Summary
+
+Describe the change here.
+EOF
+gh pr create --draft --title "Your PR Title" --body-file /tmp/pr-body.md
+```
+
+After creating or editing the PR, verify the stored body:
+
+```bash
+gh pr view <number> --json body --jq .body
+```
+
+Or specify details inline for a one-line body:
 ```bash
 gh pr create --draft --title "Your PR Title" --body "Description here"
 ```
 
 ## Tips
 
+- **Accidental staging leakage:** if a PR contains unrelated staging changes, do not force-push blindly. Start a clean branch from current `origin/main`, apply only the intended files, verify `git diff --stat origin/main...HEAD`, then push and create a replacement draft PR. Close the contaminated PR and cross-reference the replacement in a comment.
 - **Draft PRs** show as "Draft" and won't trigger auto-merge workflows
 - **Rebase before final PR** — `git rebase -i origin/main` to clean up commits
 - **Ready to review?** — Use `gh pr ready` to convert from draft to ready-for-review

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,10 @@ Approved codebase-analysis tool, used as-needed (deep architecture audits, depen
 
 Never push directly to main.
 
+### PR description safety
+
+Use `--body-file` with real newlines for multiline PR text, then verify with `gh pr view --json body --jq .body`; avoid escaped `\\n`/shell quoting. If staging leaks into a PR, rebuild from `origin/main`, keep only intended files, and check `git diff --stat origin/main...HEAD` before pushing.
+
 ### Branch & Worktree Conventions
 
 - Confirm the target branch/worktree before editing. If user references a specific branch (e.g. `fix/links-3d-graph`), push there — do not create a new design branch.


### PR DESCRIPTION
## Summary

- Document safe multiline PR body creation with `--body-file`.
- Add recovery guidance for accidental staging leakage.
- Keep `.agents` and `.claude` PR skills synchronized.

## Validation

- `git diff --check`
