### PR TITLE
Yggdrasil II · Structured migration provenance (metaEpoch/migrationBatch) + meta-agnostic timeline invariant

### DIFF
--- a/docs/api/v1/skills/addy-osmani/agent-skills.json
+++ b/docs/api/v1/skills/addy-osmani/agent-skills.json
@@ -153,7 +153,9 @@
       "timestamp": "2026-07-16T08:36:42Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Generic parent 'git-ship-done-pipeline' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Generic parent 'git-ship-done-pipeline' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ],
   "links": {

--- a/docs/api/v1/skills/addy-osmani/performance-optimization.json
+++ b/docs/api/v1/skills/addy-osmani/performance-optimization.json
@@ -129,7 +129,9 @@
       "timestamp": "2026-07-16T08:36:42Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Generic parent 'performance-tuning' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+      "details": "Generic parent 'performance-tuning' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ],
   "links": {

--- a/docs/api/v1/skills/browser-use/browser-harness.json
+++ b/docs/api/v1/skills/browser-use/browser-harness.json
@@ -157,7 +157,9 @@
       "timestamp": "2026-07-16T08:36:42Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Generic parent 'browser-control' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+      "details": "Generic parent 'browser-control' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     },
     {
       "timestamp": "2026-07-16T08:36:42Z",
@@ -165,7 +167,9 @@
       "contributor": "mbtiongson1",
       "previousValue": "4★",
       "newValue": "3★",
-      "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=True TM=73.6 (< 100.0)) — demoted to 3★ Evolved"
+      "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=True TM=73.6 (< 100.0)) — demoted to 3★ Evolved",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ],
   "links": {

--- a/docs/api/v1/skills/firecrawl/firecrawl-build-scrape.json
+++ b/docs/api/v1/skills/firecrawl/firecrawl-build-scrape.json
@@ -112,7 +112,9 @@
       "timestamp": "2026-07-16T08:36:42Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Generic parent 'web-scrape' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Generic parent 'web-scrape' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ],
   "links": {

--- a/docs/api/v1/skills/firecrawl/firecrawl-build-search.json
+++ b/docs/api/v1/skills/firecrawl/firecrawl-build-search.json
@@ -88,7 +88,9 @@
       "timestamp": "2026-07-16T08:36:42Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Generic parent 'web-search' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+      "details": "Generic parent 'web-search' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ],
   "links": {

--- a/docs/api/v1/skills/firecrawl/firecrawl-skills.json
+++ b/docs/api/v1/skills/firecrawl/firecrawl-skills.json
@@ -152,7 +152,9 @@
       "timestamp": "2026-07-16T08:36:42Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Generic parent 'firecrawl' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Generic parent 'firecrawl' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     },
     {
       "timestamp": "2026-07-16T08:36:42Z",
@@ -160,7 +162,9 @@
       "contributor": "mbtiongson1",
       "previousValue": "4★",
       "newValue": "3★",
-      "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=73.5 (< 100.0)) — demoted to 3★ Evolved"
+      "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=73.5 (< 100.0)) — demoted to 3★ Evolved",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ],
   "links": {

--- a/docs/api/v1/skills/garrytan/garrytan.json
+++ b/docs/api/v1/skills/garrytan/garrytan.json
@@ -96,7 +96,9 @@
       "timestamp": "2026-07-16T08:36:42Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Generic parent 'vertical-slice-planning' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Generic parent 'vertical-slice-planning' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     },
     {
       "timestamp": "2026-07-16T08:36:42Z",
@@ -104,7 +106,9 @@
       "contributor": "mbtiongson1",
       "previousValue": "4★",
       "newValue": "3★",
-      "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=36.0 (< 100.0)) — demoted to 3★ Evolved"
+      "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=36.0 (< 100.0)) — demoted to 3★ Evolved",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ],
   "links": {

--- a/docs/api/v1/skills/garrytan/gstack.json
+++ b/docs/api/v1/skills/garrytan/gstack.json
@@ -130,7 +130,9 @@
       "timestamp": "2026-07-16T08:36:42Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Generic parent 'founder-mode-orchestration' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Generic parent 'founder-mode-orchestration' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ],
   "links": {

--- a/docs/api/v1/skills/gsd-build/get-shit-done.json
+++ b/docs/api/v1/skills/gsd-build/get-shit-done.json
@@ -140,7 +140,9 @@
       "timestamp": "2026-07-16T08:36:43Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Generic parent 'git-ship-done-pipeline' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Generic parent 'git-ship-done-pipeline' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     },
     {
       "timestamp": "2026-07-16T08:36:43Z",
@@ -148,7 +150,9 @@
       "contributor": "mbtiongson1",
       "previousValue": "4★",
       "newValue": "3★",
-      "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=52.2 (< 100.0)) — demoted to 3★ Evolved"
+      "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=52.2 (< 100.0)) — demoted to 3★ Evolved",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ],
   "links": {

--- a/docs/api/v1/skills/mattpocock/engineering.json
+++ b/docs/api/v1/skills/mattpocock/engineering.json
@@ -52,7 +52,9 @@
       "timestamp": "2026-07-16T08:36:43Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Generic parent 'engineering-discipline' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Generic parent 'engineering-discipline' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     },
     {
       "timestamp": "2026-07-16T08:36:43Z",
@@ -60,7 +62,9 @@
       "contributor": "mbtiongson1",
       "previousValue": "4★",
       "newValue": "3★",
-      "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=0.0 (< 100.0)) — demoted to 3★ Evolved"
+      "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=0.0 (< 100.0)) — demoted to 3★ Evolved",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ],
   "suiteComponents": [

--- a/docs/api/v1/skills/mattpocock/productivity.json
+++ b/docs/api/v1/skills/mattpocock/productivity.json
@@ -46,7 +46,9 @@
       "timestamp": "2026-07-16T08:36:43Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Generic parent 'productivity' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Generic parent 'productivity' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     },
     {
       "timestamp": "2026-07-16T08:36:43Z",
@@ -54,7 +56,9 @@
       "contributor": "mbtiongson1",
       "previousValue": "4★",
       "newValue": "3★",
-      "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=0.0 (< 100.0)) — demoted to 3★ Evolved"
+      "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=0.0 (< 100.0)) — demoted to 3★ Evolved",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ],
   "suiteComponents": [

--- a/docs/api/v1/skills/mattpocock/skills.json
+++ b/docs/api/v1/skills/mattpocock/skills.json
@@ -171,7 +171,9 @@
       "timestamp": "2026-07-16T08:36:43Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Generic parent 'skill-mastery' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Generic parent 'skill-mastery' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ],
   "links": {

--- a/docs/api/v1/skills/obra/subagent-driven-development.json
+++ b/docs/api/v1/skills/obra/subagent-driven-development.json
@@ -178,7 +178,9 @@
       "timestamp": "2026-07-16T08:36:44Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Generic parent 'subagent-driven-development' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Generic parent 'subagent-driven-development' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ],
   "links": {

--- a/docs/api/v1/skills/obra/superpowers.json
+++ b/docs/api/v1/skills/obra/superpowers.json
@@ -163,7 +163,9 @@
       "timestamp": "2026-07-16T08:36:44Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Generic parent 'superpowers' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Generic parent 'superpowers' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ],
   "links": {

--- a/docs/api/v1/skills/obra/using-git-worktrees.json
+++ b/docs/api/v1/skills/obra/using-git-worktrees.json
@@ -184,7 +184,9 @@
       "timestamp": "2026-07-16T08:36:44Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Generic parent 'using-git-worktrees' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Generic parent 'using-git-worktrees' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     },
     {
       "timestamp": "2026-07-16T08:36:44Z",
@@ -192,7 +194,9 @@
       "contributor": "mbtiongson1",
       "previousValue": "4★",
       "newValue": "3★",
-      "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=117.6 (≥ 100.0)) — demoted to 3★ Evolved"
+      "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=117.6 (≥ 100.0)) — demoted to 3★ Evolved",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ],
   "links": {

--- a/docs/api/v1/skills/obra/writing-plans.json
+++ b/docs/api/v1/skills/obra/writing-plans.json
@@ -198,7 +198,9 @@
       "timestamp": "2026-07-16T08:36:44Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Generic parent 'writing-plans' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Generic parent 'writing-plans' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     },
     {
       "timestamp": "2026-07-16T08:36:44Z",
@@ -206,7 +208,9 @@
       "contributor": "mbtiongson1",
       "previousValue": "4★",
       "newValue": "3★",
-      "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=110.1 (≥ 100.0)) — demoted to 3★ Evolved"
+      "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=110.1 (≥ 100.0)) — demoted to 3★ Evolved",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ],
   "links": {

--- a/docs/api/v1/skills/openai/few-shot-learning.json
+++ b/docs/api/v1/skills/openai/few-shot-learning.json
@@ -107,7 +107,9 @@
       "timestamp": "2026-07-16T08:36:44Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Generic parent 'few-shot-learning' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+      "details": "Generic parent 'few-shot-learning' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ],
   "links": {

--- a/docs/api/v1/skills/openai/self-consistency.json
+++ b/docs/api/v1/skills/openai/self-consistency.json
@@ -87,7 +87,9 @@
       "timestamp": "2026-07-16T08:36:44Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Generic parent 'self-consistency' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+      "details": "Generic parent 'self-consistency' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     },
     {
       "timestamp": "2026-07-16T08:36:44Z",
@@ -95,7 +97,9 @@
       "contributor": "mbtiongson1",
       "previousValue": "4★",
       "newValue": "3★",
-      "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.0 (≥ 100.0)) — demoted to 3★ Evolved"
+      "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.0 (≥ 100.0)) — demoted to 3★ Evolved",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ],
   "links": {

--- a/docs/api/v1/skills/pbakaus/impeccable.json
+++ b/docs/api/v1/skills/pbakaus/impeccable.json
@@ -179,7 +179,9 @@
       "timestamp": "2026-07-16T08:36:44Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Generic parent 'ux-audit' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+      "details": "Generic parent 'ux-audit' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ],
   "links": {

--- a/docs/api/v1/skills/ruvnet/agentdb.json
+++ b/docs/api/v1/skills/ruvnet/agentdb.json
@@ -127,7 +127,9 @@
       "timestamp": "2026-07-16T08:36:44Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Generic parent 'agent-memory-platform' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Generic parent 'agent-memory-platform' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     },
     {
       "timestamp": "2026-07-16T08:36:44Z",
@@ -135,7 +137,9 @@
       "contributor": "mbtiongson1",
       "previousValue": "4★",
       "newValue": "3★",
-      "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=81.0 (< 100.0)) — demoted to 3★ Evolved"
+      "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=81.0 (< 100.0)) — demoted to 3★ Evolved",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ],
   "links": {

--- a/docs/api/v1/skills/ruvnet/dual-mode.json
+++ b/docs/api/v1/skills/ruvnet/dual-mode.json
@@ -92,7 +92,9 @@
       "timestamp": "2026-07-16T08:36:44Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Generic parent 'dual-mode' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Generic parent 'dual-mode' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     },
     {
       "timestamp": "2026-07-16T08:36:44Z",
@@ -100,7 +102,9 @@
       "contributor": "mbtiongson1",
       "previousValue": "4★",
       "newValue": "3★",
-      "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=36.0 (< 100.0)) — demoted to 3★ Evolved"
+      "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=36.0 (< 100.0)) — demoted to 3★ Evolved",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ],
   "links": {

--- a/docs/api/v1/skills/ruvnet/reasoningbank.json
+++ b/docs/api/v1/skills/ruvnet/reasoningbank.json
@@ -168,7 +168,9 @@
       "timestamp": "2026-07-16T08:36:44Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Generic parent 'reasoning-pattern-bank' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Generic parent 'reasoning-pattern-bank' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     },
     {
       "timestamp": "2026-07-16T08:36:44Z",
@@ -176,7 +178,9 @@
       "contributor": "mbtiongson1",
       "previousValue": "4★",
       "newValue": "3★",
-      "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=88.5 (< 100.0)) — demoted to 3★ Evolved"
+      "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=88.5 (< 100.0)) — demoted to 3★ Evolved",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ],
   "links": {

--- a/docs/api/v1/skills/ruvnet/ruflo-v3.json
+++ b/docs/api/v1/skills/ruvnet/ruflo-v3.json
@@ -87,7 +87,9 @@
       "timestamp": "2026-07-16T08:36:44Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Generic parent 'platform-modernization-sprint' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Generic parent 'platform-modernization-sprint' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     },
     {
       "timestamp": "2026-07-16T08:36:44Z",
@@ -95,7 +97,9 @@
       "contributor": "mbtiongson1",
       "previousValue": "4★",
       "newValue": "3★",
-      "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=36.0 (< 100.0)) — demoted to 3★ Evolved"
+      "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=36.0 (< 100.0)) — demoted to 3★ Evolved",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ],
   "links": {

--- a/docs/api/v1/skills/ruvnet/ruflo.json
+++ b/docs/api/v1/skills/ruvnet/ruflo.json
@@ -174,7 +174,9 @@
       "timestamp": "2026-07-16T08:36:44Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Generic parent 'multi-topology-orchestration' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Generic parent 'multi-topology-orchestration' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ],
   "links": {

--- a/docs/api/v1/skills/safishamsi/graphify.json
+++ b/docs/api/v1/skills/safishamsi/graphify.json
@@ -142,7 +142,9 @@
       "timestamp": "2026-07-16T08:36:44Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Generic parent 'knowledge-graph-build' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Generic parent 'knowledge-graph-build' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     },
     {
       "timestamp": "2026-07-16T08:36:44Z",
@@ -150,7 +152,9 @@
       "contributor": "mbtiongson1",
       "previousValue": "4★",
       "newValue": "3★",
-      "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=122.9 (≥ 100.0)) — demoted to 3★ Evolved"
+      "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=122.9 (≥ 100.0)) — demoted to 3★ Evolved",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ],
   "links": {

--- a/docs/api/v1/skills/stanfordnlp/dspy.json
+++ b/docs/api/v1/skills/stanfordnlp/dspy.json
@@ -92,7 +92,9 @@
       "timestamp": "2026-07-16T08:36:44Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Generic parent 'prompt-optimization' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Generic parent 'prompt-optimization' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     },
     {
       "timestamp": "2026-07-16T08:36:44Z",
@@ -100,7 +102,9 @@
       "contributor": "mbtiongson1",
       "previousValue": "4★",
       "newValue": "3★",
-      "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.0 (≥ 100.0)) — demoted to 3★ Evolved"
+      "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.0 (≥ 100.0)) — demoted to 3★ Evolved",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/docs/graph/gaia.json
+++ b/docs/graph/gaia.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./schema/skill.schema.json",
-  "generatedAt": "2026-07-16T10:00:57Z",
+  "generatedAt": "2026-07-16T11:21:23Z",
   "meta": {
     "typeLabels": {
       "basic": "Basic",
@@ -71,6 +71,16 @@
       "niche-integration": "Niche integrations",
       "experimental-feature": "Experimental features",
       "heavyweight-dependency": "Heavyweight dependencies"
+    },
+    "metaEpochs": {
+      "order": [
+        "yggdrasil-i",
+        "yggdrasil-ii"
+      ],
+      "labels": {
+        "yggdrasil-i": "Yggdrasil I",
+        "yggdrasil-ii": "Yggdrasil II"
+      }
     },
     "clusterNames": {
       "0": "Text & Event",
@@ -214,7 +224,9 @@
           "timestamp": "2026-07-16T08:31:16Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 1,
@@ -332,7 +344,9 @@
           "timestamp": "2026-07-16T08:31:16Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -414,7 +428,9 @@
           "timestamp": "2026-07-16T08:31:16Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -518,7 +534,9 @@
           "timestamp": "2026-07-16T08:31:16Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -601,7 +619,9 @@
           "timestamp": "2026-07-16T08:31:17Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -694,7 +714,9 @@
           "timestamp": "2026-07-16T08:31:17Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 1,
@@ -764,7 +786,9 @@
           "timestamp": "2026-07-16T08:31:17Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 1,
@@ -848,7 +872,9 @@
           "timestamp": "2026-07-16T08:31:17Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -983,7 +1009,9 @@
           "timestamp": "2026-07-16T08:31:17Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -1130,7 +1158,9 @@
           "timestamp": "2026-07-16T08:31:17Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 6,
@@ -1242,7 +1272,9 @@
           "timestamp": "2026-07-16T08:31:17Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 5,
@@ -1334,7 +1366,9 @@
           "timestamp": "2026-07-16T08:31:17Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 6,
@@ -1534,7 +1568,9 @@
           "timestamp": "2026-07-16T08:31:17Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 2,
@@ -1663,7 +1699,9 @@
           "timestamp": "2026-07-16T08:31:17Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 5,
@@ -1755,7 +1793,9 @@
           "timestamp": "2026-07-16T08:31:17Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -1864,7 +1904,9 @@
           "timestamp": "2026-07-16T08:31:17Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 5,
@@ -1961,7 +2003,9 @@
           "timestamp": "2026-07-16T08:31:17Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -2532,7 +2576,9 @@
           "timestamp": "2026-07-16T08:31:17Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 1,
@@ -2901,7 +2947,9 @@
           "timestamp": "2026-07-16T08:31:17Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 6,
@@ -2975,7 +3023,9 @@
           "timestamp": "2026-07-16T08:31:18Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -3078,7 +3128,9 @@
           "timestamp": "2026-07-16T08:31:18Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 5,
@@ -3243,7 +3295,9 @@
           "timestamp": "2026-07-16T08:31:18Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -3414,7 +3468,9 @@
           "timestamp": "2026-07-16T08:31:18Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -3713,7 +3769,9 @@
           "timestamp": "2026-07-16T08:31:18Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 5,
@@ -3835,7 +3893,9 @@
           "timestamp": "2026-07-16T08:31:18Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 7,
@@ -3893,7 +3953,9 @@
           "timestamp": "2026-07-16T08:31:18Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -3982,7 +4044,9 @@
           "timestamp": "2026-07-16T08:31:18Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 6,
@@ -4041,7 +4105,9 @@
           "timestamp": "2026-07-16T08:31:18Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -4124,7 +4190,9 @@
           "timestamp": "2026-07-16T08:31:18Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -4261,7 +4329,9 @@
           "timestamp": "2026-07-16T08:31:18Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -4329,7 +4399,9 @@
           "timestamp": "2026-07-16T08:31:18Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -4385,7 +4457,9 @@
           "timestamp": "2026-07-16T08:31:18Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 1,
@@ -4441,7 +4515,9 @@
           "timestamp": "2026-07-16T08:31:18Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 4,
@@ -4551,7 +4627,9 @@
           "timestamp": "2026-07-16T08:31:19Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 2,
@@ -4700,7 +4778,9 @@
           "timestamp": "2026-07-16T08:31:19Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -4774,7 +4854,9 @@
           "timestamp": "2026-07-16T08:31:19Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -4871,7 +4953,9 @@
           "timestamp": "2026-07-16T08:31:19Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -5073,7 +5157,9 @@
           "timestamp": "2026-07-16T08:31:19Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -5620,7 +5706,9 @@
           "timestamp": "2026-07-16T08:31:19Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 6,
@@ -5738,7 +5826,9 @@
           "timestamp": "2026-07-16T08:31:19Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -6092,7 +6182,9 @@
           "timestamp": "2026-07-16T08:31:19Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -6257,7 +6349,9 @@
           "timestamp": "2026-07-16T08:31:19Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 5,
@@ -6331,7 +6425,9 @@
           "timestamp": "2026-07-16T08:31:19Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -6499,7 +6595,9 @@
           "timestamp": "2026-07-16T08:31:26Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from ultimate to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from ultimate to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -6658,7 +6756,9 @@
           "timestamp": "2026-07-16T08:31:19Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 6,
@@ -6759,7 +6859,9 @@
           "timestamp": "2026-07-16T08:31:19Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -7021,7 +7123,9 @@
           "timestamp": "2026-07-16T08:31:19Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -7206,7 +7310,9 @@
           "timestamp": "2026-07-16T08:31:19Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -7325,7 +7431,9 @@
           "timestamp": "2026-07-16T08:31:20Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -7393,7 +7501,9 @@
           "timestamp": "2026-07-16T08:31:26Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from ultimate to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from ultimate to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -7501,7 +7611,9 @@
           "timestamp": "2026-07-16T08:31:20Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -7559,7 +7671,9 @@
           "timestamp": "2026-07-16T08:31:20Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 6,
@@ -7653,7 +7767,9 @@
           "timestamp": "2026-07-16T08:31:20Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -7746,7 +7862,9 @@
           "timestamp": "2026-07-16T08:31:20Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -7835,7 +7953,9 @@
           "timestamp": "2026-07-16T08:31:20Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -8004,7 +8124,9 @@
           "timestamp": "2026-07-16T08:31:20Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -8629,7 +8751,9 @@
           "timestamp": "2026-07-16T08:31:20Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "verification": {
@@ -8697,7 +8821,9 @@
           "timestamp": "2026-07-16T08:31:20Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 2,
@@ -8773,7 +8899,9 @@
           "timestamp": "2026-07-16T08:31:20Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 2,
@@ -8853,7 +8981,9 @@
           "timestamp": "2026-07-16T08:31:20Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 5,
@@ -9154,7 +9284,9 @@
           "timestamp": "2026-07-16T08:31:21Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -9233,7 +9365,9 @@
           "timestamp": "2026-07-16T08:31:21Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -9420,7 +9554,9 @@
           "timestamp": "2026-07-16T08:31:21Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -9503,7 +9639,9 @@
           "timestamp": "2026-07-16T08:31:21Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 4,
@@ -9624,7 +9762,9 @@
           "timestamp": "2026-07-16T08:31:21Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 7,
@@ -9711,7 +9851,9 @@
           "timestamp": "2026-07-16T08:31:21Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -9893,7 +10035,9 @@
           "timestamp": "2026-07-16T08:31:21Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -9991,7 +10135,9 @@
           "timestamp": "2026-07-16T08:31:21Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 1,
@@ -10053,7 +10199,9 @@
           "timestamp": "2026-07-16T08:31:21Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -10172,7 +10320,9 @@
           "timestamp": "2026-07-16T08:31:26Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from ultimate to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from ultimate to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -10259,7 +10409,9 @@
           "timestamp": "2026-07-16T08:31:21Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -10456,7 +10608,9 @@
           "timestamp": "2026-07-16T08:31:21Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -11048,7 +11202,9 @@
           "timestamp": "2026-07-16T08:31:21Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -11131,7 +11287,9 @@
           "timestamp": "2026-07-16T08:31:21Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 5,
@@ -11214,7 +11372,9 @@
           "timestamp": "2026-07-16T08:31:22Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -11348,7 +11508,9 @@
           "timestamp": "2026-07-16T08:31:22Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -11423,7 +11585,9 @@
           "timestamp": "2026-07-16T08:31:22Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -11498,7 +11662,9 @@
           "timestamp": "2026-07-16T08:31:22Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 4,
@@ -11717,7 +11883,9 @@
           "timestamp": "2026-07-16T08:31:22Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -11793,7 +11961,9 @@
           "timestamp": "2026-07-16T08:31:22Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 5,
@@ -11977,7 +12147,9 @@
           "timestamp": "2026-07-16T08:31:22Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 6,
@@ -12242,7 +12414,9 @@
           "timestamp": "2026-07-16T08:31:22Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -12433,7 +12607,9 @@
           "timestamp": "2026-07-16T08:31:22Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 2,
@@ -12590,7 +12766,9 @@
           "timestamp": "2026-07-16T08:31:22Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -12701,7 +12879,9 @@
           "timestamp": "2026-07-16T08:31:22Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 4,
@@ -12756,7 +12936,9 @@
           "timestamp": "2026-07-16T08:31:22Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 1,
@@ -12822,7 +13004,9 @@
           "timestamp": "2026-07-16T08:31:22Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 6,
@@ -12896,7 +13080,9 @@
           "timestamp": "2026-07-16T08:31:23Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -13095,7 +13281,9 @@
           "timestamp": "2026-07-16T08:31:23Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -13175,7 +13363,9 @@
           "timestamp": "2026-07-16T08:31:23Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -13238,7 +13428,9 @@
           "timestamp": "2026-07-16T08:31:23Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -13356,7 +13548,9 @@
           "timestamp": "2026-07-16T08:31:23Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -13412,7 +13606,9 @@
           "timestamp": "2026-07-16T08:31:23Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 7,
@@ -13478,7 +13674,9 @@
           "timestamp": "2026-07-16T08:31:23Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 6,
@@ -13610,7 +13808,9 @@
           "timestamp": "2026-07-16T08:31:23Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 5,
@@ -13990,7 +14190,9 @@
           "timestamp": "2026-07-16T08:31:23Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 5,
@@ -14145,7 +14347,9 @@
           "timestamp": "2026-07-16T08:31:23Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 5,
@@ -14294,7 +14498,9 @@
           "timestamp": "2026-07-16T08:31:23Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -14368,7 +14574,9 @@
           "timestamp": "2026-07-16T08:31:23Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 6,
@@ -15079,7 +15287,9 @@
           "timestamp": "2026-07-16T08:31:23Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -15190,7 +15400,9 @@
           "timestamp": "2026-07-16T08:31:24Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -15346,7 +15558,9 @@
           "timestamp": "2026-07-16T08:31:26Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from ultimate to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from ultimate to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -15455,7 +15669,9 @@
           "timestamp": "2026-07-16T08:31:24Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 4,
@@ -15575,7 +15791,9 @@
           "timestamp": "2026-07-16T08:31:24Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -15833,7 +16051,9 @@
           "timestamp": "2026-07-16T08:31:24Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -15982,7 +16202,9 @@
           "timestamp": "2026-07-16T08:31:24Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -16117,7 +16339,9 @@
           "timestamp": "2026-07-16T08:31:26Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from ultimate to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from ultimate to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -16235,7 +16459,9 @@
           "timestamp": "2026-07-16T08:31:24Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -16502,7 +16728,9 @@
           "timestamp": "2026-07-16T08:31:24Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 6,
@@ -16738,7 +16966,9 @@
           "timestamp": "2026-07-16T08:31:24Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -16855,7 +17085,9 @@
           "timestamp": "2026-07-16T08:31:24Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -17159,7 +17391,9 @@
           "timestamp": "2026-07-16T08:31:24Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -17249,7 +17483,9 @@
           "timestamp": "2026-07-16T08:31:24Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -17597,7 +17833,9 @@
           "timestamp": "2026-07-16T08:31:24Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -17685,7 +17923,9 @@
           "timestamp": "2026-07-16T08:31:24Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 5,
@@ -17756,7 +17996,9 @@
           "timestamp": "2026-07-16T08:31:25Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -17822,7 +18064,9 @@
           "timestamp": "2026-07-16T08:31:25Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 7,
@@ -18048,7 +18292,9 @@
           "timestamp": "2026-07-16T08:31:25Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 6,
@@ -18106,7 +18352,9 @@
           "timestamp": "2026-07-16T08:31:25Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -18164,7 +18412,9 @@
           "timestamp": "2026-07-16T08:31:25Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -18330,7 +18580,9 @@
           "timestamp": "2026-07-16T08:31:25Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -18410,7 +18662,9 @@
           "timestamp": "2026-07-16T08:31:25Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -18490,7 +18744,9 @@
           "timestamp": "2026-07-16T08:31:25Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -18591,7 +18847,9 @@
           "timestamp": "2026-07-16T08:31:25Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 0,
@@ -18671,7 +18929,9 @@
           "timestamp": "2026-07-16T08:31:25Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 2,
@@ -18818,7 +19078,9 @@
           "timestamp": "2026-07-16T08:31:25Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 2,
@@ -18971,7 +19233,9 @@
           "timestamp": "2026-07-16T08:31:25Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,
@@ -19046,7 +19310,9 @@
           "timestamp": "2026-07-16T08:31:25Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 7,
@@ -19186,7 +19452,9 @@
           "timestamp": "2026-07-16T08:31:26Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 5,
@@ -19245,7 +19513,9 @@
           "timestamp": "2026-07-16T08:31:26Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "cluster": 3,

--- a/docs/graph/ledger/data.json
+++ b/docs/graph/ledger/data.json
@@ -1,6 +1,6 @@
 {
   "version": "6.5.3",
-  "generatedAt": "2026-07-16T10:01:15Z",
+  "generatedAt": "2026-07-16T11:19:24Z",
   "summary": {
     "total": 280,
     "S": 5,

--- a/docs/graph/named/index.json
+++ b/docs/graph/named/index.json
@@ -518,7 +518,9 @@
             "timestamp": "2026-07-16T08:36:42Z",
             "action": "type_change",
             "contributor": "mbtiongson1",
-            "details": "Generic parent 'git-ship-done-pipeline' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+            "details": "Generic parent 'git-ship-done-pipeline' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           }
         ],
         "suiteComponents": [
@@ -678,7 +680,9 @@
             "timestamp": "2026-07-16T08:36:43Z",
             "action": "type_change",
             "contributor": "mbtiongson1",
-            "details": "Generic parent 'git-ship-done-pipeline' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+            "details": "Generic parent 'git-ship-done-pipeline' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           },
           {
             "timestamp": "2026-07-16T08:36:43Z",
@@ -686,7 +690,9 @@
             "contributor": "mbtiongson1",
             "previousValue": "4★",
             "newValue": "3★",
-            "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=52.2 (< 100.0)) — demoted to 3★ Evolved"
+            "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=52.2 (< 100.0)) — demoted to 3★ Evolved",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           }
         ],
         "suiteComponents": [
@@ -2057,7 +2063,9 @@
             "timestamp": "2026-07-16T08:36:42Z",
             "action": "type_change",
             "contributor": "mbtiongson1",
-            "details": "Generic parent 'performance-tuning' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+            "details": "Generic parent 'performance-tuning' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           }
         ],
         "suiteRef": "addy-osmani/agent-skills",
@@ -2301,7 +2309,9 @@
             "timestamp": "2026-07-16T08:36:42Z",
             "action": "type_change",
             "contributor": "mbtiongson1",
-            "details": "Generic parent 'vertical-slice-planning' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+            "details": "Generic parent 'vertical-slice-planning' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           },
           {
             "timestamp": "2026-07-16T08:36:42Z",
@@ -2309,7 +2319,9 @@
             "contributor": "mbtiongson1",
             "previousValue": "4★",
             "newValue": "3★",
-            "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=36.0 (< 100.0)) — demoted to 3★ Evolved"
+            "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=36.0 (< 100.0)) — demoted to 3★ Evolved",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           }
         ],
         "suiteRef": "garrytan/gstack",
@@ -4583,7 +4595,9 @@
             "timestamp": "2026-07-16T08:36:42Z",
             "action": "type_change",
             "contributor": "mbtiongson1",
-            "details": "Generic parent 'browser-control' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+            "details": "Generic parent 'browser-control' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           },
           {
             "timestamp": "2026-07-16T08:36:42Z",
@@ -4591,7 +4605,9 @@
             "contributor": "mbtiongson1",
             "previousValue": "4★",
             "newValue": "3★",
-            "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=True TM=73.6 (< 100.0)) — demoted to 3★ Evolved"
+            "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=True TM=73.6 (< 100.0)) — demoted to 3★ Evolved",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           }
         ],
         "trustMagnitude": 73.59,
@@ -6448,7 +6464,9 @@
             "timestamp": "2026-07-16T08:36:42Z",
             "action": "type_change",
             "contributor": "mbtiongson1",
-            "details": "Generic parent 'web-scrape' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+            "details": "Generic parent 'web-scrape' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           }
         ],
         "suiteRef": "firecrawl/firecrawl-skills",
@@ -6646,7 +6664,9 @@
             "timestamp": "2026-07-16T08:36:42Z",
             "action": "type_change",
             "contributor": "mbtiongson1",
-            "details": "Generic parent 'web-search' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+            "details": "Generic parent 'web-search' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           }
         ],
         "suiteRef": "firecrawl/firecrawl-skills",
@@ -6887,7 +6907,9 @@
             "timestamp": "2026-07-16T08:36:42Z",
             "action": "type_change",
             "contributor": "mbtiongson1",
-            "details": "Generic parent 'firecrawl' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+            "details": "Generic parent 'firecrawl' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           },
           {
             "timestamp": "2026-07-16T08:36:42Z",
@@ -6895,7 +6917,9 @@
             "contributor": "mbtiongson1",
             "previousValue": "4★",
             "newValue": "3★",
-            "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=73.5 (< 100.0)) — demoted to 3★ Evolved"
+            "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=73.5 (< 100.0)) — demoted to 3★ Evolved",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           }
         ],
         "suiteComponents": [
@@ -9219,7 +9243,9 @@
             "timestamp": "2026-07-16T08:36:44Z",
             "action": "type_change",
             "contributor": "mbtiongson1",
-            "details": "Generic parent 'ux-audit' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+            "details": "Generic parent 'ux-audit' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           }
         ],
         "trustMagnitude": 122.8,
@@ -10267,7 +10293,9 @@
             "timestamp": "2026-07-16T08:36:42Z",
             "action": "type_change",
             "contributor": "mbtiongson1",
-            "details": "Generic parent 'founder-mode-orchestration' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+            "details": "Generic parent 'founder-mode-orchestration' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           }
         ],
         "suiteComponents": [
@@ -12036,7 +12064,9 @@
             "timestamp": "2026-07-16T08:36:44Z",
             "action": "type_change",
             "contributor": "mbtiongson1",
-            "details": "Generic parent 'prompt-optimization' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+            "details": "Generic parent 'prompt-optimization' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           },
           {
             "timestamp": "2026-07-16T08:36:44Z",
@@ -12044,7 +12074,9 @@
             "contributor": "mbtiongson1",
             "previousValue": "4★",
             "newValue": "3★",
-            "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.0 (≥ 100.0)) — demoted to 3★ Evolved"
+            "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.0 (≥ 100.0)) — demoted to 3★ Evolved",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           }
         ],
         "trustMagnitude": 100.0,
@@ -14110,7 +14142,9 @@
             "timestamp": "2026-07-16T08:36:44Z",
             "action": "type_change",
             "contributor": "mbtiongson1",
-            "details": "Generic parent 'subagent-driven-development' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+            "details": "Generic parent 'subagent-driven-development' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           }
         ],
         "suiteRef": "obra/superpowers",
@@ -14534,7 +14568,9 @@
             "timestamp": "2026-07-16T08:36:44Z",
             "action": "type_change",
             "contributor": "mbtiongson1",
-            "details": "Generic parent 'writing-plans' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+            "details": "Generic parent 'writing-plans' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           },
           {
             "timestamp": "2026-07-16T08:36:44Z",
@@ -14542,7 +14578,9 @@
             "contributor": "mbtiongson1",
             "previousValue": "4★",
             "newValue": "3★",
-            "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=110.1 (≥ 100.0)) — demoted to 3★ Evolved"
+            "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=110.1 (≥ 100.0)) — demoted to 3★ Evolved",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           }
         ],
         "suiteRef": "obra/superpowers",
@@ -16744,7 +16782,9 @@
             "timestamp": "2026-07-16T08:36:43Z",
             "action": "type_change",
             "contributor": "mbtiongson1",
-            "details": "Generic parent 'engineering-discipline' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+            "details": "Generic parent 'engineering-discipline' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           },
           {
             "timestamp": "2026-07-16T08:36:43Z",
@@ -16752,7 +16792,9 @@
             "contributor": "mbtiongson1",
             "previousValue": "4★",
             "newValue": "3★",
-            "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=0.0 (< 100.0)) — demoted to 3★ Evolved"
+            "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=0.0 (< 100.0)) — demoted to 3★ Evolved",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           }
         ],
         "suiteRef": "mattpocock/skills",
