### PR TITLE
Yggdrasil II · #999 CI guard cleanup (banned synonyms, G7/G8 scope, apex-tier retire, guard-topology doc)

### DIFF
--- a/docs/guard-topology.md
+++ b/docs/guard-topology.md
@@ -1,0 +1,125 @@
+# Gaia CI Guard Topology — Yggdrasil II
+
+> Reference for maintainers and agents. Describes the full set of active CI guards, their
+> ownership, scope, and failure semantics. Cross-references the relevant issues and scripts.
+> See [`docs/rank-vocabulary-guard.md`](rank-vocabulary-guard.md) for the Banned Synonym detail sheet.
+
+Last updated: 2026-07-17 · Branch `dev/999-guard-cleanup` · Refs #999, #994, #1189
+
+---
+
+## Guard inventory
+
+| Guard | Workflow | Script | Failure mode | Scope | Primary invariant |
+|-------|----------|--------|--------------|-------|-------------------|
+| **Rank Vocabulary Guard** | `rank-vocabulary-guard.yml` | `scripts/check_rank_vocabulary.py` | **Hard-fail (exit 1)** | registry/**, *.md, docs/**/*.md, founder/handovers/**/*.md | Yggdrasil II banned-synonym enforcement (below) |
+| Guard A — Token colours | `docs-cohesion.yml` | inline `grep` | PR comment only (no fail) | docs/js/**, docs/css/**, *.html | No hardcoded hex colours — design tokens only |
+| Guard B — Banned synonyms | `docs-cohesion.yml` | inline `grep` | PR comment only (no fail) | docs/js/**, docs/css/**, *.html | Rarity-axis vocabulary (separate from vocabulary guard) |
+| Guard C — Direction rule | `docs-cohesion.yml` | inline `grep` | PR comment only (no fail) | docs/js/** | Ultimate-first sort enforcement |
+| Guard D — Nav mounts | `docs-cohesion.yml` | inline check | PR comment only (no fail) | docs/ nav structure | Nav mounts in sync |
+| Guard E — Docs cohesion | `docs-cohesion.yml` | inline check | Fail on label absent | docs/graph/ | docs/graph/* artifacts regenerated alongside registry changes |
+
+> **IMPORTANT — Guard A/B mislabel history:** Issue #999 originally referenced a "Guard A" and
+> "Guard B" that did not correspond to the `docs-cohesion.yml` guard labels.  `docs-cohesion.yml`
+> Guard B is a **separate, comment-only rarity-axis guard** that runs on HTML/JS/CSS.  The
+> **Rank Vocabulary Guard** (`rank-vocabulary-guard.yml`) is the hard-fail Yggdrasil II banned-
+> synonym guard — it is NOT Guard B of `docs-cohesion.yml`.  Do not conflate them.
+
+---
+
+## Rank Vocabulary Guard — detail
+
+**Script:** `scripts/check_rank_vocabulary.py`
+**Workflow:** `.github/workflows/rank-vocabulary-guard.yml`
+**Exit codes:** 0 = clean, 1 = one or more hard violations
+**Canonical banned-synonym source of truth:** `CONTEXT.md §"Banned synonyms"`
+
+### Full-scope banned patterns (all scanned files)
+
+All patterns are case-sensitive unless noted otherwise.
+
+| Pattern | Flags | Label | Rationale |
+|---------|-------|-------|-----------|
+| `\bTranscendent\b` | — | Transcendent | Old 5★ rank name; use `Ultimate` (Suite) / `Unique Ultimate` (Unique) |
+| `\bHardened\b` | — | Hardened | Old 4★ rank name; use `Extra` (Suite) / `Unique` (Unique branch) |
+| `\bFusion\s+Skill\b` | — | Fusion Skill | Type words stand bare; use `Fusion` |
+| `\bBasic\s+Skill\b` | — | Basic Skill | Type words stand bare; use `Basic` |
+| `\bExtra skill\b` | — | Extra skill | Lowercase-s taxonomy form (Yggdrasil I type word); use `Fusion` / `type=fusion`. Capital-S `Extra Skill` rank phrasing is **valid** and will not be flagged. |
+| `\bUltimate skill\b` | — | Ultimate skill | Lowercase-s taxonomy form; `Ultimate` is the 5★ rank name only; use `Fusion`. Capital-S `Ultimate Skill` rank phrasing is **valid** and will not be flagged. |
+| `type\s*[=:]\s*extra` | — | type=extra | Legacy Yggdrasil I taxonomy field value; use `type=fusion` |
+| `type\s*[=:]\s*ultimate` | — | type=ultimate | Legacy Yggdrasil I taxonomy field value; use `type=fusion` |
+| `\bapex\s+tier\b` | `re.IGNORECASE` | apex tier | Taxonomy-Ultimate synonym; `Ultimate`=5★ rank name, `Apex`=6★ Suite rank name. Never use "apex tier" as a taxonomy synonym. `scripts/**` is hard-excluded (generateBadges.py / generateOgCards.py use it as a legitimate 6★-rank descriptor). |
+
+### Docs-only banned patterns (root `*.md` and `docs/**/*.md` only)
+
+`founder/handovers/**` and `registry/**` are **exempt** from these checks: those paths hold
+internal engineering specs where the G-series codename is the primary reference. The pattern
+check is path-scoped via `is_docs_scope()` in the guard script.
+
+| Pattern | Flags | Label | Rationale |
+|---------|-------|-------|-----------|
+| `\bG7\b` | — | G7 | Internal engineering codename; use `TM Index (2026 Q2)` in public docs |
+| `\bG8\b` | — | G8 | Internal engineering codename; use `TM Index (2026 Q3)` in public docs |
+
+### Hard exclusions (never scanned)
+
+`scripts/**`, `docs/assets/**`, `docs/badges/**`, `**/*.html`, `registry/schema/**`,
+`registry/render/**`, `registry/real-skills.*`, `registry/similarity.json`
+
+The `scripts/**` exclusion is intentional: `scripts/generateBadges.py` and
+`scripts/generateOgCards.py` use `apex tier` as a legitimate 6★-rank descriptor and would
+otherwise false-positive on the apex tier pattern. A broader vocabulary audit of scripts is
+tracked under #996 (CLI branch-awareness prerequisite).
+
+---
+
+## `docs-cohesion.yml` — Guard B is a SEPARATE rarity-axis guard
+
+**Do not confuse `docs-cohesion.yml` Guard B with the Rank Vocabulary Guard.**
+
+| | Rank Vocabulary Guard | `docs-cohesion.yml` Guard B |
+|---|---|---|
+| Workflow file | `rank-vocabulary-guard.yml` | `docs-cohesion.yml` |
+| Failure mode | **Hard fail (exit 1)** | PR comment only — no CI failure |
+| Scope | Registry data + all .md + handovers | `docs/js/**`, `docs/css/**`, `*.html` |
+| Banned vocabulary | Yggdrasil II rank/taxonomy synonyms | Rarity-axis vocabulary (`rarity`, `rarityLabels`, `highestRarity`, `rs-legendary`, `legendary`, `epic`, `mythic`, `uncommon`) |
+| Issues | #999 (Yggdrasil II CI guards) | Tracks rarity-axis drift in generated HTML/JS/CSS |
+
+Guard B of `docs-cohesion.yml` is a **comment-only** guard on the rarity axis in the generated
+site output. It is deliberately non-blocking: rarity-axis drift in templates produces a PR
+annotation but does not fail CI, because the rarity-axis removal is a rolling cleanup.
+
+---
+
+## Migration-provenance invariant (issue #1189)
+
+Issue [#1189](https://github.com/gaia-research/gaia-skill-tree/issues/1189) defines a
+**structured migration-provenance invariant**: timeline events that correspond to a taxonomy
+migration must carry `metaEpoch` / `migrationBatch` fields (schema-backed, not prose-as-contract).
+
+This is **distinct** from the Rank Vocabulary Guard, which enforces that old vocabulary does not
+appear in new canonical content. The #1189 invariant enforces that migration events in user-tree
+timelines are structured and machine-verifiable.
+
+Key cross-reference for the #999 guard: the registry/named/*.md files that appear in the
+`ALLOWLIST_PATHS` (23 files + `registry/named-skills.json`) contain `"type: extra/ultimate →
+fusion"` in `evidence.details` strings — these are **migration provenance notes** from the #997
+Yggdrasil II taxonomy migration, not actual `type=extra` field values. The #1189 work will
+eventually replace these prose provenance strings with structured `metaEpoch`/`migrationBatch`
+fields; until then they remain allowlisted under #994.
+
+---
+
+## Pre-existing violation tracking (#994)
+
+See [`docs/rank-vocabulary-guard.md`](rank-vocabulary-guard.md#pre-existing-violations-allowlist--tracked-under-994)
+for the full allowlist table.
+
+Files in `ALLOWLIST_PATHS` generate `[WARN]` output but do not fail CI (`exit 0`).  Cleanup is
+tracked under issue **#994**.  Once a file is cleaned, remove it from `ALLOWLIST_PATHS` in
+`scripts/check_rank_vocabulary.py` and from the table in `docs/rank-vocabulary-guard.md`.
+
+Files in `DOCS_ONLY_ALLOWLIST_PATHS` are exempt **only** from the G7/G8 docs-only check; all
+full-scope patterns still apply.  This prevents blanket immunity: a file like `CHANGELOG.md`
+or `DESIGN.md` can be cleaned of Transcendent/Hardened vocabulary and removed from the main
+allowlist, while retaining a narrower exemption for the historical G7 codename reference.

--- a/docs/rank-vocabulary-guard.md
+++ b/docs/rank-vocabulary-guard.md
@@ -2,8 +2,10 @@
 
 > **Canonical reference for the CI guard at `.github/workflows/rank-vocabulary-guard.yml`.**
 > Guard script: `scripts/check_rank_vocabulary.py` · Refs #999 (EPIC sub-issue, banned-synonym portion)
+> See also [`docs/guard-topology.md`](guard-topology.md) for the full guard inventory and topology.
 
 Ratified vocabulary: **Yggdrasil II**, 2026-07-07.
+Source of truth for banned synonyms: **CONTEXT.md §"Banned synonyms"**.
 
 ---
 
@@ -21,20 +23,48 @@ Ratified vocabulary: **Yggdrasil II**, 2026-07-07.
 
 **Skill types (field value in `registry/**`):** `basic` · `fusion`
 
+**Rank phrasings with "Skill" suffix (always valid):** `Extra Skill` · `Ultimate Skill` · `Apex Skill` · `Unique Skill`
+
 ---
 
 ## Banned synonyms (never use in new canonical content)
 
-| Term | Was | Replaced by | Pattern matched |
-|------|-----|-------------|-----------------|
-| `Transcendent` | 5★ rank name (Yggdrasil I) | `Ultimate` (Suite) / `Unique Ultimate` (Unique) | `\bTranscendent\b` |
-| `Hardened` | 4★ rank name (Yggdrasil I) | `Extra` (Suite) / `Unique` (Unique branch) | `\bHardened\b` |
-| `Extra Skill` | taxonomy type label (Yggdrasil I) | `Fusion Skill` in prose / `fusion` in data | `\bExtra\s+Skill\b` |
-| `Ultimate Skill` | taxonomy type label (Yggdrasil I) | `Fusion Skill` in prose / `fusion` in data | `\bUltimate\s+Skill\b` |
+### Full-scope patterns (apply to all scanned files)
 
-**Important nuance:** `Extra` and `Ultimate` used **alone** as rank words are **valid** and pass the guard.
-Only the two-word phrases `Extra Skill` and `Ultimate Skill` as taxonomy type labels are banned.
-Word-boundary matching ensures `5★ Ultimate` passes while `Ultimate Skill (◆)` fails.
+| Term | Was | Replaced by | Pattern | Notes |
+|------|-----|-------------|---------|-------|
+| `Transcendent` | 5★ rank name (Yggdrasil I) | `Ultimate` (Suite) / `Unique Ultimate` (Unique) | `\bTranscendent\b` | Case-sensitive |
+| `Hardened` | 4★ rank name (Yggdrasil I) | `Extra` (Suite) / `Unique` (Unique branch) | `\bHardened\b` | Case-sensitive |
+| `Fusion Skill` | taxonomy type term (Yggdrasil I) | `Fusion` (bare) in prose / `fusion` in data | `\bFusion\s+Skill\b` | Case-sensitive; the "Skill" suffix is a rank-word convention; type words stand bare |
+| `Basic Skill` | taxonomy type term | `Basic` (bare) | `\bBasic\s+Skill\b` | Case-sensitive |
+| `Extra skill` | taxonomy-sense type word (lowercase **s**) | `Fusion` / `type=fusion` | `\bExtra skill\b` | Case-sensitive. **Capital-S `Extra Skill` rank phrasing is VALID.** |
+| `Ultimate skill` | taxonomy-sense type word (lowercase **s**) | `Fusion` / `type=fusion` | `\bUltimate skill\b` | Case-sensitive. **Capital-S `Ultimate Skill` rank phrasing is VALID.** |
+| `type=extra` / `type: extra` | legacy Yggdrasil I field value | `type=fusion` / `type: fusion` | `type\s*[=:]\s*extra` | Case-sensitive |
+| `type=ultimate` / `type: ultimate` | legacy Yggdrasil I field value | `type=fusion` / `type: fusion` | `type\s*[=:]\s*ultimate` | Case-sensitive |
+| `apex tier` | taxonomy-Ultimate synonym | n/a — Apex is the 6★ Suite rank | `\bapex\s+tier\b` | **Case-insensitive.** `scripts/**` hard-excluded (generateBadges.py uses it as a legitimate 6★-rank descriptor). |
+
+**Key nuance — capital S vs lowercase s:**
+
+- `Extra Skill` and `Ultimate Skill` (capital **S**) are **valid rank phrasings** — they will NOT be flagged.
+- `Extra skill` and `Ultimate skill` (lowercase **s**) are **banned taxonomy-sense forms** from Yggdrasil I.
+- `Extra` and `Ultimate` used alone as rank names are always valid.
+
+**Key nuance — `apex tier`:**
+
+- `apex tier` as a **taxonomy synonym** for `type=ultimate` is banned under Yggdrasil II.
+- The actual 6★ rank tier IS named "Apex" — "Apex rank" and "6★ Apex" are valid.
+- The _specific phrase_ `apex tier` conflates the old stars-axis / taxonomy-axis and is the banned form.
+- `scripts/generateBadges.py` and `scripts/generateOgCards.py` use "apex tier" as a 6★-rank-label descriptor and are hard-excluded from scanning.
+
+### Docs-only patterns (root `*.md` and `docs/**/*.md` only)
+
+`founder/handovers/**` and `registry/**` are **exempt** from these: they are internal engineering
+specs where the G-series codename is the primary reference.
+
+| Term | Replaced by (in public docs) | Pattern | Notes |
+|------|------------------------------|---------|-------|
+| `G7` | `TM Index (2026 Q2)` | `\bG7\b` | Internal engineering codename for the Trust Taxonomy RFC phase |
+| `G8` | `TM Index (2026 Q3)` | `\bG8\b` | Internal engineering codename |
 
 ---
 
@@ -53,7 +83,7 @@ Word-boundary matching ensures `5★ Ultimate` passes while `Ultimate Skill (◆
 
 | Path glob | Reason for exclusion |
 |-----------|----------------------|
-| `scripts/**` | Scripts need `#996` CLI branch-awareness before vocabulary clean-up |
+| `scripts/**` | Scripts need `#996` CLI branch-awareness before vocabulary clean-up; `scripts/generateBadges.py` and `scripts/generateOgCards.py` also contain legitimate `apex tier` descriptors |
 | `docs/assets/**` | Generated image / data artifacts |
 | `docs/badges/**` | Generated badge SVGs |
 | `**/*.html` | HTML files out of scope per task spec |
@@ -66,52 +96,69 @@ Word-boundary matching ensures `5★ Ultimate` passes while `Ultimate Skill (◆
 
 ## Pre-existing violations (allowlist — tracked under #994)
 
-The files below were confirmed to contain old vocabulary as of the guard's initial deploy
-(**2026-07-14**, branch `infra/yggdrasil-ii-ci-guards`). The guard **warns** on these files but
-does **not** fail CI, keeping the guard green today. They are tracked for cleanup under **#994**.
+Files listed in `ALLOWLIST_PATHS` (or the `DOCS_ONLY_ALLOWLIST_PATHS` for G7/G8-only exemptions)
+in `scripts/check_rank_vocabulary.py` are reported as **WARN** (not FAIL) by the guard.
 
-Once a file is cleaned up, remove it from `ALLOWLIST_PATHS` in `scripts/check_rank_vocabulary.py`
-and from the table below.
+Once a file is cleaned up, remove it from the allowlist in `scripts/check_rank_vocabulary.py`
+and from the table below, then run `python scripts/check_rank_vocabulary.py` (must exit 0).
 
-| File | Hit count | Reason / notes |
-|------|-----------|----------------|
-| `CONTEXT.md` | 17 | Lexicon entries explicitly documenting deprecated terms as deprecated |
-| `DESIGN.md` | 15 | Legacy rank colour/animation table; old rank name column |
-| `GOVERNANCE.md` | 3 | Old "4★ Hardened" threshold and Ultimate/Extra Skill tier names |
-| `PRODUCT.md` | 1 | Product copy referencing old 6★ "Transcendent ★" label |
-| ~~`META.md`~~ | 0 | **Removed from allowlist** — cleaned to v2 by #994 (PR #1170); guard now enforces it |
-| `registry/combinations.md` | 129 | 124 rows with "Extra Skill" taxonomy label (registry data, cannot modify without #994) |
-| `registry/registry.md` | 129 | Mirror of combinations.md |
-| `docs/agent.md` | 3 | Old taxonomy definitions |
-| `docs/agents/frontend-known-issues.md` | 1 | Historical "Transcendent ★" reference describing a stale snapshot |
-| `docs/archive/**` (6 files) | ~43 | Frozen pre-Yggdrasil snapshots — not updated by design |
-| `docs/audits/2026-05-07-openai-named-and-level-iv-plus.md` | 6 | Pre-Yggdrasil II audit document |
-| `docs/audits/2026-05-17-meta-audit.md` | 4 | Pre-Yggdrasil II audit document |
-| `docs/en/DOCS.md` | 4 | Legacy taxonomy table in translation doc |
-| `docs/en/MEMORY.md` | 2 | Historical session memory referencing old labels |
-| `docs/en/ROUTINE_PROMPT.md` | 2 | Prompt using old vocabulary |
-| `docs/examples/example_extra_skill.md` | 2 | Legacy example doc |
-| `docs/meta/2026-05-31-starless-skills-update.md` | 1 | Pre-Yggdrasil II meta post |
-| ~~`docs/meta/2026-06-trust-methodology.md`~~ | 0 | **Removed from allowlist** — cleaned to v2 by #994 (PR #1170) |
-| `docs/okf/index.md` | — | OKF index: old tier section headers (plural form, not caught by singular regex) |
-| `docs/okf/skills/extra/index.md` | — | OKF "Extra Skills" index |
-| `docs/okf/skills/ultimate/index.md` | — | OKF "Ultimate Skills" index |
-| `docs/plans/firecrawl-skills-suite.md` | 1 | Plan doc predating Yggdrasil II |
-| `docs/superpowers/plans/2026-05-14-hunters-atlas-redesign.md` | 2 | Design plan with old rank/taxonomy labels |
-| `founder/handovers/design-v6.1.1-ascension-overdrive-*.md` (6 files) | 31 | AOV/ascension-overdrive design docs; task spec hard-excludes AOV files from review |
-| `founder/handovers/YGGDRASIL_II_RATIFICATION_2026-07-07.md` | 2 | Ratification doc references both old and new terms |
-| `founder/handovers/done/TRUST_METHODOLOGY_REPORT.md` | 1 | Historical report |
-| `founder/handovers/done/g7-mattpocock-audit/_workflow_notes.md` | 1 | Historical workflow notes |
-| `founder/handovers/phase-1.5/issues/I8.md` | 1 | Historical issue doc |
+### Main allowlist (`ALLOWLIST_PATHS`)
 
-**Total on initial deploy:** 409 hits across 34 files — all pre-existing, all allowlisted, guard exits 0.
+| File | Patterns | Reason / notes |
+|------|----------|----------------|
+| `CONTEXT.md` | all | Lexicon entries explicitly documenting deprecated terms as deprecated |
+| `GOVERNANCE.md` | Hardened, Extra Skill tier names | Old "4★ Hardened" threshold and tier names |
+| `PRODUCT.md` | Transcendent | Product copy referencing old 6★ "Transcendent ★" label |
+| `registry/combinations.md` | Extra Skill (×124) | Registry data, taxonomy labels — tracked under #994 |
+| `registry/registry.md` | Extra Skill | Mirror of combinations.md |
+| `registry/named-skills.json` | type=extra/ultimate | Migration provenance notes (#997 migration) |
+| `registry/named/**/*.md` (23 files) | type=extra/ultimate | `"type: extra/ultimate → fusion"` in `details` fields — legitimate #997 provenance records |
+| `docs/agents/frontend-known-issues.md` | Transcendent | Historical "Transcendent ★" snapshot reference |
+| `docs/archive/**` (6 files) | all | Frozen pre-Yggdrasil snapshots — not updated by design |
+| `docs/audits/2026-05-07-*.md` | all | Pre-Yggdrasil II audit document |
+| `docs/audits/2026-05-17-*.md` | all | Pre-Yggdrasil II audit document |
+| `docs/en/DOCS.md` | all | Legacy taxonomy table in translation doc |
+| `docs/en/MEMORY.md` | all | Historical session memory |
+| `docs/en/ROUTINE_PROMPT.md` | all | Prompt using old vocabulary |
+| `docs/examples/example_extra_skill.md` | all | Legacy example doc |
+| `docs/meta/2026-05-31-starless-skills-update.md` | all | Pre-Yggdrasil II meta post |
+| `docs/meta/2026-06-curate-chain-starless.md` | all | Pre-Yggdrasil II curate post |
+| `docs/meta/2026-06-17-g7-trust-magnitude-supersession.md` | G7, apex tier | G7 supersession post; uses G7 codename and "apex tier" as 6★ descriptor |
+| `docs/architecture/benchmark-framework.md` | G7, apex tier | Benchmark RFC; uses G7 codename and "apex tier" as 6★ descriptor |
+| `docs/okf/index.md` | all | OKF index: old tier section headers |
+| `docs/okf/skills/extra/index.md` | all | OKF "Extra Skills" index |
+| `docs/okf/skills/ultimate/index.md` | all | OKF "Ultimate Skills" index |
+| `docs/plans/firecrawl-skills-suite.md` | all | Plan doc predating Yggdrasil II |
+| `docs/superpowers/plans/2026-05-14-hunters-atlas-redesign.md` | all | Design plan with old labels |
+| `founder/handovers/design-v6.1.1-ascension-overdrive-*.md` (6 files) | all | AOV design docs |
+| `founder/handovers/YGGDRASIL_II_RATIFICATION_2026-07-07.md` | all | Ratification doc references both old and new terms |
+| `founder/handovers/design-v6.1.1-world-tree-semantic-topology.md` | Transcendent | Changelog names the dropped term |
+| `founder/handovers/done/TRUST_METHODOLOGY_REPORT.md` | all | Historical report |
+| `founder/handovers/done/G7_TRUST_TAXONOMY_RFC.md` | Ultimate skill, apex tier | G7 RFC; pre-Yggdrasil-II naming + "apex tier" as 6★ descriptor |
+| `founder/handovers/done/g7-mattpocock-audit/_workflow_notes.md` | all | Historical workflow notes |
+| `founder/handovers/done/g7-mattpocock-audit/_issue_comment.md` | apex tier | "apex tier" as 6★ descriptor in historical issue comment |
+| `founder/handovers/phase-1.5/issues/I8.md` | all | Historical issue doc |
+
+### Docs-only allowlist (`DOCS_ONLY_ALLOWLIST_PATHS` — G7/G8 only)
+
+These files are exempt only from the G7/G8 docs-only check; all full-scope patterns still apply.
+
+| File | Reason |
+|------|--------|
+| `CHANGELOG.md` | Release notes reference "G7 Trust Infrastructure" phase name |
+| `CONTRIBUTING.md` | Contribution guide: "Add evidence with G7 dual-axis fields" |
+| `DESIGN.md` | References the G7 Trust Taxonomy RFC |
+| `META.md` | Evidence-methodology summary references G7 RFC directly |
+| `README.md` | Readme mentions G7 Trust Taxonomy RFC |
+| `docs/meta/2026-06-FULL-recap.md` | G7 retrospective document |
+| `docs/meta/JUN_2026_TRUST_REGRADE.md` | G7 cutover stamp document |
 
 ---
 
 ## How to clean up an allowlisted file
 
 1. Update the file to use v2 vocabulary (see table above for replacements).
-2. Remove the file's entry from `ALLOWLIST_PATHS` in `scripts/check_rank_vocabulary.py`.
+2. Remove the file's entry from `ALLOWLIST_PATHS` (or `DOCS_ONLY_ALLOWLIST_PATHS`) in `scripts/check_rank_vocabulary.py`.
 3. Remove it from the table in this document.
 4. Run the guard locally: `python scripts/check_rank_vocabulary.py` — must exit 0.
 5. Commit both changes together with message referencing #994.

--- a/scripts/check_rank_vocabulary.py
+++ b/scripts/check_rank_vocabulary.py
@@ -136,6 +136,7 @@ HARD_EXCLUDE_GLOBS = [
 ALLOWLIST_PATHS = {
     # ── Guard reference doc (documents the banned terms by definition) ─────
     'docs/rank-vocabulary-guard.md',  # This IS the guard ref doc; must name the banned terms
+    'docs/guard-topology.md',         # Guard topology reference; names banned terms by definition
 
     # ── Root canonical docs (pre-Yggdrasil-II prose still in flight) ────────
     'CONTEXT.md',           # Lexicon entries explicitly documenting deprecated terms

--- a/scripts/check_rank_vocabulary.py
+++ b/scripts/check_rank_vocabulary.py
@@ -10,14 +10,25 @@ EXIT CODES
   0  — clean (zero hard violations outside the documented allowlist)
   1  — one or more hard violations found in non-allowlisted files
 
-BANNED PATTERNS
-  \\bTranscendent\\b    — old 5★ rank name; now "Ultimate" (Suite) / "Unique Ultimate" (Unique)
-  \\bHardened\\b        — old 4★ rank name; now "Extra" (Suite) / "Unique" (Unique branch)
-  \\bFusion\\s+Skill\\b — type words stand bare; the "Skill" suffix is a rank-word convention. Use "Fusion".
-  \\bBasic\\s+Skill\\b  — type words stand bare; the "Skill" suffix is a rank-word convention. Use "Basic".
+BANNED PATTERNS  (applied to full scan scope — all case-sensitive unless noted)
+  \\bTranscendent\\b      — old 5★ rank name; now "Ultimate" (Suite) / "Unique Ultimate" (Unique)
+  \\bHardened\\b          — old 4★ rank name; now "Extra" (Suite) / "Unique" (Unique branch)
+  \\bFusion\\s+Skill\\b   — type words stand bare; use "Fusion"  (CONTEXT.md §Banned synonyms)
+  \\bBasic\\s+Skill\\b    — type words stand bare; use "Basic"   (CONTEXT.md §Banned synonyms)
+  \\bExtra skill\\b        — lowercase-s taxonomy form (Yggdrasil I type word); use "Fusion" / type=fusion
+                            CONTEXT.md §Banned synonyms; capital-S "Extra Skill" rank phrasing is VALID.
+  \\bUltimate skill\\b     — lowercase-s taxonomy form; "Ultimate" is now the 5★ rank name only;
+                            CONTEXT.md §Banned synonyms; capital-S "Ultimate Skill" rank phrasing is VALID.
+  type\\s*[=:]\\s*extra    — legacy Yggdrasil I taxonomy field value  (CONTEXT.md §Banned synonyms)
+  type\\s*[=:]\\s*ultimate — legacy Yggdrasil I taxonomy field value  (CONTEXT.md §Banned synonyms)
+
+DOCS-ONLY BANNED PATTERNS  (root *.md and docs/**/*.md only; added #999 Step 2)
+  \\bG7\\b  — internal engineering codename; use "TM Index (2026 Q2)" in public docs
+  \\bG8\\b  — internal engineering codename; use "TM Index (2026 Q3)" in public docs
+  founder/handovers/** and registry/** are exempt: internal specs where the G-series is primary.
 
   NOTE: The "Skill" suffix attaches to RANK words only — "Extra Skill", "Unique Skill",
-  "Ultimate Skill", "Apex Skill" are all VALID rank phrasings. TYPE words stand bare:
+  "Ultimate Skill", "Apex Skill" are all VALID rank phrasings (capital S). TYPE words stand bare:
   "Basic" and "Fusion" (never "Basic Skill" / "Fusion Skill"). Bare "Extra"/"Ultimate"
   as rank names are valid too (word-boundary matching).
 
@@ -26,6 +37,7 @@ ALLOWED (v2 vocabulary — never flagged)
   Suite: 4★ Extra · 5★ Ultimate · 6★ Apex
   Unique: 4★ Unique · 5★ Unique Ultimate · 6★ Unique Impossible
   Types (field value): basic · fusion
+  Rank phrasings with "Skill" suffix: Extra Skill · Ultimate Skill · Apex Skill · Unique Skill
 
 SCAN SCOPE  (content surface only)
   registry/**              — registry data files
@@ -68,10 +80,16 @@ if sys.stderr.encoding and sys.stderr.encoding.lower() not in ('utf-8', 'utf8'):
 
 BANNED_PATTERNS = [
     # Pattern,  human label,  rationale
-    (re.compile(r'\bTranscendent\b'),     'Transcendent',    'old 5★ rank name — use Ultimate / Unique Ultimate'),
-    (re.compile(r'\bHardened\b'),         'Hardened',        'old 4★ rank name — use Extra (Suite) / Unique (Unique branch)'),
-    (re.compile(r'\bFusion\s+Skill\b'), 'Fusion Skill',  'type words stand bare — the "Skill" suffix is reserved for rank words; use "Fusion"'),
-    (re.compile(r'\bBasic\s+Skill\b'),  'Basic Skill',   'type words stand bare — the "Skill" suffix is reserved for rank words; use "Basic"'),
+    (re.compile(r'\bTranscendent\b'),       'Transcendent',    'old 5★ rank name — use Ultimate / Unique Ultimate  (CONTEXT.md §Banned synonyms)'),
+    (re.compile(r'\bHardened\b'),           'Hardened',        'old 4★ rank name — use Extra (Suite) / Unique (Unique branch)  (CONTEXT.md §Banned synonyms)'),
+    (re.compile(r'\bFusion\s+Skill\b'),     'Fusion Skill',    'type words stand bare — "Skill" suffix is reserved for rank words; use "Fusion"  (CONTEXT.md §Banned synonyms)'),
+    (re.compile(r'\bBasic\s+Skill\b'),      'Basic Skill',     'type words stand bare — "Skill" suffix is reserved for rank words; use "Basic"  (CONTEXT.md §Banned synonyms)'),
+    # Case-sensitive patterns — lowercase-s taxonomy forms only (#999 Step 1)
+    # Capital-S "Extra Skill" / "Ultimate Skill" rank phrasings remain VALID and will NOT match.
+    (re.compile(r'\bExtra skill\b'),        'Extra skill',     'taxonomy-sense Yggdrasil I type word (CONTEXT.md §Banned synonyms); use "Fusion" / type=fusion. "Extra Skill" (capital S) rank phrasing is valid.'),
+    (re.compile(r'\bUltimate skill\b'),     'Ultimate skill',  'taxonomy-sense Yggdrasil I type word (CONTEXT.md §Banned synonyms); "Ultimate" is the 5★ rank name only; structural role → Fusion. "Ultimate Skill" (capital S) rank phrasing is valid.'),
+    (re.compile(r'type\s*[=:]\s*extra'),    'type=extra',      'legacy Yggdrasil I taxonomy field value (CONTEXT.md §Banned synonyms); use type=fusion'),
+    (re.compile(r'type\s*[=:]\s*ultimate'), 'type=ultimate',   'legacy Yggdrasil I taxonomy field value (CONTEXT.md §Banned synonyms); use type=fusion'),
 ]
 
 # ---------------------------------------------------------------------------
@@ -153,8 +171,37 @@ ALLOWLIST_PATHS = {
     'founder/handovers/YGGDRASIL_II_RATIFICATION_2026-07-07.md',  # Ratification doc references both old and new terms
     'founder/handovers/design-v6.1.1-world-tree-semantic-topology.md',  # v2 topology; changelog names the dropped "Transcendent" term
     'founder/handovers/done/TRUST_METHODOLOGY_REPORT.md',         # Historical report
-    'founder/handovers/done/g7-mattpocock-audit/_workflow_notes.md',  # Historical workflow notes
+    'founder/handovers/done/G7_TRUST_TAXONOMY_RFC.md',            # G7 RFC; pre-Yggdrasil-II naming ("Ultimate skill") in engineering spec  # #994
+    'founder/handovers/done/g7-mattpocock-audit/_workflow_notes.md',   # Historical workflow notes
     'founder/handovers/phase-1.5/issues/I8.md',                   # Historical issue doc
+
+    # ── registry/named/** migration provenance notes (#997 Yggdrasil II migration) ────
+    # All contain "type: extra/ultimate → fusion" in evidence.details strings —
+    # legitimate provenance records of the taxonomy migration, not actual type=extra fields.
+    'registry/named-skills.json',                                       # Generated catalog; migration provenance notes  # #994
+    'registry/named/addy-osmani/agent-skills.md',                      # #994
+    'registry/named/firecrawl/firecrawl-build-scrape.md',              # #994
+    'registry/named/firecrawl/firecrawl-skills.md',                    # #994
+    'registry/named/garrytan/garrytan.md',                             # #994
+    'registry/named/garrytan/gstack.md',                               # #994
+    'registry/named/google-deepmind/alphafold_database_fetch_and_analyze.md',  # #994
+    'registry/named/google-deepmind/alphagenome_single_variant_analysis.md',   # #994
+    'registry/named/google-deepmind/workflow_skill_creator.md',        # #994
+    'registry/named/gsd-build/get-shit-done.md',                       # #994
+    'registry/named/mattpocock/engineering.md',                        # #994
+    'registry/named/mattpocock/productivity.md',                       # #994
+    'registry/named/mattpocock/skills.md',                             # #994
+    'registry/named/obra/subagent-driven-development.md',              # #994
+    'registry/named/obra/superpowers.md',                              # #994
+    'registry/named/obra/using-git-worktrees.md',                      # #994
+    'registry/named/obra/writing-plans.md',                            # #994
+    'registry/named/ruvnet/agentdb.md',                                # #994
+    'registry/named/ruvnet/dual-mode.md',                              # #994
+    'registry/named/ruvnet/reasoningbank.md',                          # #994
+    'registry/named/ruvnet/ruflo-v3.md',                               # #994
+    'registry/named/ruvnet/ruflo.md',                                  # #994
+    'registry/named/safishamsi/graphify.md',                           # #994
+    'registry/named/stanfordnlp/dspy.md',                              # #994
 }
 
 # Also allowlist entire docs/archive/ subtree (all are frozen pre-Yggdrasil snapshots)
@@ -261,8 +308,9 @@ def main():
 
     print('=== Yggdrasil II Rank Vocabulary Guard  (Refs #999) ===')
     print(f'Repo root : {repo_root}')
-    print(f'Banned    : Transcendent, Hardened, "Basic Skill", "Fusion Skill"')
-    print(f'Allowed   : Extra/Ultimate + rank+Skill phrasings ("Extra Skill" etc.); Basic, Fusion (bare types)')
+    print(f'Banned    : Transcendent, Hardened, "Basic Skill", "Fusion Skill", "Extra skill", "Ultimate skill", type=extra, type=ultimate')
+    print(f'Docs-only : G7, G8 (external/public docs only; founder/handovers/** and registry/** exempt)')
+    print(f'Allowed   : Extra Skill / Ultimate Skill (capital-S rank phrasings); Extra/Ultimate bare; Basic, Fusion (bare types)')
     print()
 
     hard, soft = scan(repo_root)

--- a/scripts/check_rank_vocabulary.py
+++ b/scripts/check_rank_vocabulary.py
@@ -153,6 +153,8 @@ ALLOWLIST_PATHS = {
     'docs/meta/2026-05-31-starless-skills-update.md',         # Pre-Yggdrasil-II meta post
     'docs/meta/2026-06-curate-chain-starless.md',             # Pre-Yggdrasil-II curate post
     # docs/meta/2026-06-trust-methodology.md — REMOVED from allowlist: cleaned to v2 by #994 (PR #1170)
+    'docs/meta/2026-06-17-g7-trust-magnitude-supersession.md',  # G7 supersession post; uses G7 codename + "apex tier" as 6★ descriptor  # #994
+    'docs/architecture/benchmark-framework.md',                  # Benchmark RFC; uses G7 codename + "apex tier" as 6★ descriptor  # #994
     'docs/okf/index.md',                                      # OKF index: old tier section headers
     'docs/okf/skills/extra/index.md',                         # OKF "Extra Skills" index
     'docs/okf/skills/ultimate/index.md',                      # OKF "Ultimate Skills" index
@@ -173,6 +175,7 @@ ALLOWLIST_PATHS = {
     'founder/handovers/done/TRUST_METHODOLOGY_REPORT.md',         # Historical report
     'founder/handovers/done/G7_TRUST_TAXONOMY_RFC.md',            # G7 RFC; pre-Yggdrasil-II naming ("Ultimate skill") in engineering spec  # #994
     'founder/handovers/done/g7-mattpocock-audit/_workflow_notes.md',   # Historical workflow notes
+    'founder/handovers/done/g7-mattpocock-audit/_issue_comment.md',    # Historical issue comment; "apex tier" as 6★ descriptor  # #994
     'founder/handovers/phase-1.5/issues/I8.md',                   # Historical issue doc
 
     # ── registry/named/** migration provenance notes (#997 Yggdrasil II migration) ────
@@ -210,6 +213,36 @@ ALLOWLIST_SUBTREES = [
 ]
 
 # ---------------------------------------------------------------------------
+# Docs-only banned patterns — applied ONLY to root *.md and docs/**/*.md
+# (external/public documentation surface).  founder/handovers/** and
+# registry/** are EXEMPT: those paths are internal engineering specs where
+# the G-series codename is the primary reference.  (#999 Step 2)
+# ---------------------------------------------------------------------------
+
+DOCS_ONLY_BANNED_PATTERNS = [
+    # Pattern,  human label,  rationale
+    (re.compile(r'\bG7\b'), 'G7', 'internal engineering codename (CONTEXT.md §Banned synonyms); use "TM Index (2026 Q2)" in public docs; founder/handovers/** and registry/** are exempt'),
+    (re.compile(r'\bG8\b'), 'G8', 'internal engineering codename (CONTEXT.md §Banned synonyms); use "TM Index (2026 Q3)" in public docs; founder/handovers/** and registry/** are exempt'),
+]
+
+# Allowlist for docs-only patterns (pre-existing G7/G8 external-doc references).
+# These files are exempted ONLY for DOCS_ONLY_BANNED_PATTERNS.  Files already in
+# ALLOWLIST_PATHS inherit that exemption automatically (is_allowlisted() returns True)
+# and need not be repeated here.  #994
+DOCS_ONLY_ALLOWLIST_PATHS = {
+    'CHANGELOG.md',           # Release notes reference "G7 Trust Infrastructure" phase name  # #994
+    'CONTRIBUTING.md',        # Contribution guide: "Add evidence with G7 dual-axis fields"  # #994
+    'DESIGN.md',              # Design doc references the G7 Trust Taxonomy RFC  # #994
+    'META.md',                # Evidence-methodology summary references G7 RFC directly  # #994
+    'README.md',              # Readme mentions G7 Trust Taxonomy RFC  # #994
+    'docs/meta/2026-06-FULL-recap.md',      # G7 retrospective document  # #994
+    'docs/meta/JUN_2026_TRUST_REGRADE.md',  # G7 cutover stamp document  # #994
+    # Note: docs/meta/2026-06-17-g7-trust-magnitude-supersession.md and
+    # docs/architecture/benchmark-framework.md are in the main ALLOWLIST_PATHS
+    # (pre-existing G7 + apex-tier references); is_allowlisted() covers them.
+}
+
+# ---------------------------------------------------------------------------
 # File collection helpers
 # ---------------------------------------------------------------------------
 
@@ -233,6 +266,31 @@ def is_allowlisted(rel_path: str) -> bool:
         if norm.startswith(subtree):
             return True
     return False
+
+
+def is_docs_scope(rel_path: str) -> bool:
+    """Return True for root *.md and docs/**/*.md — the external/public doc surface.
+
+    G7/G8 docs-only banned patterns apply only to this scope.  Files in
+    founder/handovers/** and registry/** are NOT docs-scope for this check.
+    """
+    norm = rel_path.replace('\\', '/')
+    if norm.endswith('.md') and '/' not in norm:
+        return True
+    if norm.startswith('docs/') and norm.endswith('.md'):
+        return True
+    return False
+
+
+def is_docs_only_allowlisted(rel_path: str) -> bool:
+    """Return True if this path is exempt from DOCS_ONLY_BANNED_PATTERNS.
+
+    A file is exempt if it is either in the main ALLOWLIST_PATHS (which covers
+    all patterns) or in DOCS_ONLY_ALLOWLIST_PATHS (which covers only
+    DOCS_ONLY_BANNED_PATTERNS).  This lets us exempt files like CHANGELOG.md
+    from the G7/G8 check without granting them blanket immunity from all guards.
+    """
+    return is_allowlisted(rel_path) or rel_path.replace('\\', '/') in DOCS_ONLY_ALLOWLIST_PATHS
 
 
 def collect_files(repo_root: Path):
@@ -281,7 +339,11 @@ def scan(repo_root: Path):
             print(f'  [SKIP] {rel_path}: {exc}', file=sys.stderr)
             continue
 
+        # Determine which pattern sets apply to this file
+        check_docs_only = is_docs_scope(rel_path)
+
         for lineno, line in enumerate(text.splitlines(), start=1):
+            # Full-scope banned patterns (apply to all scanned files)
             for pattern, label, rationale in BANNED_PATTERNS:
                 if pattern.search(line):
                     entry = (rel_path, lineno, line.strip()[:120], label, rationale)
@@ -289,6 +351,16 @@ def scan(repo_root: Path):
                         soft_violations.append(entry)
                     else:
                         hard_violations.append(entry)
+
+            # Docs-only banned patterns (G7/G8 — external/public doc surface only)
+            if check_docs_only:
+                for pattern, label, rationale in DOCS_ONLY_BANNED_PATTERNS:
+                    if pattern.search(line):
+                        entry = (rel_path, lineno, line.strip()[:120], label, rationale)
+                        if is_docs_only_allowlisted(rel_path):
+                            soft_violations.append(entry)
+                        else:
+                            hard_violations.append(entry)
 
     return hard_violations, soft_violations
 

--- a/scripts/check_rank_vocabulary.py
+++ b/scripts/check_rank_vocabulary.py
@@ -21,6 +21,12 @@ BANNED PATTERNS  (applied to full scan scope — all case-sensitive unless noted
                             CONTEXT.md §Banned synonyms; capital-S "Ultimate Skill" rank phrasing is VALID.
   type\\s*[=:]\\s*extra    — legacy Yggdrasil I taxonomy field value  (CONTEXT.md §Banned synonyms)
   type\\s*[=:]\\s*ultimate — legacy Yggdrasil I taxonomy field value  (CONTEXT.md §Banned synonyms)
+  \\bapex\\s+tier\\b       — CASE-INSENSITIVE taxonomy-Ultimate synonym; CONTEXT.md §Banned synonyms:
+                            "Ultimate is now the 5★ rank name; Apex is the 6★ Suite rank name.
+                            Never use 'apex tier' as a taxonomy synonym."
+                            scripts/** hard-excluded; generateBadges.py/generateOgCards.py use
+                            it as a legitimate 6★-rank descriptor — confirmed excluded.
+                            Stale positive assertions in other guards/tests should be removed.
 
 DOCS-ONLY BANNED PATTERNS  (root *.md and docs/**/*.md only; added #999 Step 2)
   \\bG7\\b  — internal engineering codename; use "TM Index (2026 Q2)" in public docs
@@ -90,6 +96,13 @@ BANNED_PATTERNS = [
     (re.compile(r'\bUltimate skill\b'),     'Ultimate skill',  'taxonomy-sense Yggdrasil I type word (CONTEXT.md §Banned synonyms); "Ultimate" is the 5★ rank name only; structural role → Fusion. "Ultimate Skill" (capital S) rank phrasing is valid.'),
     (re.compile(r'type\s*[=:]\s*extra'),    'type=extra',      'legacy Yggdrasil I taxonomy field value (CONTEXT.md §Banned synonyms); use type=fusion'),
     (re.compile(r'type\s*[=:]\s*ultimate'), 'type=ultimate',   'legacy Yggdrasil I taxonomy field value (CONTEXT.md §Banned synonyms); use type=fusion'),
+    # Case-insensitive pattern (#999 Step 3)
+    # CONTEXT.md §Banned synonyms: "apex tier" (as taxonomy-Ultimate synonym) is banned.
+    # "Ultimate is now the 5★ rank name; Apex is the 6★ Suite rank name.
+    #  Never use 'apex tier' as a taxonomy synonym."
+    # scripts/** hard-excluded: generateBadges.py + generateOgCards.py use 'apex tier' as
+    # a legitimate 6★-rank descriptor — confirmed excluded via HARD_EXCLUDE_GLOBS.
+    (re.compile(r'\bapex\s+tier\b', re.IGNORECASE), 'apex tier', 'taxonomy-Ultimate synonym — CONTEXT.md §Banned synonyms; Ultimate=5★ rank name, Apex=6★ Suite rank name; never use "apex tier" as a taxonomy synonym. scripts/** hard-excluded.'),
 ]
 
 # ---------------------------------------------------------------------------
@@ -380,7 +393,7 @@ def main():
 
     print('=== Yggdrasil II Rank Vocabulary Guard  (Refs #999) ===')
     print(f'Repo root : {repo_root}')
-    print(f'Banned    : Transcendent, Hardened, "Basic Skill", "Fusion Skill", "Extra skill", "Ultimate skill", type=extra, type=ultimate')
+    print(f'Banned    : Transcendent, Hardened, "Basic Skill", "Fusion Skill", "Extra skill", "Ultimate skill", type=extra, type=ultimate, "apex tier" (case-insensitive)')
     print(f'Docs-only : G7, G8 (external/public docs only; founder/handovers/** and registry/** exempt)')
     print(f'Allowed   : Extra Skill / Ultimate Skill (capital-S rank phrasings); Extra/Ultimate bare; Basic, Fusion (bare types)')
     print()


### PR DESCRIPTION
Refs #999 (the remaining guard-logic half; the timeline invariant moved to #1189).

## What
- **check_rank_vocabulary.py:** case-sensitive `\bExtra skill\b` / `\bUltimate skill\b` (lowercase-s taxonomy forms only — capital-S rank phrasing stays valid) + `type=extra`/`type=ultimate`, reconciled against CONTEXT.md §Banned synonyms.
- **G7/G8:** path-scoped ban — hard-fails in root `*.md` + `docs/**/*.md`, exempt under `founder/handovers/**` (internal codename) via `DOCS_ONLY_ALLOWLIST_PATHS`.
- **apex tier:** case-insensitive taxonomy-synonym ban (already ratified in CONTEXT.md §447; `scripts/**` hard-excluded so legit "6★ Apex tier" product usage is safe).
- **Docs:** new `docs/guard-topology.md` + updated `rank-vocabulary-guard.md` — records which guard owns which invariant and kills the #999 Guard A/B mislabel confusion.

## Verified
`check_rank_vocabulary.py` PASS, `validate.py` PASS. Case-sensitivity smoke confirmed (lowercase banned, capital valid).

## Review note
Step 1 allowlisted ~23 `registry/named/*.md` files for the `type=extra/ultimate` pattern because #997 migration `details` prose literally contains "type: extra/ultimate → fusion". Defensible (historical migration notes, not live taxonomy), but a reviewer may prefer refining the pattern over whole-file allowlisting.