@@ -17486,7 +17528,9 @@
             "timestamp": "2026-07-16T08:36:43Z",
             "action": "type_change",
             "contributor": "mbtiongson1",
-            "details": "Generic parent 'productivity' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+            "details": "Generic parent 'productivity' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           },
           {
             "timestamp": "2026-07-16T08:36:43Z",
@@ -17494,7 +17538,9 @@
             "contributor": "mbtiongson1",
             "previousValue": "4★",
             "newValue": "3★",
-            "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=0.0 (< 100.0)) — demoted to 3★ Evolved"
+            "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=0.0 (< 100.0)) — demoted to 3★ Evolved",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           }
         ],
         "suiteRef": "mattpocock/skills",
@@ -18012,7 +18058,9 @@
             "timestamp": "2026-07-16T08:36:43Z",
             "action": "type_change",
             "contributor": "mbtiongson1",
-            "details": "Generic parent 'skill-mastery' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+            "details": "Generic parent 'skill-mastery' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           }
         ],
         "suiteComponents": [
@@ -19992,7 +20040,9 @@
             "timestamp": "2026-07-16T08:36:44Z",
             "action": "type_change",
             "contributor": "mbtiongson1",
-            "details": "Generic parent 'superpowers' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+            "details": "Generic parent 'superpowers' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           }
         ],
         "suiteComponents": [
@@ -20200,7 +20250,9 @@
             "timestamp": "2026-07-16T08:36:44Z",
             "action": "type_change",
             "contributor": "mbtiongson1",
-            "details": "Generic parent 'using-git-worktrees' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+            "details": "Generic parent 'using-git-worktrees' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           },
           {
             "timestamp": "2026-07-16T08:36:44Z",
@@ -20208,7 +20260,9 @@
             "contributor": "mbtiongson1",
             "previousValue": "4★",
             "newValue": "3★",
-            "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=117.6 (≥ 100.0)) — demoted to 3★ Evolved"
+            "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=117.6 (≥ 100.0)) — demoted to 3★ Evolved",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           }
         ],
         "suiteRef": "obra/superpowers",
@@ -20328,7 +20382,9 @@
             "timestamp": "2026-07-16T08:36:44Z",
             "action": "type_change",
             "contributor": "mbtiongson1",
-            "details": "Generic parent 'few-shot-learning' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+            "details": "Generic parent 'few-shot-learning' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           }
         ],
         "trustMagnitude": 100.0,
@@ -20427,7 +20483,9 @@
             "timestamp": "2026-07-16T08:36:44Z",
             "action": "type_change",
             "contributor": "mbtiongson1",
-            "details": "Generic parent 'self-consistency' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+            "details": "Generic parent 'self-consistency' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           },
           {
             "timestamp": "2026-07-16T08:36:44Z",
@@ -20435,7 +20493,9 @@
             "contributor": "mbtiongson1",
             "previousValue": "4★",
             "newValue": "3★",
-            "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.0 (≥ 100.0)) — demoted to 3★ Evolved"
+            "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.0 (≥ 100.0)) — demoted to 3★ Evolved",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           }
         ],
         "trustMagnitude": 100.0,
@@ -21128,7 +21188,9 @@
             "timestamp": "2026-07-16T08:36:44Z",
             "action": "type_change",
             "contributor": "mbtiongson1",
-            "details": "Generic parent 'agent-memory-platform' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+            "details": "Generic parent 'agent-memory-platform' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           },
           {
             "timestamp": "2026-07-16T08:36:44Z",
@@ -21136,7 +21198,9 @@
             "contributor": "mbtiongson1",
             "previousValue": "4★",
             "newValue": "3★",
-            "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=81.0 (< 100.0)) — demoted to 3★ Evolved"
+            "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=81.0 (< 100.0)) — demoted to 3★ Evolved",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -21501,7 +21565,9 @@
             "timestamp": "2026-07-16T08:36:44Z",
             "action": "type_change",
             "contributor": "mbtiongson1",
-            "details": "Generic parent 'dual-mode' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+            "details": "Generic parent 'dual-mode' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           },
           {
             "timestamp": "2026-07-16T08:36:44Z",
@@ -21509,7 +21575,9 @@
             "contributor": "mbtiongson1",
             "previousValue": "4★",
             "newValue": "3★",
-            "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=36.0 (< 100.0)) — demoted to 3★ Evolved"
+            "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=36.0 (< 100.0)) — demoted to 3★ Evolved",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -22720,7 +22788,9 @@
             "timestamp": "2026-07-16T08:36:44Z",
             "action": "type_change",
             "contributor": "mbtiongson1",
-            "details": "Generic parent 'reasoning-pattern-bank' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+            "details": "Generic parent 'reasoning-pattern-bank' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           },
           {
             "timestamp": "2026-07-16T08:36:44Z",
@@ -22728,7 +22798,9 @@
             "contributor": "mbtiongson1",
             "previousValue": "4★",
             "newValue": "3★",
-            "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=88.5 (< 100.0)) — demoted to 3★ Evolved"
+            "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=88.5 (< 100.0)) — demoted to 3★ Evolved",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -22832,7 +22904,9 @@
             "timestamp": "2026-07-16T08:36:44Z",
             "action": "type_change",
             "contributor": "mbtiongson1",
-            "details": "Generic parent 'platform-modernization-sprint' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+            "details": "Generic parent 'platform-modernization-sprint' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           },
           {
             "timestamp": "2026-07-16T08:36:44Z",
@@ -22840,7 +22914,9 @@
             "contributor": "mbtiongson1",
             "previousValue": "4★",
             "newValue": "3★",
-            "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=36.0 (< 100.0)) — demoted to 3★ Evolved"
+            "details": "Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch TM=36.0 (< 100.0)) — demoted to 3★ Evolved",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           }
         ],
         "suiteRef": "ruvnet/ruflo",
@@ -23040,7 +23116,9 @@
             "timestamp": "2026-07-16T08:36:44Z",
             "action": "type_change",
             "contributor": "mbtiongson1",
-            "details": "Generic parent 'multi-topology-orchestration' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+            "details": "Generic parent 'multi-topology-orchestration' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           }
         ],
         "suiteComponents": [
@@ -23927,7 +24005,9 @@
             "timestamp": "2026-07-16T08:36:44Z",
             "action": "type_change",
             "contributor": "mbtiongson1",
-            "details": "Generic parent 'knowledge-graph-build' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+            "details": "Generic parent 'knowledge-graph-build' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           },
           {
             "timestamp": "2026-07-16T08:36:44Z",
@@ -23935,7 +24015,9 @@
             "contributor": "mbtiongson1",
             "previousValue": "4★",
             "newValue": "3★",
-            "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=122.9 (≥ 100.0)) — demoted to 3★ Evolved"
+            "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=122.9 (≥ 100.0)) — demoted to 3★ Evolved",
+            "metaEpoch": "yggdrasil-ii",
+            "migrationBatch": "yggdrasil-ii@2026-07-16"
           }
         ],
         "trustMagnitude": 116.57,
@@ -24628,7 +24710,9 @@
           "timestamp": "2026-07-16T08:36:42Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Generic parent 'computational-biology-workflows' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Generic parent 'computational-biology-workflows' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         },
         {
           "timestamp": "2026-07-16T08:36:42Z",
@@ -24636,7 +24720,9 @@
           "contributor": "mbtiongson1",
           "previousValue": "4★",
           "newValue": "3★",
-          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved"
+          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "trustMagnitude": 100.82,
@@ -24745,7 +24831,9 @@
           "timestamp": "2026-07-16T08:36:42Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Generic parent 'computational-biology-workflows' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Generic parent 'computational-biology-workflows' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         },
         {
           "timestamp": "2026-07-16T08:36:42Z",
@@ -24753,7 +24841,9 @@
           "contributor": "mbtiongson1",
           "previousValue": "4★",
           "newValue": "3★",
-          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved"
+          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "trustMagnitude": 100.82,
@@ -25276,7 +25366,9 @@
           "timestamp": "2026-07-16T08:36:43Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Generic parent 'pathway-ontology-retrieval' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+          "details": "Generic parent 'pathway-ontology-retrieval' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         },
         {
           "timestamp": "2026-07-16T08:36:43Z",
@@ -25284,7 +25376,9 @@
           "contributor": "mbtiongson1",
           "previousValue": "4★",
           "newValue": "3★",
-          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved"
+          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "trustMagnitude": 100.82,
@@ -25395,7 +25489,9 @@
           "timestamp": "2026-07-16T08:36:43Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Generic parent 'genomic-data-retrieval' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+          "details": "Generic parent 'genomic-data-retrieval' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         },
         {
           "timestamp": "2026-07-16T08:36:43Z",
@@ -25403,7 +25499,9 @@
           "contributor": "mbtiongson1",
           "previousValue": "4★",
           "newValue": "3★",
-          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved"
+          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "trustMagnitude": 100.82,
@@ -25514,7 +25612,9 @@
           "timestamp": "2026-07-16T08:36:43Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Generic parent 'genomic-data-retrieval' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+          "details": "Generic parent 'genomic-data-retrieval' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         },
         {
           "timestamp": "2026-07-16T08:36:43Z",
@@ -25522,7 +25622,9 @@
           "contributor": "mbtiongson1",
           "previousValue": "4★",
           "newValue": "3★",
-          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved"
+          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "trustMagnitude": 100.82,
@@ -25633,7 +25735,9 @@
           "timestamp": "2026-07-16T08:36:43Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Generic parent 'protein-structure-analysis' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+          "details": "Generic parent 'protein-structure-analysis' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         },
         {
           "timestamp": "2026-07-16T08:36:43Z",
@@ -25641,7 +25745,9 @@
           "contributor": "mbtiongson1",
           "previousValue": "4★",
           "newValue": "3★",
-          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved"
+          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "trustMagnitude": 100.82,
@@ -25750,7 +25856,9 @@
           "timestamp": "2026-07-16T08:36:43Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Generic parent 'genomic-data-retrieval' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+          "details": "Generic parent 'genomic-data-retrieval' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         },
         {
           "timestamp": "2026-07-16T08:36:43Z",
@@ -25758,7 +25866,9 @@
           "contributor": "mbtiongson1",
           "previousValue": "4★",
           "newValue": "3★",
-          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved"
+          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "trustMagnitude": 100.82,
@@ -25867,7 +25977,9 @@
           "timestamp": "2026-07-16T08:36:43Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Generic parent 'genomic-data-retrieval' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+          "details": "Generic parent 'genomic-data-retrieval' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         },
         {
           "timestamp": "2026-07-16T08:36:43Z",
@@ -25875,7 +25987,9 @@
           "contributor": "mbtiongson1",
           "previousValue": "4★",
           "newValue": "3★",
-          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved"
+          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "trustMagnitude": 100.82,
@@ -25986,7 +26100,9 @@
           "timestamp": "2026-07-16T08:36:43Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Generic parent 'proteomic-data-retrieval' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+          "details": "Generic parent 'proteomic-data-retrieval' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         },
         {
           "timestamp": "2026-07-16T08:36:43Z",
@@ -25994,7 +26110,9 @@
           "contributor": "mbtiongson1",
           "previousValue": "4★",
           "newValue": "3★",
-          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved"
+          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "trustMagnitude": 100.82,
@@ -26105,7 +26223,9 @@
           "timestamp": "2026-07-16T08:36:43Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Generic parent 'proteomic-data-retrieval' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+          "details": "Generic parent 'proteomic-data-retrieval' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         },
         {
           "timestamp": "2026-07-16T08:36:43Z",
@@ -26113,7 +26233,9 @@
           "contributor": "mbtiongson1",
           "previousValue": "4★",
           "newValue": "3★",
-          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved"
+          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "trustMagnitude": 100.82,
@@ -26224,7 +26346,9 @@
           "timestamp": "2026-07-16T08:36:43Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Generic parent 'genomic-data-retrieval' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+          "details": "Generic parent 'genomic-data-retrieval' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         },
         {
           "timestamp": "2026-07-16T08:36:43Z",
@@ -26232,7 +26356,9 @@
           "contributor": "mbtiongson1",
           "previousValue": "4★",
           "newValue": "3★",
-          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved"
+          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "trustMagnitude": 100.82,
@@ -26549,7 +26675,9 @@
           "timestamp": "2026-07-16T08:36:43Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Generic parent 'literature-search' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+          "details": "Generic parent 'literature-search' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         },
         {
           "timestamp": "2026-07-16T08:36:43Z",
@@ -26557,7 +26685,9 @@
           "contributor": "mbtiongson1",
           "previousValue": "4★",
           "newValue": "3★",
-          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved"
+          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "trustMagnitude": 100.82,
@@ -26668,7 +26798,9 @@
           "timestamp": "2026-07-16T08:36:43Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Generic parent 'literature-search' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+          "details": "Generic parent 'literature-search' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "trustMagnitude": 100.82,
@@ -26779,7 +26911,9 @@
           "timestamp": "2026-07-16T08:36:43Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Generic parent 'genomic-data-retrieval' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+          "details": "Generic parent 'genomic-data-retrieval' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         },
         {
           "timestamp": "2026-07-16T08:36:43Z",
@@ -26787,7 +26921,9 @@
           "contributor": "mbtiongson1",
           "previousValue": "4★",
           "newValue": "3★",
-          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved"
+          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "trustMagnitude": 100.82,
@@ -26898,7 +27034,9 @@
           "timestamp": "2026-07-16T08:36:43Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Generic parent 'clinical-data-retrieval' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+          "details": "Generic parent 'clinical-data-retrieval' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         },
         {
           "timestamp": "2026-07-16T08:36:43Z",
@@ -26906,7 +27044,9 @@
           "contributor": "mbtiongson1",
           "previousValue": "4★",
           "newValue": "3★",
-          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved"
+          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "trustMagnitude": 100.82,
@@ -27017,7 +27157,9 @@
           "timestamp": "2026-07-16T08:36:43Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Generic parent 'clinical-data-retrieval' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+          "details": "Generic parent 'clinical-data-retrieval' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         },
         {
           "timestamp": "2026-07-16T08:36:43Z",
@@ -27025,7 +27167,9 @@
           "contributor": "mbtiongson1",
           "previousValue": "4★",
           "newValue": "3★",
-          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved"
+          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "trustMagnitude": 100.82,
@@ -27351,7 +27495,9 @@
           "timestamp": "2026-07-16T08:36:43Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Generic parent 'bioinformatic-sequence-analysis' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+          "details": "Generic parent 'bioinformatic-sequence-analysis' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         },
         {
           "timestamp": "2026-07-16T08:36:43Z",
@@ -27359,7 +27505,9 @@
           "contributor": "mbtiongson1",
           "previousValue": "4★",
           "newValue": "3★",
-          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved"
+          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "trustMagnitude": 100.82,
@@ -27470,7 +27618,9 @@
           "timestamp": "2026-07-16T08:36:43Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Generic parent 'molecular-databases' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+          "details": "Generic parent 'molecular-databases' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         },
         {
           "timestamp": "2026-07-16T08:36:43Z",
@@ -27478,7 +27628,9 @@
           "contributor": "mbtiongson1",
           "previousValue": "4★",
           "newValue": "3★",
-          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved"
+          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "trustMagnitude": 100.82,
@@ -27704,7 +27856,9 @@
           "timestamp": "2026-07-16T08:36:43Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Generic parent 'scientific-visualization' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+          "details": "Generic parent 'scientific-visualization' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         },
         {
           "timestamp": "2026-07-16T08:36:43Z",
@@ -27712,7 +27866,9 @@
           "contributor": "mbtiongson1",
           "previousValue": "4★",
           "newValue": "3★",
-          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved"
+          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "trustMagnitude": 100.82,
@@ -27823,7 +27979,9 @@
           "timestamp": "2026-07-16T08:36:43Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Generic parent 'pathway-ontology-retrieval' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+          "details": "Generic parent 'pathway-ontology-retrieval' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         },
         {
           "timestamp": "2026-07-16T08:36:43Z",
@@ -27831,7 +27989,9 @@
           "contributor": "mbtiongson1",
           "previousValue": "4★",
           "newValue": "3★",
-          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved"
+          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "trustMagnitude": 100.82,
@@ -27942,7 +28102,9 @@
           "timestamp": "2026-07-16T08:36:43Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Generic parent 'pathway-ontology-retrieval' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+          "details": "Generic parent 'pathway-ontology-retrieval' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         },
         {
           "timestamp": "2026-07-16T08:36:43Z",
@@ -27950,7 +28112,9 @@
           "contributor": "mbtiongson1",
           "previousValue": "4★",
           "newValue": "3★",
-          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved"
+          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "trustMagnitude": 100.82,
@@ -28061,7 +28225,9 @@
           "timestamp": "2026-07-16T08:36:43Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Generic parent 'core-platform-implementation' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+          "details": "Generic parent 'core-platform-implementation' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         },
         {
           "timestamp": "2026-07-16T08:36:43Z",
@@ -28069,7 +28235,9 @@
           "contributor": "mbtiongson1",
           "previousValue": "4★",
           "newValue": "3★",
-          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved"
+          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "trustMagnitude": 100.82,
@@ -28283,7 +28451,9 @@
           "timestamp": "2026-07-16T08:36:43Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Generic parent 'genomic-data-retrieval' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+          "details": "Generic parent 'genomic-data-retrieval' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         },
         {
           "timestamp": "2026-07-16T08:36:43Z",
@@ -28291,7 +28461,9 @@
           "contributor": "mbtiongson1",
           "previousValue": "4★",
           "newValue": "3★",
-          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved"
+          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "trustMagnitude": 100.82,
@@ -28402,7 +28574,9 @@
           "timestamp": "2026-07-16T08:36:43Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Generic parent 'genomic-data-retrieval' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+          "details": "Generic parent 'genomic-data-retrieval' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         },
         {
           "timestamp": "2026-07-16T08:36:43Z",
@@ -28410,7 +28584,9 @@
           "contributor": "mbtiongson1",
           "previousValue": "4★",
           "newValue": "3★",
-          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved"
+          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "trustMagnitude": 100.82,
@@ -28624,7 +28800,9 @@
           "timestamp": "2026-07-16T08:36:43Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Generic parent 'core-platform-implementation' type: basic (unchanged; Yggdrasil II taxonomy migration #997)"
+          "details": "Generic parent 'core-platform-implementation' type: basic (unchanged; Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         },
         {
           "timestamp": "2026-07-16T08:36:43Z",
@@ -28632,7 +28810,9 @@
           "contributor": "mbtiongson1",
           "previousValue": "4★",
           "newValue": "3★",
-          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved"
+          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "trustMagnitude": 100.82,
@@ -28743,7 +28923,9 @@
           "timestamp": "2026-07-16T08:36:43Z",
           "action": "type_change",
           "contributor": "mbtiongson1",
-          "details": "Generic parent 'skill-authoring' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)"
+          "details": "Generic parent 'skill-authoring' type: extra/ultimate → fusion (Yggdrasil II taxonomy migration #997)",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         },
         {
           "timestamp": "2026-07-16T08:36:43Z",
@@ -28751,7 +28933,9 @@
           "contributor": "mbtiongson1",
           "previousValue": "4★",
           "newValue": "3★",
-          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved"
+          "details": "Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved",
+          "metaEpoch": "yggdrasil-ii",
+          "migrationBatch": "yggdrasil-ii@2026-07-16"
         }
       ],
       "trustMagnitude": 100.82,

--- a/registry/named/addy-osmani/agent-skills.md
+++ b/registry/named/addy-osmani/agent-skills.md
@@ -91,6 +91,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''git-ship-done-pipeline'' type: extra/ultimate → fusion
     (Yggdrasil II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 evidence:
 - source: https://github.com/addyosmani/agent-skills/stargazers
   evaluator: unknown

--- a/registry/named/addy-osmani/performance-optimization.md
+++ b/registry/named/addy-osmani/performance-optimization.md
@@ -71,6 +71,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''performance-tuning'' type: basic (unchanged; Yggdrasil
     II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 evidence:
 - class: A
   source: https://github.com/addyosmani/agent-skills/blob/main/skills/performance-optimization/SKILL.md

--- a/registry/named/browser-use/browser-harness.md
+++ b/registry/named/browser-use/browser-harness.md
@@ -118,6 +118,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''browser-control'' type: basic (unchanged; Yggdrasil II
     taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:42Z'
   action: demote
   contributor: mbtiongson1
@@ -125,6 +127,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch
     origin=True TM=73.6 (< 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 73.59
 overallTrustGrade: B
 apexGateStatus:

--- a/registry/named/firecrawl/firecrawl-build-scrape.md
+++ b/registry/named/firecrawl/firecrawl-build-scrape.md
@@ -45,6 +45,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''web-scrape'' type: extra/ultimate → fusion (Yggdrasil
     II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 evidence:
 - source: https://www.youtube.com/watch?v=tBtPSV_gU6o
   evaluator: unknown

--- a/registry/named/firecrawl/firecrawl-build-search.md
+++ b/registry/named/firecrawl/firecrawl-build-search.md
@@ -36,6 +36,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''web-search'' type: basic (unchanged; Yggdrasil II taxonomy
     migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 evidence:
 - source: https://www.youtube.com/watch?v=tBtPSV_gU6o
   evaluator: unknown

--- a/registry/named/firecrawl/firecrawl-skills.md
+++ b/registry/named/firecrawl/firecrawl-skills.md
@@ -85,6 +85,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''firecrawl'' type: extra/ultimate → fusion (Yggdrasil
     II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:42Z'
   action: demote
   contributor: mbtiongson1
@@ -92,6 +94,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch
     TM=73.5 (< 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 evidence:
 - class: B
   source: https://github.com/firecrawl/firecrawl

--- a/registry/named/garrytan/garrytan.md
+++ b/registry/named/garrytan/garrytan.md
@@ -63,6 +63,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''vertical-slice-planning'' type: extra/ultimate → fusion
     (Yggdrasil II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:42Z'
   action: demote
   contributor: mbtiongson1
@@ -70,6 +72,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch
     TM=36.0 (< 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 evidence:
 - class: B
   source: https://github.com/garrytan/gstack/blob/main/autoplan/SKILL.md

--- a/registry/named/garrytan/gstack.md
+++ b/registry/named/garrytan/gstack.md
@@ -150,6 +150,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''founder-mode-orchestration'' type: extra/ultimate → fusion
     (Yggdrasil II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 589.32
 overallTrustGrade: S
 apexGateStatus:

--- a/registry/named/google-deepmind/alphafold_database_fetch_and_analyze.md
+++ b/registry/named/google-deepmind/alphafold_database_fetch_and_analyze.md
@@ -66,6 +66,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''computational-biology-workflows'' type: extra/ultimate
     → fusion (Yggdrasil II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:42Z'
   action: demote
   contributor: mbtiongson1
@@ -73,6 +75,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch
     origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 100.82
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/google-deepmind/alphagenome_single_variant_analysis.md
+++ b/registry/named/google-deepmind/alphagenome_single_variant_analysis.md
@@ -78,6 +78,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''computational-biology-workflows'' type: extra/ultimate
     → fusion (Yggdrasil II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:42Z'
   action: demote
   contributor: mbtiongson1
@@ -85,6 +87,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch
     origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 100.82
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/google-deepmind/embl_ebi_ols.md
+++ b/registry/named/google-deepmind/embl_ebi_ols.md
@@ -77,6 +77,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''pathway-ontology-retrieval'' type: basic (unchanged;
     Yggdrasil II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:43Z'
   action: demote
   contributor: mbtiongson1
@@ -84,6 +86,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch
     origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 100.82
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/google-deepmind/encode_ccres_database.md
+++ b/registry/named/google-deepmind/encode_ccres_database.md
@@ -76,6 +76,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''genomic-data-retrieval'' type: basic (unchanged; Yggdrasil
     II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:43Z'
   action: demote
   contributor: mbtiongson1
@@ -83,6 +85,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch
     origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 100.82
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/google-deepmind/ensembl_database.md
+++ b/registry/named/google-deepmind/ensembl_database.md
@@ -76,6 +76,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''genomic-data-retrieval'' type: basic (unchanged; Yggdrasil
     II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:43Z'
   action: demote
   contributor: mbtiongson1
@@ -83,6 +85,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch
     origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 100.82
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/google-deepmind/foldseek_structural_search.md
+++ b/registry/named/google-deepmind/foldseek_structural_search.md
@@ -77,6 +77,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''protein-structure-analysis'' type: basic (unchanged;
     Yggdrasil II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:43Z'
   action: demote
   contributor: mbtiongson1
@@ -84,6 +86,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch
     origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 100.82
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/google-deepmind/gnomad_database.md
+++ b/registry/named/google-deepmind/gnomad_database.md
@@ -75,6 +75,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''genomic-data-retrieval'' type: basic (unchanged; Yggdrasil
     II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:43Z'
   action: demote
   contributor: mbtiongson1
@@ -82,6 +84,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch
     origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 100.82
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/google-deepmind/gtex_database.md
+++ b/registry/named/google-deepmind/gtex_database.md
@@ -72,6 +72,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''genomic-data-retrieval'' type: basic (unchanged; Yggdrasil
     II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:43Z'
   action: demote
   contributor: mbtiongson1
@@ -79,6 +81,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch
     origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 100.82
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/google-deepmind/human_protein_atlas_database.md
+++ b/registry/named/google-deepmind/human_protein_atlas_database.md
@@ -74,6 +74,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''proteomic-data-retrieval'' type: basic (unchanged; Yggdrasil
     II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:43Z'
   action: demote
   contributor: mbtiongson1
@@ -81,6 +83,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch
     origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 100.82
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/google-deepmind/interpro_database.md
+++ b/registry/named/google-deepmind/interpro_database.md
@@ -77,6 +77,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''proteomic-data-retrieval'' type: basic (unchanged; Yggdrasil
     II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:43Z'
   action: demote
   contributor: mbtiongson1
@@ -84,6 +86,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch
     origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 100.82
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/google-deepmind/jaspar_database.md
+++ b/registry/named/google-deepmind/jaspar_database.md
@@ -76,6 +76,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''genomic-data-retrieval'' type: basic (unchanged; Yggdrasil
     II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:43Z'
   action: demote
   contributor: mbtiongson1
@@ -83,6 +85,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch
     origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 100.82
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/google-deepmind/literature_search_europepmc.md
+++ b/registry/named/google-deepmind/literature_search_europepmc.md
@@ -74,6 +74,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''literature-search'' type: basic (unchanged; Yggdrasil
     II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:43Z'
   action: demote
   contributor: mbtiongson1
@@ -81,6 +83,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch
     origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 100.82
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/google-deepmind/literature_search_openalex.md
+++ b/registry/named/google-deepmind/literature_search_openalex.md
@@ -75,6 +75,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''literature-search'' type: basic (unchanged; Yggdrasil
     II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 100.82
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/google-deepmind/ncbi_sequence_fetch.md
+++ b/registry/named/google-deepmind/ncbi_sequence_fetch.md
@@ -77,6 +77,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''genomic-data-retrieval'' type: basic (unchanged; Yggdrasil
     II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:43Z'
   action: demote
   contributor: mbtiongson1
@@ -84,6 +86,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch
     origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 100.82
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/google-deepmind/openfda_database.md
+++ b/registry/named/google-deepmind/openfda_database.md
@@ -76,6 +76,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''clinical-data-retrieval'' type: basic (unchanged; Yggdrasil
     II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:43Z'
   action: demote
   contributor: mbtiongson1
@@ -83,6 +85,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch
     origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 100.82
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/google-deepmind/opentargets_database.md
+++ b/registry/named/google-deepmind/opentargets_database.md
@@ -75,6 +75,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''clinical-data-retrieval'' type: basic (unchanged; Yggdrasil
     II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:43Z'
   action: demote
   contributor: mbtiongson1
@@ -82,6 +84,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch
     origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 100.82
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/google-deepmind/protein_sequence_similarity_search.md
+++ b/registry/named/google-deepmind/protein_sequence_similarity_search.md
@@ -91,6 +91,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''bioinformatic-sequence-analysis'' type: basic (unchanged;
     Yggdrasil II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:43Z'
   action: demote
   contributor: mbtiongson1
@@ -98,6 +100,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch
     origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 100.82
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/google-deepmind/pubchem_database.md
+++ b/registry/named/google-deepmind/pubchem_database.md
@@ -75,6 +75,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''molecular-databases'' type: basic (unchanged; Yggdrasil
     II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:43Z'
   action: demote
   contributor: mbtiongson1
@@ -82,6 +84,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch
     origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 100.82
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/google-deepmind/pymol.md
+++ b/registry/named/google-deepmind/pymol.md
@@ -76,6 +76,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''scientific-visualization'' type: basic (unchanged; Yggdrasil
     II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:43Z'
   action: demote
   contributor: mbtiongson1
@@ -83,6 +85,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch
     origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 100.82
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/google-deepmind/quickgo_database.md
+++ b/registry/named/google-deepmind/quickgo_database.md
@@ -77,6 +77,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''pathway-ontology-retrieval'' type: basic (unchanged;
     Yggdrasil II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:43Z'
   action: demote
   contributor: mbtiongson1
@@ -84,6 +86,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch
     origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 100.82
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/google-deepmind/reactome_database.md
+++ b/registry/named/google-deepmind/reactome_database.md
@@ -77,6 +77,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''pathway-ontology-retrieval'' type: basic (unchanged;
     Yggdrasil II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:43Z'
   action: demote
   contributor: mbtiongson1
@@ -84,6 +86,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch
     origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 100.82
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/google-deepmind/science_skills_common.md
+++ b/registry/named/google-deepmind/science_skills_common.md
@@ -75,6 +75,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''core-platform-implementation'' type: basic (unchanged;
     Yggdrasil II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:43Z'
   action: demote
   contributor: mbtiongson1
@@ -82,6 +84,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch
     origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 100.82
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/google-deepmind/ucsc_conservation_and_tfbs.md
+++ b/registry/named/google-deepmind/ucsc_conservation_and_tfbs.md
@@ -76,6 +76,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''genomic-data-retrieval'' type: basic (unchanged; Yggdrasil
     II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:43Z'
   action: demote
   contributor: mbtiongson1
@@ -83,6 +85,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch
     origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 100.82
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/google-deepmind/unibind_database.md
+++ b/registry/named/google-deepmind/unibind_database.md
@@ -77,6 +77,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''genomic-data-retrieval'' type: basic (unchanged; Yggdrasil
     II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:43Z'
   action: demote
   contributor: mbtiongson1
@@ -84,6 +86,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch
     origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 100.82
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/google-deepmind/uv.md
+++ b/registry/named/google-deepmind/uv.md
@@ -73,6 +73,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''core-platform-implementation'' type: basic (unchanged;
     Yggdrasil II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:43Z'
   action: demote
   contributor: mbtiongson1
@@ -80,6 +82,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch
     origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 100.82
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/google-deepmind/workflow_skill_creator.md
+++ b/registry/named/google-deepmind/workflow_skill_creator.md
@@ -77,6 +77,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''skill-authoring'' type: extra/ultimate → fusion (Yggdrasil
     II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:43Z'
   action: demote
   contributor: mbtiongson1
@@ -84,6 +86,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch
     origin=False TM=100.8 (≥ 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 100.82
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/gsd-build/get-shit-done.md
+++ b/registry/named/gsd-build/get-shit-done.md
@@ -80,6 +80,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''git-ship-done-pipeline'' type: extra/ultimate → fusion
     (Yggdrasil II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:43Z'
   action: demote
   contributor: mbtiongson1
@@ -87,6 +89,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch
     TM=52.2 (< 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 evidence:
 - source: https://github.com/gsd-build/get-shit-done/stargazers
   evaluator: unknown

--- a/registry/named/mattpocock/engineering.md
+++ b/registry/named/mattpocock/engineering.md
@@ -41,6 +41,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''engineering-discipline'' type: extra/ultimate → fusion
     (Yggdrasil II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:43Z'
   action: demote
   contributor: mbtiongson1
@@ -48,6 +50,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch
     TM=0.0 (< 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 suiteRef: mattpocock/skills
 suiteComponents:
 - mattpocock/diagnose

--- a/registry/named/mattpocock/productivity.md
+++ b/registry/named/mattpocock/productivity.md
@@ -37,6 +37,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''productivity'' type: extra/ultimate → fusion (Yggdrasil
     II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:43Z'
   action: demote
   contributor: mbtiongson1
@@ -44,6 +46,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch
     TM=0.0 (< 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 suiteRef: mattpocock/skills
 suiteComponents:
 - mattpocock/caveman

--- a/registry/named/mattpocock/skills.md
+++ b/registry/named/mattpocock/skills.md
@@ -104,6 +104,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''skill-mastery'' type: extra/ultimate → fusion (Yggdrasil
     II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 evidence:
 - source: https://github.com/mattpocock/skills/stargazers
   evaluator: mbtiongson1

--- a/registry/named/obra/subagent-driven-development.md
+++ b/registry/named/obra/subagent-driven-development.md
@@ -135,6 +135,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''subagent-driven-development'' type: extra/ultimate →
     fusion (Yggdrasil II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 117.65
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/obra/superpowers.md
+++ b/registry/named/obra/superpowers.md
@@ -136,6 +136,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''superpowers'' type: extra/ultimate → fusion (Yggdrasil
     II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 445.15
 overallTrustGrade: S
 apexGateStatus:

--- a/registry/named/obra/using-git-worktrees.md
+++ b/registry/named/obra/using-git-worktrees.md
@@ -138,6 +138,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''using-git-worktrees'' type: extra/ultimate → fusion (Yggdrasil
     II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:44Z'
   action: demote
   contributor: mbtiongson1
@@ -145,6 +147,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch
     origin=False TM=117.6 (≥ 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 117.65
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/obra/writing-plans.md
+++ b/registry/named/obra/writing-plans.md
@@ -149,6 +149,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''writing-plans'' type: extra/ultimate → fusion (Yggdrasil
     II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:44Z'
   action: demote
   contributor: mbtiongson1
@@ -156,6 +158,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch
     origin=False TM=110.1 (≥ 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 110.15
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/openai/few-shot-learning.md
+++ b/registry/named/openai/few-shot-learning.md
@@ -66,6 +66,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''few-shot-learning'' type: basic (unchanged; Yggdrasil
     II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 evidence:
 - source: https://arxiv.org/abs/2005.14165
   evaluator: mbtiongson1

--- a/registry/named/openai/self-consistency.md
+++ b/registry/named/openai/self-consistency.md
@@ -61,6 +61,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''self-consistency'' type: basic (unchanged; Yggdrasil
     II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:44Z'
   action: demote
   contributor: mbtiongson1
@@ -68,6 +70,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch
     origin=False TM=100.0 (≥ 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 evidence:
 - source: https://arxiv.org/abs/2203.11171
   evaluator: mbtiongson1

--- a/registry/named/pbakaus/impeccable.md
+++ b/registry/named/pbakaus/impeccable.md
@@ -133,6 +133,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''ux-audit'' type: basic (unchanged; Yggdrasil II taxonomy
     migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 122.8
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/ruvnet/agentdb.md
+++ b/registry/named/ruvnet/agentdb.md
@@ -102,6 +102,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''agent-memory-platform'' type: extra/ultimate → fusion
     (Yggdrasil II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:44Z'
   action: demote
   contributor: mbtiongson1
@@ -109,6 +111,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch
     TM=81.0 (< 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 201.0
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/ruvnet/dual-mode.md
+++ b/registry/named/ruvnet/dual-mode.md
@@ -70,6 +70,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''dual-mode'' type: extra/ultimate → fusion (Yggdrasil
     II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:44Z'
   action: demote
   contributor: mbtiongson1
@@ -77,6 +79,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch
     TM=36.0 (< 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 126.0
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/ruvnet/reasoningbank.md
+++ b/registry/named/ruvnet/reasoningbank.md
@@ -133,6 +133,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''reasoning-pattern-bank'' type: extra/ultimate → fusion
     (Yggdrasil II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:44Z'
   action: demote
   contributor: mbtiongson1
@@ -140,6 +142,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch
     TM=88.5 (< 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 118.5
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/ruvnet/ruflo-v3.md
+++ b/registry/named/ruvnet/ruflo-v3.md
@@ -76,6 +76,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''platform-modernization-sprint'' type: extra/ultimate
     → fusion (Yggdrasil II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:44Z'
   action: demote
   contributor: mbtiongson1
@@ -83,6 +85,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ suite-branch gate failed (suite-branch
     TM=36.0 (< 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 186.0
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/ruvnet/ruflo.md
+++ b/registry/named/ruvnet/ruflo.md
@@ -179,6 +179,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''multi-topology-orchestration'' type: extra/ultimate →
     fusion (Yggdrasil II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 482.27
 overallTrustGrade: S
 apexGateStatus:

--- a/registry/named/safishamsi/graphify.md
+++ b/registry/named/safishamsi/graphify.md
@@ -66,6 +66,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''knowledge-graph-build'' type: extra/ultimate → fusion
     (Yggdrasil II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:44Z'
   action: demote
   contributor: mbtiongson1
@@ -73,6 +75,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch
     origin=False TM=122.9 (≥ 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 116.57
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/named/stanfordnlp/dspy.md
+++ b/registry/named/stanfordnlp/dspy.md
@@ -51,6 +51,8 @@ timeline:
   contributor: mbtiongson1
   details: 'Generic parent ''prompt-optimization'' type: extra/ultimate → fusion (Yggdrasil
     II taxonomy migration #997)'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 - timestamp: '2026-07-16T08:36:44Z'
   action: demote
   contributor: mbtiongson1
@@ -58,6 +60,8 @@ timeline:
   newValue: 3★
   details: 'Yggdrasil II recalibration: 4★ unique-branch gate failed (unique-branch
     origin=False TM=100.0 (≥ 100.0)) — demoted to 3★ Evolved'
+  metaEpoch: yggdrasil-ii
+  migrationBatch: yggdrasil-ii@2026-07-16
 trustMagnitude: 100.0
 overallTrustGrade: A
 apexGateStatus:

--- a/registry/nodes/fusion/advanced-swarm-coordination.json
+++ b/registry/nodes/fusion/advanced-swarm-coordination.json
@@ -28,7 +28,9 @@
       "timestamp": "2026-07-16T08:31:16Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/adversarial-robustness-testing.json
+++ b/registry/nodes/fusion/adversarial-robustness-testing.json
@@ -90,7 +90,9 @@
       "timestamp": "2026-07-16T08:31:16Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/agent-environment-setup.json
+++ b/registry/nodes/fusion/agent-environment-setup.json
@@ -55,7 +55,9 @@
       "timestamp": "2026-07-16T08:31:16Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/agent-eval.json
+++ b/registry/nodes/fusion/agent-eval.json
@@ -76,7 +76,9 @@
       "timestamp": "2026-07-16T08:31:16Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/agent-handoff.json
+++ b/registry/nodes/fusion/agent-handoff.json
@@ -56,7 +56,9 @@
       "timestamp": "2026-07-16T08:31:17Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/agent-memory-learning.json
+++ b/registry/nodes/fusion/agent-memory-learning.json
@@ -65,7 +65,9 @@
       "timestamp": "2026-07-16T08:31:17Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/agent-memory-platform.json
+++ b/registry/nodes/fusion/agent-memory-platform.json
@@ -43,7 +43,9 @@
       "timestamp": "2026-07-16T08:31:17Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/agentic-workflow-design.json
+++ b/registry/nodes/fusion/agentic-workflow-design.json
@@ -56,7 +56,9 @@
       "timestamp": "2026-07-16T08:31:17Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/architecture-diagram.json
+++ b/registry/nodes/fusion/architecture-diagram.json
@@ -47,7 +47,9 @@
       "timestamp": "2026-07-16T08:31:17Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/automated-testing.json
+++ b/registry/nodes/fusion/automated-testing.json
@@ -50,7 +50,9 @@
       "timestamp": "2026-07-16T08:31:17Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/autonomous-data-scientist.json
+++ b/registry/nodes/fusion/autonomous-data-scientist.json
@@ -84,7 +84,9 @@
       "timestamp": "2026-07-16T08:31:17Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/autonomous-debug.json
+++ b/registry/nodes/fusion/autonomous-debug.json
@@ -65,7 +65,9 @@
       "timestamp": "2026-07-16T08:31:17Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/autonomous-web-research.json
+++ b/registry/nodes/fusion/autonomous-web-research.json
@@ -78,7 +78,9 @@
       "timestamp": "2026-07-16T08:31:17Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/brainstorming.json
+++ b/registry/nodes/fusion/brainstorming.json
@@ -38,7 +38,9 @@
       "timestamp": "2026-07-16T08:31:17Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/browser-automation.json
+++ b/registry/nodes/fusion/browser-automation.json
@@ -64,7 +64,9 @@
       "timestamp": "2026-07-16T08:31:17Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/career-operations.json
+++ b/registry/nodes/fusion/career-operations.json
@@ -29,7 +29,9 @@
       "timestamp": "2026-07-16T08:31:17Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/causal-inference.json
+++ b/registry/nodes/fusion/causal-inference.json
@@ -69,7 +69,9 @@
       "timestamp": "2026-07-16T08:31:17Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/cloud-platform-management.json
+++ b/registry/nodes/fusion/cloud-platform-management.json
@@ -28,7 +28,9 @@
       "timestamp": "2026-07-16T08:31:17Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/code-review-pipeline.json
+++ b/registry/nodes/fusion/code-review-pipeline.json
@@ -66,7 +66,9 @@
       "timestamp": "2026-07-16T08:31:17Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/collaborative-diagramming.json
+++ b/registry/nodes/fusion/collaborative-diagramming.json
@@ -46,7 +46,9 @@
       "timestamp": "2026-07-16T08:31:18Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/computational-biology-workflows.json
+++ b/registry/nodes/fusion/computational-biology-workflows.json
@@ -76,7 +76,9 @@
       "timestamp": "2026-07-16T08:31:18Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/content-moderation.json
+++ b/registry/nodes/fusion/content-moderation.json
@@ -59,7 +59,9 @@
       "timestamp": "2026-07-16T08:31:18Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/conversational-agent.json
+++ b/registry/nodes/fusion/conversational-agent.json
@@ -49,7 +49,9 @@
       "timestamp": "2026-07-16T08:31:18Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/data-analysis.json
+++ b/registry/nodes/fusion/data-analysis.json
@@ -49,7 +49,9 @@
       "timestamp": "2026-07-16T08:31:18Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/deployment-automation.json
+++ b/registry/nodes/fusion/deployment-automation.json
@@ -30,7 +30,9 @@
       "timestamp": "2026-07-16T08:31:18Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/design-generation.json
+++ b/registry/nodes/fusion/design-generation.json
@@ -30,7 +30,9 @@
       "timestamp": "2026-07-16T08:31:18Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/design-review.json
+++ b/registry/nodes/fusion/design-review.json
@@ -61,7 +61,9 @@
       "timestamp": "2026-07-16T08:31:18Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/design-system-extraction.json
+++ b/registry/nodes/fusion/design-system-extraction.json
@@ -31,7 +31,9 @@
       "timestamp": "2026-07-16T08:31:18Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/detect-anomaly.json
+++ b/registry/nodes/fusion/detect-anomaly.json
@@ -55,7 +55,9 @@
       "timestamp": "2026-07-16T08:31:18Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/dispatching-parallel-agents.json
+++ b/registry/nodes/fusion/dispatching-parallel-agents.json
@@ -40,7 +40,9 @@
       "timestamp": "2026-07-16T08:31:18Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/distributed-consensus-coordination.json
+++ b/registry/nodes/fusion/distributed-consensus-coordination.json
@@ -40,7 +40,9 @@
       "timestamp": "2026-07-16T08:31:18Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/distributed-neural-training.json
+++ b/registry/nodes/fusion/distributed-neural-training.json
@@ -28,7 +28,9 @@
       "timestamp": "2026-07-16T08:31:18Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/distributed-vector-memory.json
+++ b/registry/nodes/fusion/distributed-vector-memory.json
@@ -28,7 +28,9 @@
       "timestamp": "2026-07-16T08:31:18Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/document-analyst.json
+++ b/registry/nodes/fusion/document-analyst.json
@@ -82,7 +82,9 @@
       "timestamp": "2026-07-16T08:31:19Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/dual-mode.json
+++ b/registry/nodes/fusion/dual-mode.json
@@ -29,7 +29,9 @@
       "timestamp": "2026-07-16T08:31:19Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/e2e-testing.json
+++ b/registry/nodes/fusion/e2e-testing.json
@@ -46,7 +46,9 @@
       "timestamp": "2026-07-16T08:31:19Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/edge-optimization.json
+++ b/registry/nodes/fusion/edge-optimization.json
@@ -69,7 +69,9 @@
       "timestamp": "2026-07-16T08:31:19Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/engineering-discipline.json
+++ b/registry/nodes/fusion/engineering-discipline.json
@@ -105,7 +105,9 @@
       "timestamp": "2026-07-16T08:31:19Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/executing-plans.json
+++ b/registry/nodes/fusion/executing-plans.json
@@ -39,7 +39,9 @@
       "timestamp": "2026-07-16T08:31:19Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/explainability-audit.json
+++ b/registry/nodes/fusion/explainability-audit.json
@@ -90,7 +90,9 @@
       "timestamp": "2026-07-16T08:31:19Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/financial-modeling.json
+++ b/registry/nodes/fusion/financial-modeling.json
@@ -90,7 +90,9 @@
       "timestamp": "2026-07-16T08:31:19Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/finishing-a-development-branch.json
+++ b/registry/nodes/fusion/finishing-a-development-branch.json
@@ -40,7 +40,9 @@
       "timestamp": "2026-07-16T08:31:19Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/firecrawl.json
+++ b/registry/nodes/fusion/firecrawl.json
@@ -46,7 +46,9 @@
       "timestamp": "2026-07-16T08:31:19Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/founder-mode-orchestration.json
+++ b/registry/nodes/fusion/founder-mode-orchestration.json
@@ -81,7 +81,9 @@
       "timestamp": "2026-07-16T08:31:26Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from ultimate to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from ultimate to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/full-stack-developer.json
+++ b/registry/nodes/fusion/full-stack-developer.json
@@ -84,7 +84,9 @@
       "timestamp": "2026-07-16T08:31:19Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/function-calling.json
+++ b/registry/nodes/fusion/function-calling.json
@@ -74,7 +74,9 @@
       "timestamp": "2026-07-16T08:31:19Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/generative-media.json
+++ b/registry/nodes/fusion/generative-media.json
@@ -46,7 +46,9 @@
       "timestamp": "2026-07-16T08:31:19Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/ghostwrite.json
+++ b/registry/nodes/fusion/ghostwrite.json
@@ -37,7 +37,9 @@
       "timestamp": "2026-07-16T08:31:19Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/git-integration.json
+++ b/registry/nodes/fusion/git-integration.json
@@ -45,7 +45,9 @@
       "timestamp": "2026-07-16T08:31:20Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/git-ship-done-pipeline.json
+++ b/registry/nodes/fusion/git-ship-done-pipeline.json
@@ -40,7 +40,9 @@
       "timestamp": "2026-07-16T08:31:26Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from ultimate to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from ultimate to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/graph-driven-issue-triage.json
+++ b/registry/nodes/fusion/graph-driven-issue-triage.json
@@ -37,7 +37,9 @@
       "timestamp": "2026-07-16T08:31:20Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/grill-me.json
+++ b/registry/nodes/fusion/grill-me.json
@@ -30,7 +30,9 @@
       "timestamp": "2026-07-16T08:31:20Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/grill-with-docs.json
+++ b/registry/nodes/fusion/grill-with-docs.json
@@ -66,7 +66,9 @@
       "timestamp": "2026-07-16T08:31:20Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/grounding.json
+++ b/registry/nodes/fusion/grounding.json
@@ -65,7 +65,9 @@
       "timestamp": "2026-07-16T08:31:20Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/guardrails.json
+++ b/registry/nodes/fusion/guardrails.json
@@ -62,7 +62,9 @@
       "timestamp": "2026-07-16T08:31:20Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/humanize-prose.json
+++ b/registry/nodes/fusion/humanize-prose.json
@@ -47,7 +47,9 @@
       "timestamp": "2026-07-16T08:31:20Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/knowledge-graph-build.json
+++ b/registry/nodes/fusion/knowledge-graph-build.json
@@ -76,7 +76,9 @@
       "timestamp": "2026-07-16T08:31:20Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ],
   "verification": {

--- a/registry/nodes/fusion/knowledge-harvest.json
+++ b/registry/nodes/fusion/knowledge-harvest.json
@@ -37,7 +37,9 @@
       "timestamp": "2026-07-16T08:31:20Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/knowledge-management.json
+++ b/registry/nodes/fusion/knowledge-management.json
@@ -49,7 +49,9 @@
       "timestamp": "2026-07-16T08:31:20Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/literature-review.json
+++ b/registry/nodes/fusion/literature-review.json
@@ -52,7 +52,9 @@
       "timestamp": "2026-07-16T08:31:20Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/mathematical-animation.json
+++ b/registry/nodes/fusion/mathematical-animation.json
@@ -46,7 +46,9 @@
       "timestamp": "2026-07-16T08:31:21Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/mcp-debugger-control.json
+++ b/registry/nodes/fusion/mcp-debugger-control.json
@@ -52,7 +52,9 @@
       "timestamp": "2026-07-16T08:31:21Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/mcp-server-creation.json
+++ b/registry/nodes/fusion/mcp-server-creation.json
@@ -79,7 +79,9 @@
       "timestamp": "2026-07-16T08:31:21Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/memory-manage.json
+++ b/registry/nodes/fusion/memory-manage.json
@@ -56,7 +56,9 @@
       "timestamp": "2026-07-16T08:31:21Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/ml-artifact-management.json
+++ b/registry/nodes/fusion/ml-artifact-management.json
@@ -46,7 +46,9 @@
       "timestamp": "2026-07-16T08:31:21Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/ml-pipeline.json
+++ b/registry/nodes/fusion/ml-pipeline.json
@@ -60,7 +60,9 @@
       "timestamp": "2026-07-16T08:31:21Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/multi-agent-debate.json
+++ b/registry/nodes/fusion/multi-agent-debate.json
@@ -76,7 +76,9 @@
       "timestamp": "2026-07-16T08:31:21Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/multi-agent-orchestration-v.json
+++ b/registry/nodes/fusion/multi-agent-orchestration-v.json
@@ -70,7 +70,9 @@
       "timestamp": "2026-07-16T08:31:21Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/multi-node-orchestration.json
+++ b/registry/nodes/fusion/multi-node-orchestration.json
@@ -35,7 +35,9 @@
       "timestamp": "2026-07-16T08:31:21Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/multi-topology-orchestration.json
+++ b/registry/nodes/fusion/multi-topology-orchestration.json
@@ -44,7 +44,9 @@
       "timestamp": "2026-07-16T08:31:26Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from ultimate to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from ultimate to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/multimodal-reasoning.json
+++ b/registry/nodes/fusion/multimodal-reasoning.json
@@ -59,7 +59,9 @@
       "timestamp": "2026-07-16T08:31:21Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/ontology-alignment.json
+++ b/registry/nodes/fusion/ontology-alignment.json
@@ -90,7 +90,9 @@
       "timestamp": "2026-07-16T08:31:21Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/personal-knowledge-management.json
+++ b/registry/nodes/fusion/personal-knowledge-management.json
@@ -55,7 +55,9 @@
       "timestamp": "2026-07-16T08:31:21Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/personal.json
+++ b/registry/nodes/fusion/personal.json
@@ -83,7 +83,9 @@
       "timestamp": "2026-07-16T08:31:21Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/plan-and-execute.json
+++ b/registry/nodes/fusion/plan-and-execute.json
@@ -55,7 +55,9 @@
       "timestamp": "2026-07-16T08:31:22Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/platform-modernization-sprint.json
+++ b/registry/nodes/fusion/platform-modernization-sprint.json
@@ -31,7 +31,9 @@
       "timestamp": "2026-07-16T08:31:22Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/prd-generation.json
+++ b/registry/nodes/fusion/prd-generation.json
@@ -47,7 +47,9 @@
       "timestamp": "2026-07-16T08:31:22Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/prediction-market-analysis.json
+++ b/registry/nodes/fusion/prediction-market-analysis.json
@@ -47,7 +47,9 @@
       "timestamp": "2026-07-16T08:31:22Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/productivity.json
+++ b/registry/nodes/fusion/productivity.json
@@ -85,7 +85,9 @@
       "timestamp": "2026-07-16T08:31:22Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/project-management.json
+++ b/registry/nodes/fusion/project-management.json
@@ -48,7 +48,9 @@
       "timestamp": "2026-07-16T08:31:22Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/prompt-optimization.json
+++ b/registry/nodes/fusion/prompt-optimization.json
@@ -62,7 +62,9 @@
       "timestamp": "2026-07-16T08:31:22Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/prototype.json
+++ b/registry/nodes/fusion/prototype.json
@@ -55,7 +55,9 @@
       "timestamp": "2026-07-16T08:31:22Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/rag-pipeline.json
+++ b/registry/nodes/fusion/rag-pipeline.json
@@ -63,7 +63,9 @@
       "timestamp": "2026-07-16T08:31:22Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/re-act-reasoning.json
+++ b/registry/nodes/fusion/re-act-reasoning.json
@@ -62,7 +62,9 @@
       "timestamp": "2026-07-16T08:31:22Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/real-time-voice-assistant.json
+++ b/registry/nodes/fusion/real-time-voice-assistant.json
@@ -84,7 +84,9 @@
       "timestamp": "2026-07-16T08:31:22Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/reasoning-pattern-bank.json
+++ b/registry/nodes/fusion/reasoning-pattern-bank.json
@@ -28,7 +28,9 @@
       "timestamp": "2026-07-16T08:31:22Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/receiving-code-review.json
+++ b/registry/nodes/fusion/receiving-code-review.json
@@ -38,7 +38,9 @@
       "timestamp": "2026-07-16T08:31:22Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/recursive-self-improvement.json
+++ b/registry/nodes/fusion/recursive-self-improvement.json
@@ -46,7 +46,9 @@
       "timestamp": "2026-07-16T08:31:23Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/registry-curation.json
+++ b/registry/nodes/fusion/registry-curation.json
@@ -107,7 +107,9 @@
       "timestamp": "2026-07-16T08:31:23Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/registry-entry-audit.json
+++ b/registry/nodes/fusion/registry-entry-audit.json
@@ -53,7 +53,9 @@
       "timestamp": "2026-07-16T08:31:23Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/registry-health-scan.json
+++ b/registry/nodes/fusion/registry-health-scan.json
@@ -35,7 +35,9 @@
       "timestamp": "2026-07-16T08:31:23Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/regulatory-compliance-mapping.json
+++ b/registry/nodes/fusion/regulatory-compliance-mapping.json
@@ -90,7 +90,9 @@
       "timestamp": "2026-07-16T08:31:23Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/release-automation.json
+++ b/registry/nodes/fusion/release-automation.json
@@ -29,7 +29,9 @@
       "timestamp": "2026-07-16T08:31:23Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/requesting-code-review.json
+++ b/registry/nodes/fusion/requesting-code-review.json
@@ -39,7 +39,9 @@
       "timestamp": "2026-07-16T08:31:23Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/research.json
+++ b/registry/nodes/fusion/research.json
@@ -55,7 +55,9 @@
       "timestamp": "2026-07-16T08:31:23Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/scientific-discovery.json
+++ b/registry/nodes/fusion/scientific-discovery.json
@@ -85,7 +85,9 @@
       "timestamp": "2026-07-16T08:31:23Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/scientific-writing.json
+++ b/registry/nodes/fusion/scientific-writing.json
@@ -51,7 +51,9 @@
       "timestamp": "2026-07-16T08:31:23Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/search-engine-optimization.json
+++ b/registry/nodes/fusion/search-engine-optimization.json
@@ -53,7 +53,9 @@
       "timestamp": "2026-07-16T08:31:23Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/security-audit.json
+++ b/registry/nodes/fusion/security-audit.json
@@ -47,7 +47,9 @@
       "timestamp": "2026-07-16T08:31:23Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/skill-authoring.json
+++ b/registry/nodes/fusion/skill-authoring.json
@@ -86,7 +86,9 @@
       "timestamp": "2026-07-16T08:31:23Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/skill-fusion.json
+++ b/registry/nodes/fusion/skill-fusion.json
@@ -25,7 +25,9 @@
       "timestamp": "2026-07-16T08:31:24Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/skill-mastery.json
+++ b/registry/nodes/fusion/skill-mastery.json
@@ -128,7 +128,9 @@
       "timestamp": "2026-07-16T08:31:26Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from ultimate to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from ultimate to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/skill-performance-benchmarking.json
+++ b/registry/nodes/fusion/skill-performance-benchmarking.json
@@ -81,7 +81,9 @@
       "timestamp": "2026-07-16T08:31:24Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/skill-security-analysis.json
+++ b/registry/nodes/fusion/skill-security-analysis.json
@@ -92,7 +92,9 @@
       "timestamp": "2026-07-16T08:31:24Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/stealth-browser-interaction.json
+++ b/registry/nodes/fusion/stealth-browser-interaction.json
@@ -53,7 +53,9 @@
       "timestamp": "2026-07-16T08:31:24Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/subagent-driven-development.json
+++ b/registry/nodes/fusion/subagent-driven-development.json
@@ -39,7 +39,9 @@
       "timestamp": "2026-07-16T08:31:24Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/superpowers.json
+++ b/registry/nodes/fusion/superpowers.json
@@ -49,7 +49,9 @@
       "timestamp": "2026-07-16T08:31:26Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from ultimate to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from ultimate to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/supply-chain-optimization.json
+++ b/registry/nodes/fusion/supply-chain-optimization.json
@@ -90,7 +90,9 @@
       "timestamp": "2026-07-16T08:31:24Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/systematic-debugging.json
+++ b/registry/nodes/fusion/systematic-debugging.json
@@ -39,7 +39,9 @@
       "timestamp": "2026-07-16T08:31:24Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/text-to-sql-pipeline.json
+++ b/registry/nodes/fusion/text-to-sql-pipeline.json
@@ -59,7 +59,9 @@
       "timestamp": "2026-07-16T08:31:24Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/threat-intelligence-synthesis.json
+++ b/registry/nodes/fusion/threat-intelligence-synthesis.json
@@ -90,7 +90,9 @@
       "timestamp": "2026-07-16T08:31:24Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/tool-chaining.json
+++ b/registry/nodes/fusion/tool-chaining.json
@@ -59,7 +59,9 @@
       "timestamp": "2026-07-16T08:31:24Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/tool-creation.json
+++ b/registry/nodes/fusion/tool-creation.json
@@ -63,7 +63,9 @@
       "timestamp": "2026-07-16T08:31:24Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/translation-pipeline.json
+++ b/registry/nodes/fusion/translation-pipeline.json
@@ -59,7 +59,9 @@
       "timestamp": "2026-07-16T08:31:24Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/tree-of-thought.json
+++ b/registry/nodes/fusion/tree-of-thought.json
@@ -61,7 +61,9 @@
       "timestamp": "2026-07-16T08:31:24Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/ubiquitous-language.json
+++ b/registry/nodes/fusion/ubiquitous-language.json
@@ -44,7 +44,9 @@
       "timestamp": "2026-07-16T08:31:25Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/using-git-worktrees.json
+++ b/registry/nodes/fusion/using-git-worktrees.json
@@ -38,7 +38,9 @@
       "timestamp": "2026-07-16T08:31:25Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/verification-before-completion.json
+++ b/registry/nodes/fusion/verification-before-completion.json
@@ -39,7 +39,9 @@
       "timestamp": "2026-07-16T08:31:25Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/vertical-slice-planning.json
+++ b/registry/nodes/fusion/vertical-slice-planning.json
@@ -30,7 +30,9 @@
       "timestamp": "2026-07-16T08:31:25Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/video-intelligence.json
+++ b/registry/nodes/fusion/video-intelligence.json
@@ -30,7 +30,9 @@
       "timestamp": "2026-07-16T08:31:25Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/voice-agent.json
+++ b/registry/nodes/fusion/voice-agent.json
@@ -47,7 +47,9 @@
       "timestamp": "2026-07-16T08:31:25Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/web-accessibility.json
+++ b/registry/nodes/fusion/web-accessibility.json
@@ -53,7 +53,9 @@
       "timestamp": "2026-07-16T08:31:25Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/web-best-practices.json
+++ b/registry/nodes/fusion/web-best-practices.json
@@ -53,7 +53,9 @@
       "timestamp": "2026-07-16T08:31:25Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/web-quality-audit.json
+++ b/registry/nodes/fusion/web-quality-audit.json
@@ -74,7 +74,9 @@
       "timestamp": "2026-07-16T08:31:25Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/web-scrape.json
+++ b/registry/nodes/fusion/web-scrape.json
@@ -53,7 +53,9 @@
       "timestamp": "2026-07-16T08:31:25Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/wiki-search.json
+++ b/registry/nodes/fusion/wiki-search.json
@@ -47,7 +47,9 @@
       "timestamp": "2026-07-16T08:31:25Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/workflow-automation.json
+++ b/registry/nodes/fusion/workflow-automation.json
@@ -79,7 +79,9 @@
       "timestamp": "2026-07-16T08:31:25Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/workspace-automation.json
+++ b/registry/nodes/fusion/workspace-automation.json
@@ -48,7 +48,9 @@
       "timestamp": "2026-07-16T08:31:25Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/writing-plans.json
+++ b/registry/nodes/fusion/writing-plans.json
@@ -39,7 +39,9 @@
       "timestamp": "2026-07-16T08:31:26Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/nodes/fusion/x-twitter-automation.json
+++ b/registry/nodes/fusion/x-twitter-automation.json
@@ -31,7 +31,9 @@
       "timestamp": "2026-07-16T08:31:26Z",
       "action": "type_change",
       "contributor": "mbtiongson1",
-      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)"
+      "details": "Reclassified from extra to fusion (Yggdrasil II taxonomy migration #997)",
+      "metaEpoch": "yggdrasil-ii",
+      "migrationBatch": "yggdrasil-ii@2026-07-16"
     }
   ]
 }

--- a/registry/schema/meta.json
+++ b/registry/schema/meta.json
@@ -91,6 +91,16 @@
       "minOriginContributions": 1
     }
   },
+  "metaEpochs": {
+    "order": [
+      "yggdrasil-i",
+      "yggdrasil-ii"
+    ],
+    "labels": {
+      "yggdrasil-i": "Yggdrasil I",
+      "yggdrasil-ii": "Yggdrasil II"
+    }
+  },
   "evidence": {
     "classes": [
       "A",

--- a/registry/schema/namedSkill.schema.json
+++ b/registry/schema/namedSkill.schema.json
@@ -565,6 +565,19 @@
         "newValue": {
           "type": "string",
           "description": "The level/status after this event (e.g. '3★')."
+        },
+        "metaEpoch": {
+          "type": "string",
+          "enum": [
+            "yggdrasil-i",
+            "yggdrasil-ii"
+          ],
+          "description": "Optional structured provenance: the meta epoch (schema-generation slug) this event belongs to. Mirrors meta.json metaEpochs.order. Stamped on migration events (e.g. paired type_change/demote) so provenance is queryable without prose parsing. Absent on pre-Yggdrasil-II (legacy) events."
+        },
+        "migrationBatch": {
+          "type": "string",
+          "pattern": "^[a-z0-9-]+@\\d{4}-\\d{2}-\\d{2}$",
+          "description": "Optional structured provenance: the migration batch identifier in '<epoch-slug>@YYYY-MM-DD' form (e.g. 'yggdrasil-ii@2026-07-16'). Pairs a type_change with its resulting demote in the same batch so the migration-provenance invariant can verify them structurally. Absent on non-migration and legacy events."
         }
       }
     }

--- a/registry/schema/skill.schema.json
+++ b/registry/schema/skill.schema.json
@@ -566,6 +566,19 @@
         "newValue": {
           "type": "string",
           "description": "The level/status after this event (e.g. '3★')."
+        },
+        "metaEpoch": {
+          "type": "string",
+          "enum": [
+            "yggdrasil-i",
+            "yggdrasil-ii"
+          ],
+          "description": "Optional structured provenance: the meta epoch (schema-generation slug) this event belongs to. Mirrors meta.json metaEpochs.order. Stamped on migration events (e.g. a node type_change) so provenance is queryable without prose parsing. Absent on pre-Yggdrasil-II (legacy) events."
+        },
+        "migrationBatch": {
+          "type": "string",
+          "pattern": "^[a-z0-9-]+@\\d{4}-\\d{2}-\\d{2}$",
+          "description": "Optional structured provenance: the migration batch identifier in '<epoch-slug>@YYYY-MM-DD' form (e.g. 'yggdrasil-ii@2026-07-16'). Groups the events of one dated migration batch so provenance can be verified structurally. Absent on non-migration and legacy events."
         }
       }
     }

--- a/scripts/assemble_gaia.py
+++ b/scripts/assemble_gaia.py
@@ -72,7 +72,8 @@ def assemble(registry_root="."):
             "levelColors": meta_src["levels"]["colors"],
             "typeColors": meta_src["types"]["colors"],
             "typeSymbols": meta_src["types"]["symbols"],
-            "demeritLabels": meta_src["demerits"]["labels"]
+            "demeritLabels": meta_src["demerits"]["labels"],
+            "metaEpochs": meta_src.get("metaEpochs", {})
         }
     else:
         meta_mapped = old_data.get("meta", {})

--- a/scripts/migrate_taxonomy_v6.py
+++ b/scripts/migrate_taxonomy_v6.py
@@ -90,6 +90,18 @@ TM_FLOOR_5STAR = 250.0
 FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n?(.*)", re.DOTALL)
 
 # ---------------------------------------------------------------------------
+# Yggdrasil II structured provenance (#1189)
+# ---------------------------------------------------------------------------
+# metaEpoch is the schema-generation slug; migrationBatch pairs a type_change with
+# its resulting demote inside one dated batch, so the provenance invariant
+# (scripts/validate_timelines.py::check_migration_provenance) can verify them
+# structurally instead of parsing prose.
+META_EPOCH = "yggdrasil-ii"
+# Prose marker written by the original #997 migration. Used to detect legacy events
+# that predate structured provenance and must be UPGRADED in place (never duplicated).
+LEGACY_PROSE_MARKER = "Yggdrasil II"
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
@@ -99,6 +111,55 @@ def _now_iso() -> str:
 
 def _today_iso() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def _default_migration_batch() -> str:
+    """Default batch id in '<epoch>@YYYY-MM-DD' form (e.g. yggdrasil-ii@2026-07-16)."""
+    return f"{META_EPOCH}@{_today_iso()}"
+
+
+def _is_migration_event(e: Any) -> bool:
+    """True for a legacy Yggdrasil II type_change/demote event (prose-marked)."""
+    return (
+        isinstance(e, dict)
+        and e.get("action") in ("type_change", "demote")
+        and LEGACY_PROSE_MARKER in (e.get("details") or "")
+    )
+
+
+def _already_batched(timeline: list, migration_batch: str) -> bool:
+    """True if any event already carries this migrationBatch (already migrated)."""
+    return any(
+        isinstance(e, dict) and e.get("migrationBatch") == migration_batch
+        for e in timeline
+    )
+
+
+def _has_upgradable_events(timeline: list) -> bool:
+    """True if the timeline holds legacy Ygg II events that lack a migrationBatch."""
+    return any(
+        _is_migration_event(e) and not e.get("migrationBatch") for e in timeline
+    )
+
+
+def _stamp(event: dict, migration_batch: str) -> dict:
+    """Attach structured provenance to a freshly-built migration event, in place."""
+    event["metaEpoch"] = META_EPOCH
+    event["migrationBatch"] = migration_batch
+    return event
+
+
+def _upgrade_legacy_events(timeline: list, migration_batch: str) -> int:
+    """In-place upgrade: stamp metaEpoch/migrationBatch on legacy Yggdrasil II
+    type_change/demote events that lack a migrationBatch. Returns the number of
+    events upgraded. Never appends, removes, reorders, or rewrites `details`."""
+    upgraded = 0
+    for e in timeline:
+        if _is_migration_event(e) and not e.get("migrationBatch"):
+            e["metaEpoch"] = META_EPOCH
+            e["migrationBatch"] = migration_batch
+            upgraded += 1
+    return upgraded
 
 
 def _load_node(path: Path) -> dict:
@@ -210,6 +271,7 @@ def _derive_v6_type(data: dict, path: Path) -> tuple[str, str | None]:
 def migrate_starless_nodes(
     dry_run: bool,
     stats: dict[str, Any],
+    migration_batch: str,
 ) -> dict[str, str]:
     """Phase A wrapper — returns a mapping of nodeId -> legacyType for Phase B."""
     """Phase A: rewrite type fields and reorganise directories."""
@@ -306,17 +368,24 @@ def migrate_starless_nodes(
             if not isinstance(timeline, list):
                 timeline = []
 
-            # Idempotency: skip if already has a type_change for this migration
-            already_changed = any(
-                isinstance(e, dict) and e.get("action") == "type_change" and "Yggdrasil II" in (e.get("details") or "")
-                for e in timeline
-            )
-            if already_changed:
+            # Idempotency: skip if already stamped with this migration batch
+            if _already_batched(timeline, migration_batch):
+                already_done += 1
+                continue
+            # Upgrade path: legacy #997 events (prose-marked) that lack structured
+            # provenance — stamp them in place, never append a duplicate, never
+            # re-run gate math or re-git mv.
+            if _has_upgradable_events(timeline):
+                _upgrade_legacy_events(timeline, migration_batch)
+                data["timeline"] = timeline
+                data["updatedAt"] = _today_iso()
+                if not dry_run:
+                    _save_node(active_path, data)
                 already_done += 1
                 continue
 
             ts = _now_iso()
-            timeline.append({
+            timeline.append(_stamp({
                 "timestamp": ts,
                 "action": "type_change",
                 "contributor": "mbtiongson1",
@@ -324,7 +393,7 @@ def migrate_starless_nodes(
                     f"Reclassified from {legacy_type} to {v6_type} "
                     f"(Yggdrasil II taxonomy migration #997)"
                 ),
-            })
+            }, migration_batch))
             data["type"] = v6_type
             data["updatedAt"] = _today_iso()
             data["timeline"] = timeline
@@ -401,6 +470,7 @@ def migrate_named_skills(
     namedSkillMap: dict,
     legacy_type_map: dict[str, str],
     stats: dict[str, Any],
+    migration_batch: str,
 ) -> None:
     """Phase B: append type_change events + evaluate 4★ branch gates."""
     print("\n=== Phase B: Named-skill recalibration ===")
@@ -442,13 +512,18 @@ def migrate_named_skills(
         timeline = fm.get("timeline")
         if not isinstance(timeline, list):
             timeline = []
-        already_changed = any(
-            isinstance(e, dict)
-            and e.get("action") == "type_change"
-            and "Yggdrasil II" in (e.get("details") or "")
-            for e in timeline
-        )
-        if already_changed:
+        # Idempotency: skip if already stamped with this migration batch
+        if _already_batched(timeline, migration_batch):
+            skipped += 1
+            continue
+        # Upgrade path: legacy #997 events (prose-marked) lacking structured
+        # provenance — stamp them in place, never append a duplicate, never re-gate.
+        if _has_upgradable_events(timeline):
+            _upgrade_legacy_events(timeline, migration_batch)
+            fm["timeline"] = timeline
+            fm["updatedAt"] = _today_iso()
+            if not dry_run:
+                _save_named_skill(path, fm, body)
             skipped += 1
             continue
 
@@ -468,12 +543,12 @@ def migrate_named_skills(
                 f"Generic parent '{ref}' type: basic (unchanged; "
                 f"Yggdrasil II taxonomy migration #997)"
             )
-        type_change_event: dict = {
+        type_change_event: dict = _stamp({
             "timestamp": ts,
             "action": "type_change",
             "contributor": "mbtiongson1",
             "details": type_change_details,
-        }
+        }, migration_batch)
         timeline.append(type_change_event)
         type_changes.append({"skillId": skill_id, "level": level, "details": type_change_details})
 
@@ -515,7 +590,7 @@ def migrate_named_skills(
 
             if allow_5star_demote and gate_would_fail and not suite_preserved:
                 # Only demote 5★ when explicitly requested AND it's not a Suite
-                demote_event: dict = {
+                demote_event: dict = _stamp({
                     "timestamp": ts,
                     "action": "demote",
                     "contributor": "mbtiongson1",
@@ -526,7 +601,7 @@ def migrate_named_skills(
                         f"(TM={tm:.1f} < {TM_FLOOR_5STAR}); "
                         "demoted via --allow-5star-demote"
                     ),
-                }
+                }, migration_batch)
                 timeline.append(demote_event)
                 fm["level"] = "3★"
                 demoted = True
@@ -556,7 +631,7 @@ def migrate_named_skills(
                 print(f"  [PASS] {skill_id}: {level} {gate_detail}")
             else:
                 # Demote to 3★ Evolved
-                demote_event = {
+                demote_event = _stamp({
                     "timestamp": ts,
                     "action": "demote",
                     "contributor": "mbtiongson1",
@@ -566,7 +641,7 @@ def migrate_named_skills(
                         f"Yggdrasil II recalibration: 4★ {branch}-branch gate failed "
                         f"({gate_detail}) — demoted to 3★ Evolved"
                     ),
-                }
+                }, migration_batch)
                 timeline.append(demote_event)
                 fm["level"] = "3★"
                 demoted = True
@@ -603,6 +678,90 @@ def migrate_named_skills(
     print(f"  5★ demoted to 3★:            {len([d for d in demotions if d['previousLevel'] == '5★'])}")
     print(f"  5★ FOUNDER_CHECKPOINTs:      {len(founder_checkpoints)}")
     print(f"  Already done (skipped):      {skipped}")
+
+
+# ---------------------------------------------------------------------------
+# Backfill-only: in-place structured-provenance upgrade (no gate math, no moves)
+# ---------------------------------------------------------------------------
+
+def backfill_provenance(
+    dry_run: bool,
+    migration_batch: str,
+    stats: dict[str, Any],
+) -> None:
+    """Upgrade legacy #997 events to structured provenance across ALL registry
+    generic nodes and named skills.
+
+    Idempotent and safe to re-run on already-migrated staging data. Performs ONLY
+    in-place field stamping (metaEpoch/migrationBatch) on existing prose-marked
+    Yggdrasil II type_change/demote events. It does NOT evaluate gates, create new
+    demotions, move files, or append duplicate events. `details` prose is left
+    byte-for-byte intact so downstream regex parsers keep working.
+    """
+    print("\n=== Backfill-only: in-place structured-provenance upgrade ===")
+    print(f"  Batch: {migration_batch}")
+
+    node_upgraded = node_events = node_skipped = 0
+    for p in sorted(NODES_DIR.rglob("*.json")):
+        try:
+            data = _load_node(p)
+        except Exception:
+            continue
+        timeline = data.get("timeline")
+        if not isinstance(timeline, list):
+            continue
+        if _already_batched(timeline, migration_batch):
+            if any(_is_migration_event(e) for e in timeline):
+                node_skipped += 1
+            continue
+        n = _upgrade_legacy_events(timeline, migration_batch)
+        if n:
+            data["timeline"] = timeline
+            data["updatedAt"] = _today_iso()
+            if not dry_run:
+                _save_node(p, data)
+            node_upgraded += 1
+            node_events += n
+            print(f"  [{'dry' if dry_run else 'ok'}] node {data.get('id', p.stem)}: +{n} event(s)")
+
+    named_upgraded = named_events = named_skipped = 0
+    for p in sorted(NAMED_DIR.rglob("*.md")):
+        fm, body = _load_named_skill(p)
+        if fm is None:
+            continue
+        timeline = fm.get("timeline")
+        if not isinstance(timeline, list):
+            continue
+        if _already_batched(timeline, migration_batch):
+            if any(_is_migration_event(e) for e in timeline):
+                named_skipped += 1
+            continue
+        n = _upgrade_legacy_events(timeline, migration_batch)
+        if n:
+            fm["timeline"] = timeline
+            fm["updatedAt"] = _today_iso()
+            if not dry_run:
+                _save_named_skill(p, fm, body)
+            named_upgraded += 1
+            named_events += n
+            print(f"  [{'dry' if dry_run else 'ok'}] named {fm.get('id', p.stem)}: +{n} event(s)")
+
+    stats["backfill"] = {
+        "migrationBatch": migration_batch,
+        "nodesUpgraded": node_upgraded,
+        "nodeEventsStamped": node_events,
+        "nodesAlreadyBatched": node_skipped,
+        "namedUpgraded": named_upgraded,
+        "namedEventsStamped": named_events,
+        "namedAlreadyBatched": named_skipped,
+        "newMoves": 0,
+    }
+
+    print(f"\n  Nodes upgraded:   {node_upgraded} ({node_events} events stamped)")
+    print(f"  Nodes already batched (skipped): {node_skipped}")
+    print(f"  Named upgraded:   {named_upgraded} ({named_events} events stamped)")
+    print(f"  Named already batched (skipped): {named_skipped}")
+    print(f"  New moves:        0")
 
 
 # ---------------------------------------------------------------------------
@@ -731,8 +890,30 @@ def main() -> int:
             "NOT passed in normal Yggdrasil II migration — founder reviews first."
         ),
     )
+    parser.add_argument(
+        "--batch",
+        dest="batch",
+        default=None,
+        help=(
+            "Migration batch id ('<epoch>@YYYY-MM-DD'). "
+            f"Defaults to '{META_EPOCH}@<today>'. Stamped as migrationBatch on "
+            "every migration event (paired type_change/demote)."
+        ),
+    )
+    parser.add_argument(
+        "--backfill-only",
+        dest="backfillOnly",
+        action="store_true",
+        default=False,
+        help=(
+            "Perform ONLY the in-place structured-provenance upgrade of legacy "
+            "#997 events (no gate evaluation, no new demotions, no directory "
+            "moves). Safe to re-run on already-migrated staging data."
+        ),
+    )
     args = parser.parse_args()
     dry_run = not args.apply
+    migration_batch = args.batch or _default_migration_batch()
 
     mode = "DRY-RUN" if dry_run else "APPLY"
     print(f"=== Yggdrasil II taxonomy v6 migration ({mode}) ===")
@@ -744,8 +925,27 @@ def main() -> int:
     stats: dict[str, Any] = {
         "startedAt": _now_iso(),
         "mode": mode,
+        "migrationBatch": migration_batch,
         "allow5starDemote": args.allow5starDemote,
+        "backfillOnly": args.backfillOnly,
     }
+    print(f"  Migration batch: {migration_batch}")
+
+    # ------------------------------------------------------------------
+    # Backfill-only path: in-place structured-provenance upgrade, nothing else.
+    # ------------------------------------------------------------------
+    if args.backfillOnly:
+        backfill_provenance(dry_run=dry_run, migration_batch=migration_batch, stats=stats)
+        stats["finishedAt"] = _now_iso()
+        write_report(stats)
+        bf = stats.get("backfill", {})
+        print("\n=== SUMMARY (backfill-only) ===")
+        print(f"  Batch:              {migration_batch}")
+        print(f"  Nodes upgraded:     {bf.get('nodesUpgraded', 0)} ({bf.get('nodeEventsStamped', 0)} events)")
+        print(f"  Named upgraded:     {bf.get('namedUpgraded', 0)} ({bf.get('namedEventsStamped', 0)} events)")
+        print(f"  Already batched:    nodes={bf.get('nodesAlreadyBatched', 0)} named={bf.get('namedAlreadyBatched', 0)}")
+        print(f"  New moves:          0")
+        return 0
 
     # Build maps using nodes as they currently exist on disk.
     # For Phase B we need genericSkillMap to reflect v6 types — but since Phase A
@@ -758,7 +958,9 @@ def main() -> int:
     print(f"Building namedSkillMap: {len(namedSkillMap)} named skills")
 
     # Phase A
-    legacy_type_map = migrate_starless_nodes(dry_run=dry_run, stats=stats)
+    legacy_type_map = migrate_starless_nodes(
+        dry_run=dry_run, stats=stats, migration_batch=migration_batch
+    )
 
     # Reload genericSkillMap after phase A writes (types may have changed on disk)
     if not dry_run:
@@ -782,6 +984,7 @@ def main() -> int:
         namedSkillMap=namedSkillMap,
         legacy_type_map=legacy_type_map,
         stats=stats,
+        migration_batch=migration_batch,
     )
 
     stats["finishedAt"] = _now_iso()

--- a/scripts/validate_timelines.py
+++ b/scripts/validate_timelines.py
@@ -64,6 +64,64 @@ def _latest_level_event(timeline: list, skill_id: str) -> str | None:
     return _norm(evs[-1].get("newValue"))
 
 
+def _named_registry_entries() -> list:
+    """All registry named-skill index entries (buckets + awaiting classification)."""
+    data = json.loads(NAMED_JSON.read_text(encoding="utf-8"))
+    entries = [e for arr in (data.get("buckets") or {}).values() for e in arr]
+    entries += data.get("awaitingClassification") or []
+    return entries
+
+
+def check_migration_provenance() -> list[str]:
+    """Structural, meta-agnostic migration-provenance invariant (#1189).
+
+    Scans **registry named-skill** timelines only (from ``registry/named-skills.json``).
+    For every ``demote`` event that carries a ``migrationBatch``, the SAME skill must
+    also have a ``type_change`` event whose ``migrationBatch`` is identical. This pairs
+    a taxonomy reclassification with the demotion it triggered, so provenance is
+    verifiable from structured fields alone.
+
+    The rule is deliberately meta-agnostic: no epoch is hardcoded and no time window
+    is applied. Events lacking a ``migrationBatch`` (e.g. pre-provenance Yggdrasil I
+    demotions) are **exempt by absence** — the invariant never fires on them.
+
+    User-tree timelines are out of scope (their action enum has no ``type_change``).
+
+    Returns a list of human-readable violation strings (empty when the invariant holds).
+    """
+    violations: list[str] = []
+    entries = _named_registry_entries()
+    demotes_checked = 0
+
+    for e in entries:
+        sid = e.get("id") or "<unknown>"
+        timeline = e.get("timeline") or []
+        # migrationBatch values present on this skill's type_change events
+        type_change_batches = {
+            ev.get("migrationBatch")
+            for ev in timeline
+            if isinstance(ev, dict)
+            and ev.get("action") == "type_change"
+            and ev.get("migrationBatch")
+        }
+        for ev in timeline:
+            if not isinstance(ev, dict) or ev.get("action") != "demote":
+                continue
+            batch = ev.get("migrationBatch")
+            if not batch:
+                continue  # exempt by absence
+            demotes_checked += 1
+            if batch not in type_change_batches:
+                violations.append(
+                    f"[{sid}] demote carries migrationBatch '{batch}' but no "
+                    f"type_change on this skill shares that batch"
+                )
+
+    print(f"Migration-provenance invariant: {demotes_checked} batched demote(s) "
+          f"checked across {len(entries)} registry named skill(s).")
+    return violations
+
+
 def main() -> int:
     if not NAMED_JSON.exists():
         print(f"timelines: cannot find {NAMED_JSON}", file=sys.stderr)
@@ -112,6 +170,7 @@ def main() -> int:
 
     print(f"Transparency Gate — timeline integrity: {skills_checked} owned named "
           f"skill(s) across {trees_checked} tree(s).")
+    failed = False
     if violations:
         print(f"\n✗ {len(violations)} untracked rank change(s) — transparency violated:\n")
         for v in violations:
@@ -120,10 +179,25 @@ def main() -> int:
               "/gaia-trace-timeline skill or `gaia dev timeline <id> --user <owner> "
               "--action demote|rank_up --timestamp <iso> --notes \"…\"`, then "
               "`gaia docs build`.")
-        return 1
-    print("✓ Transparency Gate: every user-tree timeline explains its skill's "
-          "current rank — no untracked rank changes.")
-    return 0
+        failed = True
+    else:
+        print("✓ Transparency Gate: every user-tree timeline explains its skill's "
+              "current rank — no untracked rank changes.")
+
+    # Migration-provenance invariant (#1189) — registry named-skill timelines only.
+    prov_violations = check_migration_provenance()
+    if prov_violations:
+        print(f"\n✗ {len(prov_violations)} migration-provenance violation(s):\n")
+        for v in prov_violations:
+            print(f"  • {v}")
+        print("\nEvery batched demote must be paired with a same-skill type_change "
+              "sharing its migrationBatch (structured migration provenance, #1189).")
+        failed = True
+    else:
+        print("✓ Migration-provenance invariant: every batched demote is paired with "
+              "a same-skill type_change sharing its migrationBatch.")
+
+    return 1 if failed else 0
 
 
 if __name__ == "__main__":

--- a/src/gaia_cli/data/registry/schema/meta.json
+++ b/src/gaia_cli/data/registry/schema/meta.json
@@ -91,6 +91,16 @@
       "minOriginContributions": 1
     }
   },
+  "metaEpochs": {
+    "order": [
+      "yggdrasil-i",
+      "yggdrasil-ii"
+    ],
+    "labels": {
+      "yggdrasil-i": "Yggdrasil I",
+      "yggdrasil-ii": "Yggdrasil II"
+    }
+  },
   "evidence": {
     "classes": [
       "A",

--- a/src/gaia_cli/data/registry/schema/namedSkill.schema.json
+++ b/src/gaia_cli/data/registry/schema/namedSkill.schema.json
@@ -565,6 +565,19 @@
         "newValue": {
           "type": "string",
           "description": "The level/status after this event (e.g. '3★')."
+        },
+        "metaEpoch": {
+          "type": "string",
+          "enum": [
+            "yggdrasil-i",
+            "yggdrasil-ii"
+          ],
+          "description": "Optional structured provenance: the meta epoch (schema-generation slug) this event belongs to. Mirrors meta.json metaEpochs.order. Stamped on migration events (e.g. paired type_change/demote) so provenance is queryable without prose parsing. Absent on pre-Yggdrasil-II (legacy) events."
+        },
+        "migrationBatch": {
+          "type": "string",
+          "pattern": "^[a-z0-9-]+@\\d{4}-\\d{2}-\\d{2}$",
+          "description": "Optional structured provenance: the migration batch identifier in '<epoch-slug>@YYYY-MM-DD' form (e.g. 'yggdrasil-ii@2026-07-16'). Pairs a type_change with its resulting demote in the same batch so the migration-provenance invariant can verify them structurally. Absent on non-migration and legacy events."
         }
       }
     }

--- a/src/gaia_cli/data/registry/schema/skill.schema.json
+++ b/src/gaia_cli/data/registry/schema/skill.schema.json
@@ -566,6 +566,19 @@
         "newValue": {
           "type": "string",
           "description": "The level/status after this event (e.g. '3★')."
+        },
+        "metaEpoch": {
+          "type": "string",
+          "enum": [
+            "yggdrasil-i",
+            "yggdrasil-ii"
+          ],
+          "description": "Optional structured provenance: the meta epoch (schema-generation slug) this event belongs to. Mirrors meta.json metaEpochs.order. Stamped on migration events (e.g. a node type_change) so provenance is queryable without prose parsing. Absent on pre-Yggdrasil-II (legacy) events."
+        },
+        "migrationBatch": {
+          "type": "string",
+          "pattern": "^[a-z0-9-]+@\\d{4}-\\d{2}-\\d{2}$",
+          "description": "Optional structured provenance: the migration batch identifier in '<epoch-slug>@YYYY-MM-DD' form (e.g. 'yggdrasil-ii@2026-07-16'). Groups the events of one dated migration batch so provenance can be verified structurally. Absent on non-migration and legacy events."
         }
       }
     }

--- a/src/gaia_cli/data/registry/schema/sourceProposal.schema.json
+++ b/src/gaia_cli/data/registry/schema/sourceProposal.schema.json
@@ -1,0 +1,240 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://gaia-registry.github.io/schema/sourceProposal.schema.json",
+  "title": "Gaia Source Proposal",
+  "description": "Schema for a single source-curation proposal emitted by an automated crawler during a dry-run pass. A proposal represents a discovered evidence source for a named skill, pre-validated for schema fitness but NOT yet ingested into the canonical registry. Proposals are tool-agnostic: any crawler backend (Firecrawl, Haunt API, Puppeteer, GitHub API, etc.) can produce them.",
+  "type": "object",
+  "required": [
+    "proposalId",
+    "skillId",
+    "source",
+    "evidenceType",
+    "discoveredAt",
+    "discoveredBy",
+    "crawlerBackend",
+    "confidence",
+    "rationale",
+    "dryRun"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "proposalId": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]*$",
+      "minLength": 8,
+      "description": "Unique identifier for this proposal. Format: <skillId>-<shortHash>-<timestamp>. Must be deterministic for idempotency."
+    },
+    "skillId": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9_-]*/[a-z0-9][a-z0-9_-]*$",
+      "description": "Named skill ID in contributor/skill-name format. Proposals target named skills only (evidence accrues at the named layer)."
+    },
+    "genericSkillRef": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]*(-[a-z0-9]+)*$",
+      "description": "Optional reference to the abstract generic skill this named skill maps to. Informational; used by the adversarial gate to cross-check relevance."
+    },
+    "source": {
+      "type": "string",
+      "format": "uri",
+      "description": "URL of the discovered evidence source. Must be a full, resolvable HTTP(S) URL."
+    },
+    "evidenceType": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+      "description": "Evidence type from meta.json evidence.types taxonomy (e.g. github-stars-own, arxiv, social-signal, peer-review, benchmark-result, repo-own, proxy-containment). The crawler must map its discovery to a known type."
+    },
+    "numericPayload": {
+      "type": "object",
+      "description": "Type-specific numeric data required by the Trust Magnitude formula. Shape depends on evidenceType. Optional for types that use flat magnitude (e.g. self-attestation).",
+      "additionalProperties": false,
+      "properties": {
+        "stars": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "GitHub stargazer count. Used by github-stars-own and proxy-containment types."
+        },
+        "citations": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Academic citation count. Used by arxiv type."
+        },
+        "percentile": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Benchmark percentile rank. Used by benchmark-result type."
+        },
+        "reviewers": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of distinct reviewers. Used by peer-review type."
+        },
+        "views": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "View count. Used by social-signal type."
+        },
+        "likes": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Like/upvote count. Used by social-signal type."
+        },
+        "comments": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Comment count. Used by social-signal type."
+        },
+        "commits": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Commit count. Used by repo-own type."
+        },
+        "contributors": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Contributor count. Used by repo-own type."
+        },
+        "origins": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of graded origins. Used by fusion-recipe type."
+        },
+        "verifiers": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of distinct verifiers. Used by verifier-attestation type."
+        },
+        "externalStars": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Stars on the external containing project. Used by proxy-containment type."
+        },
+        "skillCountInRepo": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of skills in the repo (mothership divisor). Used by github-stars-own type."
+        }
+      }
+    },
+    "discoveredAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp when the crawler discovered this source."
+    },
+    "discoveredBy": {
+      "type": "string",
+      "description": "Identity of the bot or agent that produced this proposal. For automated curation: 'nova-gaia'.",
+      "minLength": 1
+    },
+    "crawlerBackend": {
+      "type": "string",
+      "description": "Name of the tool/API that performed the discovery (e.g. 'firecrawl-search', 'github-api', 'youtube-data-api', 'haunt', 'puppeteer', 'arxiv-api', 'hackernews-algolia'). Tool-agnostic: any backend that can fill this contract is valid.",
+      "minLength": 1
+    },
+    "crawlerVersion": {
+      "type": "string",
+      "description": "Optional version string of the crawler backend for reproducibility."
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Crawler's self-assessed confidence that this source is genuine, relevant, and correctly typed. 0.0 = no confidence, 1.0 = certain. Used by the adversarial gate as a triage signal; proposals below the configurable floor are auto-dropped before review."
+    },
+    "rationale": {
+      "type": "string",
+      "minLength": 10,
+      "description": "Human-readable explanation of why this source is relevant to the skill. Must be specific enough for an adversarial reviewer to evaluate without visiting the URL. Subjective wording ('elite', 'best', 'high-quality') should be avoided."
+    },
+    "existingEvidenceCheck": {
+      "type": "object",
+      "description": "Idempotency check: did the crawler verify this source is not already in the skill's evidence array?",
+      "additionalProperties": false,
+      "required": ["checked", "duplicate"],
+      "properties": {
+        "checked": {
+          "type": "boolean",
+          "description": "True if the crawler checked for duplicates against the current registry state."
+        },
+        "duplicate": {
+          "type": "boolean",
+          "description": "True if this source URL already exists in the skill's evidence. Duplicate proposals should be excluded from the report but may be logged for audit."
+        },
+        "existingIndex": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "If duplicate=true, the 0-based index of the matching evidence row in the skill's current evidence array."
+        }
+      }
+    },
+    "adversarialReview": {
+      "type": "object",
+      "description": "Populated by the adversarial/refute gate after the proposal is generated. Empty or absent during initial dry-run output.",
+      "additionalProperties": false,
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["pending", "accepted", "refuted", "deferred"],
+          "description": "Outcome of the adversarial review. 'pending' = not yet reviewed. 'accepted' = passed skeptic gate. 'refuted' = rejected (>=2/3 skeptics). 'deferred' = needs human review."
+        },
+        "skepticVotes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["skepticId", "vote", "reason"],
+            "additionalProperties": false,
+            "properties": {
+              "skepticId": {
+                "type": "string",
+                "description": "Identifier of the skeptic agent."
+              },
+              "vote": {
+                "type": "string",
+                "enum": ["accept", "refute"],
+                "description": "The skeptic's vote."
+              },
+              "reason": {
+                "type": "string",
+                "minLength": 10,
+                "description": "Explanation for the vote."
+              }
+            }
+          },
+          "description": "Array of skeptic votes from the 3-skeptic refute pass."
+        },
+        "reviewedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp when the adversarial review completed."
+        }
+      }
+    },
+    "dryRun": {
+      "type": "boolean",
+      "const": true,
+      "description": "MUST be true. This proposal was emitted during a dry-run pass (no registry mutation). Auto-PR publishing is not yet implemented."
+    },
+    "quotaCost": {
+      "type": "object",
+      "description": "Optional cost/quota accounting for the API calls that produced this proposal. Placeholder for future budget enforcement.",
+      "additionalProperties": false,
+      "properties": {
+        "apiCalls": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of API calls consumed to discover this source."
+        },
+        "estimatedCostUsd": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Estimated cost in USD for the API calls."
+        },
+        "backend": {
+          "type": "string",
+          "description": "Which backend's quota was consumed."
+        }
+      }
+    }
+  }
+}

--- a/src/gaia_cli/data/registry/schema/sourceProposalReport.schema.json
+++ b/src/gaia_cli/data/registry/schema/sourceProposalReport.schema.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://gaia-registry.github.io/schema/sourceProposalReport.schema.json",
+  "title": "Gaia Source Proposal Report",
+  "description": "A dry-run report containing one or more source proposals for a scheduled curation cycle. Produced by the source-curation crawler and consumed by the adversarial gate and human reviewers. This file is the unit of review: it bundles all proposals from a single crawl run, tracks quota spend, and records the pipeline phase boundary. It MUST NOT be used to mutate the canonical registry directly.",
+  "type": "object",
+  "required": [
+    "reportId",
+    "generatedAt",
+    "generatedBy",
+    "pipelinePhase",
+    "dryRun",
+    "proposals"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "reportId": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]*$",
+      "minLength": 8,
+      "description": "Unique identifier for this report. Format: <date>-<run-id>."
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp when this report was generated."
+    },
+    "generatedBy": {
+      "type": "string",
+      "const": "nova-gaia",
+      "description": "Bot identity that generated the report. Currently only 'nova-gaia' is authorized."
+    },
+    "pipelinePhase": {
+      "type": "string",
+      "enum": ["discovery", "adversarial-review", "human-review"],
+      "description": "Current dry-run phase of the source-curation pipeline. Reports may stop at 'discovery', 'adversarial-review', or 'human-review'. 'ingestion' is reserved for future auto-PR publishing and is not valid until a publisher exists."
+    },
+    "dryRun": {
+      "type": "boolean",
+      "const": true,
+      "description": "MUST be true. Auto-PR publishing is not yet implemented. When ingestion is enabled in a future release, this field will allow false."
+    },
+    "crawlConfig": {
+      "type": "object",
+      "description": "Configuration snapshot of the crawl run for reproducibility.",
+      "additionalProperties": false,
+      "properties": {
+        "targetGrades": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["S", "A", "B", "C", "ungraded"]
+          },
+          "description": "Which overall trust grades were targeted in this cycle."
+        },
+        "maxProposalsPerSkill": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 10,
+          "default": 5,
+          "description": "Maximum proposals per skill per cycle. Self-bounding: avoids flooding."
+        },
+        "confidenceFloor": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0.3,
+          "description": "Proposals below this confidence are auto-dropped before report inclusion."
+        },
+        "backends": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "List of crawler backends used in this run."
+        }
+      }
+    },
+    "quotaSummary": {
+      "type": "object",
+      "description": "Aggregate quota/cost accounting for the entire crawl run. Placeholder for future budget enforcement.",
+      "additionalProperties": false,
+      "properties": {
+        "totalApiCalls": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total API calls across all backends."
+        },
+        "estimatedTotalCostUsd": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Estimated total cost in USD."
+        },
+        "perBackend": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "calls": { "type": "integer", "minimum": 0 },
+              "costUsd": { "type": "number", "minimum": 0 }
+            }
+          },
+          "description": "Per-backend breakdown of API calls and cost."
+        }
+      }
+    },
+    "proposals": {
+      "type": "array",
+      "items": {
+        "$ref": "sourceProposal.schema.json"
+      },
+      "description": "Array of source proposals produced by this crawl run."
+    },
+    "summary": {
+      "type": "object",
+      "description": "Human-readable summary statistics for the report.",
+      "additionalProperties": false,
+      "properties": {
+        "skillsTargeted": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of distinct skills targeted in this crawl."
+        },
+        "proposalsGenerated": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total proposals generated (before dedup)."
+        },
+        "duplicatesDropped": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Proposals dropped due to existing evidence dedup."
+        },
+        "belowConfidenceDropped": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Proposals dropped for being below confidence floor."
+        },
+        "proposalsAccepted": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Proposals accepted by the deterministic adversarial/refute gate."
+        },
+        "proposalsRejected": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Proposals rejected by the deterministic adversarial/refute gate."
+        },
+        "proposalsRefuted": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Proposals marked refuted by the deterministic adversarial/refute gate."
+        },
+        "refuteReasons": {
+          "type": "array",
+          "description": "Aggregated deterministic refute reasons and counts for rejected/refuted proposals.",
+          "items": {
+            "type": "object",
+            "required": ["reason", "count"],
+            "additionalProperties": false,
+            "properties": {
+              "reason": {
+                "type": "string",
+                "minLength": 10
+              },
+              "count": {
+                "type": "integer",
+                "minimum": 1
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/test_timelines.py
+++ b/tests/test_timelines.py
@@ -9,6 +9,7 @@ guard for the silent-demotion bug (e.g. semantic-cache, ruvnet, openai).
 from __future__ import annotations
 
 import importlib.util
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -54,3 +55,84 @@ def test_repo_timelines_are_consistent():
     result = subprocess.run([sys.executable, str(REPO / "scripts" / "validate_timelines.py")],
                             cwd=str(REPO), capture_output=True, text=True)
     assert result.returncode == 0, result.stdout + result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Migration-provenance invariant (#1189) — inline RED/GREEN pure-helper tests
+#
+# check_migration_provenance() reads the registry named-skill index from
+# vt.NAMED_JSON. We point it at a scratch index built inline so the invariant
+# is exercised in isolation, independent of live registry data.
+# ---------------------------------------------------------------------------
+
+_BATCH = "yggdrasil-ii@2026-07-16"
+
+
+def _run_provenance(monkeypatch, tmp_path, entries):
+    """Point check_migration_provenance at a scratch named-skills.json of `entries`."""
+    scratch = tmp_path / "named-skills.json"
+    index = {
+        "generatedAt": "2026-07-16T00:00:00Z",
+        "buckets": {"named": entries},
+        "awaitingClassification": [],
+    }
+    scratch.write_text(json.dumps(index), encoding="utf-8")
+    monkeypatch.setattr(vt, "NAMED_JSON", scratch)
+    return vt.check_migration_provenance()
+
+
+def test_provenance_green_paired_demote_and_type_change(monkeypatch, tmp_path):
+    """GREEN: a demote paired with a type_change sharing the same batch passes."""
+    entries = [{
+        "id": "alice/skill",
+        "timeline": [
+            {"timestamp": "2026-07-16T00:00:00Z", "action": "type_change",
+             "migrationBatch": _BATCH},
+            {"timestamp": "2026-07-16T00:01:00Z", "action": "demote",
+             "migrationBatch": _BATCH, "previousValue": "4★", "newValue": "3★"},
+        ],
+    }]
+    assert _run_provenance(monkeypatch, tmp_path, entries) == []
+
+
+def test_provenance_red_batched_demote_without_type_change(monkeypatch, tmp_path):
+    """RED: a batched demote with no matching type_change is flagged."""
+    entries = [{
+        "id": "bob/skill",
+        "timeline": [
+            {"timestamp": "2026-07-16T00:01:00Z", "action": "demote",
+             "migrationBatch": _BATCH, "previousValue": "4★", "newValue": "3★"},
+        ],
+    }]
+    violations = _run_provenance(monkeypatch, tmp_path, entries)
+    assert len(violations) == 1
+    assert "bob/skill" in violations[0]
+
+
+def test_provenance_red_type_change_different_batch(monkeypatch, tmp_path):
+    """RED: a batched demote whose type_change carries a DIFFERENT batch is flagged."""
+    entries = [{
+        "id": "carol/skill",
+        "timeline": [
+            {"timestamp": "2026-07-16T00:00:00Z", "action": "type_change",
+             "migrationBatch": "yggdrasil-ii@2026-01-01"},
+            {"timestamp": "2026-07-16T00:01:00Z", "action": "demote",
+             "migrationBatch": _BATCH, "previousValue": "4★", "newValue": "3★"},
+        ],
+    }]
+    violations = _run_provenance(monkeypatch, tmp_path, entries)
+    assert len(violations) == 1
+    assert "carol/skill" in violations[0]
+
+
+def test_provenance_control_unbatched_demote_not_flagged(monkeypatch, tmp_path):
+    """CONTROL: a demote with no migrationBatch (e.g. Yggdrasil I) is exempt by absence."""
+    entries = [{
+        "id": "dave/skill",
+        "timeline": [
+            {"timestamp": "2026-06-01T00:00:00Z", "action": "demote",
+             "previousValue": "3★", "newValue": "2★",
+             "details": "Level updated from 3★ to 2★ per G7 final rankings calibration."},
+        ],
+    }]
+    assert _run_provenance(monkeypatch, tmp_path, entries) == []

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -255,5 +255,59 @@ class TestNamedSkillValidation(unittest.TestCase):
             shutil.rmtree(temp_named_dir)
 
 
+class TestMetaEpochsMetaSync(unittest.TestCase):
+    """Regression guard for the Yggdrasil II structured-provenance schema (#1189).
+
+    Ensures the metaEpochs enum and the optional metaEpoch/migrationBatch timeline
+    fields exist in lockstep across the canonical registry/schema/ tree and the
+    bundled src/gaia_cli/data/registry/schema/ mirror, and that the pre-existing
+    timeline action enum still admits type_change (which the invariant pairs against).
+    """
+
+    CANONICAL_META = os.path.join(REPO_ROOT, "registry", "schema", "meta.json")
+    BUNDLED_META = os.path.join(
+        REPO_ROOT, "src", "gaia_cli", "data", "registry", "schema", "meta.json")
+    CANONICAL_NAMED = os.path.join(REPO_ROOT, "registry", "schema", "namedSkill.schema.json")
+    BUNDLED_NAMED = os.path.join(
+        REPO_ROOT, "src", "gaia_cli", "data", "registry", "schema", "namedSkill.schema.json")
+    SYNC_SCRIPT = os.path.join(REPO_ROOT, "scripts", "sync_bundled_schemas.py")
+
+    @staticmethod
+    def _load(path):
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+
+    def test_meta_epochs_present_in_both_meta_copies(self):
+        """metaEpochs.order exists and matches in canonical and bundled meta.json."""
+        canonical = self._load(self.CANONICAL_META).get("metaEpochs", {})
+        bundled = self._load(self.BUNDLED_META).get("metaEpochs", {})
+        self.assertIn("yggdrasil-ii", canonical.get("order", []))
+        self.assertIn("yggdrasil-i", canonical.get("order", []))
+        self.assertEqual(canonical.get("order"), bundled.get("order"))
+        self.assertEqual(canonical.get("labels"), bundled.get("labels"))
+
+    def test_bundle_is_byte_identical(self):
+        """sync_bundled_schemas.py --check exits 0 (bundle byte-identical to canonical)."""
+        result = subprocess.run(
+            [sys.executable, self.SYNC_SCRIPT, "--check"],
+            cwd=REPO_ROOT, capture_output=True, text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_named_schema_declares_provenance_fields_in_both_copies(self):
+        """Both namedSkill.schema.json copies declare metaEpoch and migrationBatch."""
+        for path in (self.CANONICAL_NAMED, self.BUNDLED_NAMED):
+            props = (self._load(path)["definitions"]["timelineEvent"]["properties"])
+            self.assertIn("metaEpoch", props, f"metaEpoch missing in {path}")
+            self.assertIn("migrationBatch", props, f"migrationBatch missing in {path}")
+            # migrationBatch must keep its <slug>@YYYY-MM-DD pattern
+            self.assertIn("@", props["migrationBatch"].get("pattern", ""))
+
+    def test_timeline_action_enum_still_contains_type_change(self):
+        """The timeline action enum still admits type_change (paired by the invariant)."""
+        props = self._load(self.CANONICAL_NAMED)["definitions"]["timelineEvent"]["properties"]
+        self.assertIn("type_change", props["action"]["enum"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #1189 (resolves to `main` at the aggregate merge, not staging).

## What
Replaces the fragile prose-marker/time-window timeline pairing idea with **structured, schema-backed migration provenance** so all future metas (Ygg III, Sequoia I, …) generalize with zero validator edits.

- **Schema:** `metaEpochs` enum in `meta.json` + optional `metaEpoch`/`migrationBatch` on timeline events in `namedSkill.schema.json` AND `skill.schema.json` (canonical + bundled mirror, lockstep green).
- **Migration** (`migrate_taxonomy_v6.py`): stamps `metaEpoch`/`migrationBatch` on both the `type_change` and its paired `demote`; `--backfill-only` in-place upgrade path; batch-based idempotency (2nd run = 0 changes).
- **Backfill:** Yggdrasil II batch stamped — 130 node + 52 named `type_change`, 40 named `demote` (reconciles with #997).
- **Validator** (`validate_timelines.py`): meta-agnostic structural invariant — any `demote` carrying a `migrationBatch` must have a same-skill `type_change` with the same batch. No hardcoded epoch, no time window. Ygg I exempt by field-absence. Hard fail.
- **Tests:** 4 RED/GREEN provenance tests + 4 meta-sync regression tests.

## Verified (independent review)
- Invariant green from a clean source rebuild: **40 batched demotes checked, all paired.** Not vacuous.
- RED genuinely fails; idempotency holds; schema lockstep byte-identical; `details` prose intact.

## Scope notes
- Registry named-skill timelines only; user-trees (`skill-trees/**`) deliberately untouched (their action enum has no `type_change`).
- Pre-existing (NOT from this branch): 78 user-tree drift violations from #997 make the release-time `validate_timelines` gate red on base — separate `/gaia-trace-timeline` workstream.